### PR TITLE
Adding upgrade scenario for user account / credentials data

### DIFF
--- a/shared/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -39,6 +39,9 @@
 		822208751937E2D90000C635 /* SFSmartStoreDatabaseManager+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 822208741937E2D90000C635 /* SFSmartStoreDatabaseManager+Internal.h */; };
 		8222087E19381D020000C635 /* SFSmartStoreUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8222087C19381D020000C635 /* SFSmartStoreUtils.h */; };
 		8222087F19381D020000C635 /* SFSmartStoreUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8222087D19381D020000C635 /* SFSmartStoreUtils.m */; };
+		8222088819390D660000C635 /* SFUserAccountManagerUpgrade.h in Headers */ = {isa = PBXBuildFile; fileRef = 8222088619390D660000C635 /* SFUserAccountManagerUpgrade.h */; };
+		8222088919390D660000C635 /* SFUserAccountManagerUpgrade.m in Sources */ = {isa = PBXBuildFile; fileRef = 8222088719390D660000C635 /* SFUserAccountManagerUpgrade.m */; };
+		8222088B19391EC00000C635 /* SFUserAccountManager+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8222088A19391EC00000C635 /* SFUserAccountManager+Internal.h */; };
 		8251CA4A16ED27FA00BD1EA2 /* NSURL+SFStringUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8251CA4916ED27FA00BD1EA2 /* NSURL+SFStringUtilsTests.m */; };
 		8280EBBD16E14E9F00768DE8 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8280EBBB16E14E9F00768DE8 /* InfoPlist.strings */; };
 		8280EBCA16E14F7000768DE8 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280EBB516E14E9F00768DE8 /* UIKit.framework */; };
@@ -187,6 +190,9 @@
 		822208741937E2D90000C635 /* SFSmartStoreDatabaseManager+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SFSmartStoreDatabaseManager+Internal.h"; sourceTree = "<group>"; };
 		8222087C19381D020000C635 /* SFSmartStoreUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSmartStoreUtils.h; sourceTree = "<group>"; };
 		8222087D19381D020000C635 /* SFSmartStoreUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSmartStoreUtils.m; sourceTree = "<group>"; };
+		8222088619390D660000C635 /* SFUserAccountManagerUpgrade.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFUserAccountManagerUpgrade.h; sourceTree = "<group>"; };
+		8222088719390D660000C635 /* SFUserAccountManagerUpgrade.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFUserAccountManagerUpgrade.m; sourceTree = "<group>"; };
+		8222088A19391EC00000C635 /* SFUserAccountManager+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SFUserAccountManager+Internal.h"; sourceTree = "<group>"; };
 		8251CA4816ED27FA00BD1EA2 /* NSURL+SFStringUtilsTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+SFStringUtilsTests.h"; sourceTree = "<group>"; };
 		8251CA4916ED27FA00BD1EA2 /* NSURL+SFStringUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+SFStringUtilsTests.m"; sourceTree = "<group>"; };
 		8280EBB216E14E9F00768DE8 /* SalesforceSDKCoreTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SalesforceSDKCoreTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -579,7 +585,10 @@
 				FDC461141891EAA600E4456B /* SFUserAccount.m */,
 				FD8BB17118B6B5F100F6927C /* SFUserAccountConstants.h */,
 				FDC461161891EAA600E4456B /* SFUserAccountManager.h */,
+				8222088A19391EC00000C635 /* SFUserAccountManager+Internal.h */,
 				FDC461171891EAA600E4456B /* SFUserAccountManager.m */,
+				8222088619390D660000C635 /* SFUserAccountManagerUpgrade.h */,
+				8222088719390D660000C635 /* SFUserAccountManagerUpgrade.m */,
 			);
 			path = Security;
 			sourceTree = "<group>";
@@ -674,6 +683,7 @@
 				82A55A6F182020B00002E22A /* SFAuthErrorHandler.h in Headers */,
 				8222087E19381D020000C635 /* SFSmartStoreUtils.h in Headers */,
 				82A55A741821A48B0002E22A /* SFAuthErrorHandlerList.h in Headers */,
