### PR TITLE
Refactoring of SFSyncTarget (second part)

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKConstants.h
@@ -35,6 +35,11 @@
 #define FIX_CATEGORY_BUG(name) @interface FIXCATEGORYBUG ## name @end @implementation FIXCATEGORYBUG ## name @end
 #define SFRelease(ivar) ivar = nil;
 
+#define ABSTRACT_METHOD {\
+[self doesNotRecognizeSelector:_cmd]; \
+__builtin_unreachable(); \
+}
+
 #ifdef __clang__
 #define SFSDK_DEPRECATED(version, msg) __attribute__((deprecated("Deprecated in Salesforce Mobile SDK " #version ". " msg)))
 #else

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
@@ -22,6 +22,7 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <SalesforceRest/SFRestAPI+Blocks.h>
 #import "SFSyncState.h"
 #import "SFSyncOptions.h"
 #import "SFSyncTarget.h"
@@ -40,10 +41,6 @@ extern NSString * const kSyncManagerLocal;
 extern NSString * const kSyncManagerLocallyCreated;
 extern NSString * const kSyncManagerLocallyUpdated;
 extern NSString * const kSyncManagerLocallyDeleted;
-
-extern NSString * const kSyncManagerOptionsFieldlist;
-
-extern NSString * const kSyncManagerLastModifiedDate;
 
 // block type
 typedef void (^SFSyncSyncManagerUpdateBlock) (SFSyncState* sync);
@@ -82,6 +79,10 @@ typedef void (^SFSyncSyncManagerUpdateBlock) (SFSyncState* sync);
 /** Create and run a sync up
  */
 - (SFSyncState*) syncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+
+/** Send request with smartsync user agent
+ */
+- (void) sendRequestWithSmartSyncUserAgent:(SFRestRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(id)completeBlock;
 
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -227,10 +227,6 @@ static NSMutableDictionary *syncMgrList = nil;
         [self log:SFLogLevelError format:@"Cannot run reSync:%@:wrong type:%@", syncId, [SFSyncState syncTypeToString:sync.type]];
         return nil;
     }
-    if (sync.target.queryType != SFSyncTargetQueryTypeSoql) {
-        [self log:SFLogLevelError format:@"Cannot run reSync:%@:wrong query type:%@", syncId, [SFSyncTarget queryTypeToString:sync.target.queryType]];
-        return nil;
-    }
     if (sync.status != SFSyncStateStatusDone) {
         [self log:SFLogLevelError format:@"Cannot run reSync:%@:not done:%@", syncId, [SFSyncState syncStatusToString:sync.status]];
         return nil;

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -25,13 +25,13 @@
 #import "SFSmartSyncSyncManager.h"
 #import "SFSmartSyncCacheManager.h"
 #import "SFSmartSyncSoqlBuilder.h"
+#import "SFSmartSyncConstants.h"
 #import <SalesforceSDKCore/SFAuthenticationManager.h>
 #import <SalesforceSDKCore/SFUserAccount.h>
 #import <SalesforceSDKCore/SFSmartStore.h>
 #import <SalesforceSDKCore/SFSoupIndex.h>
 #import <SalesforceSDKCore/SFQuerySpec.h>
 #import <SalesforceSDKCore/SFJsonUtils.h>
-#import <SalesforceRestAPI/SFRestAPI+Blocks.h>
 
 // Will go away once we are done refactoring SFSyncTarget
 #import "SFMruSyncTarget.h"
@@ -54,29 +54,8 @@ NSString * const kSyncManagerLocallyCreated = @"__locally_created__";
 NSString * const kSyncManagerLocallyUpdated = @"__locally_updated__";
 NSString * const kSyncManagerLocallyDeleted = @"__locally_deleted__";
 
-// in options
-NSString * const kSyncManagerOptionsFieldlist = @"fieldlist";
-
-// in target
-NSString * const kSyncManagerTargetQueryType = @"type";
-NSString * const kSyncManagerTargetQuery = @"query";
-NSString * const kSyncManagerTargetObjectType = @"sobjectType";
-NSString * const kSyncManagerTargetFieldlist = @"fieldlist";
-
-// query types
-NSString * const kSyncManagerQueryTypeMru = @"mru";
-NSString * const kSyncManagerQueryTypeSoql = @"soql";
-NSString * const kSyncManagerQueryTypeSosl = @"sosl";
-
 // response
-NSString * const kSyncManagerObjectId = @"Id";
 NSString * const kSyncManagerLObjectId = @"id"; // e.g. create response
-NSString * const kSyncManagerObjectTypePath = @"attributes.type";
-NSString * const kSyncManagerResponseRecords = @"records";
-NSString * const kSyncManagerResponseTotalSize = @"totalSize";
-NSString * const kSyncManagerResponseNextRecordsUrl = @"nextRecordsUrl";
-NSString * const kSyncManagerRecentItems = @"recentItems";
-NSString * const kSyncManagerLastModifiedDate = @"LastModifiedDate";
 
 // dispatch queue
 char * const kSyncManagerQueue = "com.salesforce.smartsync.manager.syncmanager.QUEUE";
@@ -279,114 +258,45 @@ static NSMutableDictionary *syncMgrList = nil;
     NSString* soupName = sync.soupName;
     SFSyncStateMergeMode mergeMode = sync.mergeMode;
     SFSyncTarget* target = sync.target;
+    long long maxTimeStamp = sync.maxTimeStamp;
+
     SFRestFailBlock failRest = ^(NSError *error) {
         failSync(@"REST call failed", error);
     };
-    
-    switch (target.queryType) {
-        case SFSyncTargetQueryTypeMru:
-            [self syncDownMru:mergeMode objectType:((SFMruSyncTarget*) target).objectType fieldlist:((SFMruSyncTarget*) target).fieldlist soup:soupName updateSync:updateSync failRest:failRest];
-            break;
-        case SFSyncTargetQueryTypeSoql:
-            [self syncDownSoql:mergeMode query:((SFSoqlSyncTarget*) target).query soup:soupName updateSync:updateSync failRest:failRest maxTimeStamp:sync.maxTimeStamp];
-            break;
-        case SFSyncTargetQueryTypeSosl:
-            [self syncDownSosl:mergeMode query:((SFSoslSyncTarget*) target).query soup:soupName updateSync:updateSync failRest:failRest];
-            break;
-    }
-}
 
