### PR TITLE
Login host change mimics user switching

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -205,14 +205,6 @@ static NSString * const kVFPingPageUrl = @"/apexpages/utils/ping.apexp";
     } else {
         // Device is online.
         if (_hybridViewConfig.shouldAuthenticate) {
-            
-            SFUserAccountManager *userAccountManager = [SFUserAccountManager sharedInstance];
-            SFUserAccount *accountToLogin = userAccountManager.currentUser;
-            
-            // If account is nil, try to load another authenticated user.
-            if (accountToLogin == nil && [userAccountManager.allUserAccounts count] > 0) {
-                accountToLogin = [userAccountManager.allUserAccounts objectAtIndex:0];
-            }
             [[SFAuthenticationManager sharedManager]
              loginWithCompletion:^(SFOAuthInfo *authInfo) {
                  [self authenticationCompletion:nil authInfo:authInfo];
@@ -227,8 +219,7 @@ static NSString * const kVFPingPageUrl = @"/apexpages/utils/ping.apexp";
                      // Error is not invalid credentials, or developer otherwise wants to handle it.
                      [self loadErrorPageWithCode:error.code description:error.localizedDescription context:kErrorContextAppLoading];
                  }
-             }
-             account:accountToLogin];
+             }];
         } else {
             // Start page already set.  Just try to load through Cordova.
             [super viewDidLoad];

--- a/hybrid/SampleApps/AccountEditor/AccountEditor/AppDelegate.m
+++ b/hybrid/SampleApps/AccountEditor/AccountEditor/AppDelegate.m
@@ -24,9 +24,10 @@
 
 #import "AppDelegate.h"
 #import <SalesforceSDKCore/SFAuthenticationManager.h>
+#import <SalesforceSDKCore/SFUserAccountManager.h>
 #import <SalesforceSDKCore/SFPushNotificationManager.h>
 
-@interface AppDelegate () <SFAuthenticationManagerDelegate>
+@interface AppDelegate () <SFAuthenticationManagerDelegate, SFUserAccountManagerDelegate>
 
 - (void)initializeAppViewState;
 
@@ -49,6 +50,7 @@
         
         // Auth manager delegate, for receiving logout and login host change events.
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        [[SFUserAccountManager sharedInstance] addDelegate:self];
     }
     
     return self;
@@ -57,6 +59,7 @@
 - (void)dealloc
 {
     [[SFAuthenticationManager sharedManager] removeDelegate:self];
+    [[SFUserAccountManager sharedInstance] removeDelegate:self];
 }
 
 #pragma mark - App event lifecycle
@@ -114,12 +117,25 @@
 {
     [self log:SFLogLevelDebug msg:@"Logout notification received.  Resetting app."];
     self.viewController.appHomeUrl = nil;
+    
+    // If there are one or more existing accounts after logout, try to authenticate one of those.
+    // Alternatively, you could just go straight to re-initializing your app state, if you know
+    // your app does not support multiple accounts.  The logic below will work either way.
+    if ([[SFUserAccountManager sharedInstance].allUserAccounts count] > 0) {
+        [SFUserAccountManager sharedInstance].currentUser = [[SFUserAccountManager sharedInstance].allUserAccounts objectAtIndex:0];
+    }
+    
     [self initializeAppViewState];
 }
 
-- (void)authManager:(SFAuthenticationManager *)manager didChangeLoginHost:(SFLoginHostUpdateResult *)updateResult
+#pragma mark - SFUserAccountManagerDelegate
+
+- (void)userAccountManager:(SFUserAccountManager *)userAccountManager
+         didSwitchFromUser:(SFUserAccount *)fromUser
+                    toUser:(SFUserAccount *)toUser
 {
-    [self log:SFLogLevelDebug msg:@"Login host changed notification received.  Resetting app."];
+    [self log:SFLogLevelDebug format:@"SFUserAccountManager changed from user %@ to %@.  Resetting app.",
+     fromUser.userName, toUser.userName];
     [self initializeAppViewState];
 }
 

--- a/hybrid/SampleApps/ContactExplorer/ContactExplorer/Classes/AppDelegate.m
+++ b/hybrid/SampleApps/ContactExplorer/ContactExplorer/Classes/AppDelegate.m
@@ -24,6 +24,7 @@
 
 #import "AppDelegate.h"
 #import <SalesforceSDKCore/SFAuthenticationManager.h>
