### PR TITLE
Updating ID data now posts user did change notification

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -653,9 +653,6 @@ static Class InstanceClass = nil;
     [[SFUserAccountManager sharedInstance] saveAccounts:nil];
 
     // Notify the session is ready
-    [self willChangeValueForKey:@"currentUser"];
-    [self didChangeValueForKey:@"currentUser"];
-    
     [self willChangeValueForKey:@"haveValidSession"];
     [self didChangeValueForKey:@"haveValidSession"];
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -647,8 +647,8 @@ static Class InstanceClass = nil;
     
     // Assign the identity data to the current user
     NSAssert([SFUserAccountManager sharedInstance].currentUser != nil, @"Current user should not be nil at this point.");
-    [SFUserAccountManager sharedInstance].currentUser.idData = self.idCoordinator.idData;
-    
+    [[SFUserAccountManager sharedInstance] applyIdData:self.idCoordinator.idData];
+
     // Save the accounts
     [[SFUserAccountManager sharedInstance] saveAccounts:nil];
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountConstants.h
@@ -80,6 +80,6 @@ typedef NS_OPTIONS(NSUInteger, SFUserAccountChange) {
 
     /** The ID data changed
      */
-    SFUserAccountChangeIdData = 1 << 5,
+    SFUserAccountChangeIdData = 1 << 6
 };
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountConstants.h
@@ -77,5 +77,9 @@ typedef NS_OPTIONS(NSUInteger, SFUserAccountChange) {
     /** The community ID changed
      */
     SFUserAccountChangeCommunityId  = 1 << 5,
+
+    /** The ID data changed
+     */
+    SFUserAccountChangeIdData = 1 << 5,
 };
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -283,9 +283,16 @@ extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
 
 /** Invoke this method to apply the specified credentials to the
  current user. If no user exists, a new one is created.
+ This will post user update notification.
  @param credentials The credentials to apply
  */
 - (void)applyCredentials:(SFOAuthCredentials*)credentials;
+
+/** Invoke this method to apply the specified id data to the
+ current user. This will post user update notification.
+ @param credentials The id data to apply
+ */
+- (void)applyIdData:(SFIdentityData *)idData;
 
 /** Apply custom data to the SFUserAccount that can be
  accessed outside that user's sandbox. This data will be persisted

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -904,9 +904,17 @@ static NSString * const kUserAccountEncryptionKeyLabel = @"com.salesforce.userAc
     [self userChanged:change];
 }
 
+- (void)applyIdData:(SFIdentityData *)idData {
+    self.currentUser.idData = idData;
+    [self userChanged:SFUserAccountChangeIdData];
+}
+
 - (void)setObjectForCurrentUserCustomData:(NSObject<NSCoding> *)object forKey:(NSString *)key {
     [self.currentUser setCustomDataObject:object forKey:key];
 }
+
+#pragma mark -
+#pragma mark Switching Users
 
 - (void)switchToNewUser {
     [self switchToUser:nil];
@@ -937,6 +945,9 @@ static NSString * const kUserAccountEncryptionKeyLabel = @"com.salesforce.userAc
         }
     }];
 }
+
+#pragma mark -
+#pragma mark User Change Notifications
 
 - (void)userChanged:(SFUserAccountChange)change {
     if (![self.lastChangedOrgId isEqualToString:self.currentUser.credentials.organizationId]) {


### PR DESCRIPTION
With current implementation there's no way of knowing when `currentUser`s `idData` has been updated as it gets silently updated by `SFAuthenticationManager`. It's a bit contrary to behavior of the user account manager object - other changes trigger notifications. This makes working with `SFUserAccountManager` a bit hard. 

This PR changes this by adding logic that posts notification upon `currentUser`s `idData` update. 
