### PR TITLE
setting default lockout time default to 0

### DIFF
--- a/shared/Classes/Security/SFSecurityLockout.m
+++ b/shared/Classes/Security/SFSecurityLockout.m
@@ -32,7 +32,7 @@
 
 // Private constants
 
-static NSUInteger const kDefaultLockoutTime                  = 600;
+static NSUInteger const kDefaultLockoutTime                  = 0;
 static NSUInteger const kDefaultPasscodeLength               = 5;
 static NSString * const kSecurityTimeoutKey                  = @"security.timeout";
 static NSString * const kTimerSecurity                       = @"security.timer";


### PR DESCRIPTION
Currently it is set to 600 and hence fails to trigger session refreshes for orgs with no mobile policy configured.
