### PR TITLE
Fixed possible issue with sending invalid message to the delegate or delegate not receiving a message at all

### DIFF
--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -1034,7 +1034,7 @@ static NSString * const kAlertVersionMismatchErrorKey = @"authAlertVersionMismat
     });
     
     [self enumerateDelegates:^(id<SFAuthenticationManagerDelegate> delegate) {
-        if ([delegate respondsToSelector:@selector(authManagerDidAuthenticate:)]) {
+        if ([delegate respondsToSelector:@selector(authManagerDidAuthenticate:credentials:authInfo:)]) {
             [delegate authManagerDidAuthenticate:self credentials:coordinator.credentials authInfo:info];
         }
     }];


### PR DESCRIPTION
The problem here was that previously the app checked whether delegate responded to a selector

```
if ([delegate respondsToSelector:@selector(authManagerDidAuthenticate:)]) {
```

But then, a line below, a completely different selector is called:

```
[delegate authManagerDidAuthenticate:self credentials:coordinator.credentials authInfo:info];
```

This can result in the auth callback message not being sent at all, or being sent to an object that does not handle such message (and thus resulting in a crash). This simple change fixes the issue. 
