### PR TITLE
Setting "Skip Install" to YES for OAuth

### DIFF
--- a/shared/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
+++ b/shared/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
@@ -627,6 +627,7 @@
 				INSTALL_PATH = /Libraries;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -644,6 +645,7 @@
 				INSTALL_PATH = /Libraries;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
A fix for [Issue #416](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/416), where archiving apps seems to not work when libraries are set to install at install/archive time.  This shouldn't impact the library builds for the SDK, as we don't use the `install` target of xcodebuild.

NB: All of the other library projects are already set to skip install.
