### PR TITLE
Not hiding status bar by default

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -223,11 +223,6 @@ static NSString * const kVFPingPageUrl = @"/apexpages/utils/ping.apexp";
     }
 }
 
-- (BOOL)prefersStatusBarHidden
-{
-    return YES;
-}
-
 #pragma mark - Property implementations
 
 - (NSString *)remoteAccessConsumerKey


### PR DESCRIPTION
Otherwise there is no way to show it in a hybrid application (status bar plugin won't work)

To control the status bar appearance (overlaid or not, black, translucent etc) simply add org.apache.cordova.statusbar to your app and follow instructions on https://github.com/apache/cordova-plugin-statusbar (things can be controlled from the config.xml or from javascript)

To hide the status bar add the following to your plist:
<key>UIStatusBarHidden</key>
<true/>
<key>UIViewControllerBasedStatusBarAppearance</key>
<false/>

That will address https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/597
