### PR TITLE
Fixing crash that occurs because nil was being passed into upsertEntries error parameter.

### DIFF
--- a/shared/Classes/SmartStore/SFSmartStore.m
+++ b/shared/Classes/SmartStore/SFSmartStore.m
@@ -1353,7 +1353,8 @@ static NSString *const SOUP_LAST_MODIFIED_DATE = @"_soupLastModifiedDate";
 {
     // Specific NSError messages are generated exclusively around user-defined external ID logic.
     // Ignore them here, and preserve the interface.
-    return [self upsertEntries:entries toSoup:soupName withExternalIdPath:SOUP_ENTRY_ID error:nil];
+    NSError* error = nil;
+    return [self upsertEntries:entries toSoup:soupName withExternalIdPath:SOUP_ENTRY_ID error:&error];
 }
 
 - (NSArray*)upsertEntries:(NSArray*)entries toSoup:(NSString*)soupName withExternalIdPath:(NSString *)externalIdPath error:(NSError **)error


### PR DESCRIPTION
Fixing crash that occurs because nil was being passed into upsertEntries error parameter. Should be NSError reference (initially set to nil). Still ignoring the error, just not crashing.
