### PR TITLE
passing only data property while triggering custom document event

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
@@ -543,7 +543,7 @@ NSTimeInterval kSessionAutoRefreshInterval = 10*60.0; //  10 minutes
 {
     
     NSString *credsStr = [SFJsonUtils JSONRepresentation:creds];
-    NSString *eventStr = [[NSString alloc] initWithFormat:@"PhoneGap.fireDocumentEvent('salesforceSessionRefresh',%@);",
+    NSString *eventStr = [[NSString alloc] initWithFormat:@"PhoneGap.fireDocumentEvent('salesforceSessionRefresh',{data:%@});",
                           credsStr];
     [super writeJavascript:eventStr];
     [eventStr release];


### PR DESCRIPTION
Otherwise we are polluting the standard dom event object by adding multiple attributes from the oauth response.