+				8222088B19391EC00000C635 /* SFUserAccountManager+Internal.h in Headers */,
 				82BBB57017909D9300374DD8 /* SFIdentityCoordinator.h in Headers */,
 				FDC4611C1891EAA600E4456B /* SFUserAccountManager.h in Headers */,
 				82BBB57117909DA500374DD8 /* SFIdentityData.h in Headers */,
@@ -702,6 +712,7 @@
 				FD280B8A18A2F14D00CEF12E /* SFCommunityData.h in Headers */,
 				822208751937E2D90000C635 /* SFSmartStoreDatabaseManager+Internal.h in Headers */,
 				82E16D7217E7C52D00E019AD /* SFSDKTestRequestListener.h in Headers */,
+				8222088819390D660000C635 /* SFUserAccountManagerUpgrade.h in Headers */,
 				82E16D7317E7C59000E019AD /* TestSetupUtils.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -891,6 +902,7 @@
 				82C0C7C116E08A8F0006B3C0 /* TestSetupUtils.m in Sources */,
 				82B6BC44170276DD0089D182 /* SFRootViewManager.m in Sources */,
 				82867578181C759A007AA18A /* SFAuthenticationViewHandler.m in Sources */,
+				8222088919390D660000C635 /* SFUserAccountManagerUpgrade.m in Sources */,
 				8222087F19381D020000C635 /* SFSmartStoreUtils.m in Sources */,
 				82A55A70182020B00002E22A /* SFAuthErrorHandler.m in Sources */,
 				82A55A751821A48B0002E22A /* SFAuthErrorHandlerList.m in Sources */,

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -27,6 +27,7 @@
 #import "SFAuthenticationManager+Internal.h"
 #import "SFUserAccount.h"
 #import "SFUserAccountManager.h"
+#import "SFUserAccountManagerUpgrade.h"
 #import "SFAuthenticationViewHandler.h"
 #import "SFAuthErrorHandler.h"
 #import "SFAuthErrorHandlerList.h"
@@ -421,8 +422,12 @@ static Class InstanceClass = nil;
     if (account == nil) {
         account = [SFUserAccountManager sharedInstance].currentUser;
         if (account == nil) {
-            [self log:SFLogLevelInfo format:@"No current user account, so creating a new one."];
-            account = [[SFUserAccountManager sharedInstance] createUserAccount];
+            // Create the current user out of legacy account data, if it exists.
+            account = [SFUserAccountManagerUpgrade createUserFromLegacyAccountData];
+            if (account == nil) {
+                [self log:SFLogLevelInfo format:@"No current user account, so creating a new one."];
+                account = [[SFUserAccountManager sharedInstance] createUserAccount];
+            }
             [[SFUserAccountManager sharedInstance] saveAccounts:nil];
         }
     }

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
@@ -1,0 +1,60 @@
+/*
+ Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFUserAccountManager.h"
+
+@interface SFUserAccountManager ()
+{
+    NSMutableOrderedSet *_delegates;
+}
+
+/** A map of user accounts by user ID
+ */
+@property (nonatomic, strong) NSMutableDictionary *userAccountMap;
+
+@property (nonatomic, strong) NSString *lastChangedOrgId;
+@property (nonatomic, strong) NSString *lastChangedUserId;
+@property (nonatomic, strong) NSString *lastChangedCommunityId;
+
+/**
+ Executes the given block for each configured delegate.
+ @param block The block to execute for each delegate.
+ */
+- (void)enumerateDelegates:(void (^)(id<SFUserAccountManagerDelegate>))block;
+
+/**
+ Updates the login host in app settings, for apps that utilize login host switching from
+ the Settings app.
+ @param newLoginHost The login host to update.
+ */
+- (void)updateAppSettingsLoginHost:(NSString *)newLoginHost;
+
+/**
+ Creates a user account staged with the given auth credentials.
+ @param credentials The OAuth credentials to apply to the user account.
+ @return The new user account with the given credentials.
+ */
+- (SFUserAccount *)createUserAccountWithCredentials:(SFOAuthCredentials *)credentials;
+
+@end

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -22,7 +22,7 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "SFUserAccountManager.h"
+#import "SFUserAccountManager+Internal.h"
 #import "SFDirectoryManager.h"
 #import "SFCommunityData.h"
 
