### PR TITLE
Show auth view in willBeginAuthenticationWithView to prevent delay after pressing login button.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -1055,6 +1055,16 @@ static Class InstanceClass = nil;
             [delegate authManagerWillBeginAuthWithView:self];
         }
     }];
+
+    // Ensure this runs on the main thread.  Has to be sync, because the coordinator expects the auth view
+    // to be added to a superview by the end of this method.
+    if (![NSThread isMainThread]) {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            self.authViewHandler.authViewDisplayBlock(self, view);
+        });
+    } else {
+        self.authViewHandler.authViewDisplayBlock(self, view);
+    }
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didStartLoad:(UIWebView *)view
@@ -1086,16 +1096,6 @@ static Class InstanceClass = nil;
             [delegate authManager:self willDisplayAuthWebView:view];
         }
     }];
-    
-    // Ensure this runs on the main thread.  Has to be sync, because the coordinator expects the auth view
-    // to be added to a superview by the end of this method.
-    if (![NSThread isMainThread]) {
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            self.authViewHandler.authViewDisplayBlock(self, view);
-        });
-    } else {
-        self.authViewHandler.authViewDisplayBlock(self, view);
-    }
 }
 
 - (void)oauthCoordinatorWillBeginAuthentication:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)info {


### PR DESCRIPTION
Current state: auth web view is presented after is loaded (`[SFOAuthCoordinator webViewDidFinishLoad]`). When user has slow internet connection loading process can take some time (or fail after a timeout). This is not the greatest user experience :wink: 

After change from this PR auth web view is presented when authentication process begins (`[SFOAuthCoordinator beginUserAgentFlow]`) so we can prevent possible delay during loading time.

Moreover user is presented with an option to cancel the loading (right now he'll have to wait until something loads, or even worse - he might get bored and leave that screen before oauth gets presented).