### PR TITLE
Adding cache manager implementation

### DIFF
--- a/native/SmartSync/SmartSync.xcodeproj/project.pbxproj
+++ b/native/SmartSync/SmartSync.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		CEAAAE5D195911E600CBBFE9 /* libSmartSync.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEAAAE45195911E600CBBFE9 /* libSmartSync.a */; };
 		CEAAAE63195911E600CBBFE9 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CEAAAE61195911E600CBBFE9 /* InfoPlist.strings */; };
 		CEDA4EDF19745B870009D865 /* SFSmartSyncNetworkManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CEDA4EDE19745B870009D865 /* SFSmartSyncNetworkManager.m */; };
+		CEDA4EE319747AC30009D865 /* SFSmartSyncCacheManager.m in Sources */ = {isa = PBXBuildFile; fileRef = CEDA4EE219747AC30009D865 /* SFSmartSyncCacheManager.m */; };
 		CEF50A87196B3EB60076264C /* SFObject.m in Sources */ = {isa = PBXBuildFile; fileRef = CEF50A7D196B3EB60076264C /* SFObject.m */; };
 		CEF50A88196B3EB60076264C /* SFObjectType.m in Sources */ = {isa = PBXBuildFile; fileRef = CEF50A80196B3EB60076264C /* SFObjectType.m */; };
 		CEF50A89196B3EB60076264C /* SFObjectTypeLayout.m in Sources */ = {isa = PBXBuildFile; fileRef = CEF50A83196B3EB60076264C /* SFObjectTypeLayout.m */; };
