### PR TITLE
Removing auth 'concurrency' checks.

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
@@ -206,14 +206,6 @@ NSString * const kDefaultLoginHost = @"login.salesforce.com";
     NSLog(@"authenticate:withDict:");
     NSString *callbackId = [arguments pop];
     
-    //Verify that we're not already authenticating
-    if (nil != _authCallbackId) {
-        NSString *errorMessage = @"Authentication is already in progress.";
-        PluginResult *pluginResult = [PluginResult resultWithStatus:PGCommandStatus_ERROR messageAsString:errorMessage];
-        [self writeJavascript:[pluginResult toErrorCallbackString:callbackId]];
-        return;
-    }
-    
     _authCallbackId = [callbackId copy];
     
     NSString *argsString = [arguments pop];
@@ -458,6 +450,9 @@ NSString * const kDefaultLoginHost = @"login.salesforce.com";
 }
 
 - (void)cleanupCoordinator {
+    if (self.coordinator.view) {
+        [self.coordinator.view removeFromSuperview];
+    }
     [_coordinator setDelegate:nil];
     [_coordinator release];
     _coordinator = nil;


### PR DESCRIPTION
Originally, the OAuth plugin was guarding against the idea of concurrent authentication requests, and raising a fatal error if authentication was attempted when a previous authentication was already in progress.  Problem is, there could be any number of scenarios where previous authentication did not complete, such as switching to another login host, losing network connectivity before completing authentication, etc.

Given that authentication concurrency is not nearly as much of an issue as these other "bad app state" scenarios, the code has been updated to remove the check, and simply clean up any previous authentication that might have been in progress.
