### PR TITLE
Adding optional community URL value to test credentials

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestCredentialsData.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestCredentialsData.h
@@ -35,5 +35,6 @@
 @property (nonatomic, readonly) NSString *clientId;
 @property (nonatomic, readonly) NSString *redirectUri;
 @property (nonatomic, readonly) NSString *loginHost;
+@property (nonatomic, readonly) NSString *communityUrl;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestCredentialsData.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestCredentialsData.m
@@ -78,4 +78,9 @@
     return _credentialsDict[@"test_login_domain"];
 }
 
+- (NSString *)communityUrl
+{
+    return _credentialsDict[@"community_url"];
+}
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
@@ -72,6 +72,10 @@ static BOOL sPopulatedAuthCredentials = NO;
     SFOAuthCredentials *credentials = accountMgr.currentUser.credentials;
     credentials.instanceUrl = [NSURL URLWithString:credsData.instanceUrl];
     credentials.identityUrl = [NSURL URLWithString:credsData.identityUrl];
+    NSString *communityUrlString = credsData.communityUrl;
+    if (communityUrlString.length > 0) {
+        credentials.communityUrl = [NSURL URLWithString:communityUrlString];
+    }
     credentials.accessToken = credsData.accessToken;
     credentials.refreshToken = credsData.refreshToken;
     

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
@@ -172,13 +172,16 @@ static NSString * const OAuthRedirectURI        = @"testsfdc:///mobilesdk/detect
 - (void)exportTestingCredentials {
     //collect credentials and copy to pasteboard
     SFOAuthCredentials *creds = [SFUserAccountManager sharedInstance].currentUser.credentials;
-    NSDictionary *configDict = @{@"test_client_id": RemoteAccessConsumerKey,
-                                 @"test_login_domain": [SFUserAccountManager sharedInstance].loginHost,
-                                 @"test_redirect_uri": OAuthRedirectURI,
-                                 @"refresh_token": creds.refreshToken,
-                                 @"instance_url": [creds.instanceUrl absoluteString],
-                                 @"identity_url": [creds.identityUrl absoluteString],
-                                 @"access_token": @"__NOT_REQUIRED__"};
+    NSMutableDictionary *configDict = [NSMutableDictionary dictionaryWithDictionary:@{@"test_client_id": RemoteAccessConsumerKey,
+                                                                                      @"test_login_domain": [SFUserAccountManager sharedInstance].loginHost,
+                                                                                      @"test_redirect_uri": OAuthRedirectURI,
+                                                                                      @"refresh_token": creds.refreshToken,
+                                                                                      @"instance_url": [creds.instanceUrl absoluteString],
+                                                                                      @"identity_url": [creds.identityUrl absoluteString],
+                                                                                      @"access_token": @"__NOT_REQUIRED__"}];
+    if (creds.communityUrl != nil) {
+        configDict[@"community_url"] = [creds.communityUrl absoluteString];
+    }
     
     NSString *configJSON = [SFJsonUtils JSONRepresentation:configDict];
     UIPasteboard *gpBoard = [UIPasteboard generalPasteboard];


### PR DESCRIPTION
Allows for tests to be run for community users as well.