### PR TITLE
Fixing MKNetworkKit issue in podspec

### DIFF
--- a/SalesforceMobileSDK-iOS.podspec
+++ b/SalesforceMobileSDK-iOS.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
 
   s.prepare_command = <<-CMD
       sed -i -e 's/#import \\"Categories\\//#import \\"/g' external/MKNetworkKit/MKNetworkKit/MKNetworkKit.h
+      sed -i -e 's/#import \\"Reachability\\//#import \\"/g' external/MKNetworkKit/MKNetworkKit/MKNetworkKit.h
   CMD
 
   s.subspec 'SalesforceCommonUtils' do |commonutils|


### PR DESCRIPTION
I don't know why this only started showing up with Xcode 6.3, but MKNetworkKit.h's

        #import "Reachability/Reachability.h"

started causing issues.  The line I added here just piggy backs on other logic to do the same with other imports in MKNetworkKit.h.  I've verified that it passes `pod lib lint --allow-warnings` and installs and runs properly in a consuming app.

Not sure if you want/need to update the tag/version.  I'll leave that to you guys.