### PR TITLE
removeSoup was not clearing previous entry in _soupNameToTableName

### DIFF
--- a/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.m
+++ b/shared/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.m
@@ -931,6 +931,7 @@ NSString *const SOUP_LAST_MODIFIED_DATE = @"_soupLastModifiedDate";
     [self executeUpdateThrows:deleteNameSql withDb:db];
     
     [_indexSpecsBySoup removeObjectForKey:soupName ];
+    [_soupNameToTableName removeObjectForKey:soupName ];
     
     // Cleanup _smartSqlToSql
     NSString* soupRef = [@[@"{", soupName, @"}"] componentsJoinedByString:@""];


### PR DESCRIPTION
Creating a soup and then removing it breaks the smartstore. Once you've done that, you cannot recreate a soup with the same name.

For instance, this script should work:

``` javascript
var soupName = "KeyValue60"
navigator.smartstore.registerSoup( soupName, [{ "path": "id", "type": "string"}], function() {
    console.log("Created " + soupName + " soup");
    navigator.smartstore.soupExists( soupName, function (exist) {
        console.log(soupName +" exists? "+ exist);
            navigator.smartstore.removeSoup( soupName, function (removed) {
                console.log(soupName +" removed? "+ removed);
                navigator.smartstore.registerSoup( soupName, [{ "path": "id", "type": "string"}], function() {
                    console.log("Created " + soupName + " soup");
                        navigator.smartstore.soupExists( soupName, function (exist) {
                            console.log(soupName +" exists? "+ exist);
                            if (!exist) {
                                console.error("But I just created it?!?");
                            }
                        }, function () {
                            console.error("Couldn't check if " + soupName + " existed");
                        });   
                }, function( err ) {
                    console.error("Couldn't create " + soupName + " soup");
                } );
            }, function () {
                console.error("Couldn't removeSoup " + soupName + ".");
            });        
    }, function () {
        console.error("Couldn't check if " + soupName + " existed");
    });
}, function( err ) {
    console.error("Couldn't create " + soupName + " soup");
} );
```

I've found that `removeSoup` was not clearing the soupTableName table cache.
