### PR TITLE
MessageUI & QuartzCore dependency indicated on existing projects

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -137,9 +137,11 @@ You can also use the SDK in an existing project:
 	1. **MobileCoreServices.framework**
 	1. **SystemConfiguration.framework**
 	1. **Security.framework**
+	1. **MessageUI.framework** 
+	1. **QuartzCore.framework**
 	1. **libxml2.dylib**
 	1. **libsqlite3.dylib**
-	1. **libz.dylib**
+	1. **libz.dylib**	
 
 4. Import the SalesforceSDK header via ``#import "SFRestAPI.h"``.
 


### PR DESCRIPTION
Existing projects with SDK needs these two frameworks as well:
1.MessageUI.framework,  2.QuartzCore.framework

Updated the description for the same.
