### PR TITLE
Option to not overwrite dirty records during sync down

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartSyncPlugin/SFSmartSyncPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartSyncPlugin/SFSmartSyncPlugin.m
@@ -118,10 +118,11 @@ NSString * const kSyncDetail = @"detail";
 {
     [self runCommand:^(NSDictionary* argsDict) {
         NSString *soupName = [argsDict nonNullObjectForKey:kSyncSoupNameArg];
+        SFSyncOptions *options = [SFSyncOptions newFromDict:[argsDict nonNullObjectForKey:kSyncOptionsArg]];
         SFSyncTarget *target = [SFSyncTarget newFromDict:[argsDict nonNullObjectForKey:kSyncTargetArg]];
         
         __weak SFSmartSyncPlugin *weakSelf = self;
-        SFSyncState* sync = [self.syncManager syncDownWithTarget:target soupName:soupName updateBlock:^(SFSyncState* sync) {
+        SFSyncState* sync = [self.syncManager syncDownWithOptions:options target:target soupName:soupName updateBlock:^(SFSyncState* sync) {
             [weakSelf handleSyncUpdate:sync];
         }];
         [self log:SFLogLevelDebug format:@"syncDown # %d from soup: %@", sync.syncId, soupName];

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
@@ -23,6 +23,8 @@
  */
 
 #import "SFSyncState.h"
+#import "SFSyncOptions.h"
+#import "SFSyncTarget.h"
 
 @class SFUserAccount;
 
@@ -65,7 +67,7 @@ typedef void (^SFSyncSyncManagerUpdateBlock) (SFSyncState* sync);
 
 /** Create and run a sync down
  */
-- (SFSyncState*) syncDownWithTarget:(SFSyncTarget*)target soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+- (SFSyncState*) syncDownWithOptions:(SFSyncOptions*)options target:(SFSyncTarget*)target soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
 
 /** Create and run a sync up
  */

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -359,7 +359,7 @@ dispatch_queue_t queue;
     NSString* dirtyRecordSql = [NSString stringWithFormat:@"SELECT {%@:%@} FROM {%@} WHERE {%@:%@} = '1'", soupName, idField, soupName, soupName, kSyncManagerLocal];
     SFQuerySpec* querySpec = [SFQuerySpec newSmartQuerySpec:dirtyRecordSql withPageSize:kSyncManagerPageSize];
     
-    BOOL hasMore = TRUE;
+    BOOL hasMore = YES;
     for (NSUInteger pageIndex=0; hasMore; pageIndex++) {
         NSArray* results = [self.store queryWithQuerySpec:querySpec pageIndex:pageIndex error:nil];
         hasMore = (results.count == kSyncManagerPageSize);

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncOptions.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncOptions.h
@@ -24,14 +24,18 @@
 
 #import <Foundation/Foundation.h>
 
+#import "SFSyncState.h"
+
 extern NSString * const kSFSyncOptionsFieldlist;
 
 @interface SFSyncOptions : NSObject
 
 @property (nonatomic, strong, readonly) NSArray*  fieldlist;
+@property (nonatomic, readonly) SFSyncStateMergeMode mergeMode;
 
 /** Factory methods
  */
++ (SFSyncOptions*) newSyncOptionsForSyncDown:(SFSyncStateMergeMode)mergeMode;
 + (SFSyncOptions*) newSyncOptionsForSyncUp:(NSArray*)fieldlist;
 
 /** Methods to translate to/from dictionary

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncOptions.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncOptions.m
@@ -25,10 +25,13 @@
 #import "SFSyncOptions.h"
 
 NSString * const kSFSyncOptionsFieldlist = @"fieldlist";
+NSString * const kSFSyncOptionsMergeMode = @"mergeMode";
 
 @interface SFSyncOptions ()
 
 @property (nonatomic, strong, readwrite) NSArray*  fieldlist;
+@property (nonatomic, readwrite) SFSyncStateMergeMode mergeMode;
+
 
 // true when initiazed from empty dictionary
 @property (nonatomic) BOOL isUndefined;
@@ -42,9 +45,18 @@ NSString * const kSFSyncOptionsFieldlist = @"fieldlist";
 + (SFSyncOptions*) newSyncOptionsForSyncUp:(NSArray*)fieldlist {
     SFSyncOptions* syncOptions = [[SFSyncOptions alloc] init];
     syncOptions.fieldlist = fieldlist;
+    syncOptions.mergeMode = SFSyncStateMergeModeOverwrite;
     syncOptions.isUndefined = NO;
     return syncOptions;
 }
+
++ (SFSyncOptions*) newSyncOptionsForSyncDown:(SFSyncStateMergeMode)mergeMode {
+    SFSyncOptions* syncOptions = [[SFSyncOptions alloc] init];
+    syncOptions.mergeMode = mergeMode;
+    syncOptions.isUndefined = NO;
+    return syncOptions;
+}
+
 
 #pragma mark - From/to dictionary
 
@@ -57,6 +69,7 @@ NSString * const kSFSyncOptionsFieldlist = @"fieldlist";
         }
         else {
             syncOptions.isUndefined = NO;
+            syncOptions.mergeMode = [SFSyncState mergeModeFromString:dict[kSFSyncOptionsMergeMode]];
             syncOptions.fieldlist = dict[kSFSyncOptionsFieldlist];
         }
     }
@@ -64,7 +77,8 @@ NSString * const kSFSyncOptionsFieldlist = @"fieldlist";
 }
 
 - (NSDictionary*) asDict {
-    NSDictionary* dict = self.isUndefined ? @{} : @{ kSFSyncOptionsFieldlist: self.fieldlist };
+    NSDictionary* dict = self.isUndefined ? @{} : @{ kSFSyncOptionsFieldlist: self.fieldlist,
+                                                     kSFSyncOptionsMergeMode: [SFSyncState mergeModeToString:self.mergeMode]};
     return dict;
 }
 

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -23,9 +23,9 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SFSyncTarget.h"
-#import "SFSyncOptions.h"
 
+@class SFSyncTarget;
+@class SFSyncOptions;
 @class SFSmartStore;
 
 // soups and soup fields
@@ -64,6 +64,16 @@ extern NSString * const kSFSyncStateStatusRunning;
 extern NSString * const kSFSyncStateStatusDone;
 extern NSString * const kSFSyncStateStatusFailed;
 
+// Possible value for merge mode
+typedef enum {
+    SFSyncStateMergeModeOverwrite,
+    SFSyncStateMergeModeLeaveIfChanged
+    
+} SFSyncStateMergeMode;
+
+extern NSString * const kSFSyncStateMergeModeOverwrite;
+extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
+
 @interface SFSyncState : NSObject
 
 @property (nonatomic, readonly) NSInteger syncId;
@@ -81,7 +91,7 @@ extern NSString * const kSFSyncStateStatusFailed;
 
 /** Factory methods
  */
-+ (SFSyncState*) newSyncDownWithTarget:(SFSyncTarget*)target soupName:(NSString*)soupName store:(SFSmartStore*)store;
++ (SFSyncState*) newSyncDownWithOptions:(SFSyncOptions*)options target:(SFSyncTarget*)target soupName:(NSString*)soupName store:(SFSmartStore*)store;
 + (SFSyncState*) newSyncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName store:(SFSmartStore*)store;
 
 /** Methods to save/retrieve from smartstore
@@ -106,5 +116,7 @@ extern NSString * const kSFSyncStateStatusFailed;
 + (NSString*) syncTypeToString:(SFSyncStateSyncType)syncType;
 + (SFSyncStateStatus) syncStatusFromString:(NSString*)syncStatus;
 + (NSString*) syncStatusToString:(SFSyncStateStatus)syncStatus;
++ (SFSyncStateMergeMode) mergeModeFromString:(NSString*)mergeMode;
++ (NSString*) mergeModeToString:(SFSyncStateMergeMode)mergeMode;
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -23,6 +23,8 @@
  */
 
 #import "SFSyncState.h"
+#import "SFSyncTarget.h"
+#import "SFSyncOptions.h"
 #import <SalesforceSDKCore/SFSmartStore.h>
 #import <SalesforceSDKCore/SFSoupIndex.h>
 
@@ -50,6 +52,10 @@ NSString * const kSFSyncStateStatusRunning = @"RUNNING";
 NSString * const kSFSyncStateStatusDone = @"DONE";
 NSString * const kSFSyncStateStatusFailed = @"FAILED";
 
+// Possible value for merge mode
+NSString * const kSFSyncStateMergeModeOverwrite = @"OVERWRITE";
+NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
+
 @interface SFSyncState ()
 
 @property (nonatomic, readwrite) NSInteger syncId;
@@ -76,12 +82,12 @@ NSString * const kSFSyncStateStatusFailed = @"FAILED";
 
 #pragma mark - Factory methods
 
-+ (SFSyncState*) newSyncDownWithTarget:(SFSyncTarget*)target soupName:(NSString*)soupName store:(SFSmartStore*)store {
++ (SFSyncState*) newSyncDownWithOptions:(SFSyncOptions*)options target:(SFSyncTarget*)target soupName:(NSString*)soupName store:(SFSmartStore*)store {
     NSDictionary* dict = @{
                            kSFSyncStateType: kSFSyncStateTypeDown,
                            kSFSyncStateTarget: [target asDict],
                            kSFSyncStateSoupName: soupName,
-                           kSFSyncStateOptions: @{},
+                           kSFSyncStateOptions: [options asDict],
                            kSFSyncStateStatus: kSFSyncStateStatusNew,
                            kSFSyncStateProgress: [NSNumber numberWithInteger:0],
                            kSFSyncStateTotalSize: [NSNumber numberWithInteger:-1]
@@ -211,5 +217,23 @@ NSString * const kSFSyncStateStatusFailed = @"FAILED";
         case SFSyncStateStatusFailed: return kSFSyncStateStatusFailed;
     }
 }
+
+#pragma mark - string to/from enum for merge mode
+
++ (SFSyncStateMergeMode) mergeModeFromString:(NSString*)mergeMode {
+    if ([mergeMode isEqualToString:kSFSyncStateMergeModeLeaveIfChanged]) {
+        return SFSyncStateMergeModeLeaveIfChanged;
+    }
+    // if ([mergeMode isEqualToString:kSFSyncStateMergeModeOverwrite]) {
+    return SFSyncStateMergeModeOverwrite;
+}
+
++ (NSString*) mergeModeToString:(SFSyncStateMergeMode)mergeMode {
+    switch (mergeMode) {
+        case SFSyncStateMergeModeLeaveIfChanged: return kSFSyncStateMergeModeLeaveIfChanged;
+        case SFSyncStateMergeModeOverwrite: return kSFSyncStateMergeModeOverwrite;
+    }
+}
+
 
 @end

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/Data/SObjectDataManager.m
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/Data/SObjectDataManager.m
@@ -72,9 +72,10 @@ static char* const kSearchFilterQueueName = "com.salesforce.smartSyncExplorer.se
     }
     
     NSString *soqlQuery = [NSString stringWithFormat:@"SELECT %@ FROM %@ LIMIT %d", [self.dataSpec.fieldNames componentsJoinedByString:@","], self.dataSpec.objectType, kSyncLimit];
+    SFSyncOptions *syncOptions = [SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged];
     SFSyncTarget *syncTarget = [SFSyncTarget newSyncTargetForSOQLSyncDown:soqlQuery];
     __weak SObjectDataManager *weakSelf = self;
-    [self.syncMgr syncDownWithTarget:syncTarget soupName:self.dataSpec.soupName updateBlock:^(SFSyncState* sync) {
+    [self.syncMgr syncDownWithOptions:syncOptions target:syncTarget soupName:self.dataSpec.soupName updateBlock:^(SFSyncState* sync) {
         if ([sync isDone] || [sync hasFailed]) {
             [weakSelf refreshLocalData];
         }


### PR DESCRIPTION
Also sync up is no longer fetching all dirty records - instead it fetches all the ids