### PR TITLE
Updates to data management

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager+Internal.h
@@ -49,6 +49,12 @@ static NSString * const kStoresDirectory          = @"stores";
                               newKey:(NSString *)newKey
                                error:(NSError **)error;
 
-- (FMDatabase *)openDatabaseWithPath:(NSString *)dbPath key:(NSString *)key error:(NSError **)error;
++ (FMDatabase *)openDatabaseWithPath:(NSString *)dbPath key:(NSString *)key error:(NSError **)error;
++ (FMDatabase *)encryptOrUnencryptDb:(FMDatabase *)db
+                                name:(NSString *)storeName
+                                path:(NSString *)storePath
+                              oldKey:(NSString *)oldKey
+                              newKey:(NSString *)newKey
+                               error:(NSError **)error;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.h
@@ -142,6 +142,6 @@ extern NSString * const kSFSmartStoreDbErrorDomain;
  @param error The output NSError parameter that will be populated in the event of an error.
  @return YES if the database can be read, NO otherwise.
  */
-- (BOOL)verifyDatabaseAccess:(FMDatabase *)dbPath error:(NSError **)error;
++ (BOOL)verifyDatabaseAccess:(FMDatabase *)dbPath error:(NSError **)error;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreUpgrade.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreUpgrade.m
@@ -189,7 +189,7 @@ static NSString * const kKeyStoreEncryptedStoresKey = @"com.salesforce.smartstor
     if (db == nil || openDbError != nil) {
         [SFLogger log:[SFSmartStoreUpgrade class] level:SFLogLevelError format:@"Error opening store '%@' to update encryption: %@", storeName, [openDbError localizedDescription]];
         return NO;
-    } else if (![dbMgr verifyDatabaseAccess:db error:&verifyDbAccessError]) {
+    } else if (![[dbMgr class] verifyDatabaseAccess:db error:&verifyDbAccessError]) {
         [SFLogger log:[SFSmartStoreUpgrade class] level:SFLogLevelError format:@"Error reading the content of store '%@' during encryption upgrade: %@", storeName, [verifyDbAccessError localizedDescription]];
         [db close];
         return NO;


### PR DESCRIPTION
No real functionality changes here.  Just changing a couple of the `SFSmartStoreDatabaseManager` methods from instance level to class level, to allow the encryption/decryption process to be isolated from SmartStore itself.  `encryptOrUnencryptDb:name:path:oldKey:newKey:error:` is a new internal method signature, but it's encapsulating the functionality that was already there.

Tests pass, SmartStore sample apps all seem good.