### PR TITLE
Keystore test updates

### DIFF
--- a/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFEncryptionKey.h
+++ b/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFEncryptionKey.h
@@ -27,7 +27,7 @@
 /**
  Data object representing an symmetric encryption key, with a key value and initialization vector.
  */
-@interface SFEncryptionKey : NSObject <NSCoding>
+@interface SFEncryptionKey : NSObject <NSCoding, NSCopying>
 
 /**
  Designated initializer.

--- a/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFEncryptionKey.m
+++ b/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFEncryptionKey.m
@@ -59,6 +59,14 @@ static NSString * const kInitializationVectorCodingValue = @"com.salesforce.encr
     [aCoder encodeObject:self.initializationVector forKey:kInitializationVectorCodingValue];
 }
 
+- (id)copyWithZone:(NSZone *)zone
+{
+    SFEncryptionKey *keyCopy = [[[self class] allocWithZone:zone] init];
+    keyCopy.key = [NSData dataWithData:self.key];
+    keyCopy.initializationVector = [NSData dataWithData:self.initializationVector];
+    return keyCopy;
+}
+
 - (NSString *)keyAsString
 {
     if (!self.key) return nil;

--- a/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFKeyStoreKey.h
+++ b/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFKeyStoreKey.h
@@ -43,7 +43,7 @@ typedef NS_ENUM(NSUInteger, SFKeyStoreKeyType) {
 /**
  Data object representing the encryption key used for encrypting/decrypting the key store.
  */
-@interface SFKeyStoreKey : NSObject <NSCoding>
+@interface SFKeyStoreKey : NSObject <NSCoding, NSCopying>
 
 /**
  Designated initializer.

--- a/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFKeyStoreKey.m
+++ b/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFKeyStoreKey.m
@@ -61,4 +61,12 @@ static NSString * const kKeyStoreKeyTypeDataArchiveKey = @"com.salesforce.keysto
     [aCoder encodeObject:keyTypeNum forKey:kKeyStoreKeyTypeDataArchiveKey];
 }
 
+- (id)copyWithZone:(NSZone *)zone
+{
+    SFKeyStoreKey *keyCopy = [[[self class] allocWithZone:zone] init];
+    keyCopy.encryptionKey = [self.encryptionKey copy];
+    keyCopy.keyType = self.keyType;
+    return keyCopy;
+}
+
 @end

--- a/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFKeyStoreManager+Internal.h
+++ b/shared/SalesforceSecurity/SalesforceSecurity/Classes/SFKeyStoreManager+Internal.h
@@ -27,6 +27,9 @@
 #import "SFKeyStoreKey.h"
 
 @interface SFKeyStoreManager () <SFPasscodeManagerDelegate>
+{
+    SFKeyStoreKey *_keyStoreKey;
+}
 
 /**
  The dictionary that holds the key store.
@@ -36,7 +39,7 @@
 /**
  The key store key, used for encrypting and decrypting the key store.
  */
-@property (nonatomic, strong) SFKeyStoreKey *keyStoreKey;
+@property (nonatomic, copy) SFKeyStoreKey *keyStoreKey;
 
 /**
  Creates a default key store key from random generated key and IV values.  Used when a passcode

--- a/shared/SalesforceSecurity/SalesforceSecurityTests/SFKeyStoreTests.m
+++ b/shared/SalesforceSecurity/SalesforceSecurityTests/SFKeyStoreTests.m
@@ -9,8 +9,10 @@
 #import <XCTest/XCTest.h>
 #import "SFEncryptionKey.h"
 #import "SFKeyStoreManager+Internal.h"
+#import "SFSDKCryptoUtils.h"
+#import <SalesforceCommonUtils/NSData+SFAdditions.h>
 
-static NSUInteger const kNumThreadsInSafetyTest = 50;
+static NSUInteger const kNumThreadsInSafetyTest = 100;
 
 @interface SFKeyStoreTests : XCTestCase
 {
@@ -107,6 +109,13 @@ static NSUInteger const kNumThreadsInSafetyTest = 50;
     }
     
     while (!_threadSafetyTestCompleted) {
+        // Passcode change chaos.
+        NSUInteger randomInt = arc4random() % 10;
+        if (randomInt > 4) {
+            NSLog(@"Passcode change chaos: changing passcode.");
+            NSString *newPasscode = [[SFSDKCryptoUtils randomByteDataWithLength:32] base64Encode];
+            [[SFPasscodeManager sharedManager] changePasscode:newPasscode];
+        }
         NSLog(@"## Thread safety test sleeping...");
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     }


### PR DESCRIPTION
Adding some more "chaos" into the multi-threaded key store tests unearthed some thread safety issues with passcode / key store key changes.  I moved the onus of updating the key store dictionary's encryption into the actual setter of the key store key, to simplify the atomicity there.
