### PR TITLE
Fix for resync bug

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartSyncPlugin/SFSmartSyncPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartSyncPlugin/SFSmartSyncPlugin.m
@@ -157,7 +157,12 @@ NSString * const kSyncIsGlobalStoreArg    = @"isGlobalStore";
         SFSyncState* sync = [[self getSyncManagerInst:isGlobal]  reSync:syncId updateBlock:^(SFSyncState* sync) {
             [weakSelf handleSyncUpdate:sync isGlobal:isGlobal];
         }];
-        return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[sync asDict]];
+        if (sync) {
+            return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[sync asDict]];
+        }
+        else {
+            return [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+        }
     } command:command];
 }
 

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -128,7 +128,7 @@ static NSMutableDictionary *syncMgrList = nil;
         self.queue = dispatch_queue_create(kSyncManagerQueue,  NULL);
         [[SFAuthenticationManager sharedManager] addDelegate:self];
         [SFSyncState setupSyncsSoupIfNeeded:self.store];
-        [SFSyncState cleanupUnfinishedSyncs:self.store];
+        [SFSyncState cleanupUnfinishedSyncs:self.store pageSize:kSyncManagerPageSize];
     }
     return self;
 }

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -128,6 +128,7 @@ static NSMutableDictionary *syncMgrList = nil;
         self.queue = dispatch_queue_create(kSyncManagerQueue,  NULL);
         [[SFAuthenticationManager sharedManager] addDelegate:self];
         [SFSyncState setupSyncsSoupIfNeeded:self.store];
+        [SFSyncState cleanupUnfinishedSyncs:self.store];
     }
     return self;
 }

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -96,7 +96,7 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 
 /** Marking syncs that were running when app was stopped as failed
  */
-+ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store;
++ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store pageSize:(int)pageSize;
 
 /** Factory methods
  */

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -94,6 +94,10 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
  */
 + (void) setupSyncsSoupIfNeeded:(SFSmartStore*)store;
 
+/** Marking syncs that were running when app was stopped as failed
+ */
++ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store;
+
 /** Factory methods
  */
 + (SFSyncState*) newSyncDownWithOptions:(SFSyncOptions*)options target:(SFSyncDownTarget*)target soupName:(NSString*)soupName store:(SFSmartStore*)store;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -94,10 +94,6 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
  */
 + (void) setupSyncsSoupIfNeeded:(SFSmartStore*)store;
 
-/** Marking syncs that were running when app was stopped as failed
- */
-+ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store pageSize:(int)pageSize;
-
 /** Factory methods
  */
 + (SFSyncState*) newSyncDownWithOptions:(SFSyncOptions*)options target:(SFSyncDownTarget*)target soupName:(NSString*)soupName store:(SFSmartStore*)store;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -84,32 +84,6 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     [store registerSoup:kSFSyncStateSyncsSoupName withIndexSpecs:indexSpecs];
 }
 
-+ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store pageSize:(int)pageSize{
-    int i = 0;
-    NSArray* syncs;
-    do {
-        // We don't have an index on status - so getting all syncs
-        syncs = [store queryWithQuerySpec:[SFQuerySpec newAllQuerySpec:kSFSyncStateSyncsSoupName withOrderPath:nil withOrder:kSFSoupQuerySortOrderAscending withPageSize:pageSize] pageIndex:i error:nil];
-        NSMutableArray* modifiedSyncs = [NSMutableArray new];
-        for (NSDictionary* sync in syncs) {
-            if ([SFSyncState syncStatusFromString:sync[kSFSyncStateStatus]] == SFSyncStateStatusRunning) {
-                NSMutableDictionary* modifiedSync = [sync mutableCopy];
-                modifiedSync[kSFSyncStateStatus] = kSFSyncStateStatusFailed;
-                [modifiedSyncs addObject:modifiedSync];
-            }
-        }
-        
-        // Saving that batch
-        if (modifiedSyncs.count > 0) {
-            [store upsertEntries:modifiedSyncs toSoup:kSFSyncStateSyncsSoupName];
-        }
-        
-        // Next batch
-        i++;
-    }
-    while (syncs.count == pageSize);
-}
-
 #pragma mark - Factory methods
 
 + (SFSyncState*) newSyncDownWithOptions:(SFSyncOptions*)options target:(SFSyncDownTarget*)target soupName:(NSString*)soupName store:(SFSmartStore*)store {

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -84,16 +84,15 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     [store registerSoup:kSFSyncStateSyncsSoupName withIndexSpecs:indexSpecs];
 }
 
