### PR TITLE
Sync up should handle remotely deleted records

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
@@ -128,7 +128,7 @@ static NSString * const kSFSyncUpTargetTypeCustom = @"custom";
     };
     
     id completeBlock = ^(NSDictionary *response) {
-        if (nil != response) {
+        if (nil != response && [response[@"records"] count] > 0) {
             NSDictionary *record = response[@"records"][0];
             if (nil != record) {
                 NSString *serverLastModifiedStr = record[self.modificationDateFieldName];


### PR DESCRIPTION
Reported here: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/1062

Previous behavior:
If one updates a remotely deleted record, the sync up fails (with a crash if merge mode was leave if changed)

New behavior:
If merge mode is overwrite, then the record is recreated on the server, the local record gets the new server id
If merge mode is leave if changed, then the local record is left unchanged / dirty
In both cases the sync up should continue