@@ -73,6 +74,8 @@
 		CEAAAE62195911E600CBBFE9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		CEDA4EDD19745B870009D865 /* SFSmartSyncNetworkManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFSmartSyncNetworkManager.h; path = Manager/SFSmartSyncNetworkManager.h; sourceTree = "<group>"; };
 		CEDA4EDE19745B870009D865 /* SFSmartSyncNetworkManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFSmartSyncNetworkManager.m; path = Manager/SFSmartSyncNetworkManager.m; sourceTree = "<group>"; };
+		CEDA4EE119747AC30009D865 /* SFSmartSyncCacheManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFSmartSyncCacheManager.h; path = Manager/SFSmartSyncCacheManager.h; sourceTree = "<group>"; };
+		CEDA4EE219747AC30009D865 /* SFSmartSyncCacheManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFSmartSyncCacheManager.m; path = Manager/SFSmartSyncCacheManager.m; sourceTree = "<group>"; };
 		CEF50A7B196B3EB60076264C /* SFObject+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SFObject+Internal.h"; sourceTree = "<group>"; };
 		CEF50A7C196B3EB60076264C /* SFObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFObject.h; sourceTree = "<group>"; };
 		CEF50A7D196B3EB60076264C /* SFObject.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFObject.m; sourceTree = "<group>"; };
@@ -181,6 +184,8 @@
 		CEDA4EE019745B950009D865 /* Manager */ = {
 			isa = PBXGroup;
 			children = (
+				CEDA4EE119747AC30009D865 /* SFSmartSyncCacheManager.h */,
+				CEDA4EE219747AC30009D865 /* SFSmartSyncCacheManager.m */,
 				CEDA4EDD19745B870009D865 /* SFSmartSyncNetworkManager.h */,
 				CEDA4EDE19745B870009D865 /* SFSmartSyncNetworkManager.m */,
 			);
@@ -332,6 +337,7 @@
 				CEF50A8A196B3EB60076264C /* ObjectUtils.m in Sources */,
 				CEF50A93196B57190076264C /* SFSoslReturningBuilder.m in Sources */,
 				CE617399196F469A00C63BDE /* SFSmartSyncConstants.m in Sources */,
+				CEDA4EE319747AC30009D865 /* SFSmartSyncCacheManager.m in Sources */,
 				CEDA4EDF19745B870009D865 /* SFSmartSyncNetworkManager.m in Sources */,
 				CEF50A89196B3EB60076264C /* SFObjectTypeLayout.m in Sources */,
 				CEF50A92196B57190076264C /* SFSoslBuilder.m in Sources */,

--- a/native/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.h
+++ b/native/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.h
@@ -1,0 +1,118 @@
+/*
+ Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+
+typedef  enum {
+    SFDataCachePolicyIgnoreCacheData = 0, // ignore cache and always load from server
+    SFDataCachePolicyReloadAndReturnCacheOnFailure, // Always reload and return cache on failure
+    SFDataCachePolicyReturnCacheDataDontReload, // Use cache and don't reload cache if cache exists
+    SFDataCachePolicyReturnCacheDataAndReload, // Return cache first and reload data in background to update cache
+    SFDataCachePolicyReturnCacheDataAndReloadIfExpired, // Return cache first and reload data if based on refreshCache time internval in background to update cache and call completion block again if cache is updated
+    SFDataCachePolicyInvalidateCacheDontReload, // Invalidate cache and don't reload
+    SFDataCachePolicyInvalidateCacheAndReload, // Invalidate cache and reload data
+} SFDataCachePolicy;
+
+@class SFUserAccount;
+
+/** This class acts as a simple cache to store and retrieve data.
+ */
+@interface SFSmartSyncCacheManager : NSObject
+
+/** Singleton method for accessing cache manager instance.
+ @param user A user that will scope this manager instance data
+ */
++ (id)sharedInstance:(SFUserAccount *)user;
+
+/** Removes the shared instance associated with the specified user
+ @param user The user
+ */
++ (void)removeSharedInstance:(SFUserAccount*)user;
+
+/** Enable in memory cache. Default value is YES
+ @enableInMemoryCache YES to enable in memory cache
+ */
+- (void)setEnableInMemoryCache:(BOOL)enableInMemoryCache;
+
+/** Set to YES to make cached data persist with app upgrade. Default value is YES
+ @shouldPersistAppUpgrade YES to make cached data persist with app upgrade
+ */
+- (void)setCacheShouldPersistWithAppUpgrade:(BOOL)shouldPersistAppUpgrade;
+
+/** Clean cache
+ */
+- (void)cleanCache;
+
+/** Remove data from cache
+ @param cacheType Cache type
+ @param cacheKey Key to use to retrieve cached data
+ */
+- (void)removeCache:(NSString *)cacheType cacheKey:(NSString *)cacheKey;
+
+/** Reurn YES if need to reload cache.
+ Before calling this method, user should use `[SFDataCacheManager readDataWithCacheType:cacheKey:cachePolicy:encrypted:cachedTime]`, `[SFDataCacheManager readArchivableObjectWithCacheType:cacheKey:cachePolicy:encrypted:cachedTime]` or `[SFDataCacheManager readDictionaryObjectWithCacheType:cacheKey:cachePolicy:encrypted:cachedTime]` to find out whether cache exists or not and what is the last time cache is updated
+ @param cacheExists YES if cache already exists.
+ @param cachePolicy `SFDataCachePolicy` used to decide
+ @param cacheTime Last time cache is updated
+ @param refreshIfOlderThan Number of secconds that has to pass in order to refresh cache. Pass any value that is <=0 if you don't want cache to be refrefreshed. This value is used together with `cachePolicy` to determine if cache needs reload or not
+ */
+- (BOOL)needToReloadCache:(BOOL)cacheExists cachePolicy:(SFDataCachePolicy)cachePolicy lastCachedTime:(NSDate *)cacheTime refreshIfOlderThan:(NSTimeInterval)refreshIfOlderThan;
+
+/** Read data from cache.
+ @param cacheType Cache type
+ @param cacheKey Key to use to retrieve cached data
+ @param cachePolicy See `SFDataCachePolicy`
+ @param encrypted Yes if cache to read is encrypted
+ @cachedTime Return time the data was last updated in cache
+ */
+- (NSData *)readDataWithCacheType:(NSString *)cacheType cacheKey:(NSString *)cacheKey cachePolicy:(SFDataCachePolicy)cachePolicy encrypted:(BOOL)encrypted cachedTime:(out NSDate **)lastCachedTime;
+
+/** Write data to cache.
+ @param data Data to cache
+ @param cacheType Cache type
+ @param cacheKey Key to save cached data
+ @param encryptCache Yes to encrypt cache
+ */
+- (void)writeDataToCache:(NSData *)data cacheType:(NSString *)cacheType cacheKey:(NSString *)cacheKey encryptCache:(BOOL)encryptCache;
+
+/** Read archivable object from cache.
+ Object read with this option has to be a single object implement `NSCoding` protocol or an NSArray of objects that implement `NSCoding` protocol
+ @param cacheType Cache type
+ @param cacheKey Key to use to retrieve cached data
+ @param cachePolicy See `SFDataCachePolicy`
+ @param encrypted Yes if cache to read is encrypted
+ @cachedTime Return time the data was last updated in cache
+ */
+- (id)readArchivableObjectWithCacheType:(NSString *)cacheType cacheKey:(NSString *)cacheKey cachePolicy:(SFDataCachePolicy)cachePolicy encrypted:(BOOL)encrypted cachedTime:(out NSDate **)cachedTime;
+
+/** Write data to cache.
+ Object cached by this class has to be either a single object implement `NSCoding` protocol or an NSArray of objects that implement `NSCoding` protocol
+ @param object Object to cache
+ @param cacheType Cache type
+ @param cacheKey Key to save cached data
+ @param encryptCache Yes to encrypt cache
+ */
+- (void)writeArchivableObjectToCache:(id)object cacheType:(NSString *)cacheType cacheKey:(NSString *)cacheKey encryptCache:(BOOL)encryptCache;
+
+@end

--- a/native/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
+++ b/native/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
@@ -1,0 +1,542 @@
+/*
+ Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFSmartSyncCacheManager.h"
+#import <SalesforceSDKCore/SFUserAccount.h>
+#import <SalesforceSDKCore/SFDirectoryManager.h>
+#import <SalesforceSecurity/SFKeyStoreManager.h>
+#import <SalesforceCommonUtils/SFCrypto.h>
+#import <SalesforceCommonUtils/SFPathUtil.h>
+
+static NSString * const kRootCachePath = @"smart_sync_cache";
+static NSString * const kCacheTimeKey = @"CacheTime";
+static NSString * const kCacheEncryptedKey = @"CacheEncrypted";
+static NSString * const kCacheDataKey = @"CacheData";
+static NSString * const kPlainCacheKey = @"%@_plain";
+static NSString * const kEncryptedCacheKey = @"%@_encrypted";
+
+@interface SFSmartSyncCacheManager ()
+
+@property (nonatomic, strong) SFUserAccount *user;
+@property (nonatomic, strong) NSCache *inMemCache;
+@property (nonatomic, assign) BOOL enableInMemoryCache;
+@property (nonatomic, strong) NSString *rootCachePath;
+@property (nonatomic, assign) BOOL cacheShouldPersistWithAppUpgrade;
+
+- (void)ensurePathExists:(NSString *)path;
+- (NSString *)compositeCacheKeyFor:(NSString *)cacheType cacheKey:(NSString *)cacheKey encrypted:(BOOL)encrypted;
+- (NSString *)filePathFor:(NSString *)cacheType cacheKey:(NSString *)cacheKey encrypted:(BOOL)encrypted;
+- (NSData *)dataAtPath:(NSString *)filePath encrypted:(BOOL)encrypted cachedTime:(out NSDate **)cachedTime;
+- (BOOL)shouldInvalidateCache:(SFDataCachePolicy)cachePolicy;
+- (BOOL)shouldBypassCache:(SFDataCachePolicy)cachePolicy;
+- (void)removeCache:(NSString *)cacheType cacheKey:(NSString *)cacheKey encrypted:(BOOL)encrypted;
+
+@end
+
+@implementation SFSmartSyncCacheManager
+
+static NSMutableDictionary *cacheMgrList = nil;
+
++ (id)sharedInstance:(SFUserAccount *)user {
+    static dispatch_once_t pred;
+    dispatch_once(&pred, ^{
+        cacheMgrList = [[NSMutableDictionary alloc] init];
+	});
+    if (user) {
+        NSString *key = SFKeyForUserAndScope(user, SFUserAccountScopeCommunity);
+        id cacheMgr = [cacheMgrList objectForKey:key];
+        if (!cacheMgr) {
+            cacheMgr = [[SFSmartSyncCacheManager alloc] init:user];
+            [cacheMgrList setObject:cacheMgr forKey:key];
+        }
+        return cacheMgr;
+    } else {
+        return nil;
+    }
+}
+
++ (void)removeSharedInstance:(SFUserAccount*)user {
+    if (user) {
+        NSString *key = SFKeyForUserAndScope(user, SFUserAccountScopeCommunity);
+        [cacheMgrList removeObjectForKey:key];
+    }
+}
+
+- (id)init:(SFUserAccount *)user {
+    self = [super init];
+    if (self) {
+        self.inMemCache = [[NSCache alloc] init];
+        self.enableInMemoryCache = YES;
+        self.cacheShouldPersistWithAppUpgrade = YES;
+        self.user = user;
+    }
+    return self;
+}
+
+- (void)setCacheShouldPersistWithAppUpgrade:(BOOL)shouldPersistAppUpgrade {
+    if (_cacheShouldPersistWithAppUpgrade == shouldPersistAppUpgrade  ) {
+        return;
+    }
+
+    // Remove old file caches.
+    if (_rootCachePath) {
+
+        // Remove root cache path.
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        if ([fileManager fileExistsAtPath:_rootCachePath]) {
+            NSError *error = nil;
+            BOOL success = [fileManager removeItemAtPath:_rootCachePath error:&error];
+            if (!success) {
+                [self log:SFLogLevelError format:@"Failed to clean root cache path: [%@]", [error localizedDescription]];
+            }
+        }
+        _rootCachePath = nil;
+    }
+    _cacheShouldPersistWithAppUpgrade = shouldPersistAppUpgrade;
+}
+
+#pragma mark - Private Methods
+
+- (BOOL)shouldInvalidateCache:(SFDataCachePolicy)cachePolicy {
+    BOOL invalidateCache = NO;
+    switch (cachePolicy) {
+        case SFDataCachePolicyInvalidateCacheDontReload:
+        case SFDataCachePolicyInvalidateCacheAndReload:
+            invalidateCache = YES;
+            break;
+        default:
+            invalidateCache = NO;
+            break;
+    }
+    return invalidateCache;
+}
+
+- (BOOL)shouldBypassCache:(SFDataCachePolicy)cachePolicy {
+    BOOL byPassCache = NO;
+    switch (cachePolicy) {
+        case SFDataCachePolicyIgnoreCacheData:
+        case SFDataCachePolicyReloadAndReturnCacheOnFailure:
+        case SFDataCachePolicyInvalidateCacheDontReload:
+        case SFDataCachePolicyInvalidateCacheAndReload:
+            byPassCache = YES;
+            break;
+        case SFDataCachePolicyReturnCacheDataAndReload:
+        case SFDataCachePolicyReturnCacheDataAndReloadIfExpired:
+        case SFDataCachePolicyReturnCacheDataDontReload:
+        default:
+            byPassCache = NO;
+            break;
+    }
+    return byPassCache;
+}
+
+- (NSString *)rootCachePath {
+    if (_rootCachePath) {
+        return _rootCachePath;
+    }
+    if (nil == self.user) {
+        return nil;
+    }
+    
+    // Calculate root path for cache.
+    NSSearchPathDirectory type;
+    if (self.cacheShouldPersistWithAppUpgrade) {
+        type = NSLibraryDirectory;
+    } else {
+        type = NSCachesDirectory;
+    }
+    _rootCachePath = [[SFDirectoryManager sharedManager] directoryForUser:self.user type:type components:@[kRootCachePath]];
+
+    // This will create the root path and with proper do not backup flag applied.
+    [SFPathUtil createFileItemIfNotExist:_rootCachePath skipBackup:YES];
+    if (![[NSFileManager defaultManager] fileExistsAtPath:_rootCachePath]) {
+        _rootCachePath = nil;
+    }
+    return _rootCachePath;
+}
+
+- (void)ensurePathExists:(NSString *)path {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if (![fileManager fileExistsAtPath:path]) {
+        [fileManager createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:nil];
+    }
+}
+
+- (NSString *)compositeCacheKeyFor:(NSString *)cacheType cacheKey:(NSString *)cacheKey encrypted:(BOOL)encrypted {
+    NSString *compositeCacheKey = nil;
+    if (encrypted) {
+        compositeCacheKey = [NSString stringWithFormat:kEncryptedCacheKey, cacheKey];
+    } else {
+        compositeCacheKey = [NSString stringWithFormat:kPlainCacheKey, cacheKey];
+    }
+    return compositeCacheKey;
+}
+
+- (NSString *)filePathFor:(NSString *)cacheType cacheKey:(NSString *)cacheKey encrypted:(BOOL)encrypted {
+    NSString *compositeCacheKey = [self compositeCacheKeyFor:cacheType cacheKey:cacheKey encrypted:encrypted];
+    NSString *filePath = [[self rootCachePath] stringByAppendingPathComponent:cacheType];
+
+    // Ensure path exists.
+    [self ensurePathExists:filePath];
+    filePath = [filePath stringByAppendingPathComponent:compositeCacheKey];
+    return filePath;
+}
+
+- (void)removeCache:(NSString *)cacheType cacheKey:(NSString *)cacheKey encrypted:(BOOL)encrypted {
+    if (nil == cacheType || nil == cacheKey) {
+        return;
+    }
+    NSString *compositeCacheKey = [self compositeCacheKeyFor:cacheType cacheKey:cacheKey encrypted:encrypted];
+
+    // Clean out in memory cache.
+    [self.inMemCache removeObjectForKey:compositeCacheKey];
+    
+    // Clean out disk cache.
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSString *filePath = [self filePathFor:cacheType cacheKey:cacheKey encrypted:encrypted];
+    if ([fileManager fileExistsAtPath:filePath]) {
+        NSError *error = nil;
+        BOOL success = [fileManager removeItemAtPath:filePath error:&error];
+        if (!success) {
+            [self log:SFLogLevelError format:@"Failed to clean cache [%@]: [%@]", compositeCacheKey, [error localizedDescription]];
+        }
+    }
+}
+
+- (NSData *)dataAtPath:(NSString *)filePath encrypted:(BOOL)encrypted cachedTime:(out NSDate **)cachedTime {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    if ([fileManager fileExistsAtPath:filePath]) {
+        NSData *cachedData = [NSData dataWithContentsOfFile:filePath];
+        NSDictionary *attributes = [fileManager attributesOfItemAtPath:filePath error:nil];
+        if (attributes) {
+            if (cachedTime) {
+                *cachedTime =  [attributes fileModificationDate];
+            }
+        }
+        NSData *returnData = nil;
+        if (encrypted) {
+
+            // Decrypt data.
+            SFEncryptionKey *encryptionKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:@"CHSalesforceOneEncryptionKey" keyType:SFKeyStoreKeyTypeGenerated autoCreate:YES];
+            SFCrypto *cipher = [[SFCrypto alloc] initWithOperation:kCCDecrypt
+                                                               key:encryptionKey.key
+                                                              mode:SFCryptoModeInMemory];
+            @try {
+                returnData = [cipher decryptDataInMemory:cachedData];
+            } @catch (NSException *exception) {
+                [self log:SFLogLevelError format:@"Error decrypting file at path [%@]: [%@]", filePath, exception.debugDescription];
+                returnData = nil;
+                NSError *error = nil;
+                if (![[NSFileManager defaultManager] removeItemAtPath:filePath error:&error]) {
+                    [self log:SFLogLevelError format:@"Error deleting malformed encrypted file at path %@: %@", filePath, error];
+                }
+            }
+        } else {
+
+            // Data not encrypted.
+            returnData = cachedData;
+        }
+        return cachedData;
+    } else {
+        if (cachedTime) {
+            *cachedTime = nil;
+        }
+        return nil;
+    }
+}
+
+#pragma mark - Implement Delegate Methods
+
+- (BOOL)needToReloadCache:(BOOL)cacheExists cachePolicy:(SFDataCachePolicy)cachePolicy lastCachedTime:(NSDate *)cacheTime refreshIfOlderThan:(NSTimeInterval)refreshIfOlderThan {
+    if (cachePolicy == SFDataCachePolicyInvalidateCacheDontReload) {
+        return NO;
+    }
+    if (cachePolicy == SFDataCachePolicyReloadAndReturnCacheOnFailure) {
+        return YES;
+    }
+
+    // Cache exists.
+    if (cachePolicy == SFDataCachePolicyReturnCacheDataAndReload) {
+        return YES;
+    } else if (cachePolicy == SFDataCachePolicyReturnCacheDataDontReload) {
+        return NO;
+    }
+
+    if(!cacheExists) {
+
+        // If cache does not exist, always reload.
+        return YES;
+    }
+    if (refreshIfOlderThan <= 0) {
+        return YES;
+    }
+    if (nil == cacheTime) {
+        return YES;
+    }
+    NSTimeInterval timeDiff= [[NSDate date] timeIntervalSinceDate:cacheTime];
+    if (timeDiff > refreshIfOlderThan) {
+        return YES;
+    } else {
+        return NO;
+    }
+}
+
+- (void)cleanCache {
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+
+    // Remove root cache path.
+    if (self.rootCachePath && [fileManager fileExistsAtPath:self.rootCachePath]) {
+        NSError *error = nil;
+        BOOL success = [fileManager removeItemAtPath:self.rootCachePath error:&error];
+        if (!success) {
+            [self log:SFLogLevelError format:@"Failed to clean root cache path: [%@]", [error localizedDescription]];
+        }
+    }
+
+    // Clean out in memory cache.
+    [self.inMemCache removeAllObjects];
+}
+
+- (void)removeCache:(NSString *)cacheType cacheKey:(NSString *)cacheKey {
+
+    // Remove both encrypted and non-encrypted cache.
+    [self removeCache:cacheType cacheKey:cacheKey encrypted:YES];
+    [self removeCache:cacheType cacheKey:cacheKey encrypted:NO];
+}
+
+- (NSData *)readDataWithCacheType:(NSString *)cacheType cacheKey:(NSString *)cacheKey cachePolicy:(SFDataCachePolicy)cachePolicy encrypted:(BOOL)encrypted cachedTime:(out NSDate **)lastCachedTime {
+    BOOL byPassCache = [self shouldBypassCache:cachePolicy];
+    if (byPassCache) {
+        return nil;
+    }
+    NSDate *cachedTime = nil;
+    NSData *cachedData = nil;
+    NSString *compositeCacheKey = [self compositeCacheKeyFor:cacheType cacheKey:cacheKey encrypted:encrypted];
+
+    // Calculate local file cache path.
+    NSString *filePath = [self filePathFor:cacheType cacheKey:cacheKey encrypted:encrypted];
+    NSData *returnData = nil;
+
+    // Check in-memory cache first.
+    if (self.enableInMemoryCache) {
+        NSDictionary *inMemoryCacheInfo = [self.inMemCache objectForKey:compositeCacheKey];
+        if (inMemoryCacheInfo) {
+            cachedData = inMemoryCacheInfo[kCacheDataKey];
+            cachedTime = inMemoryCacheInfo[kCacheTimeKey];
+        }
+    }
+
+    // Check on disk cache if in-memory cache not found.
+    if (!cachedData) {
+        returnData = [self dataAtPath:filePath encrypted:encrypted cachedTime:lastCachedTime];
+
+        // Save to in memory cache.
+        if (returnData && self.enableInMemoryCache) {
+            if (lastCachedTime) {
+                if (nil == *lastCachedTime) {
+                    *lastCachedTime = [NSDate date];
+                }
+                [self.inMemCache setObject:@{kCacheDataKey : returnData, kCacheTimeKey : *lastCachedTime} forKey:compositeCacheKey];
+            } else {
+                [self.inMemCache setObject:@{kCacheDataKey : returnData} forKey:compositeCacheKey];
+            }
+        }
+    } else {
+        if (lastCachedTime) {
+            *lastCachedTime = cachedTime;
+        }
+    }
+    return returnData;
+}
+
+- (void)writeDataToCache:(NSData *)data cacheType:(NSString *)cacheType cacheKey:(NSString *)cacheKey encryptCache:(BOOL)encryptCache {
+    if (!cacheKey) {
+
+        // Cache key is nil, directly return.
+        return;
+    }
+    if (!data) {
+
+        // Set cache to nil = remove cache by key.
+        [self removeCache:cacheType cacheKey:cacheKey encrypted:encryptCache];
+    }
+    NSString *compositeCacheKey = [self compositeCacheKeyFor:cacheType cacheKey:cacheKey encrypted:encryptCache];
+
+    // Save to in-memory cache.
+    if (data && self.enableInMemoryCache) {
+        [self.inMemCache setObject:@{kCacheDataKey : data, kCacheTimeKey : [NSDate date]} forKey:compositeCacheKey];
+    }
+
+    // Write to disk.
+    NSString *filePath = [self filePathFor:cacheType cacheKey:cacheKey encrypted:encryptCache];
+    @try {
+
+        // Encrypt data.
+        SFEncryptionKey *encryptionKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:@"CHSalesforceOneEncryptionKey" keyType:SFKeyStoreKeyTypeGenerated autoCreate:YES];
+        SFCrypto *cipher = [[SFCrypto alloc] initWithOperation:kCCEncrypt
+                                                           key:encryptionKey.key
+                                                          mode:SFCryptoModeInMemory];
+        NSData *dataToWrite = nil;
+        @try {
+            dataToWrite = [cipher encryptDataInMemory:data];
+            [dataToWrite writeToFile:filePath atomically:YES];
+        } @catch (NSException *exception) {
+            [self log:SFLogLevelError format:@"Error decrypting file at path [%@]: [%@]", filePath, exception.debugDescription];
+            NSError *error = nil;
+            if (![[NSFileManager defaultManager] removeItemAtPath:filePath error:&error]) {
+                [self log:SFLogLevelError format:@"Error deleting malformed encrypted file at path %@: %@", filePath, error];
+            }
+        }
+    } @catch (NSException *exception) {
+        [self log:SFLogLevelError format:@"Failed to save to disk cache: [%@]", exception.debugDescription];
+    }
+}
+
+- (id)readArchivableObjectWithCacheType:(NSString *)cacheType cacheKey:(NSString *)cacheKey cachePolicy:(SFDataCachePolicy)cachePolicy encrypted:(BOOL)encrypted cachedTime:(out NSDate **)lastCachedTime {
+    BOOL shouldInvalidateCache = [self shouldInvalidateCache:cachePolicy];
+    if (shouldInvalidateCache) {
+        [self removeCache:cacheType cacheKey:cacheKey encrypted:encrypted];
+        return nil;
+    }
+    BOOL byPassCache = [self shouldBypassCache:cachePolicy];
+    if (byPassCache) {
+        return nil;
+    }
+    NSData *cachedData = nil;
+    NSString *compositeCacheKey = [self compositeCacheKeyFor:cacheType cacheKey:cacheKey encrypted:encrypted];
+    NSString *filePath = [self filePathFor:cacheType cacheKey:cacheKey encrypted:encrypted];
+
+    // Check in memory cache first.
+    if (self.enableInMemoryCache) {
+        NSDictionary *inMemoryCacheInfo = [self.inMemCache objectForKey:compositeCacheKey];
+        if (inMemoryCacheInfo) {
+            cachedData = inMemoryCacheInfo[kCacheDataKey];
+            if (lastCachedTime) {
+                *lastCachedTime = inMemoryCacheInfo[kCacheTimeKey];
+            }
+        }
+    }
+    if (cachedData) {
+        return cachedData;
+    }
+
+    // Check on disk cache instead.
+    cachedData = [self dataAtPath:filePath encrypted:encrypted cachedTime:lastCachedTime];
+    if (nil == cachedData) {
+        return nil;
+    }
+    id <NSCoding> unarchivedData = nil;
+    @try {
+
+        // Decrypt the data.
+        if (encrypted) {
+            SFEncryptionKey *encryptionKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:@"CHSalesforceOneEncryptionKey" keyType:SFKeyStoreKeyTypeGenerated autoCreate:YES];
+            SFCrypto *cipher = [[SFCrypto alloc] initWithOperation:kCCDecrypt
+                                                               key:encryptionKey.key
+                                                              mode:SFCryptoModeInMemory];
+            cachedData = [cipher decryptDataInMemory:cachedData];
+        }
+        unarchivedData = [NSKeyedUnarchiver unarchiveObjectWithData:cachedData];
+
+        // Save to in-memory cache.
+        if (unarchivedData && self.enableInMemoryCache) {
+            if (lastCachedTime) {
+                if (nil == *lastCachedTime) {
+                    *lastCachedTime = [NSDate date];
+                }
+                [self.inMemCache setObject:@{kCacheDataKey : unarchivedData, kCacheTimeKey : *lastCachedTime} forKey:compositeCacheKey];
+            } else {
+                [self.inMemCache setObject:@{kCacheDataKey : unarchivedData} forKey:compositeCacheKey];
+            }
+        }
+    } @catch (NSException *exception) {
+
+        // If we received an exception when unarchiving this object, remove
+        // it from disk and return a nil object.
+        unarchivedData = nil;
+        if (lastCachedTime) {
+            *lastCachedTime = nil;
+        }
+        [self log:SFLogLevelError format:@"Error unarchiving %@: %@", filePath, exception.description];
+        if (filePath) {
+            NSError *error = nil;
+            if (![[NSFileManager defaultManager] removeItemAtPath:filePath error:&error]) {
+                [self log:SFLogLevelError format:@"Error delete corrupted archive file %@: %@", filePath, exception.description];
+            }
+        }
+    } @finally {
+        return unarchivedData;
+    }
+}
+
+- (void)writeArchivableObjectToCache:(id)object cacheType:(NSString *)cacheType cacheKey:(NSString *)cacheKey encryptCache:(BOOL)encryptCache {
+    if (nil == object || nil == cacheType || nil == cacheKey) {
+        return;
+    }
+    BOOL validObjectTypes = NO;
+    if ([object conformsToProtocol:@protocol(NSCoding)]) {
+        validObjectTypes = YES;
+    } else if ([object isKindOfClass:[NSArray class]]) {
+        NSArray *objects = (NSArray *)object;
+        if (objects.count == 0) {
+            // return
+            return;
+        } else if ([objects[0] conformsToProtocol:@protocol(NSCoding)]) {
+            validObjectTypes = YES;
+        }
+    }
+    if (!validObjectTypes) {
+        [self log:SFLogLevelError format:@"Object to be persisted using %@ has to be either implement NSCoding or an NSArray of objects that implement NSCoding", [[self class] description]];
+        return;
+    }
+    NSString *compositeCacheKey = [self compositeCacheKeyFor:cacheType cacheKey:cacheKey encrypted:encryptCache];
+    NSString *filePath = [self filePathFor:cacheType cacheKey:cacheKey encrypted:encryptCache];
+
+    // Save to in-memory cache.
+    if (object && self.enableInMemoryCache) {
+        [self.inMemCache setObject:@{kCacheDataKey : object, kCacheTimeKey : [NSDate date]} forKey:compositeCacheKey];
+    }
+
+    // Write to disk.
+    if (object) {
+        @try {
+            NSData *objectData = [NSKeyedArchiver archivedDataWithRootObject:object];
+            if (encryptCache) {
+
+                // Encrypt cache if necessary.
+                SFEncryptionKey *encryptionKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:@"CHSalesforceOneEncryptionKey" keyType:SFKeyStoreKeyTypeGenerated autoCreate:YES];
+                SFCrypto *cipher = [[SFCrypto alloc] initWithOperation:kCCEncrypt key:encryptionKey.key mode:SFCryptoModeInMemory];
+                objectData = [cipher encryptDataInMemory:objectData];
+            }
+            [objectData writeToFile:filePath atomically:YES];
+        } @catch (NSException *exception) {
+
+            // If we received an exception when unarchiving this object, remove
+            // it from disk and return a nil object.
+            [self log:SFLogLevelError format:@"Error archiving %@: %@", filePath, exception.description];
+        }
+    }
+}
+
+@end

--- a/native/SmartSync/SmartSync/SmartSync-Prefix.pch
+++ b/native/SmartSync/SmartSync/SmartSync-Prefix.pch
@@ -6,4 +6,5 @@
 
 #ifdef __OBJC__
     #import <Foundation/Foundation.h>
+    #import <SalesforceCommonUtils/SFLogger.h>
 #endif


### PR DESCRIPTION
This pull request adds the cache manager header file and implementation. For now, this uses the disk for caching. At some point, we could swap out the underlying functionality to use `SmartStore` instead, while keeping the interfaces the same.
