### PR TITLE
Sync target inheritance, generalized mod date and ID fields

### DIFF
--- a/hybrid/SampleApps/NoteSync/NoteSync/SFContentSoqlSyncDownTarget.h
+++ b/hybrid/SampleApps/NoteSync/NoteSync/SFContentSoqlSyncDownTarget.h
@@ -30,7 +30,5 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
 /** Factory methods
  */
 + (SFContentSoqlSyncDownTarget*) newSyncTarget:(NSString*)query;
-+ (SFContentSoqlSyncDownTarget*) newFromDict:(NSDictionary *)dict;
-
 
 @end

--- a/hybrid/SampleApps/NoteSync/NoteSync/SFContentSoqlSyncDownTarget.m
+++ b/hybrid/SampleApps/NoteSync/NoteSync/SFContentSoqlSyncDownTarget.m
@@ -272,6 +272,14 @@ typedef void (^SFSoapSoqlResponseParseComplete) ();
     return self;
 }
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.queryType = SFSyncDownTargetQueryTypeCustom;
+    }
+    return self;
+}
+
 #pragma mark - Factory methods
 
 + (SFContentSoqlSyncDownTarget*) newSyncTarget:(NSString*)query {

--- a/hybrid/SampleApps/NoteSync/NoteSync/SFContentSoqlSyncDownTarget.m
+++ b/hybrid/SampleApps/NoteSync/NoteSync/SFContentSoqlSyncDownTarget.m
@@ -264,6 +264,14 @@ typedef void (^SFSoapSoqlResponseParseComplete) ();
 
 @implementation SFContentSoqlSyncDownTarget
 
+- (instancetype)initWithDict:(NSDictionary *)dict {
+    self = [super initWithDict:dict];
+    if (self) {
+        self.queryType = SFSyncDownTargetQueryTypeCustom;
+    }
+    return self;
+}
+
 #pragma mark - Factory methods
 
 + (SFContentSoqlSyncDownTarget*) newSyncTarget:(NSString*)query {
@@ -274,24 +282,12 @@ typedef void (^SFSoapSoqlResponseParseComplete) ();
 }
 
 
-#pragma mark - From/to dictionary
+#pragma mark - To dictionary
 
-+ (SFContentSoqlSyncDownTarget*) newFromDict:(NSDictionary*)dict {
-    SFContentSoqlSyncDownTarget* syncTarget = nil;
-    if (dict != nil && [dict count] != 0) {
-        syncTarget = [[SFContentSoqlSyncDownTarget alloc] init];
-        syncTarget.queryType = SFSyncDownTargetQueryTypeCustom;
-        syncTarget.query = dict[kSFSoqlSyncTargetQuery];
-    }
-    return syncTarget;
-}
-
-- (NSDictionary*) asDict {
-    return @{
-             kSFSyncTargetTypeKey: [SFSyncDownTarget queryTypeToString:self.queryType],
-             kSFSoqlSyncTargetQuery: self.query,
-             kSFSyncTargetiOSImplKey: NSStringFromClass([self class])
-             };
+- (NSMutableDictionary*) asDict {
+    NSMutableDictionary *dict = [super asDict];
+    dict[kSFSyncTargetiOSImplKey] = NSStringFromClass([self class]);
+    return dict;
 }
 
 # pragma mark - Data fetching

--- a/hybrid/SampleApps/NoteSync/NoteSync/SFContentSoqlSyncDownTarget.m
+++ b/hybrid/SampleApps/NoteSync/NoteSync/SFContentSoqlSyncDownTarget.m
@@ -302,7 +302,7 @@ typedef void (^SFSoapSoqlResponseParseComplete) ();
     // Resync?
     NSString* queryToRun = self.query;
     if (maxTimeStamp > 0) {
-        queryToRun = [SFSoqlSyncDownTarget addFilterForReSync:self.query maxTimeStamp:maxTimeStamp];
+        queryToRun = [SFSoqlSyncDownTarget addFilterForReSync:self.query modDateFieldName:self.modificationDateFieldName maxTimeStamp:maxTimeStamp];
     }
     
     [[SFRestAPI sharedInstance] performRequestForResourcesWithFailBlock:errorBlock completeBlock:^(NSDictionary* d) { // cheap call to refresh session

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -517,7 +517,7 @@ static NSMutableDictionary *syncMgrList = nil;
     NSMutableDictionary* fields = [NSMutableDictionary dictionary];
     if (action == SFSyncUpTargetActionCreate || action == SFSyncUpTargetActionUpdate) {
         for (NSString *fieldName in fieldList) {
-            if (![fieldName isEqualToString:kId] && ![fieldName isEqualToString:kLastModifiedDate]) {
+            if (![fieldName isEqualToString:kId] && ![fieldName isEqualToString:target.modificationDateFieldName]) {
                 NSObject* fieldValue = [SFJsonUtils projectIntoJson:record path:fieldName];
                 if (fieldValue != nil)
                     fields[fieldName] = fieldValue;

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -264,7 +264,7 @@ static NSMutableDictionary *syncMgrList = nil;
         }
         countFetched += [records count];
         NSUInteger progress = 100*countFetched / totalSize;
-        long long maxTimeStampForFetched = [self getMaxTimeStamp:records];
+        long long maxTimeStampForFetched = [target getLatestModificationTimeStamp:records];
         
         // Save records
         NSError *saveRecordsError = nil;
@@ -332,19 +332,6 @@ static NSMutableDictionary *syncMgrList = nil;
         [ids addObjectsFromArray:[self flatten:results]];
     }
     return ids;
-}
-
-- (long long) getMaxTimeStamp:(NSArray*)records {
-    long long maxTimeStamp = -1L;
-    for(NSDictionary* record in records) {
-        NSString* timeStampStr = record[kLastModifiedDate];
-        if (!timeStampStr) {
-            break; // LastModifiedDate field not present
-        }
-        long long timeStamp = [SFSmartSyncObjectUtils getMillisFromIsoString:timeStampStr];
-        maxTimeStamp = (timeStamp > maxTimeStamp ? timeStamp : maxTimeStamp);
-    }
-    return maxTimeStamp;
 }
 
 - (NSArray*) flatten:(NSArray*)results {

--- a/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncDownTarget.h
@@ -35,6 +35,5 @@ extern NSString * const kSFSyncTargetFieldlist;
 /** Factory methods
  */
 + (SFMruSyncDownTarget*) newSyncTarget:(NSString*)objectType fieldlist:(NSArray*)fieldlist;
-+ (SFMruSyncDownTarget*) newFromDict:(NSDictionary *)dict;
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncDownTarget.m
@@ -89,8 +89,8 @@ NSString * const kSFSyncTargetFieldlist = @"fieldlist";
     
     SFRestRequest *request = [[SFRestAPI sharedInstance] requestForMetadataWithObjectType:self.objectType];
     [SFSmartSyncNetworkUtils sendRequestWithSmartSyncUserAgent:request failBlock:errorBlock completeBlock:^(NSDictionary* d) {
-        NSArray* recentItems = [weakSelf pluck:d[kRecentItems] key:kId];
-        NSString* inPredicate = [@[ @"Id IN ('", [recentItems componentsJoinedByString:@"', '"], @"')"]
+        NSArray* recentItems = [weakSelf pluck:d[kRecentItems] key:self.idFieldName];
+        NSString* inPredicate = [@[ self.idFieldName, @" IN ('", [recentItems componentsJoinedByString:@"', '"], @"')"]
                                  componentsJoinedByString:@""];
         NSString* soql = [[[[SFSmartSyncSoqlBuilder withFieldsArray:self.fieldlist]
                             from:self.objectType]

--- a/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncDownTarget.m
@@ -51,6 +51,14 @@ NSString * const kSFSyncTargetFieldlist = @"fieldlist";
     return self;
 }
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.queryType = SFSyncDownTargetQueryTypeMru;
+    }
+    return self;
+}
+
 #pragma mark - Factory methods
 
 + (SFMruSyncDownTarget*) newSyncTarget:(NSString*)objectType fieldlist:(NSArray*)fieldlist {

--- a/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncDownTarget.m
@@ -41,6 +41,16 @@ NSString * const kSFSyncTargetFieldlist = @"fieldlist";
 
 @implementation SFMruSyncDownTarget
 
+- (instancetype)initWithDict:(NSDictionary *)dict {
+    self = [super initWithDict:dict];
+    if (self) {
+        self.queryType = SFSyncDownTargetQueryTypeMru;
+        self.objectType = dict[kSFSyncTargetObjectType];
+        self.fieldlist = dict[kSFSyncTargetFieldlist];
+    }
+    return self;
+}
+
 #pragma mark - Factory methods
 
 + (SFMruSyncDownTarget*) newSyncTarget:(NSString*)objectType fieldlist:(NSArray*)fieldlist {
@@ -51,25 +61,13 @@ NSString * const kSFSyncTargetFieldlist = @"fieldlist";
     return syncTarget;
 }
 
-#pragma mark - From/to dictionary
+#pragma mark - To dictionary
 
-+ (SFMruSyncDownTarget*) newFromDict:(NSDictionary*)dict {
-    SFMruSyncDownTarget* syncTarget = nil;
-    if (dict != nil && [dict count] != 0) {
-        syncTarget = [[SFMruSyncDownTarget alloc] init];
-        syncTarget.queryType = SFSyncDownTargetQueryTypeMru;
-        syncTarget.objectType = dict[kSFSyncTargetObjectType];
-        syncTarget.fieldlist = dict[kSFSyncTargetFieldlist];
-    }
-    return syncTarget;
-}
-
-- (NSDictionary*) asDict {
-    return @{
-             kSFSyncTargetTypeKey: [SFSyncDownTarget queryTypeToString:self.queryType],
-             kSFSyncTargetObjectType: self.objectType,
-             kSFSyncTargetFieldlist: self.fieldlist
-             };
+- (NSMutableDictionary*) asDict {
+    NSMutableDictionary *dict = [super asDict];
+    dict[kSFSyncTargetObjectType] = self.objectType;
+    dict[kSFSyncTargetFieldlist] = self.fieldlist;
+    return dict;
 }
 
 # pragma mark - Data fetching

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.h
@@ -91,3 +91,4 @@ extern NSString * const kLayoutObjectTypeField;
  */
 extern NSString * const kSFSyncTargetTypeKey;
 extern NSString * const kSFSyncTargetiOSImplKey;
+extern NSString * const kSFSyncTargetModificationDateFieldNameKey;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.h
@@ -91,4 +91,5 @@ extern NSString * const kLayoutObjectTypeField;
  */
 extern NSString * const kSFSyncTargetTypeKey;
 extern NSString * const kSFSyncTargetiOSImplKey;
+extern NSString * const kSFSyncTargetIdFieldNameKey;
 extern NSString * const kSFSyncTargetModificationDateFieldNameKey;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.m
@@ -76,3 +76,4 @@ NSString * const kLayoutObjectTypeField = @"objectType";
 
 NSString * const kSFSyncTargetTypeKey = @"type";
 NSString * const kSFSyncTargetiOSImplKey = @"iOSImpl";
+NSString * const kSFSyncTargetModificationDateFieldNameKey = @"modificationDateFieldName";

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.m
@@ -76,4 +76,5 @@ NSString * const kLayoutObjectTypeField = @"objectType";
 
 NSString * const kSFSyncTargetTypeKey = @"type";
 NSString * const kSFSyncTargetiOSImplKey = @"iOSImpl";
+NSString * const kSFSyncTargetIdFieldNameKey = @"idFieldName";
 NSString * const kSFSyncTargetModificationDateFieldNameKey = @"modificationDateFieldName";

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncDownTarget.h
@@ -32,14 +32,6 @@ extern NSString * const kSFSoqlSyncTargetQuery;
 @property (nonatomic, strong) NSString* query;
 
 /**
- Adds a filter for re-syncing a data set, using the default modification date field of the API.
- @param query The original query to append a re-syncing clause to.
- @param maxTimeStamp The latest modification time represented locally.
- @return The original query with an additional re-syncing clause added.
- */
-+ (NSString*) addFilterForReSync:(NSString*)query maxTimeStamp:(long long)maxTimeStamp;
-
-/**
  Adds a filter for re-syncing a data set, using the given modification date field.
  @param query The original query to append a re-syncing clause to.
  @param modDateFieldName The name of the SOQL field representing the modification date field.

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncDownTarget.h
@@ -51,7 +51,5 @@ extern NSString * const kSFSoqlSyncTargetQuery;
 /** Factory methods
  */
 + (SFSoqlSyncDownTarget*) newSyncTarget:(NSString*)query;
-+ (SFSoqlSyncDownTarget*) newFromDict:(NSDictionary *)dict;
-
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncDownTarget.m
@@ -77,7 +77,7 @@ NSString * const kSFSoqlSyncTargetQuery = @"query";
     // Resync?
     NSString* queryToRun = self.query;
     if (maxTimeStamp > 0) {
-        queryToRun = [SFSoqlSyncDownTarget addFilterForReSync:self.query maxTimeStamp:maxTimeStamp];
+        queryToRun = [SFSoqlSyncDownTarget addFilterForReSync:self.query modDateFieldName:self.modificationDateFieldName maxTimeStamp:maxTimeStamp];
     }
     
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:queryToRun];
@@ -103,11 +103,6 @@ NSString * const kSFSoqlSyncTargetQuery = @"query";
     else {
         completeBlock(nil);
     }
-}
-
-+ (NSString *)addFilterForReSync:(NSString *)query maxTimeStamp:(long long)maxTimeStamp
-{
-    return [self addFilterForReSync:query modDateFieldName:kLastModifiedDate maxTimeStamp:maxTimeStamp];
 }
 
 + (NSString*) addFilterForReSync:(NSString*)query modDateFieldName:(NSString *)modDateFieldName maxTimeStamp:(long long)maxTimeStamp

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncDownTarget.m
@@ -47,6 +47,14 @@ NSString * const kSFSoqlSyncTargetQuery = @"query";
     return self;
 }
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.queryType = SFSyncDownTargetQueryTypeSoql;
+    }
+    return self;
+}
+
 #pragma mark - Factory methods
 
 + (SFSoqlSyncDownTarget*) newSyncTarget:(NSString*)query {

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoqlSyncDownTarget.m
@@ -38,6 +38,15 @@ NSString * const kSFSoqlSyncTargetQuery = @"query";
 
 @implementation SFSoqlSyncDownTarget
 
+- (instancetype)initWithDict:(NSDictionary *)dict {
+    self = [super initWithDict:dict];
+    if (self) {
+        self.queryType = SFSyncDownTargetQueryTypeSoql;
+        self.query = dict[kSFSoqlSyncTargetQuery];
+    }
+    return self;
+}
+
 #pragma mark - Factory methods
 
 + (SFSoqlSyncDownTarget*) newSyncTarget:(NSString*)query {
@@ -50,21 +59,10 @@ NSString * const kSFSoqlSyncTargetQuery = @"query";
 
 #pragma mark - From/to dictionary
 
-+ (SFSoqlSyncDownTarget*) newFromDict:(NSDictionary*)dict {
-    SFSoqlSyncDownTarget* syncTarget = nil;
-    if (dict != nil && [dict count] != 0) {
-        syncTarget = [[SFSoqlSyncDownTarget alloc] init];
-        syncTarget.queryType = SFSyncDownTargetQueryTypeSoql;
-        syncTarget.query = dict[kSFSoqlSyncTargetQuery];
-    }
-    return syncTarget;
-}
-
-- (NSDictionary*) asDict {
-    return @{
-             kSFSyncTargetTypeKey: [SFSyncDownTarget queryTypeToString:self.queryType],
-             kSFSoqlSyncTargetQuery: self.query
-             };
+- (NSMutableDictionary*) asDict {
+    NSMutableDictionary *dict = [super asDict];
+    dict[kSFSoqlSyncTargetQuery] = self.query;
+    return dict;
 }
 
 # pragma mark - Data fetching

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncDownTarget.h
@@ -34,6 +34,5 @@ extern NSString * const kSFSoslSyncTargetQuery;
 /** Factory methods
  */
 + (SFSoslSyncDownTarget*) newSyncTarget:(NSString*)query;
-+ (SFSoslSyncDownTarget*) newFromDict:(NSDictionary *)dict;
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncDownTarget.m
@@ -50,6 +50,14 @@ NSString * const kSFSoslSyncTargetQuery = @"query";
     return self;
 }
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.queryType = SFSyncDownTargetQueryTypeSosl;
+    }
+    return self;
+}
+
 #pragma mark - Factory methods
 
 + (SFSoslSyncDownTarget*) newSyncTarget:(NSString*)query {

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSoslSyncDownTarget.m
@@ -41,6 +41,15 @@ NSString * const kSFSoslSyncTargetQuery = @"query";
 
 @implementation SFSoslSyncDownTarget
 
+- (instancetype)initWithDict:(NSDictionary *)dict {
+    self = [super initWithDict:dict];
+    if (self) {
+        self.queryType = SFSyncDownTargetQueryTypeSosl;
+        self.query = dict[kSFSoslSyncTargetQuery];
+    }
+    return self;
+}
+
 #pragma mark - Factory methods
 
 + (SFSoslSyncDownTarget*) newSyncTarget:(NSString*)query {
@@ -51,23 +60,12 @@ NSString * const kSFSoslSyncTargetQuery = @"query";
 }
 
 
-#pragma mark - From/to dictionary
+#pragma mark - To dictionary
 
-+ (SFSoslSyncDownTarget*) newFromDict:(NSDictionary*)dict {
-    SFSoslSyncDownTarget* syncTarget = nil;
-    if (dict != nil && [dict count] != 0) {
-        syncTarget = [[SFSoslSyncDownTarget alloc] init];
-        syncTarget.queryType = SFSyncDownTargetQueryTypeSosl;
-        syncTarget.query = dict[kSFSoslSyncTargetQuery];
-    }
-    return syncTarget;
-}
-
-- (NSDictionary*) asDict {
-    return @{
-             kSFSyncTargetTypeKey: [SFSyncDownTarget queryTypeToString:self.queryType],
-             kSFSoslSyncTargetQuery: self.query
-             };
+- (NSMutableDictionary*) asDict {
+    NSMutableDictionary *dict = [super asDict];
+    dict[kSFSoslSyncTargetQuery] = self.query;
+    return dict;
 }
 
 # pragma mark - Data fetching

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncDownTarget.h
@@ -47,7 +47,6 @@ typedef enum {
 /** Methods to translate to/from dictionary
  */
 + (SFSyncDownTarget*) newFromDict:(NSDictionary *)dict;
-- (NSDictionary*) asDict;
 
 /** Sart fetching records conforming to target
  */

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncDownTarget.h
@@ -62,6 +62,15 @@ typedef enum {
             errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
          completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock;
 
+/**
+ Gets the latest modification timestamp from the array of records.  Note: inheriting classes can
+ override this method to determine the timestamp in a customized way.  The default implementation
+ looks at the LastModifiedDate field of each record.
+ @param records The array of records to query.
+ @return The timestamp of the record with the most recent modification date.
+ */
+- (long long)getLatestModificationTimeStamp:(NSArray *)records;
+
 /** Enum to/from string helper methods
  */
 + (SFSyncDownTargetQueryType) queryTypeFromString:(NSString*)queryType;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncDownTarget.m
@@ -27,6 +27,7 @@
 #import "SFSoqlSyncDownTarget.h"
 #import "SFSoslSyncDownTarget.h"
 #import "SFSmartSyncConstants.h"
+#import "SFSmartSyncObjectUtils.h"
 #import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 // query types
@@ -87,6 +88,19 @@ ABSTRACT_METHOD
          completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock
 {
     completeBlock(nil);
+}
+
+- (long long)getLatestModificationTimeStamp:(NSArray *)records {
+    long long maxTimeStamp = -1L;
+    for(NSDictionary* record in records) {
+        NSString* timeStampStr = record[self.modificationDateFieldName];
+        if (!timeStampStr) {
+            break; // LastModifiedDate field not present
+        }
+        long long timeStamp = [SFSmartSyncObjectUtils getMillisFromIsoString:timeStampStr];
+        maxTimeStamp = (timeStamp > maxTimeStamp ? timeStamp : maxTimeStamp);
+    }
+    return maxTimeStamp;
 }
 
 #pragma mark - string to/from enum for query type

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncDownTarget.m
@@ -43,21 +43,36 @@ NSString * const kSFSyncTargetQueryTypeCustom = @"custom";
 + (SFSyncDownTarget*) newFromDict:(NSDictionary*)dict {
     NSString* implClassName;
     switch ([SFSyncDownTarget queryTypeFromString:dict[kSFSyncTargetTypeKey]]) {
-    case SFSyncDownTargetQueryTypeMru:
-        return [SFMruSyncDownTarget newFromDict:dict];
-    case SFSyncDownTargetQueryTypeSosl:
-        return [SFSoslSyncDownTarget newFromDict:dict];
-    case SFSyncDownTargetQueryTypeSoql:
-         return [SFSoqlSyncDownTarget newFromDict:dict];
-    case SFSyncDownTargetQueryTypeCustom:
-        implClassName = dict[kSFSyncTargetiOSImplKey];
-        return [NSClassFromString(implClassName) newFromDict:dict];
+        case SFSyncDownTargetQueryTypeMru:
+            return [[SFMruSyncDownTarget alloc] initWithDict:dict];
+        case SFSyncDownTargetQueryTypeSosl:
+            return [[SFSoslSyncDownTarget alloc] initWithDict:dict];
+        case SFSyncDownTargetQueryTypeSoql:
+            return [[SFSoqlSyncDownTarget alloc] initWithDict:dict];
+        case SFSyncDownTargetQueryTypeCustom:
+            implClassName = dict[kSFSyncTargetiOSImplKey];
+            if (implClassName.length == 0) {
+                [SFLogger log:self level:SFLogLevelError format:@"%@ Custom class name not specified.", NSStringFromSelector(_cmd)];
+                return nil;
+            }
+            Class customSyncDownClass = NSClassFromString(implClassName);
+            if (![customSyncDownClass isSubclassOfClass:[SFSyncDownTarget class]]) {
+                [SFLogger log:self level:SFLogLevelError format:@"%@ Class '%@' is not a subclass of %@.", NSStringFromSelector(_cmd), implClassName, NSStringFromClass([SFSyncDownTarget class])];
+                return nil;
+            } else {
+                return [[customSyncDownClass alloc] initWithDict:dict];
+            }
     }
+    
     // Fell through
     return nil;
 }
 
-- (NSDictionary*) asDict ABSTRACT_METHOD
+- (NSMutableDictionary *)asDict {
+    NSMutableDictionary *dict = [super asDict];
+    dict[kSFSyncTargetTypeKey] = [[self class] queryTypeToString:self.queryType];
+    return dict;
+}
 
 # pragma mark - Data fetching
 

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
@@ -24,6 +24,14 @@
 
 @interface SFSyncTarget : NSObject
 
+/**
+ The field name of the ID field of the record.  Defaults to "Id".
+ */
+@property (nonatomic, copy) NSString *idFieldName;
+
+/**
+ The field name of the modification date field of the record.  Defaults to "LastModifiedDate".
+ */
 @property (nonatomic, copy) NSString *modificationDateFieldName;
 
 /**

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
@@ -24,6 +24,27 @@
 
 @interface SFSyncTarget : NSObject
 
-- (NSDictionary*) asDict;
+/**
+ Designated initializer that initializes a sync target from the given dictionary.
+ @param dict The sync target serialized to an NSDictionary.
+ */
+- (instancetype)initWithDict:(NSDictionary *)dict;
+
+/**
+ The target represented as a dictionary.  Note: inheriting classes should initialize their
+ dictionary from the super representation, as each parent class can add fields to the
+ dictionary along the way.
+ @return The target represented as a dictionary.
+ */
+- (NSMutableDictionary *)asDict;
+
+/**
+ Gets the latest modification timestamp from the array of records.  Note: inheriting classes can
+ override this method to determine the timestamp in a customized way.  The default implementation
+ looks at the LastModifiedDate field of each record.
+ @param records The array of records to query.
+ @return The timestamp of the record with the most recent modification date.
+ */
+- (long long)getLatestModificationTimeStamp:(NSArray *)records;
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
@@ -24,6 +24,8 @@
 
 @interface SFSyncTarget : NSObject
 
+@property (nonatomic, copy) NSString *modificationDateFieldName;
+
 /**
  Designated initializer that initializes a sync target from the given dictionary.
  @param dict The sync target serialized to an NSDictionary.

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.h
@@ -48,13 +48,4 @@
  */
 - (NSMutableDictionary *)asDict;
 
-/**
- Gets the latest modification timestamp from the array of records.  Note: inheriting classes can
- override this method to determine the timestamp in a customized way.  The default implementation
- looks at the LastModifiedDate field of each record.
- @param records The array of records to query.
- @return The timestamp of the record with the most recent modification date.
- */
-- (long long)getLatestModificationTimeStamp:(NSArray *)records;
-
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
@@ -44,6 +44,14 @@
     return self;
 }
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.modificationDateFieldName = kLastModifiedDate;
+    }
+    return self;
+}
+
 - (NSMutableDictionary *)asDict {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
     dict[kSFSyncTargetModificationDateFieldNameKey] = self.modificationDateFieldName;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
@@ -24,7 +24,6 @@
 
 #import "SFSyncTarget.h"
 #import "SFSmartSyncConstants.h"
-#import "SFSmartSyncObjectUtils.h"
 #import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 @implementation SFSyncTarget
@@ -56,19 +55,6 @@
     dict[kSFSyncTargetIdFieldNameKey] = self.idFieldName;
     dict[kSFSyncTargetModificationDateFieldNameKey] = self.modificationDateFieldName;
     return dict;
-}
-
-- (long long)getLatestModificationTimeStamp:(NSArray *)records {
-    long long maxTimeStamp = -1L;
-    for(NSDictionary* record in records) {
-        NSString* timeStampStr = record[self.modificationDateFieldName];
-        if (!timeStampStr) {
-            break; // LastModifiedDate field not present
-        }
-        long long timeStamp = [SFSmartSyncObjectUtils getMillisFromIsoString:timeStampStr];
-        maxTimeStamp = (timeStamp > maxTimeStamp ? timeStamp : maxTimeStamp);
-    }
-    return maxTimeStamp;
 }
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
@@ -34,19 +34,26 @@
     
     self = [super init];
     if (self) {
-        // Currently no default behavior.
+        NSString *modificationDateFieldName = dict[kSFSyncTargetModificationDateFieldNameKey];
+        if (modificationDateFieldName.length == 0) {
+            self.modificationDateFieldName = kLastModifiedDate;
+        } else {
+            self.modificationDateFieldName = modificationDateFieldName;
+        }
     }
     return self;
 }
 
 - (NSMutableDictionary *)asDict {
-    return [NSMutableDictionary dictionary];
+    NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    dict[kSFSyncTargetModificationDateFieldNameKey] = self.modificationDateFieldName;
+    return dict;
 }
 
 - (long long)getLatestModificationTimeStamp:(NSArray *)records {
     long long maxTimeStamp = -1L;
     for(NSDictionary* record in records) {
-        NSString* timeStampStr = record[kLastModifiedDate];
+        NSString* timeStampStr = record[self.modificationDateFieldName];
         if (!timeStampStr) {
             break; // LastModifiedDate field not present
         }

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
@@ -23,10 +23,37 @@
  */
 
 #import "SFSyncTarget.h"
+#import "SFSmartSyncConstants.h"
+#import "SFSmartSyncObjectUtils.h"
 #import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 @implementation SFSyncTarget
 
-- (NSDictionary*) asDict ABSTRACT_METHOD
+- (instancetype)initWithDict:(NSDictionary *)dict {
+    if (dict == nil) return nil;
+    
+    self = [super init];
+    if (self) {
+        // Currently no default behavior.
+    }
+    return self;
+}
+
+- (NSMutableDictionary *)asDict {
+    return [NSMutableDictionary dictionary];
+}
+
+- (long long)getLatestModificationTimeStamp:(NSArray *)records {
+    long long maxTimeStamp = -1L;
+    for(NSDictionary* record in records) {
+        NSString* timeStampStr = record[kLastModifiedDate];
+        if (!timeStampStr) {
+            break; // LastModifiedDate field not present
+        }
+        long long timeStamp = [SFSmartSyncObjectUtils getMillisFromIsoString:timeStampStr];
+        maxTimeStamp = (timeStamp > maxTimeStamp ? timeStamp : maxTimeStamp);
+    }
+    return maxTimeStamp;
+}
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
@@ -34,12 +34,10 @@
     
     self = [super init];
     if (self) {
+        NSString *idFieldName = dict[kSFSyncTargetIdFieldNameKey];
         NSString *modificationDateFieldName = dict[kSFSyncTargetModificationDateFieldNameKey];
-        if (modificationDateFieldName.length == 0) {
-            self.modificationDateFieldName = kLastModifiedDate;
-        } else {
-            self.modificationDateFieldName = modificationDateFieldName;
-        }
+        self.idFieldName = (idFieldName.length > 0 ? idFieldName : kId);
+        self.modificationDateFieldName = (modificationDateFieldName.length > 0 ? modificationDateFieldName : kLastModifiedDate);
     }
     return self;
 }
@@ -47,6 +45,7 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
+        self.idFieldName = kId;
         self.modificationDateFieldName = kLastModifiedDate;
     }
     return self;
@@ -54,6 +53,7 @@
 
 - (NSMutableDictionary *)asDict {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    dict[kSFSyncTargetIdFieldNameKey] = self.idFieldName;
     dict[kSFSyncTargetModificationDateFieldNameKey] = self.modificationDateFieldName;
     return dict;
 }

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.h
@@ -99,12 +99,6 @@ typedef void (^SFSyncUpTargetErrorBlock)(NSError *error);
 + (instancetype)newFromDict:(NSDictionary *)dict;
 
 /**
- Serializes the server target to a dictionary.
- @return The serialized server target in an NSDictionary.
- */
-- (NSDictionary *)asDict;
-
-/**
  Converts a string representation of a target type into its target type.
  @param targetType The string representation of the target type.
  @return The target type value.

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
@@ -111,13 +111,13 @@ static NSString * const kSFSyncUpTargetTypeCustom = @"custom";
              modificationResultBlock:(SFSyncUpRecordModificationResultBlock)modificationResultBlock {
     
     NSString *objectType = [SFJsonUtils projectIntoJson:record path:kObjectTypeField];
-    NSString *objectId = record[kId];
+    NSString *objectId = record[self.idFieldName];
     NSDate *localLastModifiedDate = [SFSmartSyncObjectUtils getDateFromIsoDateString:record[self.modificationDateFieldName]];
     __block NSDate *serverLastModifiedDate = [NSDate dateWithTimeIntervalSince1970:0.0];
     
     SFSmartSyncSoqlBuilder *soqlBuilder = [SFSmartSyncSoqlBuilder withFields:self.modificationDateFieldName];
     [soqlBuilder from:objectType];
-    [soqlBuilder where:[NSString stringWithFormat:@"Id = '%@'", objectId]];
+    [soqlBuilder where:[NSString stringWithFormat:@"%@ = '%@'", self.idFieldName, objectId]];
     NSString *query = [soqlBuilder build];
     
     SFRestFailBlock failBlock = ^(NSError *error) {

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
@@ -104,10 +104,10 @@ static NSString * const kSFSyncUpTargetTypeCustom = @"custom";
     
     NSString *objectType = [SFJsonUtils projectIntoJson:record path:kObjectTypeField];
     NSString *objectId = record[kId];
-    NSDate *localLastModifiedDate = [SFSmartSyncObjectUtils getDateFromIsoDateString:record[kLastModifiedDate]];
+    NSDate *localLastModifiedDate = [SFSmartSyncObjectUtils getDateFromIsoDateString:record[self.modificationDateFieldName]];
     __block NSDate *serverLastModifiedDate = [NSDate dateWithTimeIntervalSince1970:0.0];
     
-    SFSmartSyncSoqlBuilder *soqlBuilder = [SFSmartSyncSoqlBuilder withFields:kLastModifiedDate];
+    SFSmartSyncSoqlBuilder *soqlBuilder = [SFSmartSyncSoqlBuilder withFields:self.modificationDateFieldName];
     [soqlBuilder from:objectType];
     [soqlBuilder where:[NSString stringWithFormat:@"Id = '%@'", objectId]];
     NSString *query = [soqlBuilder build];
@@ -123,7 +123,7 @@ static NSString * const kSFSyncUpTargetTypeCustom = @"custom";
         if (nil != response) {
             NSDictionary *record = response[@"records"][0];
             if (nil != record) {
-                NSString *serverLastModifiedStr = record[kLastModifiedDate];
+                NSString *serverLastModifiedStr = record[self.modificationDateFieldName];
                 if (nil != serverLastModifiedStr) {
                     NSDate *testServerModifiedDate = [SFSmartSyncObjectUtils getDateFromIsoDateString:serverLastModifiedStr];
                     if (testServerModifiedDate != nil) {

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
@@ -47,6 +47,14 @@ static NSString * const kSFSyncUpTargetTypeCustom = @"custom";
     return self;
 }
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.targetType = SFSyncUpTargetTypeRestStandard;
+    }
+    return self;
+}
+
 #pragma mark - Serialization and factory methods
 
 + (instancetype)newFromDict:(NSDictionary*)dict {

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -160,7 +160,7 @@ static NSException *authException = nil;
     XCTAssertEqual(resttarget.targetType, SFSyncUpTargetTypeRestStandard, @"Sync sync up target type is incorrect.");
     
     // Custom sync up target
-    TestSyncUpTarget *customTarget = [[TestSyncUpTarget alloc] init];
+    TestSyncUpTarget *customTarget = [[TestSyncUpTarget alloc] initWithDict:@{ }];
     NSDictionary *customDict = [customTarget asDict];
     XCTAssertEqualObjects(customDict[kSFSyncTargetTypeKey], @"custom", @"Should be a custom sync up target.");
     XCTAssertEqualObjects(customDict[kSFSyncTargetiOSImplKey], NSStringFromClass([TestSyncUpTarget class]), @"Custom class is incorrect.");

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -48,10 +48,6 @@
 #define RECORDS             @"records"
 #define COUNT_TEST_ACCOUNTS 10
 
-@interface SFSmartSyncSyncManager()
-- (NSString*) addFilterForReSync:(NSString*)query maxTimeStamp:(long long)maxTimeStamp;
-@end
-
 @interface SyncManagerTests : XCTestCase
 {
     SFUserAccount *currentUser;
@@ -716,14 +712,14 @@ static NSException *authException = nil;
     NSString* nameLimitQueryUpper = [NSString stringWithFormat:@"SELECT Id FROM Account WHERE LastModifiedDate > %@ and Name = 'John' LIMIT 100", dateStr];
 
     // Tests
-    XCTAssertEqualObjects(basicQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalBasicQuery maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(limitQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalLimitQuery maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalNameQuery maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameLimitQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalNameLimitQuery maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(basicQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalBasicQueryUpper maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(limitQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalLimitQueryUpper maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalNameQueryUpper maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameLimitQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalNameLimitQueryUpper maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(basicQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalBasicQuery modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(limitQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalLimitQuery modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(nameQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalNameQuery modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(nameLimitQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalNameLimitQuery modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(basicQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalBasicQueryUpper modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(limitQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalLimitQueryUpper modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(nameQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalNameQueryUpper modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
+    XCTAssertEqualObjects(nameLimitQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalNameLimitQueryUpper modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
 }
 
 

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -690,7 +690,7 @@ static NSException *authException = nil;
     NSString* dateStr = @"2015-02-05T13:12:03.956-0800";
     NSDate* date = [isoDateFormatter dateFromString:dateStr];
     long long dateLong = (long long)([date timeIntervalSince1970] * 1000.0);
-
+    
     // Original queries
     NSString* originalBasicQuery = @"select Id from Account";
     NSString* originalLimitQuery = @"select Id from Account limit 100";
@@ -700,26 +700,29 @@ static NSException *authException = nil;
     NSString* originalLimitQueryUpper = @"SELECT Id FROM Account LIMIT 100";
     NSString* originalNameQueryUpper = @"SELECT Id FROM Account WHERE Name = 'John'";
     NSString* originalNameLimitQueryUpper = @"SELECT Id FROM Account WHERE Name = 'John' LIMIT 100";
-
-    // Expected queries
-    NSString* basicQuery = [NSString stringWithFormat:@"select Id from Account where LastModifiedDate > %@", dateStr];
-    NSString* limitQuery = [NSString stringWithFormat:@"select Id from Account where LastModifiedDate > %@ limit 100", dateStr];
-    NSString* nameQuery = [NSString stringWithFormat:@"select Id from Account where LastModifiedDate > %@ and Name = 'John'", dateStr];
-    NSString* nameLimitQuery = [NSString stringWithFormat:@"select Id from Account where LastModifiedDate > %@ and Name = 'John' limit 100", dateStr];
-    NSString* basicQueryUpper = [NSString stringWithFormat:@"SELECT Id FROM Account where LastModifiedDate > %@", dateStr];
-    NSString* limitQueryUpper = [NSString stringWithFormat:@"SELECT Id FROM Account where LastModifiedDate > %@ LIMIT 100", dateStr];
-    NSString* nameQueryUpper = [NSString stringWithFormat:@"SELECT Id FROM Account WHERE LastModifiedDate > %@ and Name = 'John'", dateStr];
-    NSString* nameLimitQueryUpper = [NSString stringWithFormat:@"SELECT Id FROM Account WHERE LastModifiedDate > %@ and Name = 'John' LIMIT 100", dateStr];
-
-    // Tests
-    XCTAssertEqualObjects(basicQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalBasicQuery modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(limitQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalLimitQuery modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalNameQuery modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameLimitQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalNameLimitQuery modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(basicQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalBasicQueryUpper modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(limitQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalLimitQueryUpper modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalNameQueryUpper modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
-    XCTAssertEqualObjects(nameLimitQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalNameLimitQueryUpper modDateFieldName:kLastModifiedDate maxTimeStamp:dateLong]);
+    
+    // Test different modification date field names.
+    for (NSString *modDateFieldName in @[ @"LastModifiedDate", @"CustomModDate" ]) {
+        // Expected queries
+        NSString* basicQuery = [NSString stringWithFormat:@"select Id from Account where %@ > %@", modDateFieldName, dateStr];
+        NSString* limitQuery = [NSString stringWithFormat:@"select Id from Account where %@ > %@ limit 100", modDateFieldName, dateStr];
+        NSString* nameQuery = [NSString stringWithFormat:@"select Id from Account where %@ > %@ and Name = 'John'", modDateFieldName, dateStr];
+        NSString* nameLimitQuery = [NSString stringWithFormat:@"select Id from Account where %@ > %@ and Name = 'John' limit 100", modDateFieldName, dateStr];
+        NSString* basicQueryUpper = [NSString stringWithFormat:@"SELECT Id FROM Account where %@ > %@", modDateFieldName, dateStr];
+        NSString* limitQueryUpper = [NSString stringWithFormat:@"SELECT Id FROM Account where %@ > %@ LIMIT 100", modDateFieldName, dateStr];
+        NSString* nameQueryUpper = [NSString stringWithFormat:@"SELECT Id FROM Account WHERE %@ > %@ and Name = 'John'", modDateFieldName, dateStr];
+        NSString* nameLimitQueryUpper = [NSString stringWithFormat:@"SELECT Id FROM Account WHERE %@ > %@ and Name = 'John' LIMIT 100", modDateFieldName, dateStr];
+        
+        // Tests
+        XCTAssertEqualObjects(basicQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalBasicQuery modDateFieldName:modDateFieldName maxTimeStamp:dateLong]);
+        XCTAssertEqualObjects(limitQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalLimitQuery modDateFieldName:modDateFieldName maxTimeStamp:dateLong]);
+        XCTAssertEqualObjects(nameQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalNameQuery modDateFieldName:modDateFieldName maxTimeStamp:dateLong]);
+        XCTAssertEqualObjects(nameLimitQuery, [SFSoqlSyncDownTarget addFilterForReSync:originalNameLimitQuery modDateFieldName:modDateFieldName maxTimeStamp:dateLong]);
+        XCTAssertEqualObjects(basicQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalBasicQueryUpper modDateFieldName:modDateFieldName maxTimeStamp:dateLong]);
+        XCTAssertEqualObjects(limitQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalLimitQueryUpper modDateFieldName:modDateFieldName maxTimeStamp:dateLong]);
+        XCTAssertEqualObjects(nameQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalNameQueryUpper modDateFieldName:modDateFieldName maxTimeStamp:dateLong]);
+        XCTAssertEqualObjects(nameLimitQueryUpper, [SFSoqlSyncDownTarget addFilterForReSync:originalNameLimitQueryUpper modDateFieldName:modDateFieldName maxTimeStamp:dateLong]);
+    }
 }
 
 

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -295,10 +295,10 @@ static NSException *authException = nil;
     NSArray* rows = [store queryWithQuerySpec:query pageIndex:0 error:nil];
     for (NSArray* row in rows) {
         NSDictionary* account = row[0];
-        XCTAssertEqual(@NO, account[kSyncManagerLocal]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyCreated]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyUpdated]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyDeleted]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocal]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyCreated]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyUpdated]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyDeleted]);
     }
     
     // Check server
@@ -335,10 +335,10 @@ static NSException *authException = nil;
     NSArray* rows = [store queryWithQuerySpec:query pageIndex:0 error:nil];
     for (NSArray* row in rows) {
         NSDictionary* account = row[0];
-        XCTAssertEqual(@NO, account[kSyncManagerLocal]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyCreated]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyUpdated]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyDeleted]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocal]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyCreated]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyUpdated]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyDeleted]);
     }
 }
 
@@ -374,10 +374,10 @@ static NSException *authException = nil;
     NSArray* rows = [store queryWithQuerySpec:query pageIndex:0 error:nil];
     for (NSArray* row in rows) {
         NSDictionary* account = row[0];
-        XCTAssertEqual(@YES, account[kSyncManagerLocal]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyCreated]);
-        XCTAssertEqual(@YES, account[kSyncManagerLocallyUpdated]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyDeleted]);
+        XCTAssertEqualObjects(@YES, account[kSyncManagerLocal]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyCreated]);
+        XCTAssertEqualObjects(@YES, account[kSyncManagerLocallyUpdated]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyDeleted]);
     }
 
     // Check server
@@ -446,10 +446,10 @@ static NSException *authException = nil;
         NSDictionary* account = row[0];
         NSString* accountId = account[ACCOUNT_ID];
         idToNamesCreated[accountId] = account[ACCOUNT_NAME];
-        XCTAssertEqual(@NO, account[kSyncManagerLocal]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyCreated]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyUpdated]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyDeleted]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocal]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyCreated]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyUpdated]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyDeleted]);
         XCTAssertFalse([accountId hasPrefix:@"local_"]);
     }
     
@@ -488,10 +488,10 @@ static NSException *authException = nil;
     for (NSArray* row in rows) {
         NSDictionary* account = row[0];
         NSString* accountId = account[ACCOUNT_ID];
-        XCTAssertEqual(@NO, account[kSyncManagerLocal]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyCreated]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyUpdated]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyDeleted]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocal]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyCreated]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyUpdated]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyDeleted]);
         XCTAssertFalse([accountId hasPrefix:@"local_"]);
     }
 }
@@ -591,10 +591,10 @@ static NSException *authException = nil;
     XCTAssertEqual(3, rows.count);
     for (NSArray* row in rows) {
         NSDictionary* account = row[0];
-        XCTAssertEqual(@YES, account[kSyncManagerLocal]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyCreated]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyUpdated]);
-        XCTAssertEqual(@YES, account[kSyncManagerLocallyDeleted]);
+        XCTAssertEqualObjects(@YES, account[kSyncManagerLocal]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyCreated]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyUpdated]);
+        XCTAssertEqualObjects(@YES, account[kSyncManagerLocallyDeleted]);
     }
 
     // Check server
@@ -631,10 +631,10 @@ static NSException *authException = nil;
     XCTAssertEqual(3, rows.count);
     for (NSArray* row in rows) {
         NSDictionary* account = row[0];
-        XCTAssertEqual(@YES, account[kSyncManagerLocal]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyCreated]);
-        XCTAssertEqual(@NO, account[kSyncManagerLocallyUpdated]);
-        XCTAssertEqual(@YES, account[kSyncManagerLocallyDeleted]);
+        XCTAssertEqualObjects(@YES, account[kSyncManagerLocal]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyCreated]);
+        XCTAssertEqualObjects(@NO, account[kSyncManagerLocallyUpdated]);
+        XCTAssertEqualObjects(@YES, account[kSyncManagerLocallyDeleted]);
     }
 }
 

--- a/libs/SmartSync/SmartSyncTests/Targets/TestSyncUpTarget.m
+++ b/libs/SmartSync/SmartSyncTests/Targets/TestSyncUpTarget.m
@@ -45,21 +45,39 @@ static NSString * const kTestSyncUpSendSyncUpErrorKey = @"sendSyncUpErrorKey";
 - (instancetype)initWithRemoteModDateCompare:(TestSyncUpTargetModDateCompare)dateCompare
                           sendRemoteModError:(BOOL)sendRemoteModError
                              sendSyncUpError:(BOOL)sendSyncUpError {
-    NSDictionary *dict = @{ kTestSyncUpDateCompareKey: @(dateCompare),
-                            kTestSyncUpSendRemoteModErrorKey: @(sendRemoteModError),
-                            kTestSyncUpSendSyncUpErrorKey: @(sendSyncUpError) };
-    return [self initWithDict:dict];
+    self = [super init];
+    if (self) {
+        [self commonInitWithRemoteModDateCompare:dateCompare sendRemoteModError:sendRemoteModError sendSyncUpError:sendSyncUpError];
+    }
+    return self;
 }
 
 - (instancetype)initWithDict:(NSDictionary *)dict {
     self = [super initWithDict:dict];
     if (self) {
-        self.targetType = SFSyncUpTargetTypeCustom;
-        self.dateCompare = (dict[kTestSyncUpDateCompareKey] == nil ? TestSyncUpTargetRemoteModDateSameAsLocal : (TestSyncUpTargetModDateCompare)[dict[kTestSyncUpDateCompareKey] unsignedIntegerValue]);
-        self.sendRemoteModError = (dict[kTestSyncUpSendRemoteModErrorKey] == nil ? NO : [dict[kTestSyncUpSendRemoteModErrorKey] boolValue]);
-        self.sendSyncUpError = (dict[kTestSyncUpSendSyncUpErrorKey] == nil ? NO : [dict[kTestSyncUpSendSyncUpErrorKey] boolValue]);
+        TestSyncUpTargetModDateCompare dateCompare = (dict[kTestSyncUpDateCompareKey] == nil ? TestSyncUpTargetRemoteModDateSameAsLocal : (TestSyncUpTargetModDateCompare)[dict[kTestSyncUpDateCompareKey] unsignedIntegerValue]);
+        BOOL sendRemoteModError = (dict[kTestSyncUpSendRemoteModErrorKey] == nil ? NO : [dict[kTestSyncUpSendRemoteModErrorKey] boolValue]);
+        BOOL sendSyncUpError = (dict[kTestSyncUpSendSyncUpErrorKey] == nil ? NO : [dict[kTestSyncUpSendSyncUpErrorKey] boolValue]);
+        [self commonInitWithRemoteModDateCompare:dateCompare sendRemoteModError:sendRemoteModError sendSyncUpError:sendSyncUpError];
     }
     return self;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        [self commonInitWithRemoteModDateCompare:TestSyncUpTargetRemoteModDateSameAsLocal sendRemoteModError:NO sendSyncUpError:NO];
+    }
+    return self;
+}
+
+- (void)commonInitWithRemoteModDateCompare:(TestSyncUpTargetModDateCompare)dateCompare
+                        sendRemoteModError:(BOOL)sendRemoteModError
+                           sendSyncUpError:(BOOL)sendSyncUpError {
+    self.targetType = SFSyncUpTargetTypeCustom;
+    self.dateCompare = dateCompare;
+    self.sendRemoteModError = sendRemoteModError;
+    self.sendSyncUpError = sendSyncUpError;
 }
 
 - (NSMutableDictionary *)asDict {

--- a/libs/SmartSync/SmartSyncTests/Targets/TestSyncUpTarget.m
+++ b/libs/SmartSync/SmartSyncTests/Targets/TestSyncUpTarget.m
@@ -45,37 +45,30 @@ static NSString * const kTestSyncUpSendSyncUpErrorKey = @"sendSyncUpErrorKey";
 - (instancetype)initWithRemoteModDateCompare:(TestSyncUpTargetModDateCompare)dateCompare
                           sendRemoteModError:(BOOL)sendRemoteModError
                              sendSyncUpError:(BOOL)sendSyncUpError {
-    self = [super init];
+    NSDictionary *dict = @{ kTestSyncUpDateCompareKey: @(dateCompare),
+                            kTestSyncUpSendRemoteModErrorKey: @(sendRemoteModError),
+                            kTestSyncUpSendSyncUpErrorKey: @(sendSyncUpError) };
+    return [self initWithDict:dict];
+}
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+    self = [super initWithDict:dict];
     if (self) {
         self.targetType = SFSyncUpTargetTypeCustom;
-        self.dateCompare = dateCompare;
-        self.sendRemoteModError = sendRemoteModError;
-        self.sendSyncUpError = sendSyncUpError;
+        self.dateCompare = (dict[kTestSyncUpDateCompareKey] == nil ? TestSyncUpTargetRemoteModDateSameAsLocal : (TestSyncUpTargetModDateCompare)[dict[kTestSyncUpDateCompareKey] unsignedIntegerValue]);
+        self.sendRemoteModError = (dict[kTestSyncUpSendRemoteModErrorKey] == nil ? NO : [dict[kTestSyncUpSendRemoteModErrorKey] boolValue]);
+        self.sendSyncUpError = (dict[kTestSyncUpSendSyncUpErrorKey] == nil ? NO : [dict[kTestSyncUpSendSyncUpErrorKey] boolValue]);
     }
     return self;
 }
 
-- (instancetype)init {
-    return [self initWithRemoteModDateCompare:TestSyncUpTargetRemoteModDateSameAsLocal
-                           sendRemoteModError:NO
-                              sendSyncUpError:NO];
-}
-
-+ (TestSyncUpTarget *)newFromDict:(NSDictionary *)dict {
-    TestSyncUpTargetModDateCompare compare = (dict[kTestSyncUpDateCompareKey] == nil ? TestSyncUpTargetRemoteModDateSameAsLocal : (TestSyncUpTargetModDateCompare)[dict[kTestSyncUpDateCompareKey] unsignedIntegerValue]);
-    BOOL sendRemoteModError = (dict[kTestSyncUpSendRemoteModErrorKey] == nil ? NO : [dict[kTestSyncUpSendRemoteModErrorKey] boolValue]);
-    BOOL sendSyncUpError = (dict[kTestSyncUpSendSyncUpErrorKey] == nil ? NO : [dict[kTestSyncUpSendSyncUpErrorKey] boolValue]);
-    return [[TestSyncUpTarget alloc] initWithRemoteModDateCompare:compare sendRemoteModError:sendRemoteModError sendSyncUpError:sendSyncUpError];
-}
-
-- (NSDictionary *)asDict {
-    return @{
-             kSFSyncTargetTypeKey: [[self class] targetTypeToString:self.targetType],
-             kSFSyncTargetiOSImplKey: NSStringFromClass([self class]),
-             kTestSyncUpDateCompareKey: @(self.dateCompare),
-             kTestSyncUpSendRemoteModErrorKey: @(self.sendRemoteModError),
-             kTestSyncUpSendSyncUpErrorKey: @(self.sendSyncUpError)
-             };
+- (NSMutableDictionary *)asDict {
+    NSMutableDictionary *dict = [super asDict];
+    dict[kSFSyncTargetiOSImplKey] = NSStringFromClass([self class]);
+    dict[kTestSyncUpDateCompareKey] = @(self.dateCompare);
+    dict[kTestSyncUpSendRemoteModErrorKey] = @(self.sendRemoteModError);
+    dict[kTestSyncUpSendSyncUpErrorKey] = @(self.sendSyncUpError);
+    return dict;
 }
 
 - (void)fetchRecordModificationDates:(NSDictionary *)record

--- a/libs/SmartSync/SmartSyncTests/Targets/TestSyncUpTarget.m
+++ b/libs/SmartSync/SmartSyncTests/Targets/TestSyncUpTarget.m
@@ -81,7 +81,7 @@ static NSString * const kTestSyncUpSendSyncUpErrorKey = @"sendSyncUpErrorKey";
                                                           userInfo:@{ NSLocalizedDescriptionKey: @"RemoteModError" }];
                 modificationResultBlock(nil, nil, remoteModError);
             } else {
-                NSDate *localLastModifiedDate = [SFSmartSyncObjectUtils getDateFromIsoDateString:record[kLastModifiedDate]];
+                NSDate *localLastModifiedDate = [SFSmartSyncObjectUtils getDateFromIsoDateString:record[self.modificationDateFieldName]];
                 NSDate *remoteLastModifiedDate;
                 switch (self.dateCompare) {
                     case TestSyncUpTargetRemoteModDateGreaterThanLocal:


### PR DESCRIPTION
- Updated the creation of sync targets, both in the serialized/deserialized dictionary cases as well as standard object initializers, to inherit initializers and property setting from their ancestors.
- Updated the factory methods to use the serializer/deserializer init methods.
- Updated last modified date and ID paradigms to allow for customized field names for these properties.  Defaults are still `LastModifiedDate` and `Id`, respectively.