### PR TITLE
Fix for bug affecting dependent actions + test

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFAction.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFAction.m
@@ -354,9 +354,9 @@ NSTimeInterval const CSFActionDefaultTimeOut = 3 * 60; // 3 minutes
         return;
     }
     
-    [self willChangeValueForKey:@"executing"];
+    [self willChangeValueForKey:@"isExecuting"];
     _executing = YES;
-    [self didChangeValueForKey:@"executing"];
+    [self didChangeValueForKey:@"isExecuting"];
 
     // If this is a duplicate action, the parent must have just completed, so we can safely process our response based
     // on the result of that parent.  By calling the completion handler, the response will automatically be sent,
@@ -517,13 +517,13 @@ NSTimeInterval const CSFActionDefaultTimeOut = 3 * 60; // 3 minutes
 }
 
 - (void)completeOperationWithError:(NSError *)error {
-    [self willChangeValueForKey:@"executing"];
-    [self willChangeValueForKey:@"finished"];
+    [self willChangeValueForKey:@"isExecuting"];
+    [self willChangeValueForKey:@"isFinished"];
     _executing = NO;
     _finished = YES;
     self.error = error;
-    [self didChangeValueForKey:@"executing"];
-    [self didChangeValueForKey:@"finished"];
+    [self didChangeValueForKey:@"isExecuting"];
+    [self didChangeValueForKey:@"isFinished"];
     
     self.responseData = nil;
     

--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFSalesforceAction.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFSalesforceAction.m
@@ -43,19 +43,6 @@ static void * kObservingKey = &kObservingKey;
         _apiVersion = CSFSalesforceDefaultAPIVersion;
         _pathPrefix = CSFSalesforceActionDefaultPathPrefix;
         self.authRefreshClass = [CSFSalesforceOAuthRefresh class];
-        CSFNetwork *network = self.enqueuedNetwork;
-        [network addObserver:self forKeyPath:@"account.credentials.accessToken"
-                      options:(NSKeyValueObservingOptionInitial |
-                               NSKeyValueObservingOptionNew)
-                      context:kObservingKey];
-        [network addObserver:self forKeyPath:@"account.credentials.instanceUrl"
-                      options:(NSKeyValueObservingOptionInitial |
-                               NSKeyValueObservingOptionNew)
-                      context:kObservingKey];
-        [network addObserver:self forKeyPath:@"account.communityId"
-                      options:(NSKeyValueObservingOptionInitial |
-                               NSKeyValueObservingOptionNew)
-                      context:kObservingKey];
         NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
         [notificationCenter addObserver:self
                                selector:@selector(userAccountManagerDidChangeCurrentUser:)
@@ -71,6 +58,22 @@ static void * kObservingKey = &kObservingKey;
     [network removeObserver:self forKeyPath:@"account.credentials.instanceUrl" context:kObservingKey];
     [network removeObserver:self forKeyPath:@"account.communityId" context:kObservingKey];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)setEnqueuedNetwork:(CSFNetwork *)network {
+    _enqueuedNetwork = network;
+    [network addObserver:self forKeyPath:@"account.credentials.accessToken"
+                 options:(NSKeyValueObservingOptionInitial |
+                          NSKeyValueObservingOptionNew)
+                 context:kObservingKey];
+    [network addObserver:self forKeyPath:@"account.credentials.instanceUrl"
+                 options:(NSKeyValueObservingOptionInitial |
+                          NSKeyValueObservingOptionNew)
+                 context:kObservingKey];
+    [network addObserver:self forKeyPath:@"account.communityId"
+                 options:(NSKeyValueObservingOptionInitial |
+                          NSKeyValueObservingOptionNew)
+                 context:kObservingKey];
 }
 
 - (NSDictionary *)headersForAction {

--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetworkTests/MockNetworkTests.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetworkTests/MockNetworkTests.m
@@ -29,6 +29,52 @@
 #import "CSFNetwork+Internal.h"
 #import "CSFSalesforceAction.h"
 
+@interface MockAction : CSFAction
+
+@property (nonatomic, strong) NSString *actionName;
+@property (nonatomic, strong) dispatch_semaphore_t semaphore;
+
+- (instancetype) initWithName:(NSString*)actionName;
+
+@end
+
+@implementation MockAction
+
+- (instancetype) initWithName:(NSString*)actionName {
+    self = [super initWithResponseBlock:nil];
+    if (self) {
+        self.actionName = actionName;
+        self.semaphore = dispatch_semaphore_create(0);
+    }
+    return self;
+}
+
+- (void) completeAction {
+    dispatch_semaphore_signal(self.semaphore);
+}
+
+- (NSURLRequest*)createURLRequest:(NSError**)error {
+    NSURL* url = [NSURL URLWithString:@"https://cs1.salesforce.com/services/data"];
+    return [NSMutableURLRequest requestWithURL:url];
+}
+
+- (void)completeOperationWithError:(NSError *)error {
+    long result = dispatch_semaphore_wait(self.semaphore, dispatch_time(DISPATCH_TIME_NOW, 15LL * NSEC_PER_SEC)); // at most 15s
+    if (result != 0 && error == nil) {
+        error = [NSError errorWithDomain:CSFNetworkErrorDomain
+                                    code:CSFNetworkInternalError
+                                userInfo:@{ NSLocalizedDescriptionKey: @"Semaphore wait timed out",
+                                            CSFNetworkErrorActionKey: self }];
+    }
+    [super completeOperationWithError:error];
+}
+
+- (BOOL)isEqualToAction:(CSFAction *)action {
+    return [action isKindOfClass:[MockAction class]] && [self.actionName isEqualToString:((MockAction*)action).actionName];
+}
+
+@end
+
 @interface MockNetworkTests : XCTestCase
 
 @end
@@ -138,5 +184,42 @@
     [[SFAuthenticationManager sharedManager] logoutUser:user];
     XCTAssertNil([CSFNetwork cachedNetworkForUserAccount:user]);
 }
+
+// Test that dependent actions run after parent completes
+- (void)testDependentActions {
+    SFUserAccount *user = [TestDataAction testUserAccount];
+    CSFNetwork *network = [[CSFNetwork alloc] initWithUserAccount:user];
+    
+    MockAction *action1 = [[MockAction alloc] initWithName:@"action"];
+    MockAction *action2 = [[MockAction alloc] initWithName:@"action"];
+
+    [network executeAction:action1];
+    [network executeAction:action2];
+
+    // Expect two actions in queue, second one depending on first one
+    XCTAssertEqual(network.actionCount, 2);
+    XCTAssertTrue([action2.dependencies containsObject:action1]);
+
+    // Expect only first action running
+    XCTAssertTrue(action1.isExecuting);
+    XCTAssertFalse(action2.isExecuting);
+
+    // Finishing first one
+    [action1 completeAction];
+    [action1 waitUntilFinished];
+
+    // Expect only second action running
+    XCTAssertFalse(action1.isExecuting);
+    XCTAssertTrue(action2.isExecuting);
+
+    // Finishing second one
+    [action2 completeAction];
+    [action2 waitUntilFinished];
+
+    // Expect no actions running
+    XCTAssertFalse(action1.isExecuting);
+    XCTAssertFalse(action2.isExecuting);
+}
+
 
 @end


### PR DESCRIPTION
Fix for the bug "Dependent action does not start after parent action completes if dependent action is added while parent action is in flight."
The solution was suggested in the bug.

The tricky part was to write a test where realistic mock actions can be stopped in flight to verify the issue first and the solution next.