### PR TITLE
Fix for SmartStore not getting wiped using 'Forgot Passcode'

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -28,6 +28,7 @@
 #import "SFRootViewManager.h"
 #import "SFSDKWebUtils.h"
 #import "SFManagedPreferences.h"
+#import "SFSmartStore.h"
 #import <SalesforceOAuth/SFOAuthInfo.h>
 #import <SalesforceSecurity/SFPasscodeManager.h>
 #import <SalesforceSecurity/SFPasscodeProviderManager.h>
@@ -687,6 +688,11 @@ static int countForegrounds = 1;
 - (void)authManagerDidLogout:(SFAuthenticationManager *)manager
 {
     [self.sdkManagerFlow handlePostLogout];
+}
+
+- (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user
+{
+    [SFSmartStore removeAllStoresForUser:user];
 }
 
 #pragma mark - SFUserAccountManagerDelegate

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.m
@@ -186,10 +186,6 @@ NSString *const SOUP_LAST_MODIFIED_DATE = @"_soupLastModifiedDate";
                 self = nil;
             }
         }
-        
-        if (self != nil) {
-            [[SFAuthenticationManager sharedManager] addDelegate:self];
-        }
     }
     return self;
 }
@@ -200,7 +196,6 @@ NSString *const SOUP_LAST_MODIFIED_DATE = @"_soupLastModifiedDate";
     SFRelease(_soupNameToTableName);
     SFRelease(_indexSpecsBySoup);
     SFRelease(_smartSqlToSql);
-    [[SFAuthenticationManager sharedManager] removeDelegate:self];
     
     //remove data protection observer
     [[NSNotificationCenter defaultCenter] removeObserver:_dataProtectAvailObserverToken];
@@ -1601,13 +1596,6 @@ NSString *const SOUP_LAST_MODIFIED_DATE = @"_soupLastModifiedDate";
 {
     NSArray *indices = [self indicesForSoup:soupName withDb:db];
     return [SFSoupIndex hasFts:indices];
-}
-
-#pragma mark - SFAuthenticationManagerDelegate
-
-- (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user
-{
-    [[self class] removeAllStoresForUser:user];
 }
 
 #pragma mark - Misc


### PR DESCRIPTION
The problem was that ```SmartStore``` wouldn't get the delegate call because it hadn't been initialized yet. ```SalesforceSDKManager``` is the only class that's guaranteed to be initialized when an app starts, so this is better suited there.

I have verified it works on both native and hybrid apps. Didn't add a test, because logout and logging back in is a pain.