### PR TITLE
New build script for creating packaged libraries

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1,0 +1,150 @@
+<project name="SalesforceMobileSDK-iOS" basedir="." default="all">
+    <property name="artifactsDir" location="artifacts" />
+    
+    <target name="all" description="Build all of the library projects in the SalesforceMobileSDK workspace.">
+        <antcall target="buildCordova" />
+        <antcall target="buildSalesforceHybridSDK" />
+        <antcall target="buildSalesforceNativeSDK" />
+        <antcall target="buildSalesforceOAuth" />
+        <antcall target="buildSalesforceSDKCore" />
+    </target>
+    
+    <target name="buildCordova" description="Builds the Cordova library.">
+        <antcall target="buildLib">
+            <param name="projectName" value="Cordova" />
+            <param name="libName" value="libCordova.a" />
+            <param name="headerDir" value="include/Cordova" />
+            <param name="schemeName" value="CordovaLib" />
+        </antcall>
+    </target>
+    
+    <target name="buildSalesforceHybridSDK" description="Builds the Salesforce Hybrid SDK library.">
+        <antcall target="buildLib">
+            <param name="projectName" value="SalesforceHybridSDK" />
+            <param name="libName" value="libSalesforceHybridSDK.a" />
+            <param name="headerDir" value="include/SalesforceHybridSDK" />
+            <param name="schemeName" value="SalesforceHybridSDK" />
+        </antcall>
+    </target>
+    
+    <target name="buildSalesforceNativeSDK" description="Builds the Salesforce Native SDK library.">
+        <antcall target="buildLib">
+            <param name="projectName" value="SalesforceNativeSDK" />
+            <param name="libName" value="libSalesforceNativeSDK.a" />
+            <param name="headerDir" value="include/SalesforceNativeSDK" />
+            <param name="schemeName" value="SalesforceNativeSDK" />
+        </antcall>
+    </target>
+    
+    <target name="buildSalesforceOAuth" description="Builds the Salesforce OAuth library.">
+        <antcall target="buildLib">
+            <param name="projectName" value="SalesforceOAuth" />
+            <param name="libName" value="libSalesforceOAuth.a" />
+            <param name="headerDir" value="include/SalesforceOAuth" />
+            <param name="schemeName" value="SalesforceOAuth" />
+        </antcall>
+    </target>
+    
+    <target name="buildSalesforceSDKCore" description="Builds the Salesforce SDK Core library.">
+        <antcall target="buildLib">
+            <param name="projectName" value="SalesforceSDKCore" />
+            <param name="libName" value="libSalesforceSDKCore.a" />
+            <param name="headerDir" value="include/SalesforceSDKCore" />
+            <param name="schemeName" value="SalesforceSDKCore" />
+        </antcall>
+    </target>
+    
+    <target name="buildLib" description="Builds the Debug and Release candidates for one of the libraries, as defined by the input scheme.">
+        <antcall target="buildLibWithConfiguration">
+            <param name="buildConfiguration" value="Debug" />
+        </antcall>
+        <antcall target="buildLibWithConfiguration">
+            <param name="buildConfiguration" value="Release" />
+        </antcall>
+    </target>
+    
+    <target name="buildLibWithConfiguration">
+        <property name="buildConfiguration" value="Release" />
+        
+        <mkdir dir="${artifactsDir}/${projectName}" />
+        
+        <!-- Device -->
+        <antcall target="compileScheme">
+            <param name="sdk" value="iphoneos" />
+        </antcall>
+        <move file="${artifactsDir}/${libName}" tofile="${artifactsDir}/${projectName}/${libName}" />
+        <move file="${artifactsDir}/${headerDir}" tofile="${artifactsDir}/${projectName}/${headerDir}" />
+        
+        <!-- Simulator -->
+        <antcall target="compileScheme">
+            <param name="sdk" value="iphonesimulator" />
+        </antcall>
+        
+        <antcall target="lipo">
+            <param name="lipoLib1" value="${artifactsDir}/${projectName}/${libName}" />
+            <param name="lipoLib2" value="${artifactsDir}/${libName}" />
+        </antcall>
+        <delete dir="${artifactsDir}/${headerDir}" />
+        
+        <antcall target="compress">
+            <param name="destFile" value="${artifactsDir}/${projectName}-${buildConfiguration}.zip" />
+            <param name="baseDir" value="${artifactsDir}/${projectName}" />
+        </antcall>
+        
+        <delete dir="${artifactsDir}/${projectName}" />
+    </target>
+    
+    <target name="initArtifacts">
+        <mkdir dir="${artifactsDir}" />
+    </target>
+    
+    <target name="compileScheme" depends="initArtifacts"
+        description="Compiles one of the schemes from the SalesforceMobileSDK workspace.">
+        <property name="buildConfiguration" value="Release" />
+        
+        <echo>Building "${schemeName}" with configuration "${buildConfiguration}" for SDK "${sdk}"</echo>
+        
+        <exec executable="xcodebuild" failonerror="true" logError="true">
+            <arg value="-workspace" />
+            <arg file="../SalesforceMobileSDK.xcworkspace" />
+            <arg value="-scheme" />
+            <arg value="${schemeName}" />
+            <arg value="-configuration" />
+            <arg value="${buildConfiguration}" />
+            <arg value="-sdk" />
+            <arg value="${sdk}" />
+            <arg value="clean" />
+            <arg value="build" />
+            <arg value="CONFIGURATION_BUILD_DIR=${artifactsDir}" />
+            <arg value="ONLY_ACTIVE_ARCH=NO" />
+        </exec>
+    </target>
+    
+    <target name="lipo" description="Lipos lipoLib1 with liboLib2, stores the result as lipoLib1, and removes lipoLib2.">
+        <tempfile property="lipoOutput" deleteonexit="false" prefix="lipo" suffix=".a"/>
+        <exec executable="lipo" failonerror="true" logError="true">
+            <arg value="-create" />
+            <arg value="-output" />
+            <arg value="${lipoOutput}" />
+            <arg value="${lipoLib1}" />
+            <arg value="${lipoLib2}" />
+        </exec>
+        <move file="${lipoOutput}" tofile="${lipoLib1}"/>
+        <delete file="${lipoLib2}" />
+    </target>
+    
+    <target name="compress">
+        <exec executable="ditto">
+            <arg value="-k" /> <!-- PKZip format -->
+            <arg value="-c" /> <!-- compress -->
+            <arg value="--keepParent" />
+            <arg value="--norsrc" />
+            <arg value="${baseDir}" />
+            <arg file="${destFile}" />
+        </exec>
+    </target>
+    
+    <target name="clean" description="Cleans the build state.">
+        <delete dir="${artifactsDir}" />
+    </target>
+</project>


### PR DESCRIPTION
Should just need the one build script (at this point) for building the new libraries.
- Default target (all) builds all of the libraries (Salesforce + Cordova).
- You can build any library individually, by calling e.g. `ant buildSalesforceHybridSDK`.
- Build package output stored in _[Repo Root]_/build/artifacts (as Debug and Relase .zip files).
