### PR TITLE
Fixing path name issue in template installs

### DIFF
--- a/hybrid/sfdc_build/build.xml
+++ b/hybrid/sfdc_build/build.xml
@@ -21,7 +21,7 @@
     <property name="xcodetemplate.pgplugin.base.dir" value="${xcodetemplate.shared.base.dir}/PhoneGap"/>
     <property name="xcodetemplate.jquery.base.dir" value="${xcodetemplate.shared.base.dir}/jquery"/>
     <property name="xcodetemplate.ios.hybridcommon.dir" value="../../shared/hybrid"/>
-    <property name="xcodetemplate.shared.resources.dir" value="../../shared/Resources"/>
+    <property name="xcodetemplate.shared.resources.dir" value="../../shared/resources"/>
     
     <property id="platform.iphoneos" name="platform.iphoneos" value="iphoneos"/>
     <property id="platform.iphonesimulator" name="platform.iphonesimulator" value="iphonesimulator"/>

--- a/native/sfdc_build/build.xml
+++ b/native/sfdc_build/build.xml
@@ -12,7 +12,7 @@
     <property name="xcodetemplate.dir" value="${project.dir}/${xcodetemplate.fullname}"/>
     <property name="xcodetemplate.install.dir" value="${env.HOME}/Library/Developer/Xcode/Templates/Project Templates/Application/${xcodetemplate.fullname}"/>
     <property name="xcodetemplate.dependency.dir" value="${xcodetemplate.dir}/dependencies"/>
-    <property name="xcodetemplate.shared.resources.dir" value="../../shared/Resources"/>
+    <property name="xcodetemplate.shared.resources.dir" value="../../shared/resources"/>
   
     <property id="configuration.debug" name="configuration.debug" value="Debug"/>
     <property id="configuration.release" name="configuration.release" value="Release"/>


### PR DESCRIPTION
Fixes issue #276.  Case sensitivity of paths does not seem to be an issue in my environment, which is why this went unnoticed (I can't reproduce the error).
