### PR TITLE
Implement login hosts

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.m
@@ -80,11 +80,19 @@ static NSString * const kManagedKeyClearClipboardOnBackground = @"ClearClipboard
 }
 
 - (NSArray *)loginHosts {
-    return self.rawPreferences[kManagedKeyLoginHosts];
+    id objLoginHosts = self.rawPreferences[kManagedKeyLoginHosts];
+    if ([objLoginHosts isKindOfClass:[NSString class]]) {
+        objLoginHosts = @[ objLoginHosts ];
+    }
+    return objLoginHosts;
 }
 
 - (NSArray *)loginHostLabels {
-    return self.rawPreferences[kManagedKeyLoginHostLabels];
+    id objLoginHostLabels = self.rawPreferences[kManagedKeyLoginHostLabels];
+    if ([objLoginHostLabels isKindOfClass:[NSString class]]) {
+        objLoginHostLabels = @[ objLoginHostLabels ];
+    }
+    return objLoginHostLabels;
 }
 
 - (NSString *)connectedAppId {


### PR DESCRIPTION
- Allow managed login host properties to consume a backing string or array of strings.
- Use the first managed login host, if present, as the default host when the app is launched for the first time.