### PR TITLE
Refactoring of SFSyncTarget (first part)

### DIFF
--- a/libs/SmartSync/SmartSync.xcodeproj/project.pbxproj
+++ b/libs/SmartSync/SmartSync.xcodeproj/project.pbxproj
@@ -27,6 +27,12 @@
 		4F1283731A018ED9007F87EC /* SFSyncTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F12836F1A018ED9007F87EC /* SFSyncTarget.m */; };
 		4F1283741A018ED9007F87EC /* SFSyncOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F1283701A018ED9007F87EC /* SFSyncOptions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4F1283751A018ED9007F87EC /* SFSyncTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F1283711A018ED9007F87EC /* SFSyncTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4F1FD0781A8D7E9B006E1795 /* SFSoslSyncTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F1FD0721A8D7E9B006E1795 /* SFSoslSyncTarget.m */; };
+		4F1FD0791A8D7E9B006E1795 /* SFSoqlSyncTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F1FD0731A8D7E9B006E1795 /* SFSoqlSyncTarget.m */; };
+		4F1FD07A1A8D7E9B006E1795 /* SFMruSyncTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F1FD0741A8D7E9B006E1795 /* SFMruSyncTarget.m */; };
+		4F1FD07B1A8D7E9B006E1795 /* SFSoqlSyncTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F1FD0751A8D7E9B006E1795 /* SFSoqlSyncTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4F1FD07C1A8D7E9B006E1795 /* SFSoslSyncTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F1FD0761A8D7E9B006E1795 /* SFSoslSyncTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4F1FD07D1A8D7E9B006E1795 /* SFMruSyncTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F1FD0771A8D7E9B006E1795 /* SFMruSyncTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4F22155C19DF4BAD00FF2D26 /* SFSmartSyncSyncManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F22155A19DF4BAD00FF2D26 /* SFSmartSyncSyncManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4F22155D19DF4BAD00FF2D26 /* SFSmartSyncSyncManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F22155B19DF4BAD00FF2D26 /* SFSmartSyncSyncManager.m */; };
 		4F3A72EF19DB89CF00E6F468 /* libSalesforceRestAPI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F3A72EE19DB89CF00E6F468 /* libSalesforceRestAPI.a */; };
@@ -102,6 +108,12 @@
 		4F12836F1A018ED9007F87EC /* SFSyncTarget.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSyncTarget.m; sourceTree = "<group>"; };
 		4F1283701A018ED9007F87EC /* SFSyncOptions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSyncOptions.h; sourceTree = "<group>"; };
 		4F1283711A018ED9007F87EC /* SFSyncTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSyncTarget.h; sourceTree = "<group>"; };
+		4F1FD0721A8D7E9B006E1795 /* SFSoslSyncTarget.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSoslSyncTarget.m; sourceTree = "<group>"; };
+		4F1FD0731A8D7E9B006E1795 /* SFSoqlSyncTarget.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSoqlSyncTarget.m; sourceTree = "<group>"; };
+		4F1FD0741A8D7E9B006E1795 /* SFMruSyncTarget.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFMruSyncTarget.m; sourceTree = "<group>"; };
+		4F1FD0751A8D7E9B006E1795 /* SFSoqlSyncTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSoqlSyncTarget.h; sourceTree = "<group>"; };
+		4F1FD0761A8D7E9B006E1795 /* SFSoslSyncTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSoslSyncTarget.h; sourceTree = "<group>"; };
+		4F1FD0771A8D7E9B006E1795 /* SFMruSyncTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFMruSyncTarget.h; sourceTree = "<group>"; };
 		4F22155A19DF4BAD00FF2D26 /* SFSmartSyncSyncManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFSmartSyncSyncManager.h; path = Manager/SFSmartSyncSyncManager.h; sourceTree = "<group>"; };
 		4F22155B19DF4BAD00FF2D26 /* SFSmartSyncSyncManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFSmartSyncSyncManager.m; path = Manager/SFSmartSyncSyncManager.m; sourceTree = "<group>"; };
 		4F3A72EE19DB89CF00E6F468 /* libSalesforceRestAPI.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libSalesforceRestAPI.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -346,6 +358,12 @@
 		CEF50A84196B3EB60076264C /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				4F1FD0721A8D7E9B006E1795 /* SFSoslSyncTarget.m */,
