### PR TITLE
Proper cleanup of CSFNetwork shared instance on logout

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Queue/CSFNetwork.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Queue/CSFNetwork.m
@@ -104,16 +104,6 @@ static NSMutableDictionary *SharedInstances = nil;
     return instance;
 }
 
-+ (void)cleanupNetworkForUserAccount:(SFUserAccount *)userAccount {
-    @synchronized (SharedInstances) {
-        NSString *key = CSFNetworkInstanceKey(userAccount);
-        [SharedInstances removeObjectForKey:key];
-    }
-}
-
-#pragma mark -
-#pragma mark object lifecycle
-
 - (id)init {
     self = [super init];
     if (self) {
@@ -131,15 +121,13 @@ static NSMutableDictionary *SharedInstances = nil;
         self.actionQueue = dispatch_queue_create("com.salesforce.network.action", DISPATCH_QUEUE_SERIAL);
         
         NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-#ifdef SFPlatformiOS
+        #ifdef SFPlatformiOS
 		[notificationCenter addObserver:self
 												 selector:@selector(applicationDidBecomeActive:)
 													 name:UIApplicationDidBecomeActiveNotification
 												   object:nil];
         #endif
         [notificationCenter postNotificationName:CSFNetworkInitializedNotification object:self];
-        [notificationCenter addObserver:self selector:@selector(userWillLogOutNotification:)
-                                   name:kSFUserWillLogoutNotification object:nil];
     }
     return self;
 }
@@ -221,7 +209,7 @@ static NSMutableDictionary *SharedInstances = nil;
         action.duplicateParentAction = duplicateAction;
         [action addDependency:duplicateAction];
     }
-
+    
     [self.queue addOperation:action];
 }
 
@@ -230,7 +218,7 @@ static NSMutableDictionary *SharedInstances = nil;
         if (completionBlock) {
             completionBlock(nil, nil);
         }
-
+        
         return;
     }
 
@@ -248,7 +236,7 @@ static NSMutableDictionary *SharedInstances = nil;
             [self executeAction:action];
         }
     }
-
+    
     [self.queue addOperation:parentOperation];
 }
 
@@ -256,7 +244,6 @@ static NSMutableDictionary *SharedInstances = nil;
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"context = %@", context];
     return [self.queue.operations filteredArrayUsingPredicate:predicate];
 }
-
 - (void)cancelAllActions {
     [self.queue cancelAllOperations];
 }
@@ -302,13 +289,6 @@ static NSMutableDictionary *SharedInstances = nil;
 //       This way we don't ahve to reference UIKit from the network stack, and the consumer
 //       is capable of handling the unauthorized response.
 - (void)receivedDevicedUnauthorizedError:(CSFAction *)action {
-}
-
-#pragma mark - Handling Login State
-
-- (void)userWillLogOutNotification:(NSNotification *)notification {
-    SFUserAccount *userAccount = notification.userInfo[kSFUserAccountKey];
-    [[self class] cleanupNetworkForUserAccount:userAccount];
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -176,11 +176,6 @@ extern NSString * const kSFUserLoggedInNotification;
 extern NSString * const kSFAuthenticationManagerFinishedNotification;
 
 /**
- Key for account object present in user info in notifications.
- */
-extern NSString * const kSFUserAccountKey;
-
-/**
  This class handles all the authentication related tasks, which includes login, logout and session refresh
  */
 @interface SFAuthenticationManager : NSObject <SFOAuthCoordinatorDelegate, SFIdentityCoordinatorDelegate, SFUserAccountManagerDelegate>

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -58,10 +58,6 @@ NSString * const kSFUserLogoutNotification = @"kSFUserLogoutOccurred";
 NSString * const kSFUserLoggedInNotification = @"kSFUserLoggedIn";
 NSString * const kSFAuthenticationManagerFinishedNotification = @"kSFAuthenticationManagerFinishedNotification";
 
-// Public notification name user info keys
-
-NSString * const kSFUserAccountKey = @"account";
-
 // Auth error handler name constants
 
 static NSString * const kSFInvalidCredentialsAuthErrorHandler = @"InvalidCredentialsErrorHandler";
@@ -435,7 +431,7 @@ static Class InstanceClass = nil;
     
     [self log:SFLogLevelInfo format:@"Logging out user '%@'.", user.userName];
     
-    NSDictionary *userInfo = @{ kSFUserAccountKey: user };
+    NSDictionary *userInfo = @{ @"account": user };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserWillLogoutNotification
                                                         object:self
                                                       userInfo:userInfo];
@@ -474,9 +470,7 @@ static Class InstanceClass = nil;
     userAccountManager.currentUser = nil;
     [self didChangeValueForKey:@"haveValidSession"];
     
-    NSNotification *logoutNotification = [NSNotification notificationWithName:kSFUserLogoutNotification
-                                                                       object:self
-                                                                     userInfo:userInfo];
+    NSNotification *logoutNotification = [NSNotification notificationWithName:kSFUserLogoutNotification object:self];
     [[NSNotificationCenter defaultCenter] postNotification:logoutNotification];
     [self enumerateDelegates:^(id<SFAuthenticationManagerDelegate> delegate) {
         if ([delegate respondsToSelector:@selector(authManagerDidLogout:)]) {


### PR DESCRIPTION
* Reverted fix submitted by external contributor
* Cleaning up the CSFNetwork in SharedInstances on logout the same way we do with smarstore, sync manager, metadata manager etc
