### PR TITLE
Avoiding SFRootViewManager to present/dismiss inspector

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
@@ -316,7 +316,7 @@ NSString * const kIsGlobalStoreArg    = @"isGlobalStore";
 - (void)pgShowInspector:(CDVInvokedUrlCommand *)command
 {
     [self runCommand:^(NSDictionary* argsDict) {
-        [SFSmartStoreInspectorViewController present];
+        [SFSmartStoreInspectorViewController present:self.viewController];
         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"OK"];
     } command:command];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreInspectorViewController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreInspectorViewController.h
@@ -32,7 +32,7 @@
 /**
  Show smart store inspector
  */
-+ (void) present;
++ (void) present:(UIViewController*) currentViewController;
 
 /**
  Hide smart store inspector

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreInspectorViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreInspectorViewController.m
@@ -88,14 +88,28 @@ static NSUInteger   const kLabelTag              = 99;
 
 #pragma mark - Present / dimiss
 
-+ (void) present
++ (void) present:(UIViewController*)currentViewController
 {
-    [[SFRootViewManager sharedManager] pushViewController:[SFSmartStoreInspectorViewController sharedInstance]];
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [SFSmartStoreInspectorViewController present:currentViewController];
+        });
+        return;
+    }
+
+    [currentViewController presentViewController:[SFSmartStoreInspectorViewController sharedInstance] animated:NO completion:nil];
 }
 
 + (void) dismiss
 {
-    [[SFRootViewManager sharedManager] popViewController:[SFSmartStoreInspectorViewController sharedInstance]];
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [SFSmartStoreInspectorViewController dismiss];
+        });
+        return;
+    }
+
+    [[[SFSmartStoreInspectorViewController sharedInstance] presentingViewController] dismissViewControllerAnimated:NO completion:nil];
 }
 
 #pragma mark - Results setter


### PR DESCRIPTION
Dev can either call present (which now takes a UIViewController) and dismiss or get the sharedInstance and present it themselves
SFRootViewManager was getting stuck in waitForPresentCompletion on iOS8