### PR TITLE
Not calling parent's applicationDidBecomeActive

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Container/SFContainerAppDelegate.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Container/SFContainerAppDelegate.m
@@ -28,7 +28,7 @@
 #import "SalesforceOAuthPlugin.h"
 
 // Public constants
-NSString * const kSFMobileSDKVersion = @"1.1.4";
+NSString * const kSFMobileSDKVersion = @"1.1.5";
 NSString * const kUserAgentPropKey = @"UserAgent";
 NSString * const kAppHomeUrlPropKey = @"AppHomeUrl";
 
@@ -114,6 +114,8 @@ NSString * const kSFSmartStorePluginName = @"com.salesforce.smartstore";
     //Touch this to ensure that we have a SmartStore plugin instance that
     //can listen for file data protection notifications.
     [self getCommandInstance:kSFSmartStorePluginName];
+    
+    [super applicationDidBecomeActive:application];
 }
 
 #pragma mark - PhoneGap helpers

--- a/native/SalesforceSDK/SalesforceSDK/Classes/SFRestAPI.m
+++ b/native/SalesforceSDK/SalesforceSDK/Classes/SFRestAPI.m
@@ -31,7 +31,7 @@
 #import "SFRestRequest.h"
 #import "SFSessionRefresher.h"
 
-static NSString * const kSFMobileSDKVersion = @"1.1.4";
+static NSString * const kSFMobileSDKVersion = @"1.1.5";
 NSString* const kSFRestDefaultAPIVersion = @"v23.0";
 NSString* const kSFRestErrorDomain = @"com.salesforce.RestAPI.ErrorDomain";
 NSInteger const kSFRestErrorCode = 999;


### PR DESCRIPTION
The SalesforceHybridSDK was (erroneously) not calling the app delegate's parent applicationDidBecomeActive method, after doing the work in the child class.  PhoneGap's active event was not being fired, as a result.