+#import <SalesforceSDKCore/SFUserAccountManager.h>
 #import <SalesforceSDKCore/SFPushNotificationManager.h>
 
 @interface AppDelegate () <SFAuthenticationManagerDelegate, SFUserAccountManagerDelegate>
@@ -116,12 +117,14 @@
 {
     [self log:SFLogLevelDebug msg:@"Logout notification received.  Resetting app."];
     self.viewController.appHomeUrl = nil;
-    [self initializeAppViewState];
-}
-
-- (void)authManager:(SFAuthenticationManager *)manager didChangeLoginHost:(SFLoginHostUpdateResult *)updateResult
-{
-    [self log:SFLogLevelDebug msg:@"Login host changed notification received.  Resetting app."];
+    
+    // If there are one or more existing accounts after logout, try to authenticate one of those.
+    // Alternatively, you could just go straight to re-initializing your app state, if you know
+    // your app does not support multiple accounts.  The logic below will work either way.
+    if ([[SFUserAccountManager sharedInstance].allUserAccounts count] > 0) {
+        [SFUserAccountManager sharedInstance].currentUser = [[SFUserAccountManager sharedInstance].allUserAccounts objectAtIndex:0];
+    }
+    
     [self initializeAppViewState];
 }
 

--- a/hybrid/SampleApps/HybridFileExplorer/HybridFileExplorer/AppDelegate.m
+++ b/hybrid/SampleApps/HybridFileExplorer/HybridFileExplorer/AppDelegate.m
@@ -24,9 +24,10 @@
 
 #import "AppDelegate.h"
 #import <SalesforceSDKCore/SFAuthenticationManager.h>
+#import <SalesforceSDKCore/SFUserAccountManager.h>
 #import <SalesforceSDKCore/SFPushNotificationManager.h>
 
-@interface AppDelegate () <SFAuthenticationManagerDelegate>
+@interface AppDelegate () <SFAuthenticationManagerDelegate, SFUserAccountManagerDelegate>
 
 - (void)initializeAppViewState;
 
@@ -49,6 +50,7 @@
         
         // Auth manager delegate, for receiving logout and login host change events.
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        [[SFUserAccountManager sharedInstance] addDelegate:self];
     }
     
     return self;
@@ -57,6 +59,7 @@
 - (void)dealloc
 {
     [[SFAuthenticationManager sharedManager] removeDelegate:self];
+    [[SFUserAccountManager sharedInstance] removeDelegate:self];
 }
 
 #pragma mark - App event lifecycle
@@ -114,12 +117,25 @@
 {
     [self log:SFLogLevelDebug msg:@"Logout notification received.  Resetting app."];
     self.viewController.appHomeUrl = nil;
+    
+    // If there are one or more existing accounts after logout, try to authenticate one of those.
+    // Alternatively, you could just go straight to re-initializing your app state, if you know
+    // your app does not support multiple accounts.  The logic below will work either way.
+    if ([[SFUserAccountManager sharedInstance].allUserAccounts count] > 0) {
+        [SFUserAccountManager sharedInstance].currentUser = [[SFUserAccountManager sharedInstance].allUserAccounts objectAtIndex:0];
+    }
+    
     [self initializeAppViewState];
 }
 
-- (void)authManager:(SFAuthenticationManager *)manager didChangeLoginHost:(SFLoginHostUpdateResult *)updateResult
+#pragma mark - SFUserAccountManagerDelegate
+
+- (void)userAccountManager:(SFUserAccountManager *)userAccountManager
+         didSwitchFromUser:(SFUserAccount *)fromUser
+                    toUser:(SFUserAccount *)toUser
 {
-    [self log:SFLogLevelDebug msg:@"Login host changed notification received.  Resetting app."];
+    [self log:SFLogLevelDebug format:@"SFUserAccountManager changed from user %@ to %@.  Resetting app.",
+     fromUser.userName, toUser.userName];
     [self initializeAppViewState];
 }
 

