### PR TITLE
Adding SFUSerAccountManager delegate

### DIFF
--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -363,6 +363,8 @@ static Class InstanceClass = nil;
                                     [weakSelf dismissAuthViewControllerIfPresent];
                                 }];
         
+        [[SFUserAccountManager sharedInstance] addDelegate:self];
+        
         // Set up default auth error handlers.
         self.authErrorHandlerList = [self populateDefaultAuthErrorHandlerList];
         


### PR DESCRIPTION
If you want your delegate methods called, it helps if you're a delegate. :P  User switching to new users was automatically bypassing authentication on mydomain URLs, because cookies were not being cleared.