+				4F1FD0731A8D7E9B006E1795 /* SFSoqlSyncTarget.m */,
+				4F1FD0741A8D7E9B006E1795 /* SFMruSyncTarget.m */,
+				4F1FD0751A8D7E9B006E1795 /* SFSoqlSyncTarget.h */,
+				4F1FD0761A8D7E9B006E1795 /* SFSoslSyncTarget.h */,
+				4F1FD0771A8D7E9B006E1795 /* SFMruSyncTarget.h */,
 				4F12836E1A018ED9007F87EC /* SFSyncOptions.m */,
 				4F12836F1A018ED9007F87EC /* SFSyncTarget.m */,
 				4F1283701A018ED9007F87EC /* SFSyncOptions.h */,
@@ -375,8 +393,10 @@
 			files = (
 				82722FFF19D4FD170066A350 /* SFSmartSyncMetadataManager.h in Headers */,
 				8272300019D4FD170066A350 /* SFSmartSyncCacheManager.h in Headers */,
+				4F1FD07D1A8D7E9B006E1795 /* SFMruSyncTarget.h in Headers */,
 				4F22155C19DF4BAD00FF2D26 /* SFSmartSyncSyncManager.h in Headers */,
 				8272300219D4FD170066A350 /* SFObject.h in Headers */,
+				4F1FD07B1A8D7E9B006E1795 /* SFSoqlSyncTarget.h in Headers */,
 				4F1283741A018ED9007F87EC /* SFSyncOptions.h in Headers */,
 				8272300319D4FD170066A350 /* SFObjectType.h in Headers */,
 				8272300419D4FD170066A350 /* SFObjectTypeLayout.h in Headers */,
@@ -384,6 +404,7 @@
 				8272300619D4FD170066A350 /* SFSmartSyncConstants.h in Headers */,
 				4F1283751A018ED9007F87EC /* SFSyncTarget.h in Headers */,
 				8272300719D4FD170066A350 /* SFSmartSyncSoqlBuilder.h in Headers */,
+				4F1FD07C1A8D7E9B006E1795 /* SFSoslSyncTarget.h in Headers */,
 				820789241A1D26D9009E9831 /* SFSmartSyncPersistableObject+Internal.h in Headers */,
 				8272300819D4FD170066A350 /* SFSmartSyncSoslBuilder.h in Headers */,
 				4F12836C1A004A1B007F87EC /* SFSyncState.h in Headers */,
@@ -506,6 +527,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				820789221A1D2555009E9831 /* SFSmartSyncPersistableObject.m in Sources */,
+				4F1FD07A1A8D7E9B006E1795 /* SFMruSyncTarget.m in Sources */,
 				4F12836D1A004A1B007F87EC /* SFSyncState.m in Sources */,
 				CECDF84119A5468E007A29E5 /* SFSmartSyncObjectUtils.m in Sources */,
 				CEF50A91196B57190076264C /* SFSmartSyncSoqlBuilder.m in Sources */,
@@ -516,6 +538,8 @@
 				CEDA4EE319747AC30009D865 /* SFSmartSyncCacheManager.m in Sources */,
 				4F1283721A018ED9007F87EC /* SFSyncOptions.m in Sources */,
 				CEF50A89196B3EB60076264C /* SFObjectTypeLayout.m in Sources */,
+				4F1FD0781A8D7E9B006E1795 /* SFSoslSyncTarget.m in Sources */,
+				4F1FD0791A8D7E9B006E1795 /* SFSoqlSyncTarget.m in Sources */,
 				CEF50A92196B57190076264C /* SFSmartSyncSoslBuilder.m in Sources */,
 				CEF50A87196B3EB60076264C /* SFObject.m in Sources */,
 				CEB808B8199AFD1900EF2F9D /* SFSmartSyncMetadataManager.m in Sources */,

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -33,6 +33,11 @@
 #import <SalesforceSDKCore/SFJsonUtils.h>
 #import <SalesforceRestAPI/SFRestAPI+Blocks.h>
 
+// Will go away once we are done refactoring SFSyncTarget
+#import "SFMruSyncTarget.h"
+#import "SFSoqlSyncTarget.h"
+#import "SFSoslSyncTarget.h"
+
 // For user agent
 NSString * const kUserAgent = @"User-Agent";
 NSString * const kSmartSync = @"SmartSync";
@@ -280,13 +285,13 @@ static NSMutableDictionary *syncMgrList = nil;
     
     switch (target.queryType) {
         case SFSyncTargetQueryTypeMru:
-            [self syncDownMru:mergeMode objectType:target.objectType fieldlist:target.fieldlist soup:soupName updateSync:updateSync failRest:failRest];
+            [self syncDownMru:mergeMode objectType:((SFMruSyncTarget*) target).objectType fieldlist:((SFMruSyncTarget*) target).fieldlist soup:soupName updateSync:updateSync failRest:failRest];
             break;
         case SFSyncTargetQueryTypeSoql:
-            [self syncDownSoql:mergeMode query:target.query soup:soupName updateSync:updateSync failRest:failRest maxTimeStamp:sync.maxTimeStamp];
+            [self syncDownSoql:mergeMode query:((SFSoqlSyncTarget*) target).query soup:soupName updateSync:updateSync failRest:failRest maxTimeStamp:sync.maxTimeStamp];
             break;
         case SFSyncTargetQueryTypeSosl:
-            [self syncDownSosl:mergeMode query:target.query soup:soupName updateSync:updateSync failRest:failRest];
+            [self syncDownSosl:mergeMode query:((SFSoslSyncTarget*) target).query soup:soupName updateSync:updateSync failRest:failRest];
             break;
     }
 }

