### PR TITLE
fixing the redirect url after the session refresh on community user

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -412,7 +412,7 @@ static NSString * const kVFPingPageUrl = @"/apexpages/utils/ping.apexp";
 {
     // TODO: This piece of code has got to go at some point, once we standardize on the correct redirection for communities as well.
     if ([[url absoluteString] rangeOfString:kLoginRedirect].location != NSNotFound) {
-        return self.startPage;
+        return _hybridViewConfig.startPage;
     }
     return nil;
 }


### PR DESCRIPTION
Currently on token refresh after session timeout, the community user gets redirected to a wrong start url. Fixing that in this small patch.
