### PR TITLE
Fix for resync bugs

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -128,7 +128,7 @@ static NSMutableDictionary *syncMgrList = nil;
         self.queue = dispatch_queue_create(kSyncManagerQueue,  NULL);
         [[SFAuthenticationManager sharedManager] addDelegate:self];
         [SFSyncState setupSyncsSoupIfNeeded:self.store];
-        [SFSyncState cleanupUnfinishedSyncs:self.store];
+        [SFSyncState cleanupUnfinishedSyncs:self.store pageSize:kSyncManagerPageSize];
     }
     return self;
 }

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -128,6 +128,7 @@ static NSMutableDictionary *syncMgrList = nil;
         self.queue = dispatch_queue_create(kSyncManagerQueue,  NULL);
         [[SFAuthenticationManager sharedManager] addDelegate:self];
         [SFSyncState setupSyncsSoupIfNeeded:self.store];
+        [SFSyncState cleanupUnfinishedSyncs:self.store];
     }
     return self;
 }

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -96,7 +96,7 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 
 /** Marking syncs that were running when app was stopped as failed
  */
-+ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store;
++ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store pageSize:(int)pageSize;
 
 /** Factory methods
  */

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -94,6 +94,10 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
  */
 + (void) setupSyncsSoupIfNeeded:(SFSmartStore*)store;
 
+/** Marking syncs that were running when app was stopped as failed
+ */
++ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store;
+
 /** Factory methods
  */
 + (SFSyncState*) newSyncDownWithOptions:(SFSyncOptions*)options target:(SFSyncDownTarget*)target soupName:(NSString*)soupName store:(SFSmartStore*)store;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -84,16 +84,15 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     [store registerSoup:kSFSyncStateSyncsSoupName withIndexSpecs:indexSpecs];
 }
 
-+ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store {
++ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store pageSize:(int)pageSize{
     int i = 0;
-    int pageSize = 25;
     NSArray* syncs;
     do {
         // We don't have an index on status - so getting all syncs
-        syncs = [store queryWithQuerySpec:[SFQuerySpec newAllQuerySpec:kSFSyncStateSyncsSoupName withOrderPath:nil withOrder:nil withPageSize:pageSize] pageIndex:i error:nil];
+        syncs = [store queryWithQuerySpec:[SFQuerySpec newAllQuerySpec:kSFSyncStateSyncsSoupName withOrderPath:nil withOrder:kSFSoupQuerySortOrderAscending withPageSize:pageSize] pageIndex:i error:nil];
         NSMutableArray* modifiedSyncs = [NSMutableArray new];
         for (NSDictionary* sync in syncs) {
-            if (sync[kSFSyncStateStatus] == kSFSyncStateStatusRunning) {
+            if ([SFSyncState syncStatusFromString:sync[kSFSyncStateStatus]] == SFSyncStateStatusRunning) {
                 NSMutableDictionary* modifiedSync = [sync mutableCopy];
                 modifiedSync[kSFSyncStateStatus] = kSFSyncStateStatusFailed;
                 [modifiedSyncs addObject:modifiedSync];


### PR DESCRIPTION
At start up we mark any syncs that were running when the app quits as failed to allow resync