--- a/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncTarget.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ Copyright (c) 2015, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -23,31 +23,18 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "SFSyncTarget.h"
 
-typedef enum {
-  SFSyncTargetQueryTypeMru,
-  SFSyncTargetQueryTypeSosl,
-  SFSyncTargetQueryTypeSoql
-} SFSyncTargetQueryType;
+extern NSString * const kSFSyncTargetFieldlist;
 
-extern NSString * const kSFSyncTargetQueryType;
+@interface SFMruSyncTarget : SFSyncTarget
 
-@interface SFSyncTarget : NSObject
+@property (nonatomic, strong, readonly) NSString* objectType;
+@property (nonatomic, strong, readonly) NSArray*  fieldlist;
 
-@property (nonatomic)         SFSyncTargetQueryType queryType;
-
-// True when initialized from empty dictionary
-@property (nonatomic) BOOL    isUndefined;
-
-
-/** Methods to translate to/from dictionary
+/** Factory methods
  */
-+ (SFSyncTarget*) newFromDict:(NSDictionary *)dict;
-- (NSDictionary*) asDict;
-
-/** Enum to/from string helper methods
- */
-+ (SFSyncTargetQueryType) queryTypeFromString:(NSString*)queryType;
-+ (NSString*) queryTypeToString:(SFSyncTargetQueryType)queryType;
++ (SFMruSyncTarget*) newSyncTarget:(NSString*)objectType fieldlist:(NSArray*)fieldlist;
++ (SFMruSyncTarget*) newFromDict:(NSDictionary *)dict;
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncTarget.m
@@ -1,0 +1,86 @@
+/*
+ Copyright (c) 2015, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFMruSyncTarget.h"
+
+NSString * const kSFSyncTargetObjectType = @"sobjectType";
+NSString * const kSFSyncTargetFieldlist = @"fieldlist";
+
+@interface SFMruSyncTarget ()
+
+@property (nonatomic, strong, readwrite) NSString* objectType;
+@property (nonatomic, strong, readwrite) NSArray*  fieldlist;
+
+@end
+
+@implementation SFMruSyncTarget
+
+#pragma mark - Factory methods
+
++ (SFMruSyncTarget*) newSyncTarget:(NSString*)objectType fieldlist:(NSArray*)fieldlist {
+    SFMruSyncTarget* syncTarget = [[SFMruSyncTarget alloc] init];
+    syncTarget.queryType = SFSyncTargetQueryTypeMru;
+    syncTarget.objectType = objectType;
+    syncTarget.fieldlist = fieldlist;
+    syncTarget.isUndefined = NO;
+    return syncTarget;
+}
+
+#pragma mark - From/to dictionary
+
++ (SFMruSyncTarget*) newFromDict:(NSDictionary*)dict {
+    SFMruSyncTarget* syncTarget = [[SFMruSyncTarget alloc] init];
+    if (syncTarget) {
+        if (dict == nil || [dict count] == 0) {
+            syncTarget.isUndefined = YES;
+        }
+        else {
+            syncTarget.isUndefined = NO;
+            syncTarget.queryType = SFSyncTargetQueryTypeMru;
+            syncTarget.objectType = dict[kSFSyncTargetObjectType];
+            syncTarget.fieldlist = dict[kSFSyncTargetFieldlist];
+        }
+    }
+    
+    return syncTarget;
+}
+
+- (NSDictionary*) asDict {
+    NSDictionary* dict;
+
+    if (self.isUndefined) {
+        dict = @{};
+    }
+    else {
+        dict = @{
+        kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
+        kSFSyncTargetObjectType: self.objectType,
+        kSFSyncTargetFieldlist: self.fieldlist
+        };
+    }
+
+    return dict;
+}
+
+@end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncTarget.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ Copyright (c) 2015, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -23,31 +23,17 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "SFSyncTarget.h"
 
-typedef enum {
-  SFSyncTargetQueryTypeMru,
-  SFSyncTargetQueryTypeSosl,
-  SFSyncTargetQueryTypeSoql
-} SFSyncTargetQueryType;
+extern NSString * const kSFSoqlSyncTargetQuery;
 
-extern NSString * const kSFSyncTargetQueryType;
+@interface SFSoqlSyncTarget : SFSyncTarget
 
-@interface SFSyncTarget : NSObject
+@property (nonatomic, strong, readonly) NSString* query;
 
-@property (nonatomic)         SFSyncTargetQueryType queryType;
-
-// True when initialized from empty dictionary
-@property (nonatomic) BOOL    isUndefined;
-
-
-/** Methods to translate to/from dictionary
+/** Factory methods
  */
