### PR TITLE
Don't let snapshot view setup/teardown issues crash the app

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -313,7 +313,12 @@ static NSString * const kAppSettingsAccountLogout = @"account_logout_pref";
         }
     }];
     
-    [self removeSnapshotView];
+    @try {
+        [self removeSnapshotView];
+    }
+    @catch (NSException *exception) {
+        [self log:SFLogLevelWarning format:@"Exception thrown while removing security snapshot view: '%@'. Will continue to resume app.", [exception reason]];
+    }
     
     BOOL shouldLogout = [[self class] logoutSettingEnabled];
     SFLoginHostUpdateResult *result = [[SFUserAccountManager sharedInstance] updateLoginHost];
@@ -377,7 +382,12 @@ static NSString * const kAppSettingsAccountLogout = @"account_logout_pref";
         }
     }];
     
-    [self removeSnapshotView];
+    @try {
+        [self removeSnapshotView];
+    }
+    @catch (NSException *exception) {
+        [self log:SFLogLevelWarning format:@"Exception thrown while removing security snapshot view: '%@'. Will continue to resume app.", [exception reason]];
+    }
 }
 
 - (void)handleAppWillResignActive:(NSNotification *)notification
@@ -391,7 +401,12 @@ static NSString * const kAppSettingsAccountLogout = @"account_logout_pref";
     }];
     
     // Set up snapshot security view, if it's configured.
-    [self setupSnapshotView];
+    @try {
+        [self setupSnapshotView];
+    }
+    @catch (NSException *exception) {
+        [self log:SFLogLevelWarning format:@"Exception thrown while setting up security snapshot view: '%@'. Continuing resign active.", [exception reason]];
+    }
 }
 
 - (void)handleAuthCompleted:(NSNotification *)notification


### PR DESCRIPTION
Sometimes the security snapshot view setup can raise an assertion, like if there's already another view transition in progress (which it has no knowledge of).  The setup and teardown of the security snapshot view should not be able to crash an app.
