### PR TITLE
Fix inactivity expiration

### DIFF
--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -226,7 +226,7 @@ static BOOL _showPasscode = YES;
 + (BOOL)inactivityExpired
 {
 	NSInteger elapsedTime = [[NSDate date] timeIntervalSinceDate:[SFInactivityTimerCenter lastActivityTimestamp]];
-	return (securityLockoutTime > 0) && (elapsedTime > securityLockoutTime);
+	return (securityLockoutTime > 0) && (elapsedTime >= securityLockoutTime);
 }
 
 + (void)setupTimer


### PR DESCRIPTION
The inactivity timer is going to fire at the lockout time, if no actions are taken in between.  With the greater-than comparison, `inactivityExpired` was always returning `NO` when the timer fired.  The disparity was causing issues with apps that otherwise depend on inactivityExpired as a guarding function.