-+ (SFSyncTarget*) newFromDict:(NSDictionary *)dict;
-- (NSDictionary*) asDict;
-
-/** Enum to/from string helper methods
- */
-+ (SFSyncTargetQueryType) queryTypeFromString:(NSString*)queryType;
-+ (NSString*) queryTypeToString:(SFSyncTargetQueryType)queryType;
++ (SFSoqlSyncTarget*) newSyncTarget:(NSString*)query;
++ (SFSoqlSyncTarget*) newFromDict:(NSDictionary *)dict;
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncTarget.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ Copyright (c) 2015, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -22,32 +22,61 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <Foundation/Foundation.h>
+#import "SFsoqlSyncTarget.h"
 
-typedef enum {
-  SFSyncTargetQueryTypeMru,
-  SFSyncTargetQueryTypeSosl,
-  SFSyncTargetQueryTypeSoql
-} SFSyncTargetQueryType;
+NSString * const kSFSoqlSyncTargetQuery = @"query";
 
-extern NSString * const kSFSyncTargetQueryType;
+@interface SFSoqlSyncTarget ()
 
-@interface SFSyncTarget : NSObject
+@property (nonatomic, strong, readwrite) NSString* query;
 
-@property (nonatomic)         SFSyncTargetQueryType queryType;
+@end
 
-// True when initialized from empty dictionary
-@property (nonatomic) BOOL    isUndefined;
+@implementation SFSoqlSyncTarget
+
+#pragma mark - Factory methods
+
++ (SFSoqlSyncTarget*) newSyncTarget:(NSString*)query {
+    SFSoqlSyncTarget* syncTarget = [[SFSoqlSyncTarget alloc] init];
+    syncTarget.queryType = SFSyncTargetQueryTypeSoql;
+    syncTarget.query = query;
+    syncTarget.isUndefined = NO;
+    return syncTarget;
+}
 
 
-/** Methods to translate to/from dictionary
- */
-+ (SFSyncTarget*) newFromDict:(NSDictionary *)dict;
-- (NSDictionary*) asDict;
+#pragma mark - From/to dictionary
 
