### PR TITLE
Removing decimal portion to avoid error when running install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,9 +32,9 @@ then
     echo "Could not determine Xcode version.  Is xcodebuild on your path?"
     exit 3
 fi
-xcode_ver_num=`echo $xcode_ver | sed 's/^Xcode \([0-9][0-9]*\)\.\([0-9][0-9]*\)/\1\2/'`
+xcode_ver_num=`echo $xcode_ver | sed 's/^Xcode \([0-9][0-9]*\)\.\([0-9][0-9]*\).*$/\1\2/'`
 xcode_ver_str=`echo $xcode_ver | sed 's/^Xcode //'`
-if [[ ${xcode_ver_num%.*} -lt $XCODE_MIN_VERSION ]]
+if [[ $xcode_ver_num -lt $XCODE_MIN_VERSION ]]
 then
     echo "Current configured Xcode version ($xcode_ver_str) is less than the minimum required version ($XCODE_MIN_VERSION_STR)."
     exit 4

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ then
     echo "Could not determine iOS SDK version.  Is xcodebuild on your path?"
     exit 1
 fi
-ios_ver_num=`echo $ios_ver | sed 's/SDKVersion: \([0-9][0-9]*\)\.\([0-9][0-9]*\)/\1\2/'`
+ios_ver_num=`echo $ios_ver | sed 's/SDKVersion: \([0-9][0-9]*\)\.\([0-9][0-9]*\).*$/\1\2/'`
 ios_ver_str=`echo $ios_ver | sed 's/SDKVersion: //'`
 if [[ $ios_ver_num -lt $IOS_MIN_VERSION_NUM ]]
 then

--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ then
 fi
 xcode_ver_num=`echo $xcode_ver | sed 's/^Xcode \([0-9][0-9]*\)\.\([0-9][0-9]*\)/\1\2/'`
 xcode_ver_str=`echo $xcode_ver | sed 's/^Xcode //'`
-if [[ $xcode_ver_num -lt $XCODE_MIN_VERSION ]]
+if [[ ${xcode_ver_num%.*} -lt $XCODE_MIN_VERSION ]]
 then
     echo "Current configured Xcode version ($xcode_ver_str) is less than the minimum required version ($XCODE_MIN_VERSION_STR)."
     exit 4


### PR DESCRIPTION
If your xcode_ver_num has a decimal portion (mine is 61.1) then you would get the following error:
./install.sh: line 37: [[: 61.1: syntax error: invalid arithmetic operator (error token is ".1")

