### PR TITLE
Updating SmartStore encryption to key store-based

### DIFF
--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -29,7 +29,6 @@
 #import <SalesforceCommonUtils/SFKeychainItemWrapper.h>
 #import "SFUserAccountManager.h"
 #import <SalesforceSecurity/SFPasscodeManager.h>
-#import "SFSmartStore.h"
 #import "SFAuthenticationManager.h"
 #import "SFRootViewManager.h"
 #import "SFPreferences.h"
@@ -68,9 +67,6 @@ static BOOL _showPasscode = YES;
 
 + (void)initialize
 {
-    // Initialize SmartStore for encryption sync, prior to passcode operations, by making an innocuous call.
-    [SFSmartStore class];
-    
     [SFSecurityLockout upgradeSettings];  // Ensures a lockout time value in the keychain.
     securityLockoutTime = [[SFSecurityLockout readLockoutTimeFromKeychain] unsignedIntegerValue];
     

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore+Internal.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore+Internal.h
@@ -36,10 +36,9 @@
 
 /**
  Simply open the db file.
- @param forCreation Whether the DB is to be created, or an existing DB should be opened.
  @return YES if we were able to open the DB file.
  */
-- (BOOL)openStoreDatabase:(BOOL)forCreation;
+- (BOOL)openStoreDatabase;
 
 /**
  @param db This method is expected to be called from [fmdbqueue inDatabase:^(){ ... }]
@@ -76,17 +75,6 @@
  @return The key used to encrypt the store.
  */
 + (NSString *)encKey;
-
-/**
- Change the encryption key for a database.
- @param db The DB associated with the encryption.
- @param storeName The store name associated with the request.
- @param oldKey The original key for the encryption.
- @param newKey The new key to re-encrypt with.
- @return The updated database, post encryption action.  Note: This may be a new instance of
- FMDatabase, depending on the action.
- */
-+ (FMDatabase *)changeKeyForDb:(FMDatabase *)db name:(NSString *)storeName oldKey:(NSString *)oldKey newKey:(NSString *)newKey;
 
 /**
  FOR UNIT TESTING.  Removes all of the shared smart store objects from memory (persisted stores remain).

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.h
@@ -90,16 +90,7 @@ extern NSString * const kSFSmartStoreErrorDomain;
  */
 + (BOOL)persistentStoreExists:(NSString*)storeName;
 
-/**
- Changes the encryption key for all of the stores associated with the app.
- @param oldKey The original encryption key.
- @param newKey The new encryption key.
- */
-+ (void)changeKeyForStores:(NSString *)oldKey newKey:(NSString *)newKey;
-
 #pragma mark - Soup manipulation methods
-
-
 
 /**
  @param soupName the name of the soup

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreUpgrade+Internal.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreUpgrade+Internal.h
@@ -1,43 +1,94 @@
-
+/*
+ Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import "SFSmartStoreUpgrade.h"
 
+/**
+ Enumeration of types of encryption used for the default encryption of stores.
+ */
+typedef enum {
+    SFSmartStoreDefaultEncryptionTypeNone,
+    SFSmartStoreDefaultEncryptionTypeMac,
+    SFSmartStoreDefaultEncryptionTypeIdForVendor,
+    SFSmartStoreDefaultEncryptionTypeBaseAppId
+} SFSmartStoreLegacyDefaultEncryptionType;
+
 @interface SFSmartStoreUpgrade ()
+
+/**
+ @return The default key to use, if no encryption key exists.
+ */
++ (NSString *)legacyDefaultKey;
+
+/**
+ Determines whether the given store uses a legacy default key for encryption.
+ @param storeName The store associated with the setting.
+ @return YES if it does, NO if it doesn't.
+ */
++ (BOOL)usesLegacyDefaultKey:(NSString *)storeName;
+
+/**
+ Sets a property specifying whether the given store uses a default key for encryption.
+ @param usesDefault Whether the store uses a default key.
+ @param storeName The store for which the setting applies.
+ */
++ (void)setUsesLegacyDefaultKey:(BOOL)usesDefault forStore:(NSString *)storeName;
 
 /**
  Sets the default encryption type for the given store.
  @param encType The type of default encryption being used for the store.
  @param storeName The name of the store to set the value for.
  */
-+ (void)setDefaultEncryptionType:(SFSmartStoreDefaultEncryptionType)encType forStore:(NSString *)storeName;
++ (void)setLegacyDefaultEncryptionType:(SFSmartStoreLegacyDefaultEncryptionType)encType forStore:(NSString *)storeName;
 
 /**
  Gets the default encryption type for the given store.
  @param storeName The name of the story to query for its default encryption type.
  @return An SFSmartStoreDefaultEncryptionType enumerated value specifying the default encryption type.
  */
-+ (SFSmartStoreDefaultEncryptionType)defaultEncryptionTypeForStore:(NSString *)storeName;
++ (SFSmartStoreLegacyDefaultEncryptionType)legacyDefaultEncryptionTypeForStore:(NSString *)storeName;
 
 /**
  @return The default key, based on the MAC address.
  */
-+ (NSString *)defaultKeyMac;
++ (NSString *)legacyDefaultKeyMac;
 
 /**
  @return The default key, based on the idForVendor value.
  */
-+ (NSString *)defaultKeyIdForVendor;
++ (NSString *)legacyDefaultKeyIdForVendor;
 
 /**
  @return The default key, based on the base app id.
  */
-+ (NSString *)defaultKeyBaseAppId;
++ (NSString *)legacyDefaultKeyBaseAppId;
 
 /**
  Creates a default key with the given seed.
  @param seed The seed for creating the default key.
  @return The default key, based on the seed.
  */
-+ (NSString *)defaultKeyWithSeed:(NSString *)seed;
++ (NSString *)legacyDefaultKeyWithSeed:(NSString *)seed;
 
 @end

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreUpgrade.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreUpgrade.h
@@ -1,45 +1,48 @@
-//
-//  SFSmartStoreUpgrade.h
-//  SalesforceSDKCore
-//
-//  Created by Kevin Hawkins on 5/12/14.
-//  Copyright (c) 2014 salesforce.com. All rights reserved.
-//
+/*
+ Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #import <Foundation/Foundation.h>
 
-/**
- Enumeration of types of encryption used for the default encryption of stores.
- */
-typedef enum {
-    SFSmartStoreDefaultEncryptionTypeNone,
-    SFSmartStoreDefaultEncryptionTypeMac,
-    SFSmartStoreDefaultEncryptionTypeIdForVendor,
-    SFSmartStoreDefaultEncryptionTypeBaseAppId,
-    SFSmartStoreDefaultEncryptionTypeKeyStore
-} SFSmartStoreDefaultEncryptionType;
-
 @interface SFSmartStoreUpgrade : NSObject
 
-+ (void)updateDefaultEncryption;
+/**
+ Updates the encryption scheme of each SmartStore database to the currently supported scheme.
+ */
++ (void)updateEncryption;
 
 /**
- Determines whether the given store uses a legacy default key for encryption.
- @param storeName The store associated with the setting.
- @return YES if it does, NO if it doesn't.
+ Whether or not a given store is encrypted based on the key store key.
+ @param storeName The store to query.
+ @return YES if the store is encrypted with the key store, NO otherwise.
  */
-+ (BOOL)usesDefaultKey:(NSString *)storeName;
++ (BOOL)usesKeyStoreEncryption:(NSString *)storeName;
 
 /**
- Sets a property specifying whether the given store uses a default key for encryption.
- @param usesDefault Whether the store uses a default key.
- @param storeName The store for which the setting applies.
+ Sets a flag denoting whether or not the store uses encryption based the key store key.
+ @param usesKeyStoreEncryption YES if it does, NO if it doesn't.
+ @param storeName The store to which the flag applies.
  */
-+ (void)setUsesDefaultKey:(BOOL)usesDefault forStore:(NSString *)storeName;
-
-/**
- @return The default key to use, if no encryption key exists.
- */
-+ (NSString *)defaultKey;
++ (void)setUsesKeyStoreEncryption:(BOOL)usesKeyStoreEncryption forStore:(NSString *)storeName;
 
 @end


### PR DESCRIPTION
Here's the follow-up to the last PR, which actually updates the encryption of each SmartStore from whatever it was to be key store-based.  The tests still need to be fixed, but this is otherwise functioning.
