### PR TITLE
Making sure login host from settings is current at startup.

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Container/SFContainerAppDelegate.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Container/SFContainerAppDelegate.m
@@ -29,7 +29,7 @@
 #import "NSURL+SFStringUtils.h"
 
 // Public constants
-NSString * const kSFMobileSDKVersion = @"1.1.7";
+NSString * const kSFMobileSDKVersion = @"1.1.8";
 NSString * const kUserAgentPropKey = @"UserAgent";
 NSString * const kAppHomeUrlPropKey = @"AppHomeUrl";
 NSString * const kSFMobileSDKHybridDesignator = @"Hybrid";

--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
@@ -166,6 +166,7 @@ NSString * const kDefaultLoginHost = @"login.salesforce.com";
     if (self) {
         _appDelegate = (SFContainerAppDelegate *)[self appDelegate];
         [[self class] ensureAccountDefaultsExist];
+        [[self class] updateLoginHost];
     }
     
     return self;

--- a/native/SalesforceSDK/SalesforceSDK/Classes/SFRestAPI.m
+++ b/native/SalesforceSDK/SalesforceSDK/Classes/SFRestAPI.m
@@ -31,7 +31,7 @@
 #import "SFRestRequest.h"
 #import "SFSessionRefresher.h"
 
-static NSString * const kSFMobileSDKVersion = @"1.1.7";
+static NSString * const kSFMobileSDKVersion = @"1.1.8";
 NSString* const kSFRestDefaultAPIVersion = @"v23.0";
 NSString* const kSFRestErrorDomain = @"com.salesforce.RestAPI.ErrorDomain";
 NSInteger const kSFRestErrorCode = 999;


### PR DESCRIPTION
I didn't realize that we weren't validating the login host when the app starts up.  This was causing an issue after the last patch, as that information was no longer being updated at app launch.
