### PR TITLE
This fixes several broken unit tests as initializing the dictionary with...

### DIFF
--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI.m
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI.m
@@ -316,7 +316,10 @@ static BOOL kIsTestRun;
 }
 
 - (SFRestRequest *)requestForQuery:(NSString *)soql {
-    NSDictionary *queryParams = @{@"q": soql};
+    NSDictionary *queryParams = nil;
+    if (soql) {
+        queryParams = @{@"q": soql};
+    }
     NSString *path = [NSString stringWithFormat:@"/%@/query", self.apiVersion];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:queryParams];
 }


### PR DESCRIPTION
... "nil" as a value causes crash. This was causing 2 tests to fail: testSOQLError and testUploadDownloadDeleteFile.