-/** Enum to/from string helper methods
- */
-+ (SFSyncTargetQueryType) queryTypeFromString:(NSString*)queryType;
-+ (NSString*) queryTypeToString:(SFSyncTargetQueryType)queryType;
++ (SFSoqlSyncTarget*) newFromDict:(NSDictionary*)dict {
+    SFSoqlSyncTarget* syncTarget = [[SFSoqlSyncTarget alloc] init];
+    if (syncTarget) {
+        if (dict == nil || [dict count] == 0) {
+            syncTarget.isUndefined = YES;
+        }
+        else {
+            syncTarget.isUndefined = NO;
+            syncTarget.queryType = SFSyncTargetQueryTypeSoql;
+            syncTarget.query = dict[kSFSoqlSyncTargetQuery];
+        }
+    }
+    
+    return syncTarget;
+}
+
+- (NSDictionary*) asDict {
+    NSDictionary* dict;
+
+    if (self.isUndefined) {
+        dict = @{};
+    }
+    else {
+        dict = @{
+        kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
+        kSFSoqlSyncTargetQuery: self.query
+        };
+    }
+
+    return dict;
+}
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncTarget.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ Copyright (c) 2015, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -23,31 +23,17 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "SFSyncTarget.h"
 
-typedef enum {
-  SFSyncTargetQueryTypeMru,
-  SFSyncTargetQueryTypeSosl,
-  SFSyncTargetQueryTypeSoql
-} SFSyncTargetQueryType;
+extern NSString * const kSFSoslSyncTargetQuery;
 
-extern NSString * const kSFSyncTargetQueryType;
+@interface SFSoslSyncTarget : SFSyncTarget
 
-@interface SFSyncTarget : NSObject
+@property (nonatomic, strong, readonly) NSString* query;
 
-@property (nonatomic)         SFSyncTargetQueryType queryType;
-
-// True when initialized from empty dictionary
-@property (nonatomic) BOOL    isUndefined;
-
-
-/** Methods to translate to/from dictionary
+/** Factory methods
  */
-+ (SFSyncTarget*) newFromDict:(NSDictionary *)dict;
-- (NSDictionary*) asDict;
-
-/** Enum to/from string helper methods
- */
-+ (SFSyncTargetQueryType) queryTypeFromString:(NSString*)queryType;
-+ (NSString*) queryTypeToString:(SFSyncTargetQueryType)queryType;
++ (SFSoslSyncTarget*) newSyncTarget:(NSString*)query;
++ (SFSoslSyncTarget*) newFromDict:(NSDictionary *)dict;
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncTarget.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2014, salesforce.com, inc. All rights reserved.
+ Copyright (c) 2015, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -22,32 +22,61 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <Foundation/Foundation.h>
+#import "SFSoslSyncTarget.h"
 
-typedef enum {
-  SFSyncTargetQueryTypeMru,
-  SFSyncTargetQueryTypeSosl,
-  SFSyncTargetQueryTypeSoql
-} SFSyncTargetQueryType;
+NSString * const kSFSoslSyncTargetQuery = @"query";
 
-extern NSString * const kSFSyncTargetQueryType;
+@interface SFSoslSyncTarget ()
 
-@interface SFSyncTarget : NSObject
+@property (nonatomic, strong, readwrite) NSString* query;
 
-@property (nonatomic)         SFSyncTargetQueryType queryType;
+@end
 
-// True when initialized from empty dictionary
-@property (nonatomic) BOOL    isUndefined;
+@implementation SFSoslSyncTarget
+
+#pragma mark - Factory methods
+
++ (SFSoslSyncTarget*) newSyncTarget:(NSString*)query {
+    SFSoslSyncTarget* syncTarget = [[SFSoslSyncTarget alloc] init];
+    syncTarget.queryType = SFSyncTargetQueryTypeSosl;
+    syncTarget.query = query;
+    syncTarget.isUndefined = NO;
+    return syncTarget;
+}
 
 
-/** Methods to translate to/from dictionary
- */
-+ (SFSyncTarget*) newFromDict:(NSDictionary *)dict;
-- (NSDictionary*) asDict;
+#pragma mark - From/to dictionary
 
