### PR TITLE
Consume managed settings

### DIFF
--- a/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.h
+++ b/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.h
@@ -58,7 +58,30 @@ enum {
     kSFOAuthErrorRateLimitExceeded,
     kSFOAuthErrorUnsupportedResponseType,
     kSFOAuthErrorWrongVersion,              // credentials do not match current Connected App version in the org
-    kSFOAuthErrorBrowserLaunchFailed
+    kSFOAuthErrorBrowserLaunchFailed,
+    kSFOAuthErrorUnknownAdvancedAuthConfig
+};
+
+/**
+ Enumeration of advanced auth configuration.
+ */
+typedef NS_ENUM(NSUInteger, SFOAuthAdvancedAuthConfiguration) {
+    /**
+     Advanced authentication is not configured (default)
+     */
+    SFOAuthAdvancedAuthConfigurationNone = 0,
+    
+    /**
+     Advanced authentication is allowed.  Coordinator will attempt to retrieve advanced auth
+     configuration from the org, to determine whether to initiate advanced authentication.
+     */
+    SFOAuthAdvancedAuthConfigurationAllow,
+    
+    /**
+     Advanced authentication is required.  Coordinator will initiate advanced authentication
+     regardless of org settings.
+     */
+    SFOAuthAdvancedAuthConfigurationRequire
 };
 
 /**
@@ -246,11 +269,11 @@ typedef NS_ENUM(NSUInteger, SFOAuthAdvancedAuthState) {
 @property (nonatomic, assign) NSTimeInterval timeout;
 
 /**
- Whether or not to attempt advanced authentication.  Default is NO.  Keep the default value
- if you don't need advanced authentication options, as this requires an additional round
- trip to the service to get authentication configuration data.
+ The configuration for advanced authentication.  Default is SFOAuthAdvancedAuthConfigurationNone.
+ Keep the default value if you don't need advanced authentication options, as this requires an
+ additional round trip to the service to get authentication configuration data.
  */
