### PR TITLE
For smartstore to be available in the background parent directories must not use NSFileProtectionComplete

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.h
@@ -110,7 +110,7 @@ extern NSString * const kSFSmartStoreDbErrorDomain;
 - (BOOL)createStoreDir:(NSString *)storeName;
 
 /**
- Sets filesystem protection on the store DB contents.
+ Sets filesystem protection on the store DB file, directory and ancestor directories.
  @param storeName The store associated with the protection.
  @param protection The file system protection desired.
  @return YES if the call completes without errors, NO otherwise.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.m
@@ -352,7 +352,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     NSString *storeDir = [self storeDirectoryForStoreName:storeName];
     if (![[NSFileManager defaultManager] fileExistsAtPath:storeDir]) {
         // This store has not yet been created; create it.
-        result = [[NSFileManager defaultManager] createDirectoryAtPath:storeDir withIntermediateDirectories:YES attributes:nil error:&error];
+        result = [SFDirectoryManager ensureDirectoryExists:storeDir error:&error];
         
         if (error != nil) {
             [self log:SFLogLevelError format:@"Couldn't create store dir for store: %@ - error:%@", storeName, error];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.m
@@ -363,33 +363,48 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     return result;
 }
 
-- (NSString*)getStoreDirProtection:(NSString *)storeName
+- (NSString*)getDirProtection:(NSString *)dirPath
 {
     NSError* error = nil;
-    NSString *dbFilePath = [self fullDbFilePathForStoreName:storeName];
-    NSDictionary *attr = [[NSFileManager defaultManager] attributesOfItemAtPath:dbFilePath error:&error];
+    NSDictionary *attr = [[NSFileManager defaultManager] attributesOfItemAtPath:dirPath error:&error];
     NSString* result = attr[NSFileProtectionKey];
     if (error != nil) {
-        [self log:SFLogLevelError format:@"Couldn't get protection for store: %@ - error:%@", storeName, error];
+        [self log:SFLogLevelError format:@"Couldn't get protection of dir: %@ - error:%@", dirPath, error];
     }
     return result;
 }
 
-- (BOOL)protectStoreDirIfNeeded:(NSString *)storeName protection:(NSString*)protection
-{
-    if ([self getStoreDirProtection:storeName] == protection) {
-        // already has the protection we want
+- (BOOL) protectDir:(NSString*)dirPath protection:(NSString*)protection {
+    NSString* currentProtection = [self getDirProtection:dirPath];
+    if (currentProtection == nil) {
+        // We don't own the dir, we are done
         return YES;
     }
-
-    NSError* error= nil;
-    NSString *dbFilePath = [self fullDbFilePathForStoreName:storeName];
-    NSDictionary *attr = @{NSFileProtectionKey: protection};
-    BOOL result = [[NSFileManager defaultManager] setAttributes:attr ofItemAtPath:dbFilePath error:&error];
-    if (error != nil) {
-        [self log:SFLogLevelError format:@"Couldn't protect store: %@ - error:%@", storeName, error];
+    else {
+        // Change protection if not the one desired
+        if (![currentProtection isEqualToString:protection]) {
+            NSError* error = nil;
+            NSDictionary *attr = @{NSFileProtectionKey: protection};
+            BOOL result = [[NSFileManager defaultManager] setAttributes:attr ofItemAtPath:dirPath error:&error];
+            if (error != nil || !result) {
+                [self log:SFLogLevelError format:@"Couldn't protect dir: %@ - error:%@", dirPath, error];
+                return NO;
+            }
+            else {
+                [self log:SFLogLevelDebug format:@"Protecting dir: %@ with %@", dirPath, protection];
+            }
+        }
+        // Go to parent directory
+        NSString* parentDirPath = [dirPath stringByDeletingLastPathComponent];
+        return [self protectDir:parentDirPath protection:protection];
     }
-    return result;
+}
+
+
+- (BOOL)protectStoreDirIfNeeded:(NSString *)storeName protection:(NSString*)protection
+{
+    NSString *dbFilePath = [self fullDbFilePathForStoreName:storeName];
+    return [self protectDir:dbFilePath protection:NSFileProtectionCompleteUntilFirstUserAuthentication];
 }
 
 - (void)removeStoreDir:(NSString *)storeName

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
@@ -45,7 +45,7 @@ static NSString * const kDefaultCommunityName = @"internal";
     if (![manager fileExistsAtPath:directory]) {
         return [manager createDirectoryAtPath:directory
                   withIntermediateDirectories:YES
-                                   attributes:@{NSFileProtectionKey: NSFileProtectionComplete}
+                                   attributes:@{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication}
                                         error:error];
     } else {
         return YES;


### PR DESCRIPTION
To try it out go to https://github.com/wmathurin/BackgroundTester
In Podfile, uncomment one of the configs
```
# for Mobile SDK 3.3 with parent directory using NSFileProtectionComplete ==> doesn't work when phone locked
# pod 'SalesforceMobileSDK-iOS', :git => 'https://github.com/wmathurin/SalesforceMobileSDK-iOS.git', :commit => '63c2627', :submodules => 'true'

# for Mobile SDK 3.3 with parent directory using NSFileProtectionCompleteUntilFirstUserAuthentication ==> works when phone locked
# pod 'SalesforceMobileSDK-iOS', :git => 'https://github.com/wmathurin/SalesforceMobileSDK-iOS.git', :commit => 'e3a3e93', :submodules => 'true'