-/** Enum to/from string helper methods
- */
-+ (SFSyncTargetQueryType) queryTypeFromString:(NSString*)queryType;
-+ (NSString*) queryTypeToString:(SFSyncTargetQueryType)queryType;
++ (SFSoslSyncTarget*) newFromDict:(NSDictionary*)dict {
+    SFSoslSyncTarget* syncTarget = [[SFSoslSyncTarget alloc] init];
+    if (syncTarget) {
+        if (dict == nil || [dict count] == 0) {
+            syncTarget.isUndefined = YES;
+        }
+        else {
+            syncTarget.isUndefined = NO;
+            syncTarget.queryType = SFSyncTargetQueryTypeSosl;
+            syncTarget.query = dict[kSFSoslSyncTargetQuery];
+        }
+    }
+    
+    return syncTarget;
+}
+
+- (NSDictionary*) asDict {
+    NSDictionary* dict;
+
+    if (self.isUndefined) {
+        dict = @{};
+    }
+    else {
+        dict = @{
+        kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
+        kSFSoslSyncTargetQuery: self.query
+        };
+    }
+
+    return dict;
+}
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
@@ -23,117 +23,38 @@
  */
 
 #import "SFSyncTarget.h"
+#import "SFMruSyncTarget.h"
+#import "SFSoqlSyncTarget.h"
+#import "SFSoslSyncTarget.h"
 
 NSString * const kSFSyncTargetQueryType = @"type";
-NSString * const kSFSyncTargetQuery = @"query";
-NSString * const kSFSyncTargetObjectType = @"sobjectType";
-NSString * const kSFSyncTargetFieldlist = @"fieldlist";
 
 // query types
 NSString * const kSFSyncTargetQueryTypeMru = @"mru";
 NSString * const kSFSyncTargetQueryTypeSoql = @"soql";
 NSString * const kSFSyncTargetQueryTypeSosl = @"sosl";
 
-@interface SFSyncTarget ()
-
-@property (nonatomic, readwrite)         SFSyncTargetQueryType queryType;
-@property (nonatomic, strong, readwrite) NSString* query;
-@property (nonatomic, strong, readwrite) NSString* objectType;
-@property (nonatomic, strong, readwrite) NSArray*  fieldlist;
-@property (nonatomic, readwrite)         BOOL isUndefined;
-
-@end
-
 @implementation SFSyncTarget