--- a/hybrid/SampleApps/SmartStoreExplorer/SmartStoreExplorer/Classes/AppDelegate.m
+++ b/hybrid/SampleApps/SmartStoreExplorer/SmartStoreExplorer/Classes/AppDelegate.m
@@ -24,9 +24,10 @@
 
 #import "AppDelegate.h"
 #import <SalesforceSDKCore/SFAuthenticationManager.h>
+#import <SalesforceSDKCore/SFUserAccountManager.h>
 #import <SalesforceSDKCore/SFPushNotificationManager.h>
 
-@interface AppDelegate () <SFAuthenticationManagerDelegate>
+@interface AppDelegate () <SFAuthenticationManagerDelegate, SFUserAccountManagerDelegate>
 
 - (void)initializeAppViewState;
 
@@ -49,6 +50,7 @@
         
         // Auth manager delegate, for receiving logout and login host change events.
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        [[SFUserAccountManager sharedInstance] addDelegate:self];
     }
     
     return self;
@@ -57,6 +59,7 @@
 - (void)dealloc
 {
     [[SFAuthenticationManager sharedManager] removeDelegate:self];
+    [[SFUserAccountManager sharedInstance] removeDelegate:self];
 }
 
 #pragma mark - App event lifecycle
@@ -114,12 +117,25 @@
 {
     [self log:SFLogLevelDebug msg:@"Logout notification received.  Resetting app."];
     self.viewController.appHomeUrl = nil;
+    
+    // If there are one or more existing accounts after logout, try to authenticate one of those.
+    // Alternatively, you could just go straight to re-initializing your app state, if you know
+    // your app does not support multiple accounts.  The logic below will work either way.
+    if ([[SFUserAccountManager sharedInstance].allUserAccounts count] > 0) {
+        [SFUserAccountManager sharedInstance].currentUser = [[SFUserAccountManager sharedInstance].allUserAccounts objectAtIndex:0];
+    }
+    
     [self initializeAppViewState];
 }
 
-- (void)authManager:(SFAuthenticationManager *)manager didChangeLoginHost:(SFLoginHostUpdateResult *)updateResult
+#pragma mark - SFUserAccountManagerDelegate
+
+- (void)userAccountManager:(SFUserAccountManager *)userAccountManager
+         didSwitchFromUser:(SFUserAccount *)fromUser
+                    toUser:(SFUserAccount *)toUser
 {
-    [self log:SFLogLevelDebug msg:@"Login host changed notification received.  Resetting app."];
+    [self log:SFLogLevelDebug format:@"SFUserAccountManager changed from user %@ to %@.  Resetting app.",
+     fromUser.userName, toUser.userName];
     [self initializeAppViewState];
 }
 

--- a/hybrid/SampleApps/VFConnector/VFConnector/Classes/AppDelegate.m
+++ b/hybrid/SampleApps/VFConnector/VFConnector/Classes/AppDelegate.m
@@ -24,9 +24,10 @@
 
 #import "AppDelegate.h"
 #import <SalesforceSDKCore/SFAuthenticationManager.h>
+#import <SalesforceSDKCore/SFUserAccountManager.h>
 #import <SalesforceSDKCore/SFPushNotificationManager.h>
 
-@interface AppDelegate () <SFAuthenticationManagerDelegate>
+@interface AppDelegate () <SFAuthenticationManagerDelegate, SFUserAccountManagerDelegate>
 
 - (void)initializeAppViewState;
 
@@ -49,6 +50,7 @@
         
         // Auth manager delegate, for receiving logout and login host change events.
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        [[SFUserAccountManager sharedInstance] addDelegate:self];
     }
     
     return self;
@@ -57,6 +59,7 @@
 - (void)dealloc
 {
     [[SFAuthenticationManager sharedManager] removeDelegate:self];
+    [[SFUserAccountManager sharedInstance] removeDelegate:self];
 }
 
 #pragma mark - App event lifecycle
@@ -114,12 +117,25 @@
 {
     [self log:SFLogLevelDebug msg:@"Logout notification received.  Resetting app."];
     self.viewController.appHomeUrl = nil;
+    
+    // If there are one or more existing accounts after logout, try to authenticate one of those.
+    // Alternatively, you could just go straight to re-initializing your app state, if you know
+    // your app does not support multiple accounts.  The logic below will work either way.
+    if ([[SFUserAccountManager sharedInstance].allUserAccounts count] > 0) {
+        [SFUserAccountManager sharedInstance].currentUser = [[SFUserAccountManager sharedInstance].allUserAccounts objectAtIndex:0];
+    }
+    
     [self initializeAppViewState];
 }
 
