### PR TITLE
Fixes error alertview so it shows friendly message

### DIFF
--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -1061,7 +1061,7 @@ static Class InstanceClass = nil;
     if (nil == _statusAlert) {
         // show alert and allow retry
         _statusAlert = [[UIAlertView alloc] initWithTitle:[SFSDKResourceUtils localizedString:kAlertErrorTitleKey]
-                                                  message:[NSString stringWithFormat:[SFSDKResourceUtils localizedString:kAlertConnectionErrorFormatStringKey], error]
+                                                  message:[NSString stringWithFormat:[SFSDKResourceUtils localizedString:kAlertConnectionErrorFormatStringKey], [error localizedDescription]]
                                                  delegate:self
                                         cancelButtonTitle:[SFSDKResourceUtils localizedString:kAlertRetryButtonKey]
                                         otherButtonTitles: nil];


### PR DESCRIPTION
This fixes an issue where an unfriendly error message is shown to the user if the Deny access when logging in.

In the old code the raw error was displayed in the UIAlertView - in the new code the localizedDescription is displayed.
