### PR TITLE
Allowing REST responses to be returned as raw data

### DIFF
--- a/native/SalesforceNativeSDK/SalesforceNativeSDK/Classes/SFRestAPI+Blocks.m
+++ b/native/SalesforceNativeSDK/SalesforceNativeSDK/Classes/SFRestAPI+Blocks.m
@@ -210,8 +210,8 @@ static char CompleteBlockKey;
     [self sendActionForRequest:request success:NO withObject:[[self class] errorWithDescription:@"Timed out."]];
 }
 
-- (void)request:(SFRestRequest *)request didLoadResponse:(id)jsonResponse {    
-    [self sendActionForRequest:request success:YES withObject:jsonResponse];
+- (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse {    
+    [self sendActionForRequest:request success:YES withObject:dataResponse];
 }
 
 @end

--- a/native/SalesforceNativeSDK/SalesforceNativeSDK/Classes/SFRestAPI.h
+++ b/native/SalesforceNativeSDK/SalesforceNativeSDK/Classes/SFRestAPI.h
@@ -79,6 +79,12 @@ extern NSString * const kSFMobileSDKNativeDesignator;
  request.endpoint prefix, it will add the request.endpoint prefix 
  (kSFDefaultRestEndpoint by default) to the request path.
  
+ You can also specify whether or not you want the request's response to be parsed.  By default,
+ the response associated with the request will be parsed as JSON, and the structured JSON
+ object will be returned.  By setting `request.parseResponse = NO`, the response data will be returned
+ as a binary `NSData` object.  This can be useful for requests that return non-JSON data, such as
+ binary data.
+ 
  
  For example, this sample code calls the `requestForDescribeWithObjectType:` method to return
  information about the Account object.
@@ -91,8 +97,8 @@ extern NSString * const kSFMobileSDKNativeDesignator;
  
     #pragma mark - SFRestDelegate
  
-    - (void)request:(SFRestRequest *)request didLoadResponse:(id)jsonResponse {
-        NSDictionary *dict = (NSDictionary *)jsonResponse;
+    - (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse {
+        NSDictionary *dict = (NSDictionary *)dataResponse;
         NSArray *fields = (NSArray *)[dict objectForKey:@"fields"];
         // ...
     }

--- a/native/SalesforceNativeSDK/SalesforceNativeSDK/Classes/SFRestRequest.h
+++ b/native/SalesforceNativeSDK/SalesforceNativeSDK/Classes/SFRestRequest.h
@@ -56,9 +56,11 @@ extern NSString * const kSFDefaultRestEndpoint;
 /**
  * Sent when a request has finished loading.
  * @param request The request that was loaded.
- * @param jsonResponse The JSON data in the response.
+ * @param dataResponse The data from the response.  By default, this will be an object
+ * containing the parsed JSON response.  However, if `request.parseResponse` was set
+ * to `NO`, the data will be contained in a binary `NSData` object.
  */
-- (void)request:(SFRestRequest *)request didLoadResponse:(id)jsonResponse;
+- (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse;
 
 /**
  * Sent when a request has failed due to an error.
@@ -128,6 +130,12 @@ extern NSString * const kSFDefaultRestEndpoint;
  * Typically kSFDefaultRestEndpoint but you may use eg custom Apex endpoints
  */
 @property (nonatomic, strong) NSString *endpoint;
+
+/**
+ * Whether or not to parse the response data as structured JSON data.  Defaults to `YES`. If
+ * set to `NO`, response data will be returned as binary data in an `NSData` object.
+ */
+@property (nonatomic, assign) BOOL parseResponse;
 
 ///---------------------------------------------------------------------------------------
 /// @name Initialization

--- a/native/SalesforceNativeSDK/SalesforceNativeSDK/Classes/SFRestRequest.m
+++ b/native/SalesforceNativeSDK/SalesforceNativeSDK/Classes/SFRestRequest.m
@@ -36,6 +36,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
 @synthesize method=_method;
 @synthesize delegate=_delegate;
 @synthesize endpoint=_endpoint;
+@synthesize parseResponse=_parseResponse;
 
 - (id)initWithMethod:(SFRestMethod)method path:(NSString *)path queryParams:(NSDictionary *)queryParams {
     self = [super init];
@@ -44,6 +45,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         self.path = path;
         self.queryParams = queryParams;
         self.endpoint = kSFDefaultRestEndpoint;
+        self.parseResponse = YES;
     }
     return self;
 }

--- a/native/SalesforceNativeSDK/SalesforceNativeSDKTests/SFNativeRestRequestListener.m
+++ b/native/SalesforceNativeSDK/SalesforceNativeSDKTests/SFNativeRestRequestListener.m
@@ -60,8 +60,8 @@
 
 #pragma mark - SFRestDelegate
 
-- (void)request:(SFRestRequest *)request didLoadResponse:(id)jsonResponse {
-    self.jsonResponse = jsonResponse;
+- (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse {
+    self.dataResponse = dataResponse;
     self.returnStatus = kTestRequestStatusDidLoad;
 }
 

--- a/native/SampleApps/NativeSqlAggregator/NativeSqlAggregator/Classes/RootViewController.m
+++ b/native/SampleApps/NativeSqlAggregator/NativeSqlAggregator/Classes/RootViewController.m
@@ -58,9 +58,9 @@
     self.title = @"NativeSqlAggregator";
 }
 
-- (void)request:(SFRestRequest *)request didLoadResponse:(id)jsonResponse
+- (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse
 {
-    NSArray *records = [jsonResponse objectForKey:@"records"];
+    NSArray *records = [dataResponse objectForKey:@"records"];
     if (nil != records) {
         NSDictionary *firstRecord = [records objectAtIndex:0];
         if (nil != firstRecord) {

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/RestAPIExplorerViewController.m
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/RestAPIExplorerViewController.m
@@ -352,10 +352,10 @@
 
 #pragma mark - SFRestDelegate
 
-- (void)request:(SFRestRequest *)request didLoadResponse:(id)jsonResponse {
+- (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse {
     _tfResult.backgroundColor = [UIColor colorWithRed:1.0 green:204/255.0 blue:102/255.0 alpha:1.0];
     _tfResponseFor.text = [self formatRequest:request];
-    _tfResult.text = [jsonResponse description];
+    _tfResult.text = [dataResponse description];
 }
 
 - (void)request:(SFRestRequest*)request didFailLoadWithError:(NSError*)error {

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.h
@@ -41,13 +41,13 @@ typedef enum {
 } SFAccountManagerServiceType;
 
 @interface SFSDKTestRequestListener : NSObject <SFIdentityCoordinatorDelegate, SFOAuthCoordinatorDelegate> {
-    id _jsonResponse;
+    id _dataResponse;
     NSError *_lastError;
     NSString *_returnStatus;
     NSTimeInterval _maxWaitTime;
 }
 
-@property (nonatomic, retain) id jsonResponse;
+@property (nonatomic, retain) id dataResponse;
 @property (nonatomic, retain) NSError *lastError;
 @property (nonatomic, retain) NSString *returnStatus;
 

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
@@ -47,7 +47,7 @@ NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
 
 @implementation SFSDKTestRequestListener
 
-@synthesize jsonResponse = _jsonResponse;
+@synthesize dataResponse = _dataResponse;
 @synthesize lastError = _lastError;
 @synthesize returnStatus = _returnStatus;
 
@@ -87,7 +87,7 @@ NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
         [self clearAccountManagerDelegate];
     }
     
-    self.jsonResponse = nil;
+    self.dataResponse = nil;
     self.lastError = nil;
     self.returnStatus = nil;
 }


### PR DESCRIPTION
This allows you to set a property on your `SFRestRequest` object (`parseResponse`) to specify whether the REST response should be parsed as JSON data.  Defaults to `YES`, for backward compatibility.  When set to `NO`, the data returned will be a binary `NSData` object.

No public interface changes, but I did change the name of the response property in `[SFRestDelegate request:didLoadResponse:]` to be `dataResponse`, which is more appropriate than the previous `jsonResponse`.
