### PR TITLE
stringByStandardizingPath not only gets rid of . and .. in the path

### DIFF
--- a/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFLocalhostSubstitutionCache.m
+++ b/hybrid/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFLocalhostSubstitutionCache.m
@@ -44,7 +44,7 @@
     
     // When passed @"" returned full path to www directory
     if ([resourcepath length] == 0) {
-        return [[mainBundle bundlePath] stringByAppendingPathComponent:WWW_DIR];
+        return [[[mainBundle bundlePath] stringByAppendingPathComponent:WWW_DIR] stringByStandardizingPath];
     }
     
     // Otherwise


### PR DESCRIPTION
but also remove an initial component of “/private” from the path if the result still indicates an existing file or directory (checked by consulting the file system).

The /private only shows up when running on device (not in simulator) but causes the if (![filePath hasPrefix:wwwDirPath]) check to always fail.

Without this fix, loading files from localhost doesn't work on device
