### PR TITLE
Fixing a keystore state issue on encryption key change

### DIFF
--- a/libs/SalesforceSecurity/SalesforceSecurity/Classes/SFGeneratedKeyStore.m
+++ b/libs/SalesforceSecurity/SalesforceSecurity/Classes/SFGeneratedKeyStore.m
@@ -101,12 +101,11 @@ static NSString * const kGeneratedKeyStoreEncryptionKeyDataArchiveKey = @"com.sa
         
         // Update the key store dictionary as part of the key update process.
         NSDictionary *origKeyStoreDict = [self keyStoreDictionaryWithKey:_keyStoreKey.encryptionKey];  // Old key.
-        _keyStoreKey = [keyStoreKey copy];
         if (origKeyStoreDict == nil) {
             [self log:SFLogLevelError msg:kKeyStoreDecryptionFailedMessage];
-            self.keyStoreDictionary = nil;
+            [self setKeyStoreDictionary:nil withKey:keyStoreKey.encryptionKey];
         } else {
-            self.keyStoreDictionary = origKeyStoreDict;
+            [self setKeyStoreDictionary:origKeyStoreDict withKey:keyStoreKey.encryptionKey];
         }
         
         // Store the key store key in the keychain.
@@ -128,6 +127,8 @@ static NSString * const kGeneratedKeyStoreEncryptionKeyDataArchiveKey = @"com.sa
                 [self log:SFLogLevelError msg:@"Error saving key store key to the keychain."];
             }
         }
+        
+        _keyStoreKey = [keyStoreKey copy];
     }
 }
 

--- a/libs/SalesforceSecurity/SalesforceSecurity/Classes/SFKeyStore+Internal.h
+++ b/libs/SalesforceSecurity/SalesforceSecurity/Classes/SFKeyStore+Internal.h
@@ -63,4 +63,11 @@ static NSString * const kKeyStoreDecryptionFailedMessage = @"Could not decrypt k
  */
 - (NSDictionary *)keyStoreDictionaryWithKey:(SFEncryptionKey *)decryptKey;
 
+/**
+ Sets the key store dictionary, encrypting it with the specified key.
+ @param keyStoreDictionary The new/updated dictionary to set.
+ @param theEncryptionKey The key used to encrypt the database.
+ */
+- (void)setKeyStoreDictionary:(NSDictionary *)keyStoreDictionary withKey:(SFEncryptionKey *)theEncryptionKey;
+
 @end

--- a/libs/SalesforceSecurity/SalesforceSecurity/Classes/SFPasscodeKeyStore.m
+++ b/libs/SalesforceSecurity/SalesforceSecurity/Classes/SFPasscodeKeyStore.m
@@ -108,9 +108,9 @@ static NSString * const kPasscodeKeyStoreEncryptionKeyDataArchiveKey = @"com.sal
         NSDictionary *origKeyStoreDict = [self keyStoreDictionaryWithKey:_keyStoreKey.encryptionKey];  // Old key.
         if (origKeyStoreDict == nil) {
             [self log:SFLogLevelError msg:kKeyStoreDecryptionFailedMessage];
-            self.keyStoreDictionary = nil;
+            [self setKeyStoreDictionary:nil withKey:keyStoreKey.encryptionKey];
         } else {
-            self.keyStoreDictionary = origKeyStoreDict;
+            [self setKeyStoreDictionary:origKeyStoreDict withKey:keyStoreKey.encryptionKey];
         }
         
         // Store the key store key in the keychain.


### PR DESCRIPTION
In the generated key store case, I moved the ultimate setting of the `_keyStoreKey` property to the end of the setter, to reflect the passcode key store case.  For the passcode key store case, the dictionary was getting re-encrypted with the wrong key.  Both use the same pattern (and proper key) now.