-@property (nonatomic, assign) BOOL allowAdvancedAuthentication;
+@property (nonatomic, assign) SFOAuthAdvancedAuthConfiguration advancedAuthConfiguration;
 
 /**
  The current state of any in-progress advanced authentication flow.

--- a/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.m
+++ b/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.m
@@ -238,7 +238,9 @@ static NSString * const kHttpPostContentType                    = @"application/
                 // Unknown advanced auth state.
                 NSError *unknownConfigError = [[self class] errorWithType:kSFOAuthErrorTypeUnknownAdvancedAuthConfig
                                                               description:[NSString stringWithFormat:@"Unknown advanced auth config: %lu", (unsigned long)self.advancedAuthConfiguration]];
-                [self notifyDelegateOfFailure:unknownConfigError authInfo:self.authInfo];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [weakSelf notifyDelegateOfFailure:unknownConfigError authInfo:weakSelf.authInfo];
+                });
                 break;
             }
         }

--- a/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.m
+++ b/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.m
@@ -97,6 +97,7 @@ static NSString * const kSFOAuthErrorTypeUnsupportedResponseType    = @"unsuppor
 static NSString * const kSFOAuthErrorTypeTimeout                    = @"auth_timeout";
 static NSString * const kSFOAuthErrorTypeWrongVersion               = @"wrong_version";     // credentials do not match current Connected App version in the org
 static NSString * const kSFOAuthErrorTypeBrowserLaunchFailed        = @"browser_launch_failed";
+static NSString * const kSFOAuthErrorTypeUnknownAdvancedAuthConfig  = @"unknown_advanced_auth_config";
 
 static NSUInteger kSFOAuthReponseBufferLength                   = 512; // bytes
 
@@ -121,7 +122,7 @@ static NSString * const kHttpPostContentType                    = @"application/
 @synthesize scopes                      = _scopes;
 @synthesize refreshFlowConnectionTimer  = _refreshFlowConnectionTimer;
 @synthesize refreshTimerThread          = _refreshTimerThread;
-@synthesize allowAdvancedAuthentication = _allowAdvancedAuthentication;
+@synthesize advancedAuthConfiguration   = _advancedAuthConfiguration;
 @synthesize advancedAuthState           = _advancedAuthState;
 @synthesize codeVerifier                = _codeVerifier;
 @synthesize authInfo                    = _authInfo;
@@ -170,11 +171,11 @@ static NSString * const kHttpPostContentType                    = @"application/
     }
     if (self.credentials.logLevel < kSFOAuthLogLevelWarning) {
         [self log:SFLogLevelDebug format:@"%@ authenticating as %@ %@ refresh token on '%@://%@' ...",
-              NSStringFromSelector(_cmd),
-              self.credentials.clientId, (nil == self.credentials.refreshToken ? @"without" : @"with"),
-              self.credentials.protocol, self.credentials.domain];
+         NSStringFromSelector(_cmd),
+         self.credentials.clientId, (nil == self.credentials.refreshToken ? @"without" : @"with"),
+         self.credentials.protocol, self.credentials.domain];
     }
-
+    
     self.authenticating = YES;
     
     if (self.credentials.refreshToken) {
@@ -189,35 +190,57 @@ static NSString * const kHttpPostContentType                    = @"application/
         [self log:SFLogLevelDebug msg:@"Network is not available, so bypassing login"];
         NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorNotConnectedToInternet userInfo:nil];
         [self notifyDelegateOfFailure:error authInfo:self.authInfo];
-		return;
+        return;
     }
     
     if (self.credentials.refreshToken) {
         // clear any access token we may have and begin refresh flow
         [self notifyDelegateOfBeginAuthentication];
         [self.oauthCoordinatorFlow beginTokenEndpointFlow:SFOAuthTokenEndpointFlowRefresh];
-    } else if (self.allowAdvancedAuthentication) {
-        // In advanced auth mode, we have to get auth configuration settings from the org, where
-        // available, and initiate advanced auth flows, if configured.
-        __weak SFOAuthCoordinator *weakSelf = self;
-        [self.oauthCoordinatorFlow retrieveOrgAuthConfiguration:^(SFOAuthOrgAuthConfiguration *orgAuthConfig, NSError *error) {
-            if (error) {
-                // That's fatal.
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [weakSelf notifyDelegateOfFailure:error authInfo:self.authInfo];
-                });
-            } else if (orgAuthConfig.useNativeBrowserForAuth) {
-                weakSelf.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];
-                [weakSelf notifyDelegateOfBeginAuthentication];
-                [weakSelf.oauthCoordinatorFlow beginNativeBrowserFlow];
-            } else {
-                [self notifyDelegateOfBeginAuthentication];
-                [weakSelf.oauthCoordinatorFlow beginUserAgentFlow];
-            }
-        }];
     } else {
-        [self notifyDelegateOfBeginAuthentication];
-        [self.oauthCoordinatorFlow beginUserAgentFlow];
+        switch (self.advancedAuthConfiguration) {
+            case SFOAuthAdvancedAuthConfigurationNone: {
+                [self notifyDelegateOfBeginAuthentication];
+                [self.oauthCoordinatorFlow beginUserAgentFlow];
+                break;
+            }
+            case SFOAuthAdvancedAuthConfigurationAllow: {
+                __weak SFOAuthCoordinator *weakSelf = self;
+                // If advanced auth mode is allowed, we have to get auth configuration settings from the org, where
+                // available, and initiate advanced auth flows, if configured.
+                [self.oauthCoordinatorFlow retrieveOrgAuthConfiguration:^(SFOAuthOrgAuthConfiguration *orgAuthConfig, NSError *error) {
+                    if (error) {
+                        // That's fatal.
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            [weakSelf notifyDelegateOfFailure:error authInfo:self.authInfo];
+                        });
+                    } else if (orgAuthConfig.useNativeBrowserForAuth) {
+                        weakSelf.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];
+                        [weakSelf notifyDelegateOfBeginAuthentication];
+                        [weakSelf.oauthCoordinatorFlow beginNativeBrowserFlow];
+                    } else {
+                        [self notifyDelegateOfBeginAuthentication];
+                        [weakSelf.oauthCoordinatorFlow beginUserAgentFlow];
+                    }
+                }];
+                break;
+            }
+            case SFOAuthAdvancedAuthConfigurationRequire: {
+                // Advanced auth mode is required.  Begin the advanced browser flow.
+                self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];
+                [self notifyDelegateOfBeginAuthentication];
+                [self.oauthCoordinatorFlow beginNativeBrowserFlow];
+                break;
+            }
+            default: {
+                // Unknown advanced auth state.
+                NSError *unknownConfigError = [[self class] errorWithType:kSFOAuthErrorTypeUnknownAdvancedAuthConfig
+                                                              description:[NSString stringWithFormat:@"Unknown advanced auth config: %lu", (unsigned long)self.advancedAuthConfiguration]];
+                [self notifyDelegateOfFailure:unknownConfigError authInfo:self.authInfo];
+                break;
+            }
+        }
+        
     }
 }
 
@@ -920,6 +943,8 @@ static NSString * const kHttpPostContentType                    = @"application/
         code = kSFOAuthErrorWrongVersion;
     } else if ([type isEqualToString:kSFOAuthErrorTypeBrowserLaunchFailed]) {
         code = kSFOAuthErrorBrowserLaunchFailed;
+    } else if ([type isEqualToString:kSFOAuthErrorTypeUnknownAdvancedAuthConfig]) {
+        code = kSFOAuthErrorUnknownAdvancedAuthConfig;
     }
 
     NSDictionary *dict = @{kSFOAuthError: type,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -27,6 +27,7 @@
 #import "SFSecurityLockout+Internal.h"
 #import "SFRootViewManager.h"
 #import "SFSDKWebUtils.h"
+#import "SFManagedPreferences.h"
 #import <SalesforceOAuth/SFOAuthInfo.h>
 #import <SalesforceSecurity/SFPasscodeManager.h>
 #import <SalesforceSecurity/SFPasscodeProviderManager.h>
@@ -205,6 +206,9 @@ static NSString * const kAppSettingsAccountLogout = @"account_logout_pref";
         [self configureWithAppConfig];
     }
     
+    // Managed settings should override any equivalent local app settings.
+    [self configureManagedSettings];
+    
     if ([SFRootViewManager sharedManager].mainWindow == nil) {
         NSString *noWindowError = [NSString stringWithFormat:@"%@ cannot perform launch before the UIApplication main window property has been initialized.  Cannot continue.", [self class]];
         [self log:SFLogLevelError msg:noWindowError];
@@ -257,6 +261,22 @@ static NSString * const kAppSettingsAccountLogout = @"account_logout_pref";
     self.connectedAppCallbackUri = self.appConfig.oauthRedirectURI;
     self.authScopes = [self.appConfig.oauthScopes allObjects];
     self.authenticateAtLaunch = self.appConfig.shouldAuthenticate;
+}
+
+- (void)configureManagedSettings
+{
+    if ([SFManagedPreferences sharedPreferences].requireCertificateAuthentication) {
+//        [SFAuthenticationManager sharedManager].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        [SFAuthenticationManager sharedManager].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationAllow;
+    }
+    
+    if ([[SFManagedPreferences sharedPreferences].connectedAppId length] > 0) {
+        self.connectedAppId = [SFManagedPreferences sharedPreferences].connectedAppId;
+    }
+    
+    if ([[SFManagedPreferences sharedPreferences].connectedAppCallbackUri length] > 0) {
+        self.connectedAppCallbackUri = [SFManagedPreferences sharedPreferences].connectedAppCallbackUri;
+    }
 }
 
 - (void)sendLaunchError:(NSError *)theLaunchError

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -260,11 +260,11 @@ extern NSString * const kSFAuthenticationManagerFinishedNotification;
 @property (nonatomic, strong) SFIdentityCoordinator *idCoordinator;
 
 /**
- Whether or not to enable advanced authentication.  Default is NO.  Leave the default value
- unless you need advanced authentication, as it requires an additional round trip to the
+ Advanced authentication configuration.  Default is SFOAuthAdvancedAuthConfigurationNone.  Leave the
+ default value unless you need advanced authentication, as it requires an additional round trip to the
  service to retrieve org authentication configuration.
  */
