### PR TITLE
where is a reserved word in Swift

### DIFF
--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+QueryBuilder.h
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+QueryBuilder.h
@@ -33,7 +33,7 @@
  * NSString *soqlQuery = 
  * [SFRestAPI SOQLQueryWithFields:[NSArray arrayWithObjects:@"Id", @"Name", @"Company", @"Status", nil]
  *                             sObject:@"Lead"
- *                               where:nil
+ *                               whereClause:nil
  *                               limit:10];
  *   							   
  *   							   
@@ -99,7 +99,7 @@ extern NSInteger const kMaxSOSLSearchLimit;
  */
 + (NSString *) SOQLQueryWithFields:(NSArray *)fields 
                            sObject:(NSString *)sObject 
-                             where:(NSString *)where 
+                             whereClause:(NSString *)whereClause
                              limit:(NSInteger)limit;
 
 /**
@@ -114,7 +114,7 @@ extern NSInteger const kMaxSOSLSearchLimit;
  */
 + (NSString *) SOQLQueryWithFields:(NSArray *)fields 
                            sObject:(NSString *)sObject 
-                             where:(NSString *)where 
+                             whereClause:(NSString *)whereClause
                            groupBy:(NSArray *)groupBy 
                             having:(NSString *)having
                            orderBy:(NSArray *)orderBy 

--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+QueryBuilder.m
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+QueryBuilder.m
@@ -88,17 +88,17 @@ NSInteger const kMaxSOSLSearchLimit      = 200;
 	return query;
 }
 
