### PR TITLE
Community ID shouldn't be nil'ed out when user accounts are loaded

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -567,7 +567,7 @@ static NSString * const kUserAccountEncryptionKeyLabel = @"com.salesforce.userAc
     self.previousCommunityId = self.activeCommunityId;
     
     SFUserAccount *account = [self userAccountForUserIdentity:curUserIdentity];
-    account.communityId = nil;
+    account.communityId = self.previousCommunityId;
     self.currentUser = account;
     
     // update the client ID in case it's changed (via settings, etc)


### PR DESCRIPTION
Not sure why the community ID was being nil'ed originally, but the end result is that, when the app is launched again, the community ID of the current user will not be persisted.