### PR TITLE
Adding podspec header updates script to lib projects

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork.xcodeproj/project.pbxproj
+++ b/libs/SalesforceNetwork/SalesforceNetwork.xcodeproj/project.pbxproj
@@ -647,6 +647,7 @@
 				827DD3D81A7BF55F00519F03 /* CopyFiles */,
 				827DD4C01A7C050400519F03 /* Headers */,
 				8253495C1A8C1B7A0019FE0B /* ShellScript */,
+				825BE47B1AE023150048E6DF /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -716,6 +717,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$SRCROOT/../../shared/common/build/tools/generate_headers.sh\" -o \"$TARGET_BUILD_DIR/Headers/$PRODUCT_NAME/$PRODUCT_NAME.h\" -u \"$SRCROOT/$PRODUCT_NAME.h\"";
+		};
+		825BE47B1AE023150048E6DF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PROJECT_DIR}/../../shared/common/build/tools/update_podspec_headers.sh\" -s networksdk";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
+++ b/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
@@ -402,6 +402,7 @@
 				CFA9ADD113AA86D80024260E /* Frameworks */,
 				82BBB58A1790A2BD00374DD8 /* Headers */,
 				827DD5121A8304FB00519F03 /* ShellScript */,
+				825BE47C1AE025150048E6DF /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -502,6 +503,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "docOutputDir=\"${PROJECT_DIR}/../../build/artifacts/doc/build_out/${PROJECT_NAME}\"\nif [ ! -d \"$docOutputDir\" ]; then\nmkdir -p \"$docOutputDir\"\nfi\n\n/usr/bin/headerdoc2html \\\n-o \"$docOutputDir\" \\\n${PROJECT_DIR}/SalesforceOAuth/ -j -C -L -N -Q -t --tocformat=\"default\"";
+		};
+		825BE47C1AE025150048E6DF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PROJECT_DIR}/../../shared/common/build/tools/update_podspec_headers.sh\" -s oauth";
 		};
 		827DD5121A8304FB00519F03 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/libs/SalesforceRestAPI/SalesforceRestAPI.xcodeproj/project.pbxproj
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI.xcodeproj/project.pbxproj
@@ -408,6 +408,7 @@
 				82C0C72B16E076DE0006B3C0 /* Frameworks */,
 				82BBB560179084E500374DD8 /* Headers */,
 				827DD5131A83053100519F03 /* ShellScript */,
+				825BE4801AE0253B0048E6DF /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -509,6 +510,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "docOutputDir=\"${PROJECT_DIR}/../../build/artifacts/doc/build_out/${PROJECT_NAME}\"\nif [ ! -d \"$docOutputDir\" ]; then\nmkdir -p \"$docOutputDir\"\nfi\n\n/usr/bin/headerdoc2html \\\n-o \"$docOutputDir\" \\\n${PROJECT_DIR}/SalesforceRestAPI/ -j -C -L -N -Q -t --tocformat=\"default\"";
+		};
+		825BE4801AE0253B0048E6DF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PROJECT_DIR}/../../shared/common/build/tools/update_podspec_headers.sh\" -s restapi";
 		};
 		827DD5131A83053100519F03 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 				82D53D2F1A3618CD00E46F8F /* CopyFiles */,
 				82D53D4F1A36242B00E46F8F /* Headers */,
 				827DD5171A83066B00519F03 /* ShellScript */,
+				825BE4841AE025910048E6DF /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -272,6 +273,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		825BE4841AE025910048E6DF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PROJECT_DIR}/../../shared/common/build/tools/update_podspec_headers.sh\" -s salesforcesdkcommon";
+		};
 		8276EE041A7853D30083F7EA /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -824,6 +824,7 @@
 				8220B74916D804CA00EC3921 /* Frameworks */,
 				82BBB56817909AFC00374DD8 /* Headers */,
 				827DD5141A83056000519F03 /* ShellScript */,
+				825BE4811AE025500048E6DF /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -940,6 +941,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "docOutputDir=\"${PROJECT_DIR}/../../build/artifacts/doc/build_out/${PROJECT_NAME}\"\nif [ ! -d \"$docOutputDir\" ]; then\nmkdir -p \"$docOutputDir\"\nfi\n\n/usr/bin/headerdoc2html \\\n-o \"$docOutputDir\" \\\n${PROJECT_DIR}/SalesforceSDKCore/ -j -C -L -N -Q -t --tocformat=\"default\"";
+		};
+		825BE4811AE025500048E6DF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PROJECT_DIR}/../../shared/common/build/tools/update_podspec_headers.sh\" -s sdkcore";
 		};
 		827DD5141A83056000519F03 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/libs/SalesforceSecurity/SalesforceSecurity.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSecurity/SalesforceSecurity.xcodeproj/project.pbxproj
