### PR TITLE
Add Content-Length header to POST requests

### DIFF
--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.m
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.m
@@ -237,6 +237,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
             }
             self.action.parameters.bodyStream = [NSInputStream inputStreamWithData:bodyData];
             [self setHeaderValue:@"application/json" forHeaderName:@"Content-Type"];
+            [self setHeaderValue:[NSString stringWithFormat:@"%lu", bodyData.length] forHeaderName:@"Content-Length"];
         } else {
             [self convertQueryParamsToActionParams];
         }


### PR DESCRIPTION
Some server endpoints want the Content-Length header on their POSTs.