@@ -96,34 +96,6 @@ static NSString * const kUserPrefix = @"005";
     
     return self;
 }
-
-@end
-
-@interface SFUserAccountManager ()
-{
-    NSMutableOrderedSet *_delegates;
-}
-
-/** A map of user accounts by user ID
- */
-@property (nonatomic, strong) NSMutableDictionary *userAccountMap;
-
-@property (nonatomic, strong) NSString *lastChangedOrgId;
-@property (nonatomic, strong) NSString *lastChangedUserId;
-@property (nonatomic, strong) NSString *lastChangedCommunityId;
-
-/**
- Executes the given block for each configured delegate.
- @param block The block to execute for each delegate.
- */
-- (void)enumerateDelegates:(void (^)(id<SFUserAccountManagerDelegate>))block;
-
-/**
- Updates the login host in app settings, for apps that utilize login host switching from
- the Settings app.
- @param newLoginHost The login host to update.
- */
-- (void)updateAppSettingsLoginHost:(NSString *)newLoginHost;
 
 @end
 

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManagerUpgrade.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManagerUpgrade.h
@@ -1,0 +1,38 @@
+/*
+ Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+#import "SFUserAccount.h"
+
+@interface SFUserAccountManagerUpgrade : NSObject
+
+/**
+ If legacy account data exists, create a user account from that data, and then remove
+ the legacy data.
+ @return An `SFUserAccount` object based on the legacy data, or `nil` if there is no legacy
+ account data.
+ */
++ (SFUserAccount *)createUserFromLegacyAccountData;
+
+@end

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManagerUpgrade.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManagerUpgrade.m
@@ -1,0 +1,57 @@
+/*
+ Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFUserAccountManagerUpgrade.h"
+#import "SFUserAccountManager+Internal.h"
+#import <SalesforceOAuth/SFOAuthCredentials.h>
+
+static NSString * const kOAuthCredentialsDataKeyPrefix  = @"oauth_credentials_data";
+static NSString * const kLegacyDefaultAccountIdentifier = @"Default";
+
+@implementation SFUserAccountManagerUpgrade
+
++ (SFUserAccount *)createUserFromLegacyAccountData
+{
+    NSString *legacyCredentialsDataKey = [SFUserAccountManagerUpgrade legacyCredentialsDataKey];
+    NSData *encodedCredentialsData = [[NSUserDefaults standardUserDefaults] objectForKey:legacyCredentialsDataKey];
+    if (encodedCredentialsData == nil) {
+        // No legacy data.
+        return nil;
+    }
+    
+    [SFLogger log:[SFUserAccountManagerUpgrade class] level:SFLogLevelInfo msg:@"Found legacy account data.  Creating SFUserAccount based on that data."];
+    SFOAuthCredentials *legacyCredentials = [NSKeyedUnarchiver unarchiveObjectWithData:encodedCredentialsData];
+    SFUserAccount *accountFromLegacy = [[SFUserAccountManager sharedInstance] createUserAccountWithCredentials:legacyCredentials];
+    
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:legacyCredentialsDataKey];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+    return accountFromLegacy;
+}
+
++ (NSString *)legacyCredentialsDataKey
+{
+    return [NSString stringWithFormat:@"%@-%@-%@", kOAuthCredentialsDataKeyPrefix, [SFUserAccountManager sharedInstance].loginHost, kLegacyDefaultAccountIdentifier];
+}
+
+@end


### PR DESCRIPTION
Migrating old `SFAccountManager` data to `SFUserAccount` paradigm on upgrade.
