### PR TITLE
No local references to shared store variables

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.h
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.h
@@ -42,7 +42,7 @@ extern NSString * const kSmartStorePluginIdentifier;
 }
 
 
-@property (nonatomic, strong) SFSmartStore *store;
+@property (nonatomic, readonly) SFSmartStore *store;
 @property (nonatomic, strong) NSMutableDictionary *cursorCache; 
 
 

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
@@ -71,8 +71,11 @@ NSString * const kReIndexDataArg      = @"reIndexData";
 - (void)resetSharedStore
 {
     [[self cursorCache] removeAllObjects];
-    self.store = nil;
-    self.store = [SFSmartStore sharedStoreWithName:kDefaultSmartStoreName];
+}
+
+- (SFSmartStore *)store
+{
+    return [SFSmartStore sharedStoreWithName:kDefaultSmartStoreName];
 }
 
 - (CDVPlugin*) initWithWebView:(UIWebView*)theWebView 
@@ -82,7 +85,6 @@ NSString * const kReIndexDataArg      = @"reIndexData";
     if (nil != self)  {
         [self log:SFLogLevelDebug msg:@"SFSmartStorePlugin initWithWebView"];
         _cursorCache = [[NSMutableDictionary alloc] init];
-        self.store = [SFSmartStore sharedStoreWithName:kDefaultSmartStoreName];
     }
     return self;
 }

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
@@ -43,7 +43,7 @@ static NSString * const kSmartStoreCacheDataPath       = @"cache_data";
 @interface SFSmartSyncCacheManager () <SFAuthenticationManagerDelegate>
 
 @property (nonatomic, strong) SFUserAccount *user;
-@property (nonatomic, strong) SFSmartStore *store;
+@property (nonatomic, readonly) SFSmartStore *store;
 @property (nonatomic, strong) NSCache *inMemCache;
 @property (nonatomic, assign) BOOL enableInMemoryCache;
 
@@ -93,10 +93,13 @@ static NSMutableDictionary *cacheMgrList = nil;
         self.inMemCache = [[NSCache alloc] init];
         self.enableInMemoryCache = YES;
         self.user = user;
-        self.store = [SFSmartStore sharedStoreWithName:kDefaultSmartStoreName user:user];
         [[SFAuthenticationManager sharedManager] addDelegate:self];
     }
     return self;
+}
+
+- (SFSmartStore *)store {
+    return [SFSmartStore sharedStoreWithName:kDefaultSmartStoreName user:self.user];
 }
 
 - (void)dealloc {

--- a/native/SampleApps/NativeSqlAggregator/NativeSqlAggregator/Classes/SmartStoreInterface.h
+++ b/native/SampleApps/NativeSqlAggregator/NativeSqlAggregator/Classes/SmartStoreInterface.h
@@ -36,7 +36,7 @@ extern NSString* const kAggregateQueryStr;
 
 @interface SmartStoreInterface : NSObject
 
-@property (nonatomic, strong) SFSmartStore *store;
+@property (nonatomic, readonly) SFSmartStore *store;
 
 /**
  * Creates a soup for accounts.

--- a/native/SampleApps/NativeSqlAggregator/NativeSqlAggregator/Classes/SmartStoreInterface.m
+++ b/native/SampleApps/NativeSqlAggregator/NativeSqlAggregator/Classes/SmartStoreInterface.m
@@ -44,9 +44,14 @@ NSString* const kAggregateQueryStr = @"SELECT {Account:Name}, COUNT({Opportunity
 {
     self = [super init];
     if (nil != self)  {
-        self.store = [SFSmartStore sharedStoreWithName:kDefaultSmartStoreName];
+        
     }
     return self;
+}
+
+- (SFSmartStore *)store
+{
+    return [SFSmartStore sharedStoreWithName:kDefaultSmartStoreName];
 }
 
 - (void)createAccountsSoup

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/Data/SObjectDataManager.m
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/Data/SObjectDataManager.m
@@ -38,7 +38,7 @@ static char* const kSearchFilterQueueName = "com.salesforce.smartSyncExplorer.se
 
 @property (nonatomic, weak) UITableViewController *parentVc;
 @property (nonatomic, strong) SFSmartSyncSyncManager *syncMgr;
-@property (nonatomic, strong) SFSmartStore *store;
+@property (nonatomic, readonly) SFSmartStore *store;
 @property (nonatomic, strong) SObjectDataSpec *dataSpec;
 @property (nonatomic, strong) NSArray *fullDataRowList;
 @property (nonatomic, copy) SFSyncSyncManagerUpdateBlock syncCompletionBlock;
@@ -53,7 +53,6 @@ static char* const kSearchFilterQueueName = "com.salesforce.smartSyncExplorer.se
     if (self) {
         self.parentVc = parentVc;
         self.syncMgr = [SFSmartSyncSyncManager sharedInstance:[SFUserAccountManager sharedInstance].currentUser];
-        self.store = [SFSmartStore sharedStoreWithName:kDefaultSmartStoreName];
         self.dataSpec = dataSpec;
         _searchFilterQueue = dispatch_queue_create(kSearchFilterQueueName, NULL);
     }
@@ -61,6 +60,10 @@ static char* const kSearchFilterQueueName = "com.salesforce.smartSyncExplorer.se
 }
 
 - (void)dealloc {
+}
+
+- (SFSmartStore *)store {
+    return [SFSmartStore sharedStoreWithName:kDefaultSmartStoreName];
 }
 
 - (void)refreshRemoteData {


### PR DESCRIPTION
I found that setting an explicit local reference to shared SmartStore instances can be dangerous, especially for objects that hang around between logouts.  So I'm doing away with those in the SDK.
