### PR TITLE
Not calling super UIWebViewDelegate methods was causing issues

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -468,13 +468,13 @@ static NSString * const kVFPingPageUrl = @"/apexpages/utils/ping.apexp";
 
 - (void)webViewDidStartLoad:(UIWebView *)webView
 {
-    [self log:SFLogLevelDebug msg:@"SalesforceOAuthPlugin: Started loading web page."];
+    [self log:SFLogLevelDebug msg:@"Started loading web page."];
     [super webViewDidStartLoad:webView];
 }
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
 {
-    NSLog(@"SalesforceOAuthPlugin: Error while attempting to load web page: %@", error);
+    [self log:SFLogLevelError format:@"Error while attempting to load web page: %@", error];
     [super webView:webView didFailLoadWithError:error];
 }
 


### PR DESCRIPTION
The issue with multi-page plugin calls not working, which was [reported on developerforce](http://boards.developerforce.com/t5/Mobile/Handling-cordova-in-the-server-side-for-iOS/td-p/676917), was due to not calling `[super webViewDidStartLoad:]`, which resets a request count variable in Cordova between page loads as part of the re-sync between client JS and native code.