-- (void)authManager:(SFAuthenticationManager *)manager didChangeLoginHost:(SFLoginHostUpdateResult *)updateResult
+#pragma mark - SFUserAccountManagerDelegate
+
+- (void)userAccountManager:(SFUserAccountManager *)userAccountManager
+         didSwitchFromUser:(SFUserAccount *)fromUser
+                    toUser:(SFUserAccount *)toUser
 {
-    [self log:SFLogLevelDebug msg:@"Login host changed notification received.  Resetting app."];
+    [self log:SFLogLevelDebug format:@"SFUserAccountManager changed from user %@ to %@.  Resetting app.",
+     fromUser.userName, toUser.userName];
     [self initializeAppViewState];
 }
 

--- a/native/SampleApps/FileExplorer/FileExplorer/Classes/AppDelegate.m
+++ b/native/SampleApps/FileExplorer/FileExplorer/Classes/AppDelegate.m
@@ -34,7 +34,7 @@
 static NSString * const RemoteAccessConsumerKey = @"3MVG9Iu66FKeHhINkB1l7xt7kR8czFcCTUhgoA8Ol2Ltf1eYHOU4SqQRSEitYFDUpqRWcoQ2.dBv_a1Dyu5xa";
 static NSString * const OAuthRedirectURI        = @"testsfdc:///mobilesdk/detect/oauth/done";
 
-@interface AppDelegate () <SFAuthenticationManagerDelegate>
+@interface AppDelegate () <SFAuthenticationManagerDelegate, SFUserAccountManagerDelegate>
 
 /**
  * Success block to call when authentication completes.
@@ -78,6 +78,7 @@ static NSString * const OAuthRedirectURI        = @"testsfdc:///mobilesdk/detect
         
         // Auth manager delegate, for receiving logout and login host change events.
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        [[SFUserAccountManager sharedInstance] addDelegate:self];
         
         // Blocks to execute once authentication has completed.  You could define these at the different boundaries where
         // authentication is initiated, if you have specific logic for each case.
@@ -96,6 +97,7 @@ static NSString * const OAuthRedirectURI        = @"testsfdc:///mobilesdk/detect
 - (void)dealloc
 {
     [[SFAuthenticationManager sharedManager] removeDelegate:self];
+    [[SFUserAccountManager sharedInstance] removeDelegate:self];
 }
 
 #pragma mark - App delegate lifecycle
@@ -156,12 +158,27 @@ static NSString * const OAuthRedirectURI        = @"testsfdc:///mobilesdk/detect
 {
     [self log:SFLogLevelDebug msg:@"SFAuthenticationManager logged out.  Resetting app."];
     [self initializeAppViewState];
-    [[SFAuthenticationManager sharedManager] loginWithCompletion:self.initialLoginSuccessBlock failure:self.initialLoginFailureBlock];
+    
+    // If there are one or more existing accounts after logout, try to authenticate one of those.
+    // Alternatively, you could just call [[SFAuthenticationManager sharedManager] loginWithCompletion:failure:]
+    // if you know your app does not support multiple accounts.  The logic below will work either way.
+    SFUserAccount *existingAccount = nil;
+    if ([[SFUserAccountManager sharedInstance].allUserAccounts count] > 0) {
+        existingAccount = [[SFUserAccountManager sharedInstance].allUserAccounts objectAtIndex:0];
+    }
+    [[SFAuthenticationManager sharedManager] loginWithCompletion:self.initialLoginSuccessBlock
+                                                         failure:self.initialLoginFailureBlock
+                                                         account:existingAccount];
 }
 
-- (void)authManager:(SFAuthenticationManager *)manager didChangeLoginHost:(SFLoginHostUpdateResult *)updateResult
+#pragma mark - SFUserAccountManagerDelegate
+
+- (void)userAccountManager:(SFUserAccountManager *)userAccountManager
+         didSwitchFromUser:(SFUserAccount *)fromUser
+                    toUser:(SFUserAccount *)toUser
 {
-    [self log:SFLogLevelDebug msg:@"SFAuthenticationManager changed the login host.  Resetting app."];
+    [self log:SFLogLevelDebug format:@"SFUserAccountManager changed from user %@ to %@.  Resetting app.",
+     fromUser.userName, toUser.userName];
     [self initializeAppViewState];
     [[SFAuthenticationManager sharedManager] loginWithCompletion:self.initialLoginSuccessBlock failure:self.initialLoginFailureBlock];
 }

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
@@ -172,13 +172,6 @@ static NSString * const OAuthRedirectURI        = @"testsfdc:///mobilesdk/detect
                                                          account:existingAccount];
 }
 
-- (void)authManager:(SFAuthenticationManager *)manager didChangeLoginHost:(SFLoginHostUpdateResult *)updateResult
-{
-    [self log:SFLogLevelDebug msg:@"SFAuthenticationManager changed the login host.  Resetting app."];
-    [self initializeAppViewState];
-    [[SFAuthenticationManager sharedManager] loginWithCompletion:self.initialLoginSuccessBlock failure:self.initialLoginFailureBlock];
-}
-
 #pragma mark - SFUserAccountManagerDelegate
 
 - (void)userAccountManager:(SFUserAccountManager *)userAccountManager

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -109,14 +109,6 @@ typedef void (^SFOAuthFlowFailureCallbackBlock)(SFOAuthInfo *, NSError *);
 - (BOOL)authManagerIsNetworkAvailable:(SFAuthenticationManager*)manager;
 
 /**
- Called when the login host changes from one value to another.
- @param manager The instance of SFAuthenticationManager making the call.
- @param updateResult The results of the update, including previous login host, new login host, and whether there was
- an actual change.
- */
-- (void)authManager:(SFAuthenticationManager *)manager didChangeLoginHost:(SFLoginHostUpdateResult *)updateResult;
-
-/**
  Called after the auth manager logs out.
  @param manager The instance of SFAuthenticationManager making the call.
  */

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -381,8 +381,8 @@ static Class InstanceClass = nil;
         if (logoutAppSettingEnabled) {
             [self clearAccountState:YES];
         } else if (result.loginHostChanged) {
-            [self cancelAuthentication];
-            [self clearAccountState:NO];
+            // Authentication hasn't started yet.  Just reset the current user.
+            [SFUserAccountManager sharedInstance].currentUser = nil;
         }
     }
     
