### PR TITLE
'xcodebuild install' is buggy, always strips symbols

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -264,8 +264,8 @@
             <arg value="-sdk" />
             <arg value="${sdk}" />
             <arg value="clean" />
-            <arg value="install" />
-            <arg value="DSTROOT=${artifactsDir}" />
+            <arg value="build" />
+            <arg value="CONFIGURATION_BUILD_DIR=${artifactsDir}" />
             <arg value="ONLY_ACTIVE_ARCH=NO" />
         </exec>
     </target>


### PR DESCRIPTION
Reverting back to using the `build` target of `xcodebuild`, because the `install` target is buggy, and always strips symbols, regardless of project configuration to the contrary.  This makes 'Debug' libraries less than ideal for debugging anything.