-
-#pragma mark - Factory methods
-
-+ (SFSyncTarget*) newSyncTargetForMRUSyncDown:(NSString*)objectType fieldlist:(NSArray*)fieldlist {
-    SFSyncTarget* syncTarget = [[SFSyncTarget alloc] init];
-    syncTarget.queryType = SFSyncTargetQueryTypeMru;
-    syncTarget.objectType = objectType;
-    syncTarget.fieldlist = fieldlist;
-    syncTarget.isUndefined = NO;
-    return syncTarget;
-}
-
-+ (SFSyncTarget*) newSyncTargetForSOSLSyncDown:(NSString*)query {
-    SFSyncTarget* syncTarget = [[SFSyncTarget alloc] init];
-    syncTarget.queryType = SFSyncTargetQueryTypeSosl;
-    syncTarget.query = query;
-    syncTarget.isUndefined = NO;
-    return syncTarget;
-}
-
-+ (SFSyncTarget*) newSyncTargetForSOQLSyncDown:(NSString*)query {
-    SFSyncTarget* syncTarget = [[SFSyncTarget alloc] init];
-    syncTarget.queryType = SFSyncTargetQueryTypeSoql;
-    syncTarget.query = query;
-    syncTarget.isUndefined = NO;
-    return syncTarget;
-}
-
 
 #pragma mark - From/to dictionary
 
 + (SFSyncTarget*) newFromDict:(NSDictionary*)dict {
-    SFSyncTarget* syncTarget = [[SFSyncTarget alloc] init];
-    if (syncTarget) {
-        if (dict == nil || [dict count] == 0) {
-            syncTarget.isUndefined = YES;
-        }
-        else {
-            syncTarget.isUndefined = NO;
-            syncTarget.queryType = [SFSyncTarget queryTypeFromString:dict[kSFSyncTargetQueryType]];
-            switch (syncTarget.queryType) {
-                case SFSyncTargetQueryTypeMru:
-                    syncTarget.objectType = dict[kSFSyncTargetObjectType];
-                    syncTarget.fieldlist = dict[kSFSyncTargetFieldlist];
-                    break;
-                case SFSyncTargetQueryTypeSosl:
-                    syncTarget.query = dict[kSFSyncTargetQuery];
-                    break;
-                case SFSyncTargetQueryTypeSoql:
-                    syncTarget.query = dict[kSFSyncTargetQuery];
-                    break;
-            }
-        }
+    switch ([SFSyncTarget queryTypeFromString:dict[kSFSyncTargetQueryType]]) {
+    case SFSyncTargetQueryTypeMru:
+        return [SFMruSyncTarget newFromDict:dict];
+    case SFSyncTargetQueryTypeSosl:
+        return [SFSoslSyncTarget newFromDict:dict];
+    case SFSyncTargetQueryTypeSoql:
+        return [SFSoqlSyncTarget newFromDict:dict];
     }
-    
-    return syncTarget;
+    // Fell through
+    return nil;
 }
 
 - (NSDictionary*) asDict {
-    NSDictionary* dict;
-
-    if (self.isUndefined) {
-        dict = @{};
-    }
-    else {
-        switch (self.queryType) {
-            case SFSyncTargetQueryTypeSoql:
-                dict = @{
-                         kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
-                         kSFSyncTargetQuery: self.query
-                         };
-                break;
-            case SFSyncTargetQueryTypeSosl:
-                dict = @{
-                         kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
-                         kSFSyncTargetQuery: self.query
-                         };
-                break;
-            case SFSyncTargetQueryTypeMru:
-                dict = @{
-                         kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
-                         kSFSyncTargetObjectType: self.objectType,
-                         kSFSyncTargetFieldlist: self.fieldlist
-                         };
-                break;
-        }
-    }
-
-    return dict;
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"You must override asDict in a subclass"
+                                 userInfo:nil];
 }
 
 #pragma mark - string to/from enum for query type

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/Data/SObjectDataManager.m
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/Data/SObjectDataManager.m
@@ -27,6 +27,9 @@
 #import <SalesforceSDKCore/SFQuerySpec.h>
 #import <SalesforceSDKCore/SFUserAccountManager.h>
 
+// Will go away once we are done refactoring SFSyncTarget
+#import <SmartSync/SFSoqlSyncTarget.h>
+
 static NSUInteger kMaxQueryPageSize = 1000;
 static NSUInteger kSyncLimit = 10000;
 static char* const kSearchFilterQueueName = "com.salesforce.smartSyncExplorer.searchFilterQueue";
@@ -85,7 +88,7 @@ static char* const kSearchFilterQueueName = "com.salesforce.smartSyncExplorer.se
         // first time
         NSString *soqlQuery = [NSString stringWithFormat:@"SELECT %@, LastModifiedDate FROM %@ LIMIT %d", [self.dataSpec.fieldNames componentsJoinedByString:@","], self.dataSpec.objectType, kSyncLimit];
         SFSyncOptions *syncOptions = [SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged];
-        SFSyncTarget *syncTarget = [SFSyncTarget newSyncTargetForSOQLSyncDown:soqlQuery];
+        SFSyncTarget *syncTarget = [SFSoqlSyncTarget newSyncTarget:soqlQuery];
         [self.syncMgr syncDownWithTarget:syncTarget options:syncOptions soupName:self.dataSpec.soupName updateBlock:updateBlock];
     }
     else {


### PR DESCRIPTION
SFSyncTarget is now an abstract class with three concrete subclasses SFMruSyncTarget, SFSoqlSyncTarget and SFSoslSyncTarget
Not done yet: the code fetching data from the server during syncDown is still in SFSmartSyncSyncManager instead of being in the SF*SyncTarget class
All smartsync tests (hybrid and native) passing