### PR TITLE
Fixing SFAuthViewController project access

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
@@ -137,6 +137,9 @@
 		7DE73A4414F6B6E600D489DE /* SFPluginTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DE73A4114F6B6E600D489DE /* SFPluginTestSuite.m */; };
 		7DE73A4514F6B6E600D489DE /* SFPluginTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DE73A4114F6B6E600D489DE /* SFPluginTestSuite.m */; };
 		7DE73A4614F6B6E600D489DE /* SFPluginTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DE73A4114F6B6E600D489DE /* SFPluginTestSuite.m */; };
+		820273D61649E73F00DB814C /* SFAuthorizingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 82CD5BED164823600070BD3D /* SFAuthorizingViewController.m */; };
+		820273D81649E74000DB814C /* SFAuthorizingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 82CD5BED164823600070BD3D /* SFAuthorizingViewController.m */; };
+		820273D91649E74200DB814C /* SFAuthorizingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 82CD5BED164823600070BD3D /* SFAuthorizingViewController.m */; };
 		82031D9C15B4EF4500073595 /* CordovaResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 82031D9B15B4EF4500073595 /* CordovaResources.bundle */; };
 		82031D9D15B4EF6100073595 /* CordovaResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 82031D9B15B4EF4500073595 /* CordovaResources.bundle */; };
 		821C5E7F1583FBA000433F92 /* LICENSE.txt in Resources */ = {isa = PBXBuildFile; fileRef = 821C5E7E1583FBA000433F92 /* LICENSE.txt */; };
@@ -2280,6 +2283,7 @@
 				8287610D15FFD4140064B877 /* SFSmartStoreDatabaseManager.m in Sources */,
 				4FA1DA5E162CB6D800BC1B52 /* CDVPlugin+SFAdditions.m in Sources */,
 				4F3793EB162CD0080094E5C7 /* SFSDKInfoPlugin.m in Sources */,
+				820273D91649E74200DB814C /* SFAuthorizingViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2359,6 +2363,7 @@
 				828E7BB6164202FD00F8D8AF /* CDVPlugin+SFAdditions.m in Sources */,
 				828E7BBB1642044C00F8D8AF /* SFSDKInfoPlugin.m in Sources */,
 				828E7BBC1642050700F8D8AF /* FMDatabaseAdditions.m in Sources */,
+				820273D61649E73F00DB814C /* SFAuthorizingViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2407,6 +2412,7 @@
 				8287610B15FFD3960064B877 /* SFSmartStoreDatabaseManager.m in Sources */,
 				4FA1DA5D162CB6CE00BC1B52 /* CDVPlugin+SFAdditions.m in Sources */,
 				4F3793EA162CD0070094E5C7 /* SFSDKInfoPlugin.m in Sources */,
+				820273D81649E74000DB814C /* SFAuthorizingViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
SFAuthorizingViewController wasn't exposed enough in the hybrid SDK project to allow the unit tests to run successfully in the build.
