### PR TITLE
Clearing SmartSync user/store state on logout

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -116,6 +116,13 @@ typedef void (^SFOAuthFlowFailureCallbackBlock)(SFOAuthInfo *, NSError *);
 - (BOOL)authManagerIsNetworkAvailable:(SFAuthenticationManager*)manager;
 
 /**
+ Called before the auth manager logs out the given user.
+ @param manager The instance of SFAuthenticationManager making the call.
+ @param user The user that will be logged out.
+ */
+- (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user;
+
+/**
  Called after the auth manager logs out.
  @param manager The instance of SFAuthenticationManager making the call.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore+Internal.h
@@ -26,11 +26,12 @@
 #import "SFSmartStore.h"
 #import "SFUserAccount.h"
 #import "SFSmartStoreDatabaseManager.h"
+#import "SFAuthenticationManager.h"
 
 @class FMDatabase;
 @class FMResultSet;
 
-@interface SFSmartStore ()
+@interface SFSmartStore () <SFAuthenticationManagerDelegate>
 
 @property (nonatomic, strong) FMDatabaseQueue *storeQueue;
 @property (nonatomic, strong) SFUserAccount *user;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.m
@@ -170,7 +170,9 @@ NSString *const SOUP_LAST_MODIFIED_DATE = @"_soupLastModifiedDate";
             }
         }
         
-        
+        if (self != nil) {
+            [[SFAuthenticationManager sharedManager] addDelegate:self];
+        }
     }
     return self;
 }
@@ -181,6 +183,7 @@ NSString *const SOUP_LAST_MODIFIED_DATE = @"_soupLastModifiedDate";
     SFRelease(_soupNameToTableName);
     SFRelease(_indexSpecsBySoup);
     SFRelease(_smartSqlToSql);
+    [[SFAuthenticationManager sharedManager] removeDelegate:self];
     
     //remove data protection observer
     [[NSNotificationCenter defaultCenter] removeObserver:_dataProtectAvailObserverToken];
@@ -1451,5 +1454,11 @@ NSString *const SOUP_LAST_MODIFIED_DATE = @"_soupLastModifiedDate";
     }
 }
 
+#pragma mark - SFAuthenticationManagerDelegate
+
+- (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user
+{
+    [[self class] removeAllStoresForUser:user];
+}
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncNetworkManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncNetworkManager.m
@@ -23,11 +23,12 @@
  */
 
 #import "SFSmartSyncNetworkManager.h"
+#import <SalesforceSDKCore/SFAuthenticationManager.h>
 #import <SalesforceSDKCore/SFUserAccount.h>
 #import <SalesforceNetworkSDK/SFNetworkEngine.h>
 #import <SalesforceNetworkSDK/SFNetworkUtils.h>
 
-@interface SFSmartSyncNetworkManager ()
+@interface SFSmartSyncNetworkManager () <SFAuthenticationManagerDelegate>
 
 @property (nonatomic, strong) SFUserAccount *user;
 @property (nonatomic, strong) NSURL *serverRootUrl;
@@ -73,8 +74,13 @@ static NSMutableDictionary *networkMgrList = nil;
     self = [super init];
     if (self) {
         self.user = user;
+        [[SFAuthenticationManager sharedManager] addDelegate:self];
     }
     return self;
+}
+
+- (void)dealloc {
+    [[SFAuthenticationManager sharedManager] removeDelegate:self];
 }
 
 - (NSString *)accessToken {
@@ -142,6 +148,12 @@ static NSMutableDictionary *networkMgrList = nil;
     // Enqueues operation now.
     [networkEngine enqueueOperation:operation];
     return  operation;
+}
+
+#pragma mark - SFAuthenticationManagerDelegate
+
+- (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user {
+    [[self class] removeSharedInstance:user];
 }
 
 @end


### PR DESCRIPTION
There were issues with stale SmartStore and user data between logouts.  I also took the opportunity to move SmartStore clearing out of SFAuthenticationManager, following the same delegate pattern.
