### PR TITLE
Keystore updates

### DIFF
--- a/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFKeyStoreManager+Internal.h
+++ b/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFKeyStoreManager+Internal.h
@@ -80,4 +80,12 @@
  */
 - (NSDictionary *)keyStoreDictionaryWithKey:(SFEncryptionKey *)decryptKey;
 
+/**
+ Creates a keychain ID that should be unique across app installs/re-installs, making sure
+ that erroneous keychain data is not present if the app is re-installed.
+ @param baseKeychainId The identifier that the keychain key is based on.
+ @return An identifier with the base ID and unique data appended to it.
+ */
+- (NSString *)buildUniqueKeychainId:(NSString *)baseKeychainId;
+
 @end

--- a/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFSDKCryptoUtils.m
+++ b/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFSDKCryptoUtils.m
@@ -84,6 +84,10 @@ NSUInteger const kSFPBKDFDefaultSaltByteLength = 32;
 + (NSData *)aes256EncryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv
 {
     // Ensure the proper key, IV sizes.
+    if (key == nil) {
+        [SFLogger log:[self class] level:SFLogLevelError msg:@"aes256EncryptData: encryption key is nil.  Cannot encrypt data."];
+        return nil;
+    }
     NSMutableData *mutableKey = [key mutableCopy];
     [mutableKey setLength:kCCKeySizeAES256];
     NSMutableData *mutableIv = [iv mutableCopy];
@@ -98,7 +102,7 @@ NSUInteger const kSFPBKDFDefaultSaltByteLength = 32;
                                              [mutableIv bytes],
                                              &cryptor);
 	if (status != kCCSuccess) {
-        [SFLogger log:[self class] level:SFLogLevelError format:@"Error creating cryptor with CCCryptorCreate().  Status code: %d", status];
+        [SFLogger log:[self class] level:SFLogLevelError format:@"Error creating encryption cryptor with CCCryptorCreate().  Status code: %d", status];
 		return nil;
 	}
 	
@@ -111,6 +115,10 @@ NSUInteger const kSFPBKDFDefaultSaltByteLength = 32;
 + (NSData *)aes256DecryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv
 {
     // Ensure the proper key, IV sizes.
+    if (key == nil) {
+        [SFLogger log:[self class] level:SFLogLevelError msg:@"aes256DecryptData: decryption key is nil.  Cannot decrypt data."];
+        return nil;
+    }
     NSMutableData *mutableKey = [key mutableCopy];
     [mutableKey setLength:kCCKeySizeAES256];
     NSMutableData *mutableIv = [iv mutableCopy];
@@ -125,7 +133,7 @@ NSUInteger const kSFPBKDFDefaultSaltByteLength = 32;
                                              [mutableIv bytes],
                                              &cryptor);
 	if (status != kCCSuccess) {
-        [SFLogger log:[self class] level:SFLogLevelError format:@"Error creating cryptor with CCCryptorCreate().  Status code: %d", status];
+        [SFLogger log:[self class] level:SFLogLevelError format:@"Error creating decryption cryptor with CCCryptorCreate().  Status code: %d", status];
 		return nil;
 	}
 	


### PR DESCRIPTION
- Adding some more logging and boundary conditions to encryption/decryption in `SFSDKCryptoUtils`.
- Adding more entropy to the keychain keys for the key store, since data can linger between app installs.

@prabhuamol : Heads up.
