### PR TITLE
Fixed issues with network layer not being usable after signing

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -176,6 +176,11 @@ extern NSString * const kSFUserLoggedInNotification;
 extern NSString * const kSFAuthenticationManagerFinishedNotification;
 
 /**
+ Key for account object present in user info in notifications.
+ */
+extern NSString * const kSFUserAccountKey;
+
+/**
  This class handles all the authentication related tasks, which includes login, logout and session refresh
  */
 @interface SFAuthenticationManager : NSObject <SFOAuthCoordinatorDelegate, SFIdentityCoordinatorDelegate, SFUserAccountManagerDelegate>

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -58,6 +58,10 @@ NSString * const kSFUserLogoutNotification = @"kSFUserLogoutOccurred";
 NSString * const kSFUserLoggedInNotification = @"kSFUserLoggedIn";
 NSString * const kSFAuthenticationManagerFinishedNotification = @"kSFAuthenticationManagerFinishedNotification";
 
+// Public notification name user info keys
+
+NSString * const kSFUserAccountKey = @"account";
+
 // Auth error handler name constants
 
 static NSString * const kSFInvalidCredentialsAuthErrorHandler = @"InvalidCredentialsErrorHandler";
@@ -431,7 +435,7 @@ static Class InstanceClass = nil;
     
     [self log:SFLogLevelInfo format:@"Logging out user '%@'.", user.userName];
     
-    NSDictionary *userInfo = @{ @"account": user };
+    NSDictionary *userInfo = @{ kSFUserAccountKey: user };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserWillLogoutNotification
                                                         object:self
                                                       userInfo:userInfo];
@@ -471,7 +475,9 @@ static Class InstanceClass = nil;
     userAccountManager.currentUser = nil;
     [self didChangeValueForKey:@"haveValidSession"];
     
-    NSNotification *logoutNotification = [NSNotification notificationWithName:kSFUserLogoutNotification object:self];
+    NSNotification *logoutNotification = [NSNotification notificationWithName:kSFUserLogoutNotification
+                                                                       object:self
+                                                                     userInfo:userInfo];
     [[NSNotificationCenter defaultCenter] postNotification:logoutNotification];
     [self enumerateDelegates:^(id<SFAuthenticationManagerDelegate> delegate) {
         if ([delegate respondsToSelector:@selector(authManagerDidLogout:)]) {


### PR DESCRIPTION
This PR fixes https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/1014 by resetting network shared instance for given account upon sign out. 

Also, minor code beautification :wink: