### PR TITLE
Don't prematurely clean up helper objects in SFAuthenticationManager

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -821,10 +821,8 @@ static Class InstanceClass = nil;
     
     [SFAuthenticationManager removeAllCookies];
     [self.coordinator stopAuthentication];
-    self.coordinator.delegate = nil;
-    self.idCoordinator.delegate = nil;
-    SFRelease(_idCoordinator);
-    SFRelease(_coordinator);
+    self.idCoordinator.idData = nil;
+    self.coordinator.credentials = nil;
 }
 
 - (void)cleanupStatusAlert


### PR DESCRIPTION
I unearthed this one by clicking Deny in the authorization screen, which would crash the app (though only on device, for some reason).  But in reality, anything that would go through the auth flow that throws an alert error during the auth process, would cause a similar crash.  The issue is that the `clearAccountState:` method is called ultimately as part of the `SFOAuthCoordinatorDelegate` callback, which was causing the dealloc of the `SFOAuthCoordinator` instance before it was finished working internally.

Realistically, the helper objects in question don't need to be released before the parent object is dealloc'ed—they'll get properly repurposed when new auth starts.  So I just set their user-centric properties to `nil` on the cleanup, so there's no ambiguity there.  I'm not sure those would matter either, but it seemed like the right thing to do.