### PR TITLE
Adding support for custom_attributes identity data

### DIFF
--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.h
@@ -218,6 +218,11 @@
 @property (readonly) int mobileAppScreenLockTimeout;
 
 /**
+ * An optional dictionary of custom attributes defined on the Connected App.
+ */
+@property (strong, nonatomic, readonly) NSDictionary *customAttributes;
+
+/**
  * The date this record was last modified.
  */
 @property (strong, nonatomic, readonly) NSDate *lastModifiedDate;

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.m
@@ -61,6 +61,7 @@ NSString * const kSFIdentityUtcOffsetKey                  = @"utcOffset";
 NSString * const kSFIdentityMobilePolicyKey               = @"mobile_policy";
 NSString * const kSFIdentityMobileAppPinLengthKey         = @"pin_length";
 NSString * const kSFIdentityMobileAppScreenLockTimeoutKey = @"screen_lock";
+NSString * const kSFIdentityCustomAttributesKey           = @"custom_attributes";
 NSString * const kSFIdentityLastModifiedDateKey           = @"last_modified_date";
 
 NSString * const kSFIdentityDateFormatString              = @"yyyy-MM-dd'T'HH:mm:ss.SSSZZZ";
@@ -314,6 +315,11 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
     } else {
         return -1;
     }
+}
+
+- (NSDictionary *)customAttributes
+{
+    return [self.dictRepresentation objectForKey:kSFIdentityCustomAttributesKey];
 }
 
 - (NSDate *)lastModifiedDate


### PR DESCRIPTION
[This](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/390) happens now, as it turns out. :)
