### PR TITLE
Adding logic to ignore soft errors in the hybrid web view

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
@@ -137,4 +137,17 @@ typedef void (^SFOAuthPluginAuthSuccessBlock)(SFOAuthInfo *, NSDictionary *);
  */
 + (NSString *)sfHybridViewUserAgentString;
 
+/**
+ Determines whether an error that occurs during the web view load is fatal or not.  For example,
+ redirects can sometimes generate an NSURLErrorCancelled error in the web view, which shouldn't
+ otherwise halt the progress of the app.
+ 
+ If this method returns YES, web view processing will stop, and the configured error page will be
+ loaded with the details of the error.
+ 
+ @param error The web view error to evaluate.
+ @return YES if the error is fatal, NO otherwise.
+ */
++ (BOOL)isFatalWebViewError:(NSError *)error;
+
 @end

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -549,9 +549,20 @@ static NSString * const kVFPingPageUrl = @"/apexpages/utils/ping.apexp";
 {
     [self log:SFLogLevelError format:@"Error while attempting to load web page: %@", error];
     if ([webView isEqual:self.webView]) {
-        [self loadErrorPageWithCode:[error code] description:[error localizedDescription] context:kErrorContextAppLoading];
+        if ([[self class] isFatalWebViewError:error]) {
+            [self loadErrorPageWithCode:[error code] description:[error localizedDescription] context:kErrorContextAppLoading];
+        }
         [super webView:webView didFailLoadWithError:error];
     }
+}
+
++ (BOOL)isFatalWebViewError:(NSError *)error
+{
+    if ([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled) {
+        return NO;
+    }
+    
+    return YES;
 }
 
 #pragma mark - URL evaluation helpers


### PR DESCRIPTION
Request cancellation is the main one I've seen so far, which occurs somewhat frequently during certain types of redirect cycles.  We shouldn't be fatally dumping to the error page for recoverable errors like these.