-@property (nonatomic, assign) BOOL enableAdvancedAuthenticationMode;
+@property (nonatomic, assign) SFOAuthAdvancedAuthConfiguration advancedAuthConfiguration;
 
 /**
  Adds a delegate to the list of authentication manager delegates.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -274,7 +274,7 @@ static NSString * const kAlertVersionMismatchErrorKey = @"authAlertVersionMismat
 @synthesize connectedAppVersionAuthErrorHandler = _connectedAppVersionAuthErrorHandler;
 @synthesize networkFailureAuthErrorHandler = _networkFailureAuthErrorHandler;
 @synthesize genericAuthErrorHandler = _genericAuthErrorHandler;
-@synthesize enableAdvancedAuthenticationMode = _enableAdvancedAuthenticationMode;
+@synthesize advancedAuthConfiguration = _advancedAuthConfiguration;
 
 #pragma mark - Singleton initialization / management
 
@@ -511,10 +511,10 @@ static Class InstanceClass = nil;
     }
 }
 
-- (void)setEnableAdvancedAuthenticationMode:(BOOL)enableAdvancedAuthenticationMode
+- (void)setAdvancedAuthConfiguration:(SFOAuthAdvancedAuthConfiguration)advancedAuthConfiguration
 {
-    _enableAdvancedAuthenticationMode = enableAdvancedAuthenticationMode;
-    self.coordinator.allowAdvancedAuthentication = enableAdvancedAuthenticationMode;
+    _advancedAuthConfiguration = advancedAuthConfiguration;
+    self.coordinator.advancedAuthConfiguration = advancedAuthConfiguration;
 }
 
 - (BOOL)handleAdvancedAuthenticationResponse:(NSURL *)appUrlResponse
@@ -791,7 +791,7 @@ static Class InstanceClass = nil;
     self.coordinator.delegate = nil;
     self.coordinator = [[SFOAuthCoordinator alloc] initWithCredentials:account.credentials];
     self.coordinator.scopes = account.accessScopes;
-    self.coordinator.allowAdvancedAuthentication = self.enableAdvancedAuthenticationMode;
+    self.coordinator.advancedAuthConfiguration = self.advancedAuthConfiguration;
     self.coordinator.delegate = self;
     
     // re-create the identity coordinator for the current user

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.m
@@ -75,7 +75,7 @@ static NSString * const kManagedKeyConnectedAppCallbackUri = @"ManagedAppCallbac
 }
 
 - (BOOL)requireCertificateAuthentication {
-    return self.rawPreferences[kManagedKeyRequireCertAuth];
+    return [self.rawPreferences[kManagedKeyRequireCertAuth] boolValue];
 }
 
 - (NSArray *)loginHosts {


### PR DESCRIPTION
- Changed advanced auth to be a tri-state check—managed settings will short-circuit the process to go into advanced authentication.

- Consuming any OAuth Consumer Key and OAuth Redirect URI values sent by MDM.