### PR TITLE
Fixing hybrid logout

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Container/SFContainerAppDelegate.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Container/SFContainerAppDelegate.m
@@ -36,7 +36,7 @@
 #import "CDVCommandDelegate.h"
 
 // Public constants
-NSString * const kSFMobileSDKVersion = @"1.4.1";
+NSString * const kSFMobileSDKVersion = @"1.4.2";
 NSString * const kUserAgentPropKey = @"UserAgent";
 NSString * const kAppHomeUrlPropKey = @"AppHomeUrl";
 NSString * const kSFMobileSDKHybridDesignator = @"Hybrid";

--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
@@ -107,8 +107,6 @@ static NSString * const kUserAgentCredentialsDictKey    = @"userAgentString";
 
 - (void)dealloc
 {
-    [[SFAccountManager sharedInstance] clearAccountState:NO];
-    
     SFRelease(_authCallbackId);
     SFRelease(_remoteAccessConsumerKey);
     SFRelease(_oauthRedirectURI);

--- a/native/SalesforceSDK/SalesforceSDK/Classes/SFRestAPI.m
+++ b/native/SalesforceSDK/SalesforceSDK/Classes/SFRestAPI.m
@@ -32,7 +32,7 @@
 #import "SFSessionRefresher.h"
 #import "SFAccountManager.h"
 
-NSString * const kSFMobileSDKVersion = @"1.4.1";
+NSString * const kSFMobileSDKVersion = @"1.4.2";
 NSString* const kSFRestDefaultAPIVersion = @"v23.0";
 NSString* const kSFRestErrorDomain = @"com.salesforce.RestAPI.ErrorDomain";
 NSInteger const kSFRestErrorCode = 999;

--- a/shared/Classes/Security/SFAuthenticationManager.m
+++ b/shared/Classes/Security/SFAuthenticationManager.m
@@ -345,7 +345,7 @@ static NSInteger  const kIdentityAlertViewTag = 555;
     
     // TODO: This is another NIB file that's delivered as part of the app templates, and should be
     // moved into a bundle (along with the root vc NIB file mentioned above.
-    [self log:SFLogLevelDebug msg:@"SFOAuthFlowManager: Presenting auth view controller."];
+    [self log:SFLogLevelDebug msg:@"Presenting auth view controller."];
     self.authViewController = [[[SFAuthorizingViewController alloc] initWithNibName:nil bundle:nil] autorelease];
     [self.authViewController setOauthView:webView];
     [self.viewController presentViewController:self.authViewController animated:YES completion:NULL];
@@ -413,25 +413,25 @@ static NSInteger  const kIdentityAlertViewTag = 555;
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator willBeginAuthenticationWithView:(UIWebView *)view
 {
-    [self log:SFLogLevelDebug msg:@"SFOAuthFlowManager: oauthCoordinator:willBeginAuthenticationWithView"];
+    [self log:SFLogLevelDebug msg:@"oauthCoordinator:willBeginAuthenticationWithView"];
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(UIWebView *)view
 {
-    [self log:SFLogLevelDebug msg:@"SFOAuthFlowManager: oauthCoordinator:didBeginAuthenticationWithView"];
+    [self log:SFLogLevelDebug msg:@"oauthCoordinator:didBeginAuthenticationWithView"];
     _isInitialLogin = YES;
     [self presentAuthViewController:view];
 }
 
 - (void)oauthCoordinatorDidAuthenticate:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)info
 {
-    [self log:SFLogLevelDebug format:@"SFOAuthFlowManager: oauthCoordinatorDidAuthenticate for userId: %@, auth info: %@", coordinator.credentials.userId, info];
+    [self log:SFLogLevelDebug format:@"oauthCoordinatorDidAuthenticate for userId: %@, auth info: %@", coordinator.credentials.userId, info];
     [self dismissAuthViewControllerIfPresent:@selector(loggedIn)];
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFailWithError:(NSError *)error authInfo:(SFOAuthInfo *)info
 {
-    [self log:SFLogLevelDebug format:@"SFOAuthFlowManager: oauthCoordinator:didFailWithError: %@, authInfo: %@", error, info];
+    [self log:SFLogLevelDebug format:@"oauthCoordinator:didFailWithError: %@, authInfo: %@", error, info];
     
     BOOL showAlert = YES;
     if (info.authType == SFOAuthTypeRefresh) {


### PR DESCRIPTION
Fix for issue #184.

There was a straggling account manager cleanup in the OAuth plugin, which was yanking the OAuth coordinator out from under the app at logout.  Took that out.   Also, cleaned up the logging messages in the authentication manager a bit.

(NB: I didn't rebuild the native dist libraries, since they're not impacted by this change.)
