### PR TITLE
Testing DB upgrade and key store encryption changes

### DIFF
--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.h
@@ -119,12 +119,11 @@ extern NSString * const kSFSmartStoreDbErrorDomain;
 - (NSString*)fullDbFilePathForStoreName:(NSString*)storeName;
 
 /**
- Verifies that the database contents at the given path can be read with the given encryption key.
- @param dbPath The path to the database to read.
- @param key The encryption key used against the database.
+ Verifies that the database contents for the given DB can be read.
+ @param db The instance of the database to read.
  @param error The output NSError parameter that will be populated in the event of an error.
  @return YES if the database can be read, NO otherwise.
  */
-- (BOOL)verifyDatabaseAccess:(NSString *)dbPath key:(NSString *)key error:(NSError **)error;
+- (BOOL)verifyDatabaseAccess:(FMDatabase *)dbPath error:(NSError **)error;
 
 @end

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.m
@@ -207,10 +207,23 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     }
     
     // As a sanity check, verify that the new encrypted DB can be opened and read.
-    if (![self verifyDatabaseAccess:encDbPath key:newKey error:error]) {
+    NSError *openNewlyEncryptedDbError = nil;
+    FMDatabase *newlyEncryptedDb = [self openDatabaseWithPath:encDbPath key:newKey error:&openNewlyEncryptedDbError];
+    if (!newlyEncryptedDb) {
+        if (error != nil) {
+            NSString *errorDesc = [NSString stringWithFormat:kSFSmartStoreVerifyDbErrorDesc, encDbPath, [openNewlyEncryptedDbError localizedDescription]];
+            *error = [NSError errorWithDomain:kSFSmartStoreDbErrorDomain
+                                         code:kSFSmartStoreVerifyDbErrorCode
+                                     userInfo:[NSDictionary dictionaryWithObject:errorDesc forKey:NSLocalizedDescriptionKey]];
+        }
+        [[NSFileManager defaultManager] removeItemAtPath:encDbPath error:nil];
+        return db;
+    } else if (![self verifyDatabaseAccess:newlyEncryptedDb error:error]) {
+        [newlyEncryptedDb close];
         [[NSFileManager defaultManager] removeItemAtPath:encDbPath error:nil];
         return db;
     }
+    [newlyEncryptedDb close];
     
     // New database created and verified.  Move it into place of the old one.
     [db close];
@@ -256,26 +269,14 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     }
 }
 
-- (BOOL)verifyDatabaseAccess:(NSString *)dbPath key:(NSString *)key error:(NSError **)error
+- (BOOL)verifyDatabaseAccess:(FMDatabase *)db error:(NSError **)error
 {
-    NSError *openDbError = nil;
-    FMDatabase *db = [self openDatabaseWithPath:dbPath key:key error:&openDbError];
-    if (!db) {
-        if (error != nil) {
-            NSString *errorDesc = [NSString stringWithFormat:kSFSmartStoreVerifyDbErrorDesc, dbPath, [openDbError localizedDescription]];
-            *error = [NSError errorWithDomain:kSFSmartStoreDbErrorDomain
-                                         code:kSFSmartStoreVerifyDbErrorCode
-                                     userInfo:[NSDictionary dictionaryWithObject:errorDesc forKey:NSLocalizedDescriptionKey]];
-        }
-        return NO;
-    }
-    
     NSString *sqlCommand = @"SELECT name FROM sqlite_master LIMIT 1";
     FMResultSet *rs = [db executeQuery:sqlCommand];
     if (rs == nil) {
         // May not be results, but rs should never be nil coming back.
         if (error != nil) {
-            NSString *errorDesc = [NSString stringWithFormat:kSFSmartStoreVerifyReadDbErrorDesc, dbPath, [db lastErrorMessage]];
+            NSString *errorDesc = [NSString stringWithFormat:kSFSmartStoreVerifyReadDbErrorDesc, [db databasePath], [db lastErrorMessage]];
             *error = [NSError errorWithDomain:kSFSmartStoreDbErrorDomain
                                          code:kSFSmartStoreVerifyReadDbErrorCode
                                      userInfo:[NSDictionary dictionaryWithObject:errorDesc forKey:NSLocalizedDescriptionKey]];
@@ -285,7 +286,6 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     }
     
     [rs close];
-    [db close];
     return YES;
 }
 

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreUpgrade.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreUpgrade.m
@@ -120,11 +120,16 @@ static NSString * const kKeyStoreEncryptedStoresKey = @"com.salesforce.smartstor
     NSString * const kDecryptionErrorMessage = @"Error decrypting the encrypted store '%@': %@";
     
     NSError *openDbError = nil;
+    NSError *verifyDbAccessError = nil;
     FMDatabase *db = [[SFSmartStoreDatabaseManager sharedManager] openStoreDatabaseWithName:storeName
                                                                                         key:oldKey
                                                                                       error:&openDbError];
     if (db == nil || openDbError != nil) {
         [SFLogger log:[SFSmartStoreUpgrade class] level:SFLogLevelError format:@"Error opening store '%@' to update encryption: %@", storeName, [openDbError localizedDescription]];
+        return NO;
+    } else if (![[SFSmartStoreDatabaseManager sharedManager] verifyDatabaseAccess:db error:&verifyDbAccessError]) {
+        [SFLogger log:[SFSmartStoreUpgrade class] level:SFLogLevelError format:@"Error reading the content of store '%@' during encryption upgrade: %@", storeName, [verifyDbAccessError localizedDescription]];
+        [db close];
         return NO;
     }
     


### PR DESCRIPTION
Updated the unit tests to test the various aspects of using the key store for the encryption key for SmartStore, including upgrade scenarios from previous encryption.  This should close out the SmartStore encryption updates story.