-+ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store {
++ (void) cleanupUnfinishedSyncs:(SFSmartStore*)store pageSize:(int)pageSize{
     int i = 0;
-    int pageSize = 25;
     NSArray* syncs;
     do {
         // We don't have an index on status - so getting all syncs
-        syncs = [store queryWithQuerySpec:[SFQuerySpec newAllQuerySpec:kSFSyncStateSyncsSoupName withOrderPath:nil withOrder:nil withPageSize:pageSize] pageIndex:i error:nil];
+        syncs = [store queryWithQuerySpec:[SFQuerySpec newAllQuerySpec:kSFSyncStateSyncsSoupName withOrderPath:nil withOrder:kSFSoupQuerySortOrderAscending withPageSize:pageSize] pageIndex:i error:nil];
         NSMutableArray* modifiedSyncs = [NSMutableArray new];
         for (NSDictionary* sync in syncs) {
-            if (sync[kSFSyncStateStatus] == kSFSyncStateStatusRunning) {
+            if ([SFSyncState syncStatusFromString:sync[kSFSyncStateStatus]] == SFSyncStateStatusRunning) {
                 NSMutableDictionary* modifiedSync = [sync mutableCopy];
                 modifiedSync[kSFSyncStateStatus] = kSFSyncStateStatusFailed;
                 [modifiedSyncs addObject:modifiedSync];

--- a/libs/SmartSync/SmartSyncTests/SFSyncUpdateCallbackQueue.h
+++ b/libs/SmartSync/SmartSyncTests/SFSyncUpdateCallbackQueue.h
@@ -36,7 +36,7 @@
 /**
  Run re-sync
  */
-- (void)runReSync:(NSNumber*)syncId syncManager:(SFSmartSyncSyncManager*)syncManager;
+- (SFSyncState*)runReSync:(NSNumber*)syncId syncManager:(SFSmartSyncSyncManager*)syncManager;
 
 /**
  Get next sync update

--- a/libs/SmartSync/SmartSyncTests/SFSyncUpdateCallbackQueue.m
+++ b/libs/SmartSync/SmartSyncTests/SFSyncUpdateCallbackQueue.m
@@ -58,9 +58,9 @@
     }];
 }
 
-- (void)runReSync:(NSNumber*)syncId syncManager:(SFSmartSyncSyncManager*)syncManager
+- (SFSyncState*) runReSync:(NSNumber*)syncId syncManager:(SFSmartSyncSyncManager*)syncManager
 {
-    [syncManager reSync:syncId updateBlock:^(SFSyncState *sync) {
+    return [syncManager reSync:syncId updateBlock:^(SFSyncState *sync) {
         @synchronized(self.queue) {
             [self.queue addObject:[sync copy]];
         }

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -807,7 +807,7 @@ static NSException *authException = nil;
     }
 }
 
-- (void) testResyncRunningSync
+- (void) testReSyncRunningSync
 {
     // Create test data
     [self createTestData];

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -48,6 +48,9 @@
 #define RECORDS             @"records"
 #define COUNT_TEST_ACCOUNTS 10
 
+/**
+ Soql sync down target that pauses for a second at the beginning of the fetch
+ */
 @interface SlowSoqlSyncDownTarget : SFSoqlSyncDownTarget
 @end
 


### PR DESCRIPTION
Sync manager only does one sync at a time, so we now capture the currently running sync id in a property.
Resync checks if that property value matches the one you want to re-sync -- and only in that case does it not run.
So if the original sync was interrupted by backgrounding or killing the app, resync should succeed.