### PR TITLE
#652: Do not cache user data.

### DIFF
--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator.h
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator.h
@@ -79,7 +79,7 @@ enum {
  * Salesforce service.  This data will be based on the requesting user, and the OAuth app
  * credentials he/she is using to request this information.
  */
-@interface SFIdentityCoordinator : NSObject <NSURLConnectionDataDelegate, NSURLConnectionDataDelegate>
+@interface SFIdentityCoordinator : NSObject <NSURLConnectionDataDelegate>
 
 /**
  * The designated initializer of SFIdentityCoordinator.  Creates an instance with the specified


### PR DESCRIPTION
`SFIdentityCoordinator` was caching the user data.
