### PR TITLE
Passcode fixes, SmartStore plugin logging

### DIFF
--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -333,11 +333,13 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
         // Only go through sanity checks for locking if we don't want to force the passcode screen.
         if (![SFSecurityLockout hasValidSession]) {
             [self log:SFLogLevelInfo msg:@"Skipping 'lock' since not authenticated"];
+            [SFSecurityLockout unlockSuccessPostProcessing:SFSecurityLockoutActionNone];
             return;
         }
         
         if ([SFSecurityLockout lockoutTime] == 0) {
             [self log:SFLogLevelInfo msg:@"Skipping 'lock' since pin policies are not configured."];
+            [SFSecurityLockout unlockSuccessPostProcessing:SFSecurityLockoutActionNone];
             return;
         }
     }


### PR DESCRIPTION
Two unrelated changes:
1. Adding some debug timing logging to `SFSmartStorePlugin`.
2. Fixing a passcode issue where the "fall-through" condition for no passcode was not properly linking back the response to the asynchronous method call.