-+ (NSString *)SOQLQueryWithFields:(NSArray *)fields sObject:(NSString *)sObject where:(NSString *)where limit:(NSInteger)limit {
++ (NSString *)SOQLQueryWithFields:(NSArray *)fields sObject:(NSString *)sObject whereClause:(NSString *)whereClause limit:(NSInteger)limit {
 	return [self SOQLQueryWithFields:fields
 							 sObject:sObject
-							   where:where
+							   whereClause:whereClause
 							 groupBy:nil
 							  having:nil
 							 orderBy:nil
 							   limit:limit];
 }
 
-+ (NSString *)SOQLQueryWithFields:(NSArray *)fields sObject:(NSString *)sObject where:(NSString *)where groupBy:(NSArray *)groupBy having:(NSString *)having orderBy:(NSArray *)orderBy limit:(NSInteger)limit {
++ (NSString *)SOQLQueryWithFields:(NSArray *)fields sObject:(NSString *)sObject whereClause:(NSString *)whereClause groupBy:(NSArray *)groupBy having:(NSString *)having orderBy:(NSArray *)orderBy limit:(NSInteger)limit {
 	if( !fields || [fields count] == 0 )
 		return nil;
 
@@ -109,8 +109,8 @@ NSInteger const kMaxSOSLSearchLimit      = 200;
 							  [[[NSSet setWithArray:fields] allObjects] componentsJoinedByString:@","],
 							  sObject];
 
-	if( where && [where length] > 0 )
-		[query appendFormat:@" where %@", where];
+	if( whereClause && [whereClause length] > 0 )
+		[query appendFormat:@" where %@", whereClause];
 
 	if( groupBy && [groupBy count] > 0 ) {
 		[query appendFormat:@" group by %@", [groupBy componentsJoinedByString:@","]];

--- a/libs/SalesforceRestAPI/SalesforceRestAPITests/SalesforceRestAPITests.m
+++ b/libs/SalesforceRestAPI/SalesforceRestAPITests/SalesforceRestAPITests.m
@@ -1291,10 +1291,10 @@ XCTAssertNil( e, @"%@ errored but should not have. Error: %@",testName,e); \
 
 - (void) testSOQL {
 
-    XCTAssertNil( [SFRestAPI SOQLQueryWithFields:nil sObject:nil where:nil limit:0],
+    XCTAssertNil( [SFRestAPI SOQLQueryWithFields:nil sObject:nil whereClause:nil limit:0],
                 @"Invalid query did not result in nil output.");
     
-    XCTAssertNil( [SFRestAPI SOQLQueryWithFields:@[@"Id"] sObject:nil where:nil limit:0],
+    XCTAssertNil( [SFRestAPI SOQLQueryWithFields:@[@"Id"] sObject:nil whereClause:nil limit:0],
                 @"Invalid query did not result in nil output.");
     
     NSString *simpleQuery = @"select id from Lead where id<>null limit 10";
@@ -1303,14 +1303,14 @@ XCTAssertNil( e, @"%@ errored but should not have. Error: %@",testName,e); \
     XCTAssertTrue( [simpleQuery isEqualToString:
                         [SFRestAPI SOQLQueryWithFields:@[@"id"]
                                                sObject:@"Lead"
-                                                 where:@"id<>null"
+                                                 whereClause:@"id<>null"
                                                  limit:10]],                 
                  @"Simple SOQL query does not match.");
     
     
     NSString *generatedComplexQuery = [SFRestAPI SOQLQueryWithFields:@[@"id", @"status"]
                                                              sObject:@"Lead"
-                                                               where:@"id<>null"
+                                                               whereClause:@"id<>null"
                                                              groupBy:@[@"status"]
                                                               having:nil
                                                              orderBy:nil

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.m
@@ -369,7 +369,7 @@ refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan
             if (![SFSmartSyncObjectUtils isEmpty:self.communityId]) {
                 whereClause = [NSString stringWithFormat:@"%@ AND NetworkId = '%@'", whereClause, self.communityId];
             }
-            [queryBuilder where:whereClause];
+            [queryBuilder whereClause:whereClause];
             [queryBuilder limit:limit];
         } else {
             BOOL objectContainedLastViewedDate = NO;
@@ -401,7 +401,7 @@ refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan
                     whereClause = [NSString stringWithFormat:@"%@ AND %@ = '%@'", whereClause, networkFieldName, self.communityId];
                 }
             }
-            [queryBuilder where:whereClause];
+            [queryBuilder whereClause:whereClause];
         }
         NSString * queryString = [queryBuilder build];
         
@@ -824,8 +824,8 @@ refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan
         if (![SFSmartSyncObjectUtils isEmpty:self.communityId] && ![SFSmartSyncObjectUtils isEmpty:networkFieldName]) {
             whereClause = [NSString stringWithFormat:@"%@ AND %@ = '%@'", whereClause, networkFieldName, self.communityId];
         }
-        queryBuilder = [queryBuilder where:whereClause];
-        NSString *queryString = [[queryBuilder where:whereClause] build];
+        queryBuilder = [queryBuilder whereClause:whereClause];
+        NSString *queryString = [[queryBuilder whereClause:whereClause] build];
         
         SFRestDictionaryResponseBlock completeBlock = ^(NSDictionary* responseAsJson) {
             NSArray *records = responseAsJson[@"records"];

--- a/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFMruSyncDownTarget.m
@@ -94,7 +94,7 @@ NSString * const kSFSyncTargetFieldlist = @"fieldlist";
                                  componentsJoinedByString:@""];
         NSString* soql = [[[[SFSmartSyncSoqlBuilder withFieldsArray:self.fieldlist]
                             from:self.objectType]
-                           where:inPredicate]
+                           whereClause:inPredicate]
                           build];
         
         

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncSoqlBuilder.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncSoqlBuilder.h
@@ -51,10 +51,10 @@
 
 /** A builder to help create a SOQL statement.
  *
- * @param where a conditional statement
+ * @param whereClause a conditional statement
  * @return the builder
  */
-- (SFSmartSyncSoqlBuilder *) where:(NSString *) where;
+- (SFSmartSyncSoqlBuilder *) whereClause:(NSString *) whereClause;
 
 /** A builder to help create a SOQL statement.
  *

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncSoqlBuilder.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncSoqlBuilder.m
@@ -63,8 +63,8 @@
      return self;
 }
      
-- (SFSmartSyncSoqlBuilder *) where:(NSString *) where {
-    [properties setObject:where forKey:@"where"];
+- (SFSmartSyncSoqlBuilder *) whereClause:(NSString *) whereClause {
+    [properties setObject:whereClause forKey:@"whereClause"];
      return self;
 }
      
@@ -138,10 +138,10 @@
     }
     [query appendString:@" from "];
     [query appendString:from];
-    NSString *where = [properties objectForKey:@"where"];
-    if ([where length] > 0) {
+    NSString *whereClause = [properties objectForKey:@"whereClause"];
+    if ([whereClause length] > 0) {
         [query appendString:@" where "];
-        [query appendString:where];
+        [query appendString:whereClause];
     }
     NSString *groupBy = [properties objectForKey:@"groupBy"];
     if ([groupBy length] > 0) {

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncSoslReturningBuilder.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncSoslReturningBuilder.h
@@ -47,10 +47,10 @@
 
 /** A builder to help create a returning statement.
  *
- * @param where a description of how search results for the given object should be filtered, based on individual field values. If unspecified, the search retrieves all the rows in the object that are visible to the user
+ * @param whereClause a description of how search results for the given object should be filtered, based on individual field values. If unspecified, the search retrieves all the rows in the object that are visible to the user
  * @return the builder
  */
-- (SFSmartSyncSoslReturningBuilder *) where:(NSString *) where;
+- (SFSmartSyncSoslReturningBuilder *) whereClause:(NSString *) whereClause;
 
 /** A builder to help create a returning statement.
  *

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncSoslReturningBuilder.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncSoslReturningBuilder.m
@@ -65,8 +65,8 @@
     return self;
 }
 
-- (SFSmartSyncSoslReturningBuilder *) where:(NSString *) where {
-    [properties setObject:where forKey:@"where"];
+- (SFSmartSyncSoslReturningBuilder *) whereClause:(NSString *) whereClause {
+    [properties setObject:whereClause forKey:@"whereClause"];
     return self;
 }
 
@@ -100,10 +100,10 @@
     NSString *fields = [properties objectForKey:@"fields"];
     if ([fields length] > 0) {
         [query appendFormat:@"(%@", fields];
-        NSString *where = [properties objectForKey:@"where"];
-        if ([where length] > 0) {
+        NSString *whereClause = [properties objectForKey:@"whereClause"];
+        if ([whereClause length] > 0) {
             [query appendString:@" where "];
-            [query appendString: where];
+            [query appendString: whereClause];
         }
         NSString *orderBy = [properties objectForKey:@"orderBy"];
         if ([orderBy length] > 0) {

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
@@ -117,7 +117,7 @@ static NSString * const kSFSyncUpTargetTypeCustom = @"custom";
     
     SFSmartSyncSoqlBuilder *soqlBuilder = [SFSmartSyncSoqlBuilder withFields:self.modificationDateFieldName];
     [soqlBuilder from:objectType];
-    [soqlBuilder where:[NSString stringWithFormat:@"%@ = '%@'", self.idFieldName, objectId]];
+    [soqlBuilder whereClause:[NSString stringWithFormat:@"%@ = '%@'", self.idFieldName, objectId]];
     NSString *query = [soqlBuilder build];
     
     SFRestFailBlock failBlock = ^(NSError *error) {


### PR DESCRIPTION
No longer using "where" as parameter or variable name

NB: Common utils still does in some of its classes (SFSoqlBuilder.h and SFSoslReturningBuilder.h)