### PR TITLE
Custom Request Parsing

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFAction.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFAction.m
@@ -537,7 +537,7 @@ NSTimeInterval const CSFActionDefaultTimeOut = 3 * 60; // 3 minutes
     
     NSError *jsonParseError = nil;
     if ([self.responseData length] > 0) {
-        content = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonParseError];
+        content = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&jsonParseError];
     }
     
     // If it's an error here, it's a basic parsing error.


### PR DESCRIPTION

##### Description
This fixes a case where a picklist request such as the following cannot be parsed:

```objc
SFRestRequest *req =[SFRestRequest requestWithMethod:SFRestMethodGET path:@"/<redacted>/picklistValues" queryParams:nil];
req.endpoint = @"/services/apexrest";
```

The issue is the JSON that the API returns for the above request is actually a string. With this change there will be no failure within the `Salesforce iOS SDK` and the user can then parse the result using `NSJSONSerialization` again.

The option `NSJSONReadingAllowFragments` shouldn't break any other other request parsing as it adds supports for "fragments" rather than making them required

##### Next steps
Maybe we want to add another check underneath line 540 with something like:
```objc
if (!error && [content isKindOfClass:[NSString class]]) {

    NSString *stringContent = [content copy];
    content = [NSJSONSerialization JSONObjectWithData:[stringContent dataUsingEncoding:NSUTF8StringEncoding] options:kNilOptions error:&jsonParseError];
}
```