### PR TITLE
CDVAvailability.h needs to be public in the hybrid framework

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
@@ -363,7 +363,7 @@
 		828C07D615A39A47002523B2 /* SFHybridViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 828C07D415A39A47002523B2 /* SFHybridViewController.m */; };
 		828E7B3E1641DF9500F8D8AF /* CDV.h in Headers */ = {isa = PBXBuildFile; fileRef = 828E7B1A1641DF9500F8D8AF /* CDV.h */; };
 		828E7B3F1641DF9500F8D8AF /* CDVAccelerometer.h in Headers */ = {isa = PBXBuildFile; fileRef = 828E7B1B1641DF9500F8D8AF /* CDVAccelerometer.h */; };
-		828E7B401641DF9500F8D8AF /* CDVAvailability.h in Headers */ = {isa = PBXBuildFile; fileRef = 828E7B1C1641DF9500F8D8AF /* CDVAvailability.h */; };
+		828E7B401641DF9500F8D8AF /* CDVAvailability.h in Headers */ = {isa = PBXBuildFile; fileRef = 828E7B1C1641DF9500F8D8AF /* CDVAvailability.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		828E7B411641DF9500F8D8AF /* CDVBattery.h in Headers */ = {isa = PBXBuildFile; fileRef = 828E7B1D1641DF9500F8D8AF /* CDVBattery.h */; };
 		828E7B421641DF9500F8D8AF /* CDVCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 828E7B1E1641DF9500F8D8AF /* CDVCamera.h */; };
 		828E7B431641DF9500F8D8AF /* CDVCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 828E7B1F1641DF9500F8D8AF /* CDVCapture.h */; };

--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Container/SFContainerAppDelegate.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Container/SFContainerAppDelegate.m
@@ -36,7 +36,7 @@
 #import "CDVCommandDelegate.h"
 
 // Public constants
-NSString * const kSFMobileSDKVersion = @"1.4.2";
+NSString * const kSFMobileSDKVersion = @"1.4.3";
 NSString * const kUserAgentPropKey = @"UserAgent";
 NSString * const kAppHomeUrlPropKey = @"AppHomeUrl";
 NSString * const kSFMobileSDKHybridDesignator = @"Hybrid";

--- a/native/SalesforceSDK/SalesforceSDK/Classes/SFRestAPI.m
+++ b/native/SalesforceSDK/SalesforceSDK/Classes/SFRestAPI.m
@@ -32,7 +32,7 @@
 #import "SFSessionRefresher.h"
 #import "SFAccountManager.h"
 
-NSString * const kSFMobileSDKVersion = @"1.4.2";
+NSString * const kSFMobileSDKVersion = @"1.4.3";
 NSString* const kSFRestDefaultAPIVersion = @"v23.0";
 NSString* const kSFRestErrorDomain = @"com.salesforce.RestAPI.ErrorDomain";
 NSInteger const kSFRestErrorCode = 999;


### PR DESCRIPTION
It's referenced by CDVCommandDelegate.h, but it's not public in our framework.  This got missed in the Cordova 2.2. update.
