### PR TITLE
Send the configured passcode data for the verify case

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -437,7 +437,10 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
         }
     }
     
-    [SFSecurityLockout presentPasscodeController:SFPasscodeControllerModeVerify passcodeConfig:SFPasscodeConfigurationDataNull];
+    SFPasscodeConfigurationData configData;
+    configData.lockoutTime = [self lockoutTime];
+    configData.passcodeLength = [self passcodeLength];
+    [SFSecurityLockout presentPasscodeController:SFPasscodeControllerModeVerify passcodeConfig:configData];
     [self log:SFLogLevelInfo msg:@"Device locked."];
     sForcePasscodeDisplay = NO;
 }


### PR DESCRIPTION
Some consumers may still want to make use of passcode length and/or lockout time in their verification implementation.