@@ -320,6 +320,7 @@
 				820AB72118E230EC00E25E1D /* Frameworks */,
 				82AA403018E398AF00BD34D8 /* Headers */,
 				827DD5151A83060D00519F03 /* ShellScript */,
+				825BE4821AE025660048E6DF /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -400,6 +401,19 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "docOutputDir=\"${PROJECT_DIR}/../../build/artifacts/doc/build_out/${PROJECT_NAME}\"\nif [ ! -d \"$docOutputDir\" ]; then\nmkdir -p \"$docOutputDir\"\nfi\n\n/usr/bin/headerdoc2html \\\n-o \"$docOutputDir\" \\\n${PROJECT_DIR}/SalesforceSecurity/ -j -C -L -N -Q -t --tocformat=\"default\"";
+		};
+		825BE4821AE025660048E6DF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PROJECT_DIR}/../../shared/common/build/tools/update_podspec_headers.sh\" -s salesforcesecurity";
 		};
 		827DD5151A83060D00519F03 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/libs/SmartSync/SmartSync.xcodeproj/project.pbxproj
+++ b/libs/SmartSync/SmartSync.xcodeproj/project.pbxproj
@@ -470,6 +470,7 @@
 				CEAAAE42195911E600CBBFE9 /* Frameworks */,
 				82722FFE19D4FCDF0066A350 /* Headers */,
 				827DD5161A83064400519F03 /* ShellScript */,
+				825BE4831AE0257D0048E6DF /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -539,6 +540,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		825BE4831AE0257D0048E6DF /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PROJECT_DIR}/../../shared/common/build/tools/update_podspec_headers.sh\" -s smartsync";
+		};
 		827DD5161A83064400519F03 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/shared/common/build/tools/update_podspec_headers.sh
+++ b/shared/common/build/tools/update_podspec_headers.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Copyright (c) 2015, salesforce.com, inc. All rights reserved.
+# 
+# Redistribution and use of this software in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice, this list of conditions
+# and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice, this list of
+# conditions and the following disclaimer in the documentation and/or other materials provided
+# with the distribution.
+# * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+# endorse or promote products derived from this software without specific prior written
+# permission of salesforce.com, inc.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+# WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# Script to update the podspec with the latest public header files.  Meant to be run as a post-build
+# script in the Xcode projects.
+#
+
+# set -x
+set -e
+
+SUBSPEC_NAME=""
+
+function usage()
+{
+	local appName=`basename $0`
+	echo "Usage:"
+	echo "$appName -s <Subspec Name>"
+}
+
+function parseOpts()
+{
+	while getopts :s: commandLineOpt; do
+		case ${commandLineOpt} in
+			s)
+			    SUBSPEC_NAME=${OPTARG};;
+			?)
+			    echo "Unknown option '-${OPTARG}'."
+			    usage
+			    exit 1
+		esac
+	done
+
+	# Validate that we got the required command line arg(s).
+	if [ "${SUBSPEC_NAME}" == "" ]; then
+		echo "No option specified for Subspec Name."
+		usage
+		exit 2
+	fi
+}
+
+parseOpts "$@"
+
+repoDir=$(cd "$(dirname ${BASH_SOURCE[0]})" && cd ../../../.. && pwd)
+publicHeaderDirectory="${TARGET_BUILD_DIR}/${PUBLIC_HEADERS_FOLDER_PATH}"
+podSpecFile="${repoDir}/SalesforceMobileSDK-iOS.podspec"
+projectDir=`echo "${PROJECT_DIR}" | sed "s#${repoDir}/##g"`
+
+cd "$repoDir"
+
+# Create the public header file list out of the public headers in the build folder.
+publicHeaderFileList=""
+isFirstFile=1
+for headerFile in `ls -1 "${publicHeaderDirectory}"`; do
+	repoHeaderFile=`find ${projectDir} -name $headerFile`
+	if [ "$repoHeaderFile" != "" ]; then
+		if [ $isFirstFile -eq 1 ]; then
+			publicHeaderFileList="'$repoHeaderFile'"
+			isFirstFile=0
+		else
+			publicHeaderFileList=`echo "${publicHeaderFileList}, '$repoHeaderFile'"`
+		fi
+	fi
+done
+
+# Replace the old headers with the new ones.
+searchPattern='^( *'"${SUBSPEC_NAME}"'\.public_header_files = ).*$'
+replacementPattern='\1'"${publicHeaderFileList}"
+sed -E "s#$searchPattern#$replacementPattern#g" "$podSpecFile" > "${podSpecFile}.new"
+mv "${podSpecFile}.new" "${podSpecFile}"


### PR DESCRIPTION
This will make sure the public headers of the CocoaPods subspecs stay up to date when you're building.