### PR TITLE
Changing podspec to refer to tag

### DIFF
--- a/SalesforceMobileSDK-iOS.podspec
+++ b/SalesforceMobileSDK-iOS.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "6.0"
 
   s.source       = { :git => "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git",
-                     :branch => "unstable",
+                     :tag => "v#{s.version}",
                      :submodules => true }
 
   s.prepare_command = <<-CMD


### PR DESCRIPTION
Looking through the [Podspec Syntax Reference](http://guides.cocoapods.org/syntax/podspec.html), I notice that there's no specification of `branch` in there.  Looks like you only override that location in your [Podfile definition](http://guides.cocoapods.org/using/the-podfile.html).  So I'm switching to the more common `tag` specification for the pod spec.  We were also pointing to the wrong branch anyway. ;-)