### PR TITLE
logout signature added in header as per the documentation

### DIFF
--- a/native/SalesforceSDK/SalesforceSDK/Classes/NativeApp/SFNativeRestAppDelegate.h
+++ b/native/SalesforceSDK/SalesforceSDK/Classes/NativeApp/SFNativeRestAppDelegate.h
@@ -86,7 +86,10 @@
  Kickoff the login process.
  */
 - (void)login;
-
+/**
+ Logout by clearing current session & data. 
+ */
+- (void)logout;
 /**
  Sent whenever the use has been logged in using current settings.
  Be sure to call super if you override this.


### PR DESCRIPTION
It is listed in documentation as public but not available in .h files. Difficult to see if you use salesforce template for ios project (uses compiled .a version of lib)

Ref: http://forcedotcom.github.io/SalesforceMobileSDK-iOS/Documentation/SalesforceSDK/Classes/SFNativeRestAppDelegate.html#//api/name/logout
