### PR TITLE
Adding hybrid custom error handling

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.h
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.h
@@ -32,9 +32,6 @@
  * Cordova plugin for managing authentication with the Salesforce service, via OAuth.
  */
 @interface SalesforceOAuthPlugin : CDVPlugin
-{
-    NSString *_authCallbackId;
-}
 
 #pragma mark - Plugin exported to javascript
 

--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
@@ -109,10 +109,12 @@ typedef void (^SFOAuthPluginAuthSuccessBlock)(SFOAuthInfo *, NSDictionary *);
 - (void)authenticateWithCompletionBlock:(SFOAuthPluginAuthSuccessBlock)completionBlock failureBlock:(SFOAuthFlowFailureCallbackBlock)failureBlock;
 
 /**
- Loads an error page, in the event of a local bootstrap failure.
+ Loads an error page, in the event of an otherwise unhandled error.
+ @param errorCode A numberic error code associated with the error.
  @param errorDescription The error description associated with the failure.
+ @param errorContext The context in which the error occurred.
  */
-- (void)loadErrorPage:(NSString *)errorDescription;
+- (void)loadErrorPageWithCode:(NSInteger)errorCode description:(NSString *)errorDescription context:(NSString *)errorContext;
 
 /**
  Convert the post-authentication credentials into a Dictionary, to return to

--- a/shared/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.m
+++ b/shared/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.m
@@ -637,8 +637,12 @@ static NSString * const kHttpPostContentType                    = @"application/
 	NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithCapacity:pairs.count];
 	for (NSString *pair in pairs) {
         NSArray *keyValue = [pair componentsSeparatedByString:@"="];
-		NSString *key = [[keyValue objectAtIndex:0] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-		NSString *value = [[keyValue objectAtIndex:1] stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+		NSString *key = [[[keyValue objectAtIndex:0]
+                          stringByReplacingOccurrencesOfString:@"+" withString:@" "]
+                         stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+		NSString *value = [[[keyValue objectAtIndex:1]
+                            stringByReplacingOccurrencesOfString:@"+" withString:@" "]
+                           stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
 		[dict setObject:value forKey:key];
 	}
 	NSDictionary *result = [NSDictionary dictionaryWithDictionary:dict];
@@ -648,7 +652,6 @@ static NSString * const kHttpPostContentType                    = @"application/
 + (NSError *)errorWithType:(NSString *)type description:(NSString *)description {
     NSAssert(type, @"error type can't be nil");
     
-    NSString *localized = [NSString stringWithFormat:@"%@ %@ : %@", kSFOAuthErrorDomain, type, description];
     NSInteger code = kSFOAuthErrorUnknown;
     if ([type isEqualToString:kSFOAuthErrorTypeAccessDenied]) {
         code = kSFOAuthErrorAccessDenied;
@@ -679,8 +682,7 @@ static NSString * const kHttpPostContentType                    = @"application/
     }
 
     NSDictionary *dict = [NSDictionary dictionaryWithObjectsAndKeys:type,        kSFOAuthError,
-                                                                    description, kSFOAuthErrorDescription,
-                                                                    localized,   NSLocalizedDescriptionKey,
+                                                                    description,   NSLocalizedDescriptionKey,
                                                                     nil];
     NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain code:code userInfo:dict];
     return error;

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthErrorHandler.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthErrorHandler.h
@@ -41,13 +41,13 @@ typedef BOOL (^SFAuthErrorHandlerEvalBlock)(NSError *, SFOAuthInfo *);
 /**
  The canonical name of the error handler.
  */
-@property (nonatomic, copy) NSString *name;
+@property (nonatomic, readonly) NSString *name;
 
 /**
  The block of code that will evaluate the error.  The block should return YES if it can
  handle the error, and NO if the error should be passed on to the next handler.
  */
-@property (nonatomic, copy) SFAuthErrorHandlerEvalBlock evalBlock;
+@property (nonatomic, readonly) SFAuthErrorHandlerEvalBlock evalBlock;
 
 /**
  Designated initializer for SFAuthErrorHandler.

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthErrorHandler.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthErrorHandler.m
@@ -34,8 +34,8 @@
 {
     self = [super init];
     if (self) {
-        self.name = name;
-        self.evalBlock = evalBlock;
+        _name = [name copy];
+        _evalBlock = [evalBlock copy];
     }
     return self;
 }

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthErrorHandlerList.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthErrorHandlerList.h
@@ -70,4 +70,11 @@
  */
 - (void)removeAuthErrorHandler:(SFAuthErrorHandler *)errorHandler;
 