@@ -595,13 +595,7 @@ static Class InstanceClass = nil;
     } else if (result.loginHostChanged) {
         [self log:SFLogLevelInfo format:@"Login host changed ('%@' to '%@').  Switching to new login host.", result.originalLoginHost, result.updatedLoginHost];
         [self cancelAuthentication];
-        [self clearAccountState:NO];
-        [SFUserAccountManager sharedInstance].currentUser = nil;
-        [self enumerateDelegates:^(id<SFAuthenticationManagerDelegate> delegate) {
-            if ([delegate respondsToSelector:@selector(authManager:didChangeLoginHost:)]) {
-                [delegate authManager:self didChangeLoginHost:result];
-            }
-        }];
+        [[SFUserAccountManager sharedInstance] switchToNewUser];
     } else {
         // Check to display pin code screen.
         [SFSecurityLockout setLockScreenFailureCallbackBlock:^{

--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -779,14 +779,8 @@ static NSString * const kUserPrefix = @"005";
     SFUserAccount *tempNewCurrentUser = newCurrentUser;
     
     // If newCurrentUser is nil, we're switching to a "new" (unconfigured) user.
-    if (newCurrentUser == nil) {
-        if (self.temporaryUser == nil) {
-            tempNewCurrentUser = [self createUserAccount];
-        } else {
-            // Don't know what the app state would be that you would be switching to a new user while the temporary
-            // account still exists, but in any case, don't create an additional temporary account instance.
-            tempNewCurrentUser = self.temporaryUser;
-        }
+    if (tempNewCurrentUser == nil) {
+        tempNewCurrentUser = [self createUserAccount];
     }
     
     SFUserAccount *origCurrentUser = self.currentUser;


### PR DESCRIPTION
Changed the functionality of switching the login host from the Settings app, to line up with switching to a new user in user switching.