-/** Run a sync down for a mru target
- */
-- (void) syncDownMru:(SFSyncStateMergeMode)mergeMode objectType:(NSString*)sobjectType fieldlist:(NSArray*)fieldlist soup:(NSString*)soupName updateSync:(SyncUpdateBlock)updateSync failRest:(SFRestFailBlock)failRest {
-    __weak SFSmartSyncSyncManager *weakSelf = self;
-    
-    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForMetadataWithObjectType:sobjectType];
-    [self sendRequestWithSmartSyncUserAgent:request failBlock:failRest completeBlock:^(NSDictionary* d) {
-        NSArray* recentItems = [weakSelf pluck:d[kSyncManagerRecentItems] key:kSyncManagerObjectId];
-        NSString* inPredicate = [@[ @"Id IN ('", [recentItems componentsJoinedByString:@"', '"], @"')"]
-                                 componentsJoinedByString:@""];
-        NSString* soql = [[[[SFSmartSyncSoqlBuilder withFieldsArray:fieldlist]
-                            from:sobjectType]
-                           where:inPredicate]
-                          build];
-        [weakSelf syncDownSoql:mergeMode query:soql soup:soupName updateSync:updateSync failRest:failRest maxTimeStamp:0L];
-    }];
-}
-
-- (NSArray*) pluck:(NSArray*)arrayOfDictionaries key:(NSString*)key {
-    NSMutableArray* result = [NSMutableArray array];
-    for (NSDictionary* d in arrayOfDictionaries) {
-        [result addObject:d[key]];
-    }
-    return result;
-}
-
-/** Run a sync down for a soql target
- */
-- (void) syncDownSoql:(SFSyncStateMergeMode)mergeMode query:(NSString*)query soup:(NSString*)soupName updateSync:(SyncUpdateBlock)updateSync failRest:(SFRestFailBlock)failRest maxTimeStamp:(long long)maxTimeStamp {
     __block NSUInteger countFetched = 0;
-    __block SFRestDictionaryResponseBlock completeBlockRecurse = ^(NSDictionary *d) {};
+    __block NSUInteger totalSize = 0;
+    __block SFSyncTargetFetchCompleteBlock completeBlockRecurse = ^(NSArray *records) {};
     __weak SFSmartSyncSyncManager *weakSelf = self;
-    SFRestDictionaryResponseBlock completeBlockSOQL = ^(NSDictionary *d) {
-        NSUInteger totalSize = [d[kSyncManagerResponseTotalSize] integerValue];
+    
+    SFSyncTargetFetchCompleteBlock completeBlock = ^(NSArray* records) {
+        totalSize = target.totalSize;
         if (countFetched == 0) { // after first request only
             updateSync(nil, totalSize == 0 ? 100 : 0, totalSize, kSyncManagerUnchanged);
             if (totalSize == 0) {
                 return;
             }
         }
-
-        NSArray* recordsFetched = d[kSyncManagerResponseRecords];
-        countFetched += [recordsFetched count];
+        
+        countFetched += [records count];
         NSUInteger progress = 100*countFetched / totalSize;
-        long long maxTimeStampForFetched = [self getMaxTimeStamp:recordsFetched];
+        long long maxTimeStampForFetched = [self getMaxTimeStamp:records];
         
         // Save records
-        [weakSelf saveRecords:recordsFetched soup:soupName mergeMode:mergeMode];
+        [weakSelf saveRecords:records soup:soupName mergeMode:mergeMode];
         // Update status
         updateSync(nil, progress, totalSize, maxTimeStampForFetched);
         
         // Fetch next records if any
-        NSString* nextRecordsUrl = d[kSyncManagerResponseNextRecordsUrl];
-        if (nextRecordsUrl) {
-            SFRestRequest* request = [SFRestRequest requestWithMethod:SFRestMethodGET path:nextRecordsUrl queryParams:nil];
-            [weakSelf sendRequestWithSmartSyncUserAgent:request failBlock:failRest completeBlock:completeBlockRecurse];
+        if (countFetched < totalSize) {
+            [target continueFetch:self errorBlock:failRest completeBlock:completeBlockRecurse];
         }
     };
     // initialize the alias
-    completeBlockRecurse = completeBlockSOQL;
+    completeBlockRecurse = completeBlock;
     
-    // Resync?
-    NSString* queryToRun = query;
-    if (maxTimeStamp > 0) {
-        queryToRun = [self addFilterForReSync:query maxTimeStamp:maxTimeStamp];
-    }
-
-    // Send request
-    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:queryToRun];
-    [self sendRequestWithSmartSyncUserAgent:request failBlock:failRest completeBlock:completeBlockSOQL];
-}
-
-/** Run a sync down for a sosl target
- */
-- (void) syncDownSosl:(SFSyncStateMergeMode)mergeMode  query:(NSString*)query soup:(NSString*)soupName updateSync:(SyncUpdateBlock)updateSync failRest:(SFRestFailBlock)failRest {
-    __weak SFSmartSyncSyncManager *weakSelf = self;
-    SFRestArrayResponseBlock completeBlockSOSL = ^(NSArray *recordsFetched) {
-        NSUInteger totalSize = [recordsFetched count];
-        updateSync(nil, totalSize == 0 ? 100 : 0, totalSize, kSyncManagerUnchanged);
-        if (totalSize == 0) {
-            return;
-        }
-        // Save records
-        [weakSelf saveRecords:recordsFetched soup:soupName mergeMode:mergeMode];
-        // Update status
-        updateSync(kSFSyncStateStatusRunning, 100, totalSize, kSyncManagerUnchanged);
-    };
-    
-    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearch:query];
-    [self sendRequestWithSmartSyncUserAgent:request failBlock:failRest completeBlock:completeBlockSOSL];
-
+    // Start fetch
+    [target startFetch:self maxTimeStamp:maxTimeStamp errorBlock:failRest completeBlock:completeBlock];
 }
 
 - (void) saveRecords:(NSArray*)records soup:(NSString*)soupName mergeMode:(SFSyncStateMergeMode)mergeMode{
@@ -394,13 +304,13 @@ static NSMutableDictionary *syncMgrList = nil;
     
     NSSet* idsToSkip = nil;
     if (mergeMode == SFSyncStateMergeModeLeaveIfChanged) {
-        idsToSkip = [self getDirtyRecordIds:soupName idField:kSyncManagerObjectId];
+        idsToSkip = [self getDirtyRecordIds:soupName idField:kId];
     }
     
     // Prepare for smartstore
     for (NSDictionary* record in records) {
         // Skip?
-        if (idsToSkip != nil && [idsToSkip containsObject:record[kSyncManagerObjectId]]) {
+        if (idsToSkip != nil && [idsToSkip containsObject:record[kId]]) {
             continue;
         }
         
@@ -413,7 +323,7 @@ static NSMutableDictionary *syncMgrList = nil;
     }
     
     // Save to smartstore
-    [self.store upsertEntries:recordsToSave toSoup:soupName withExternalIdPath:kSyncManagerObjectId error:nil];
+    [self.store upsertEntries:recordsToSave toSoup:soupName withExternalIdPath:kId error:nil];
 }
 
 - (NSSet*) getDirtyRecordIds:(NSString*)soupName idField:(NSString*)idField {
@@ -434,7 +344,7 @@ static NSMutableDictionary *syncMgrList = nil;
 - (long long) getMaxTimeStamp:(NSArray*)records {
     long long maxTimeStamp = -1L;
     for(NSDictionary* record in records) {
-        NSString* timeStampStr = record[kSyncManagerLastModifiedDate];
+        NSString* timeStampStr = record[kLastModifiedDate];
         if (!timeStampStr) {
             break; // LastModifiedDate field not present
         }
@@ -452,30 +362,6 @@ static NSMutableDictionary *syncMgrList = nil;
     }
     return millis;
 }
-
-- (NSString*) addFilterForReSync:(NSString*)query maxTimeStamp:(long long)maxTimeStamp {
-    NSString* queryToRun = query;
-    if (maxTimeStamp > 0) {
-        NSDate* maxTimeStampDate = [NSDate dateWithTimeIntervalSince1970:((double)maxTimeStamp)/1000.0];
-        NSString* extraPredicate = [@[kSyncManagerLastModifiedDate, @">", [isoDateFormatter stringFromDate:maxTimeStampDate]] componentsJoinedByString:@" "];
-        if ([[query lowercaseString] rangeOfString:@" where "].location != NSNotFound) {
-            queryToRun = [self appendToFirstOccurence:query pattern:@" where " stringToAppend:[@[extraPredicate, @" and "] componentsJoinedByString:@""]];
-        }
-        else {
-            queryToRun = [self appendToFirstOccurence:query pattern:@" from[ ]+[^ ]*" stringToAppend:[@[@" where ", extraPredicate] componentsJoinedByString:@""]];
-        }
-    }
-    return queryToRun;
-}
-
-- (NSString*) appendToFirstOccurence:(NSString*)str pattern:(NSString*)pattern stringToAppend:(NSString*)stringToAppend {
-    NSRegularExpression* regexp = [NSRegularExpression regularExpressionWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:nil];
-    NSRange rangeFirst = [regexp rangeOfFirstMatchInString:str options:0 range:NSMakeRange(0, [str length])];
-    NSString* firstMatch = [str substringWithRange:rangeFirst];
-    NSString* modifiedStr = [str stringByReplacingCharactersInRange:rangeFirst withString:[@[firstMatch, stringToAppend] componentsJoinedByString:@""]];
-    return modifiedStr;
-}
-
 
 - (NSArray*) flatten:(NSArray*)results {
     NSMutableArray* flatArray = [NSMutableArray new];
@@ -566,14 +452,14 @@ static NSMutableDictionary *syncMgrList = nil;
     NSNumber* soupEntryId = record[SOUP_ENTRY_ID];
 
     // Getting type and id
-    NSString* objectType = [SFJsonUtils projectIntoJson:record path:kSyncManagerObjectTypePath];
-    NSString* objectId = record[kSyncManagerObjectId];
+    NSString* objectType = [SFJsonUtils projectIntoJson:record path:kObjectTypeField];
+    NSString* objectId = record[kId];
 
     // Fields to save (in the case of create or update)
     NSMutableDictionary* fields = [NSMutableDictionary dictionary];
     if (action == kSyncManagerActionCreate || action == kSyncManagerActionUpdate) {
         for (NSString* fieldName in options.fieldlist) {
-            if (![fieldName isEqualToString:kSyncManagerObjectId]) {
+            if (![fieldName isEqualToString:kId]) {
                 if (record[fieldName] != nil)
                     fields[fieldName] = record[fieldName];
             }
@@ -607,7 +493,7 @@ static NSMutableDictionary *syncMgrList = nil;
     // Create handler
     SFRestDictionaryResponseBlock completeBlockCreate = ^(NSDictionary *d) {
         // Replace id with server id during create
-        record[kSyncManagerObjectId] = d[kSyncManagerLObjectId];
+        record[kId] = d[kSyncManagerLObjectId];
         completeBlockUpdate(d);
     };
 
@@ -634,17 +520,17 @@ static NSMutableDictionary *syncMgrList = nil;
 }
 
 - (void)sendRequestWithSmartSyncUserAgent:(SFRestRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(id)completeBlock {
-    [request setHeaderValue:[SFRestAPI userAgentString:kSmartSync] forHeaderName:kUserAgent];
+    //[request setHeaderValue:[SFRestAPI userAgentString:kSmartSync] forHeaderName:kUserAgent];
     [self.restClient sendRESTRequest:request failBlock:failBlock completeBlock:completeBlock];
 }
 
 - (void)isNewerThanServer:(SFSyncState*)sync recordIds:(NSArray*)recordIds index:(NSUInteger)i record:(NSMutableDictionary*)record action:(SFSyncManagerAction)action updateSync:(SyncUpdateBlock)updateSync failRest:(SFRestFailBlock)failRest {
-    NSString* objectType = [SFJsonUtils projectIntoJson:record path:kSyncManagerObjectTypePath];
-    NSString* objectId = record[kSyncManagerObjectId];
-    NSString* lastModifiedDateString = record[kSyncManagerLastModifiedDate];
+    NSString* objectType = [SFJsonUtils projectIntoJson:record path:kObjectTypeField];
+    NSString* objectId = record[kId];
+    NSString* lastModifiedDateString = record[kLastModifiedDate];
     long long lastModifiedDate = [self getTimeMillisFromString:lastModifiedDateString];
     __block long long serverLastModified = -1;
-    SFSmartSyncSoqlBuilder *soqlBuilder = [SFSmartSyncSoqlBuilder withFields:kSyncManagerLastModifiedDate];
+    SFSmartSyncSoqlBuilder *soqlBuilder = [SFSmartSyncSoqlBuilder withFields:kLastModifiedDate];
     [soqlBuilder from:objectType];
     [soqlBuilder where:[NSString stringWithFormat:@"Id = '%@'", objectId]];
     NSString *query = [soqlBuilder build];
@@ -658,7 +544,7 @@ static NSMutableDictionary *syncMgrList = nil;
             if (nil != d) {
                 NSDictionary *record = d[@"records"][0];
                 if (nil != record) {
-                    NSString *serverLastMod = record[kSyncManagerLastModifiedDate];
+                    NSString *serverLastMod = record[kLastModifiedDate];
                     if (nil != serverLastMod) {
                         serverLastModified = [self getTimeMillisFromString:serverLastMod];
                     }

--- a/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncTarget.m
@@ -47,44 +47,28 @@ NSString * const kSFSyncTargetFieldlist = @"fieldlist";
     syncTarget.queryType = SFSyncTargetQueryTypeMru;
     syncTarget.objectType = objectType;
     syncTarget.fieldlist = fieldlist;
-    syncTarget.isUndefined = NO;
     return syncTarget;
 }
 
 #pragma mark - From/to dictionary
 
 + (SFMruSyncTarget*) newFromDict:(NSDictionary*)dict {
-    SFMruSyncTarget* syncTarget = [[SFMruSyncTarget alloc] init];
-    if (syncTarget) {
-        if (dict == nil || [dict count] == 0) {
-            syncTarget.isUndefined = YES;
-        }
-        else {
-            syncTarget.isUndefined = NO;
-            syncTarget.queryType = SFSyncTargetQueryTypeMru;
-            syncTarget.objectType = dict[kSFSyncTargetObjectType];
-            syncTarget.fieldlist = dict[kSFSyncTargetFieldlist];
-        }
+    SFMruSyncTarget* syncTarget = nil;
+    if (dict != nil && [dict count] != 0) {
+        syncTarget = [[SFMruSyncTarget alloc] init];
+        syncTarget.queryType = SFSyncTargetQueryTypeMru;
+        syncTarget.objectType = dict[kSFSyncTargetObjectType];
+        syncTarget.fieldlist = dict[kSFSyncTargetFieldlist];
     }
-    
     return syncTarget;
 }
 
 - (NSDictionary*) asDict {
-    NSDictionary* dict;
-
-    if (self.isUndefined) {
-        dict = @{};
-    }
-    else {
-        dict = @{
-        kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
-        kSFSyncTargetObjectType: self.objectType,
-        kSFSyncTargetFieldlist: self.fieldlist
-        };
-    }
-
-    return dict;
+    return @{
+             kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
+             kSFSyncTargetObjectType: self.objectType,
+             kSFSyncTargetFieldlist: self.fieldlist
+             };
 }
 
 # pragma mark - Data fetching

--- a/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncTarget.m
@@ -83,4 +83,12 @@ NSString * const kSFSyncTargetFieldlist = @"fieldlist";
     return dict;
 }
 
+# pragma mark - Data fetching
+
+- (void) startFetch:(SFSmartSyncSyncManager*)syncManager maxTimeStamp:(long long)maxTimeStamp completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
+{
+    // TBD
+    completeBlock(0, nil);
+}
+
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.h
@@ -34,6 +34,11 @@ extern NSString * const kAttributes;
 extern NSString * const kRecentlyViewed;
 extern NSString * const kRawData;
 extern NSString * const kObjectTypeField;
+extern NSString * const kLastModifiedDate;
+extern NSString * const kResponseRecords;
+extern NSString * const kResponseTotalSize;
+extern NSString * const kResponseNextRecordsUrl;
+extern NSString * const kRecentItems;
 
 /**
  * Salesforce object types.

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.m
@@ -34,6 +34,11 @@ NSString * const kAttributes = @"attributes";
 NSString * const kRecentlyViewed = @"RecentlyViewed";
 NSString * const kRawData = @"rawData";
 NSString * const kObjectTypeField = @"attributes.type";
+NSString * const kLastModifiedDate = @"LastModifiedDate";
+NSString * const kResponseRecords = @"records";
+NSString * const kResponseTotalSize = @"totalSize";
+NSString * const kResponseNextRecordsUrl = @"nextRecordsUrl";
+NSString * const kRecentItems = @"recentItems";
 
 NSString * const kAccount = @"Account";
 NSString * const kLead = @"Lead";

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncObjectUtils.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncObjectUtils.h
@@ -30,6 +30,10 @@
 
 + (NSString *)formatLocalDateToGMTString:(NSDate *)localDate;
 
++ (long long) getMillisFromIsoString:(NSString*) dateStr;
+
++ (NSString*) getIsoStringFromMillis:(long long) millis;
+
 + (BOOL)isEmpty:(NSString *)value;
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncObjectUtils.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncObjectUtils.m
@@ -25,8 +25,15 @@
 #import "SFSmartSyncObjectUtils.h"
 
 __strong static NSDateFormatter *utcDateFormatter;
+__strong static NSDateFormatter *isoDateFormatter;
 
 @implementation SFSmartSyncObjectUtils
+
++ (void) initialize {
+    utcDateFormatter = [NSDateFormatter new];
+    isoDateFormatter = [NSDateFormatter new];
+    isoDateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+}
 
 + (NSString *)formatValue:(id)value {
     if (nil == value) {
@@ -60,6 +67,22 @@ __strong static NSDateFormatter *utcDateFormatter;
     }
     NSString *dateString = [utcDateFormatter stringFromDate:localDate];
     return dateString;
+}
+
++ (long long) getMillisFromIsoString:(NSString*) dateStr {
+    NSDate* date = [isoDateFormatter dateFromString:dateStr];
+    if (nil == date) {
+        return -1;
+    }
+    return (long long) (date.timeIntervalSince1970 * 1000.0);
+}
+
++ (NSString*) getIsoStringFromMillis:(long long) millis {
+    if (millis < 0) {
+        return nil;
+    }
+    NSDate* date = [NSDate dateWithTimeIntervalSince1970:((double)millis)/1000.0];
+    return [isoDateFormatter stringFromDate:date];
 }
 
 + (BOOL)isEmpty:(NSString *)value {

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncTarget.h
@@ -31,9 +31,12 @@ extern NSString * const kSFSoqlSyncTargetQuery;
 
 @property (nonatomic, strong, readonly) NSString* query;
 
++ (NSString*) addFilterForReSync:(NSString*)query maxTimeStamp:(long long)maxTimeStamp;
+
 /** Factory methods
  */
 + (SFSoqlSyncTarget*) newSyncTarget:(NSString*)query;
 + (SFSoqlSyncTarget*) newFromDict:(NSDictionary *)dict;
+
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncTarget.m
@@ -44,7 +44,6 @@ NSString * const kSFSoqlSyncTargetQuery = @"query";
     SFSoqlSyncTarget* syncTarget = [[SFSoqlSyncTarget alloc] init];
     syncTarget.queryType = SFSyncTargetQueryTypeSoql;
     syncTarget.query = query;
-    syncTarget.isUndefined = NO;
     return syncTarget;
 }
 
@@ -52,35 +51,21 @@ NSString * const kSFSoqlSyncTargetQuery = @"query";
 #pragma mark - From/to dictionary
 
 + (SFSoqlSyncTarget*) newFromDict:(NSDictionary*)dict {
-    SFSoqlSyncTarget* syncTarget = [[SFSoqlSyncTarget alloc] init];
-    if (syncTarget) {
-        if (dict == nil || [dict count] == 0) {
-            syncTarget.isUndefined = YES;
-        }
-        else {
-            syncTarget.isUndefined = NO;
-            syncTarget.queryType = SFSyncTargetQueryTypeSoql;
-            syncTarget.query = dict[kSFSoqlSyncTargetQuery];
-        }
+    SFSoqlSyncTarget* syncTarget = nil;
+    if (dict != nil && [dict count] != 0) {
+        syncTarget = [[SFSoqlSyncTarget alloc] init];
+        syncTarget.queryType = SFSyncTargetQueryTypeMru;
+        syncTarget.queryType = SFSyncTargetQueryTypeSoql;
+        syncTarget.query = dict[kSFSoqlSyncTargetQuery];
     }
-    
     return syncTarget;
 }
 
 - (NSDictionary*) asDict {
-    NSDictionary* dict;
-
-    if (self.isUndefined) {
-        dict = @{};
-    }
-    else {
-        dict = @{
-        kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
-        kSFSoqlSyncTargetQuery: self.query
-        };
-    }
-
-    return dict;
+    return @{
+             kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
+             kSFSoqlSyncTargetQuery: self.query
+             };
 }
 
 # pragma mark - Data fetching

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncTarget.m
@@ -79,4 +79,19 @@ NSString * const kSFSoqlSyncTargetQuery = @"query";
     return dict;
 }
 
+# pragma mark - Data fetching
+
+- (void) startFetch:(SFSmartSyncSyncManager*)syncManager maxTimeStamp:(long long)maxTimeStamp completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
+{
+    // TBD
+    completeBlock(0, nil);
+}
+
+- (void) continueFetch:(SFSmartSyncSyncManager*)syncManager completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
+{
+    // TBD
+    completeBlock(-1, nil);
+}
+
+
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncTarget.m
@@ -23,8 +23,16 @@
  */
 
 #import "SFSoslSyncTarget.h"
+#import "SFSmartSyncSyncManager.h"
+#import <SalesforceRestAPI/SFRestAPI+Blocks.h>
 
 NSString * const kSFSoslSyncTargetQuery = @"query";
+
+@interface SFSmartSyncSyncManager ()
+
+- (void) sendRequestWithSmartSyncUserAgent:(SFRestRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(id)completeBlock;
+
+@end
 
 @interface SFSoslSyncTarget ()
 
@@ -78,5 +86,22 @@ NSString * const kSFSoslSyncTargetQuery = @"query";
 
     return dict;
 }
+
+# pragma mark - Data fetching
+
+- (void) startFetch:(SFSmartSyncSyncManager*)syncManager
+       maxTimeStamp:(long long)maxTimeStamp
+      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
+         errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock
+{
+    SFRestArrayResponseBlock completeBlockSOSL = ^(NSArray *records) {
+        NSUInteger totalSize = [records count];
+        completeBlock(totalSize, records);
+    };
+    
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearch:self.query];
+    [syncManager sendRequestWithSmartSyncUserAgent:request failBlock:errorBlock completeBlock:completeBlockSOSL];
+}
+
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncTarget.m
@@ -48,7 +48,6 @@ NSString * const kSFSoslSyncTargetQuery = @"query";
     SFSoslSyncTarget* syncTarget = [[SFSoslSyncTarget alloc] init];
     syncTarget.queryType = SFSyncTargetQueryTypeSosl;
     syncTarget.query = query;
-    syncTarget.isUndefined = NO;
     return syncTarget;
 }
 
@@ -56,35 +55,20 @@ NSString * const kSFSoslSyncTargetQuery = @"query";
 #pragma mark - From/to dictionary
 
 + (SFSoslSyncTarget*) newFromDict:(NSDictionary*)dict {
-    SFSoslSyncTarget* syncTarget = [[SFSoslSyncTarget alloc] init];
-    if (syncTarget) {
-        if (dict == nil || [dict count] == 0) {
-            syncTarget.isUndefined = YES;
-        }
-        else {
-            syncTarget.isUndefined = NO;
-            syncTarget.queryType = SFSyncTargetQueryTypeSosl;
-            syncTarget.query = dict[kSFSoslSyncTargetQuery];
-        }
+    SFSoslSyncTarget* syncTarget = nil;
+    if (dict != nil && [dict count] != 0) {
+        syncTarget = [[SFSoslSyncTarget alloc] init];
+        syncTarget.queryType = SFSyncTargetQueryTypeSosl;
+        syncTarget.query = dict[kSFSoslSyncTargetQuery];
     }
-    
     return syncTarget;
 }
 
 - (NSDictionary*) asDict {
-    NSDictionary* dict;
-
-    if (self.isUndefined) {
-        dict = @{};
-    }
-    else {
-        dict = @{
-        kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
-        kSFSoslSyncTargetQuery: self.query
-        };
-    }
-
-    return dict;
+    return @{
+             kSFSyncTargetQueryType: [SFSyncTarget queryTypeToString:self.queryType],
+             kSFSoslSyncTargetQuery: self.query
+             };
 }
 
 # pragma mark - Data fetching

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncTarget.m
@@ -24,7 +24,7 @@
 
 #import "SFSoslSyncTarget.h"
 #import "SFSmartSyncSyncManager.h"
-#import <SalesforceRestAPI/SFRestAPI+Blocks.h>
+#import "SFSmartSyncConstants.h"
 
 NSString * const kSFSoslSyncTargetQuery = @"query";
 
@@ -91,16 +91,16 @@ NSString * const kSFSoslSyncTargetQuery = @"query";
 
 - (void) startFetch:(SFSmartSyncSyncManager*)syncManager
        maxTimeStamp:(long long)maxTimeStamp
-      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
          errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock
+      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
 {
-    SFRestArrayResponseBlock completeBlockSOSL = ^(NSArray *records) {
-        NSUInteger totalSize = [records count];
-        completeBlock(totalSize, records);
-    };
+    __weak SFSoslSyncTarget* weakSelf = self;
     
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearch:self.query];
-    [syncManager sendRequestWithSmartSyncUserAgent:request failBlock:errorBlock completeBlock:completeBlockSOSL];
+    [syncManager sendRequestWithSmartSyncUserAgent:request failBlock:errorBlock completeBlock:^(NSArray* records){
+        weakSelf.totalSize = [records count];
+        completeBlock(records);
+    }];
 }
 
 

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncOptions.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncOptions.h
@@ -34,9 +34,6 @@ extern NSString * const kSFSyncOptionsMergeMode;
 @property (nonatomic, strong, readonly) NSArray*  fieldlist;
 @property (nonatomic, readonly) SFSyncStateMergeMode mergeMode;
 
-// True when initialized from empty dictionary
-@property (nonatomic, readonly) BOOL isUndefined;
-
 /** Factory methods
  */
 + (SFSyncOptions*) newSyncOptionsForSyncDown:(SFSyncStateMergeMode)mergeMode;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncOptions.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncOptions.m
@@ -31,7 +31,6 @@ NSString * const kSFSyncOptionsMergeMode = @"mergeMode";
 
 @property (nonatomic, strong, readwrite) NSArray*  fieldlist;
 @property (nonatomic, readwrite)         SFSyncStateMergeMode mergeMode;
-@property (nonatomic, readwrite)         BOOL isUndefined;
 
 @end
 
@@ -47,14 +46,12 @@ NSString * const kSFSyncOptionsMergeMode = @"mergeMode";
     SFSyncOptions* syncOptions = [[SFSyncOptions alloc] init];
     syncOptions.fieldlist = fieldlist;
     syncOptions.mergeMode = mergeMode;
-    syncOptions.isUndefined = NO;
     return syncOptions;
 }
 
 + (SFSyncOptions*) newSyncOptionsForSyncDown:(SFSyncStateMergeMode)mergeMode {
     SFSyncOptions* syncOptions = [[SFSyncOptions alloc] init];
     syncOptions.mergeMode = mergeMode;
-    syncOptions.isUndefined = NO;
     return syncOptions;
 }
 
@@ -62,17 +59,11 @@ NSString * const kSFSyncOptionsMergeMode = @"mergeMode";
 #pragma mark - From/to dictionary
 
 + (SFSyncOptions*) newFromDict:(NSDictionary*)dict {
-    SFSyncOptions* syncOptions = [[SFSyncOptions alloc] init];
-    
-    if (syncOptions) {
-        if (dict == nil || [dict count] == 0) {
-            syncOptions.isUndefined = YES;
-        }
-        else {
-            syncOptions.isUndefined = NO;
-            syncOptions.mergeMode = [SFSyncState mergeModeFromString:dict[kSFSyncOptionsMergeMode]];
-            syncOptions.fieldlist = dict[kSFSyncOptionsFieldlist];
-        }
+    SFSyncOptions* syncOptions = nil;
+    if (dict != nil && [dict count] != 0) {
+        syncOptions = [[SFSyncOptions alloc] init];
+        syncOptions.mergeMode = [SFSyncState mergeModeFromString:dict[kSFSyncOptionsMergeMode]];
+        syncOptions.fieldlist = dict[kSFSyncOptionsFieldlist];
     }
     return syncOptions;
 }

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -102,7 +102,6 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
 + (SFSyncState*) newSyncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName store:(SFSmartStore*)store {
     NSDictionary* dict = @{
                            kSFSyncStateType: kSFSyncStateTypeUp,
-                           kSFSyncStateTarget: @{},
                            kSFSyncStateSoupName: soupName,
                            kSFSyncStateOptions: [options asDict],
                            kSFSyncStateStatus: kSFSyncStateStatusNew,
@@ -144,7 +143,7 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
 - (void) fromDict:(NSDictionary*) dict {
     self.syncId = [(NSNumber*) dict[kSFSyncStateId] integerValue];
     self.type = [SFSyncState syncTypeFromString:dict[kSFSyncStateType]];
-    self.target = [SFSyncTarget newFromDict:dict[kSFSyncStateTarget]];
+    self.target = (dict[kSFSyncStateTarget] == nil ? nil : [SFSyncTarget newFromDict:dict[kSFSyncStateTarget]]);
     self.soupName = dict[kSFSyncStateSoupName];
     self.options = [SFSyncOptions newFromDict:dict[kSFSyncStateOptions]];
     self.status = [SFSyncState syncStatusFromString:dict[kSFSyncStateStatus]];

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
@@ -26,7 +26,7 @@
 
 @class SFSmartSyncSyncManager;
 
-typedef void (^SFSyncTargetFetchCompleteBlock) (NSInteger totalSize, NSArray* records);
+typedef void (^SFSyncTargetFetchCompleteBlock) (NSArray* records);
 typedef void (^SFSyncTargetFetchErrorBlock) (NSError *e);
 
 
@@ -46,6 +46,8 @@ extern NSString * const kSFSyncTargetQueryType;
 // True when initialized from empty dictionary
 @property (nonatomic) BOOL    isUndefined;
 
+// Set during a fetch
+@property (nonatomic)         NSUInteger totalSize;
 
 /** Methods to translate to/from dictionary
  */
@@ -56,15 +58,15 @@ extern NSString * const kSFSyncTargetQueryType;
  */
 - (void) startFetch:(SFSmartSyncSyncManager*)syncManager
        maxTimeStamp:(long long)maxTimeStamp
-      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
-         errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock;
+         errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock
+      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock;
 
 /**
  * Continue fetching records conforming to target if any
  */
 - (void) continueFetch:(SFSmartSyncSyncManager*)syncManager
-      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
-         errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock;
+            errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock
+         completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock;
 
 /** Enum to/from string helper methods
  */

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
@@ -24,6 +24,13 @@
 
 #import <Foundation/Foundation.h>
 
+@class SFSmartSyncSyncManager;
+
+typedef void (^SFSyncTargetFetchCompleteBlock) (NSInteger totalSize, NSArray* records);
+typedef void (^SFSyncTargetFetchErrorBlock) (NSError *e);
+
+
+
 typedef enum {
   SFSyncTargetQueryTypeMru,
   SFSyncTargetQueryTypeSosl,
@@ -44,6 +51,20 @@ extern NSString * const kSFSyncTargetQueryType;
  */
 + (SFSyncTarget*) newFromDict:(NSDictionary *)dict;
 - (NSDictionary*) asDict;
+
+/** Sart fetching records conforming to target
+ */
+- (void) startFetch:(SFSmartSyncSyncManager*)syncManager
+       maxTimeStamp:(long long)maxTimeStamp
+      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
+         errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock;
+
+/**
+ * Continue fetching records conforming to target if any
+ */
+- (void) continueFetch:(SFSmartSyncSyncManager*)syncManager
+      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
+         errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock;
 
 /** Enum to/from string helper methods
  */

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
@@ -34,17 +34,16 @@ typedef void (^SFSyncTargetFetchErrorBlock) (NSError *e);
 typedef enum {
   SFSyncTargetQueryTypeMru,
   SFSyncTargetQueryTypeSosl,
-  SFSyncTargetQueryTypeSoql
+  SFSyncTargetQueryTypeSoql,
+  SFSyncTargetQueryTypeCustom
 } SFSyncTargetQueryType;
 
 extern NSString * const kSFSyncTargetQueryType;
+extern NSString * const kSFSyncTargetiOSImpl;
 
 @interface SFSyncTarget : NSObject
 
 @property (nonatomic)         SFSyncTargetQueryType queryType;
-
-// True when initialized from empty dictionary
-@property (nonatomic) BOOL    isUndefined;
 
 // Set during a fetch
 @property (nonatomic)         NSUInteger totalSize;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
@@ -26,31 +26,34 @@
 #import "SFMruSyncTarget.h"
 #import "SFSoqlSyncTarget.h"
 #import "SFSoslSyncTarget.h"
-
-#define ABSTRACT_METHOD {\
-[self doesNotRecognizeSelector:_cmd]; \
-__builtin_unreachable(); \
-}
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 NSString * const kSFSyncTargetQueryType = @"type";
+NSString * const kSFSyncTargetiOSImpl = @"iOSImpl";
 
 // query types
 NSString * const kSFSyncTargetQueryTypeMru = @"mru";
 NSString * const kSFSyncTargetQueryTypeSoql = @"soql";
 NSString * const kSFSyncTargetQueryTypeSosl = @"sosl";
+NSString * const kSFSyncTargetQueryTypeCustom = @"custom";
+
 
 @implementation SFSyncTarget
 
 #pragma mark - From/to dictionary
 
 + (SFSyncTarget*) newFromDict:(NSDictionary*)dict {
+    NSString* implClassName;
     switch ([SFSyncTarget queryTypeFromString:dict[kSFSyncTargetQueryType]]) {
     case SFSyncTargetQueryTypeMru:
         return [SFMruSyncTarget newFromDict:dict];
     case SFSyncTargetQueryTypeSosl:
         return [SFSoslSyncTarget newFromDict:dict];
     case SFSyncTargetQueryTypeSoql:
-        return [SFSoqlSyncTarget newFromDict:dict];
+         return [SFSoqlSyncTarget newFromDict:dict];
+    case SFSyncTargetQueryTypeCustom:
+        implClassName = dict[kSFSyncTargetiOSImpl];
+        return [NSClassFromString(implClassName) newFromDict:dict];
     }
     // Fell through
     return nil;
@@ -82,8 +85,11 @@ ABSTRACT_METHOD
     if ([queryType isEqualToString:kSFSyncTargetQueryTypeMru]) {
         return SFSyncTargetQueryTypeMru;
     }
-    // Must be SOSL
-    return SFSyncTargetQueryTypeSosl;
+    if ([queryType isEqualToString:kSFSyncTargetQueryTypeSoql]) {
+        return SFSyncTargetQueryTypeSoql;
+    }
+    // Must be custom
+    return SFSyncTargetQueryTypeCustom;
 }
 
 + (NSString*) queryTypeToString:(SFSyncTargetQueryType)queryType {
@@ -91,6 +97,7 @@ ABSTRACT_METHOD
         case SFSyncTargetQueryTypeMru:  return kSFSyncTargetQueryTypeMru;
         case SFSyncTargetQueryTypeSosl: return kSFSyncTargetQueryTypeSosl;
         case SFSyncTargetQueryTypeSoql: return kSFSyncTargetQueryTypeSoql;
+        case SFSyncTargetQueryTypeCustom: return kSFSyncTargetQueryTypeCustom;
     }
 }
 

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
@@ -27,6 +27,11 @@
 #import "SFSoqlSyncTarget.h"
 #import "SFSoslSyncTarget.h"
 
+#define ABSTRACT_METHOD {\
+[self doesNotRecognizeSelector:_cmd]; \
+__builtin_unreachable(); \
+}
+
 NSString * const kSFSyncTargetQueryType = @"type";
 
 // query types
@@ -51,10 +56,21 @@ NSString * const kSFSyncTargetQueryTypeSosl = @"sosl";
     return nil;
 }
 
-- (NSDictionary*) asDict {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:@"You must override asDict in a subclass"
-                                 userInfo:nil];
+- (NSDictionary*) asDict ABSTRACT_METHOD
+
+# pragma mark - Data fetching
+
+- (void) startFetch:(SFSmartSyncSyncManager*)syncManager
+       maxTimeStamp:(long long)maxTimeStamp
+      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
+         errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock
+ABSTRACT_METHOD
+
+- (void) continueFetch:(SFSmartSyncSyncManager*)syncManager
+      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
+         errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock
+{
+    completeBlock(-1, nil);
 }
 
 #pragma mark - string to/from enum for query type

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
@@ -62,15 +62,15 @@ NSString * const kSFSyncTargetQueryTypeSosl = @"sosl";
 
 - (void) startFetch:(SFSmartSyncSyncManager*)syncManager
        maxTimeStamp:(long long)maxTimeStamp
-      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
          errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock
+      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
 ABSTRACT_METHOD
 
 - (void) continueFetch:(SFSmartSyncSyncManager*)syncManager
-      completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
-         errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock
+            errorBlock:(SFSyncTargetFetchErrorBlock)errorBlock
+         completeBlock:(SFSyncTargetFetchCompleteBlock)completeBlock
 {
-    completeBlock(-1, nil);
+    completeBlock(nil);
 }
 
 #pragma mark - string to/from enum for query type

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -551,38 +551,36 @@ static NSException *authException = nil;
     XCTAssertEqual(expectedTotalSize, sync.totalSize);
     
     if (expectedTarget) {
-        XCTAssertFalse(sync.target.isUndefined);
-        if (sync.target) {
-            XCTAssertEqual(expectedTarget.queryType, sync.target.queryType);
-            if (expectedTarget.queryType == SFSyncTargetQueryTypeSoql) {
-                XCTAssertTrue([sync.target isKindOfClass:[SFSoqlSyncTarget class]]);
-                XCTAssertEqualObjects(((SFSoqlSyncTarget*)expectedTarget).query, ((SFSoqlSyncTarget*)sync.target).query);
-            }
-            else if (expectedTarget.queryType == SFSyncTargetQueryTypeSosl) {
-                XCTAssertTrue([sync.target isKindOfClass:[SFSoslSyncTarget class]]);
-                XCTAssertEqualObjects(((SFSoslSyncTarget*)expectedTarget).query, ((SFSoslSyncTarget*)sync.target).query);
-
-            }
-            else if (expectedTarget.queryType == SFSyncTargetQueryTypeMru) {
-                XCTAssertTrue([sync.target isKindOfClass:[SFMruSyncTarget class]]);
-                XCTAssertEqualObjects(((SFMruSyncTarget*)expectedTarget).objectType, ((SFMruSyncTarget*)sync.target).objectType);
-                XCTAssertEqualObjects(((SFMruSyncTarget*)expectedTarget).fieldlist, ((SFMruSyncTarget*)sync.target).fieldlist);
-            }
+        XCTAssertNotNil(sync.target);
+        XCTAssertEqual(expectedTarget.queryType, sync.target.queryType);
+        if (expectedTarget.queryType == SFSyncTargetQueryTypeSoql) {
+            XCTAssertTrue([sync.target isKindOfClass:[SFSoqlSyncTarget class]]);
+            XCTAssertEqualObjects(((SFSoqlSyncTarget*)expectedTarget).query, ((SFSoqlSyncTarget*)sync.target).query);
+        }
+        else if (expectedTarget.queryType == SFSyncTargetQueryTypeSosl) {
+            XCTAssertTrue([sync.target isKindOfClass:[SFSoslSyncTarget class]]);
+            XCTAssertEqualObjects(((SFSoslSyncTarget*)expectedTarget).query, ((SFSoslSyncTarget*)sync.target).query);
+        }
+        else if (expectedTarget.queryType == SFSyncTargetQueryTypeMru) {
+            XCTAssertTrue([sync.target isKindOfClass:[SFMruSyncTarget class]]);
+            XCTAssertEqualObjects(((SFMruSyncTarget*)expectedTarget).objectType, ((SFMruSyncTarget*)sync.target).objectType);
+            XCTAssertEqualObjects(((SFMruSyncTarget*)expectedTarget).fieldlist, ((SFMruSyncTarget*)sync.target).fieldlist);
+        }
+        else if (expectedTarget.queryType == SFSyncTargetQueryTypeCustom) {
+            XCTAssertTrue([sync.target isKindOfClass:[SFSyncTarget class]]);
         }
     }
     else {
-        XCTAssertTrue(sync.target.isUndefined);
+        XCTAssertNil(sync.target);
     }
 
     if (expectedOptions) {
-        XCTAssertFalse(sync.options.isUndefined);
-        if (sync.target) {
-            XCTAssertEqual(expectedOptions.mergeMode, sync.options.mergeMode);
-            XCTAssertEqualObjects(expectedOptions.fieldlist, sync.options.fieldlist);
-        }
+        XCTAssertNotNil(sync.options);
+        XCTAssertEqual(expectedOptions.mergeMode, sync.options.mergeMode);
+        XCTAssertEqualObjects(expectedOptions.fieldlist, sync.options.fieldlist);
     }
     else {
-        XCTAssertTrue(sync.options.isUndefined);
+        XCTAssertNil(sync.options);
     }
 }
 

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -28,8 +28,6 @@
 #import <SalesforceSDKCore/SFUserAccountManager.h>
 #import <SalesforceSDKCore/TestSetupUtils.h>
 #import <SalesforceSDKCore/SFJsonUtils.h>
-#import <SalesforceRestAPI/SFRestAPI.h>
-#import <SalesforceRestAPI/SFRestAPI+Blocks.h>
 #import <SalesforceSDKCore/SFAuthenticationManager.h>
 #import <SalesforceSDKCore/SFSmartStore.h>
 #import <SalesforceSDKCore/SFSoupIndex.h>
@@ -460,14 +458,14 @@ static NSException *authException = nil;
     NSString* nameLimitQueryUpper = [NSString stringWithFormat:@"SELECT Id FROM Account WHERE LastModifiedDate > %@ and Name = 'John' LIMIT 100", dateStr];
 
     // Tests
-    XCTAssertEqualObjects(basicQuery, [syncManager addFilterForReSync:originalBasicQuery maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(limitQuery, [syncManager addFilterForReSync:originalLimitQuery maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameQuery, [syncManager addFilterForReSync:originalNameQuery maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameLimitQuery, [syncManager addFilterForReSync:originalNameLimitQuery maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(basicQueryUpper, [syncManager addFilterForReSync:originalBasicQueryUpper maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(limitQueryUpper, [syncManager addFilterForReSync:originalLimitQueryUpper maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameQueryUpper, [syncManager addFilterForReSync:originalNameQueryUpper maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameLimitQueryUpper, [syncManager addFilterForReSync:originalNameLimitQueryUpper maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(basicQuery, [SFSoqlSyncTarget addFilterForReSync:originalBasicQuery maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(limitQuery, [SFSoqlSyncTarget addFilterForReSync:originalLimitQuery maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(nameQuery, [SFSoqlSyncTarget addFilterForReSync:originalNameQuery maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(nameLimitQuery, [SFSoqlSyncTarget addFilterForReSync:originalNameLimitQuery maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(basicQueryUpper, [SFSoqlSyncTarget addFilterForReSync:originalBasicQueryUpper maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(limitQueryUpper, [SFSoqlSyncTarget addFilterForReSync:originalLimitQueryUpper maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(nameQueryUpper, [SFSoqlSyncTarget addFilterForReSync:originalNameQueryUpper maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(nameLimitQueryUpper, [SFSoqlSyncTarget addFilterForReSync:originalNameLimitQueryUpper maxTimeStamp:dateLong]);
 }
 
 


### PR DESCRIPTION
Data fetching now handled by SFSyncTarget sub classes
Next: allowing custom target 