+/**
+ Determines whether the given error handler is in the list.
+ @param errorHandler The error handler to look for in the list.
+ @return YES if the error handler is in the list, NO otherwise.
+ */
+- (BOOL)authErrorHandlerInList:(SFAuthErrorHandler *)errorHandler;
+
 @end

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthErrorHandlerList.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthErrorHandlerList.m
@@ -90,6 +90,12 @@
     [self.authHandlerMutableArray removeObject:errorHandler];
 }
 
+- (BOOL)authErrorHandlerInList:(SFAuthErrorHandler *)errorHandler
+{
+    NSArray *resultArray = [self.authHandlerMutableArray filteredArrayUsingPredicate:[NSPredicate predicateWithFormat: @"SELF == %@", errorHandler]];
+    return ([resultArray count] > 0);
+}
+
 #pragma mark - Private methods
 
 - (SFAuthErrorHandler *)retrieveAuthErrorHandlerWithName:(NSString *)name

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -31,6 +31,7 @@
 @class SFAuthorizingViewController;
 @class SFAuthenticationManager;
 @class SFAuthenticationViewHandler;
+@class SFAuthErrorHandler;
 @class SFAuthErrorHandlerList;
 
 /**
@@ -110,30 +111,6 @@ extern NSString * const kSFUserLogoutNotification;
  */
 extern NSString * const kSFUserLoggedInNotification;
 
-/**
- The name of the auth error handler dealing with invalid credentials.
- @see authErrorHandlerList
- */
-extern NSString * const kSFInvalidCredentialsAuthErrorHandler;
-
-/**
- The name of the auth error handler dealing with Connected App version mismatches.
- @see authErrorHandlerList
- */
-extern NSString * const kSFConnectedAppVersionAuthErrorHandler;
-
-/**
- The name of the auth error handler dealing with auth network failures.
- @see authErrorHandlerList
- */
-extern NSString * const kSFNetworkFailureAuthErrorHandler;
-
-/**
- The name of the catch-all auth error handler dealing with unhandled errors.
- @see authErrorHandlerList
- */
-extern NSString * const kSFGenericFailureAuthErrorHandler;
-
 @interface SFAuthenticationManager : NSObject <SFOAuthCoordinatorDelegate, SFIdentityCoordinatorDelegate>
 
 /**
@@ -192,6 +169,26 @@ extern NSString * const kSFGenericFailureAuthErrorHandler;
  to the default, and override the authViewController property with your style changes.
  */
 @property (nonatomic, strong) SFAuthenticationViewHandler *authViewHandler;
+
+/**
+ The auth handler for invalid credentials.
+ */
+@property (nonatomic, readonly) SFAuthErrorHandler *invalidCredentialsAuthErrorHandler;
+
+/**
+ The auth handler for Connected App version errors.
+ */
+@property (nonatomic, readonly) SFAuthErrorHandler *connectedAppVersionAuthErrorHandler;
+
+/**
+ The auth handler for failures due to network connectivity.
+ */
+@property (nonatomic, readonly) SFAuthErrorHandler *networkFailureAuthErrorHandler;
+
+/**
+ The generic auth handler for any unhandled errors.
+ */
+@property (nonatomic, readonly) SFAuthErrorHandler *genericAuthErrorHandler;
 
 /**
  The list of auth error handler filters to pass each authentication error through.  You can add or
@@ -273,6 +270,13 @@ extern NSString * const kSFGenericFailureAuthErrorHandler;
  @return YES if the URL matches the login redirect URL pattern, NO otherwise.
  */
 + (BOOL)isLoginRedirectUrl:(NSURL *)url;
+
+/**
+ Determines whether an error is due to invalid auth credentials.
+ @param error The error to check against an invalid credentials error.
+ @return YES if the error is due to invalid credentials, NO otherwise.
+ */
++ (BOOL)errorIsInvalidAuthCredentials:(NSError *)error;
 
 /**
  Remove any cookies with the given names from the given domains.


### PR DESCRIPTION
Making updates so that hybrid apps can also customize their auth error handling.  The new error handling essentially goes like this:
- First, in the default case, nothing changes—unhandled errors will be displayed via an alert view dialog.
- If the developer removes one or more error handling filters and an error falls through to the `loginWithCompletion:failure` error block, the following occurs:
  - If it's during the page load process, or during the refresh of an expired session, the user will be taken to the error page configured in `bootconfig.json`, or a default page if the error page doesn't exist.
  - If it's during authentication through the OAuth plugin, the error will be returned on the error callback.
