### PR TITLE
POST requests cannot be replayed after auth refresh

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Support/CSFParameterStorage.h
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Support/CSFParameterStorage.h
@@ -46,11 +46,14 @@
  
  @discussion
  This property can be used in circumstances where URL Form-Encoded or Multipart request bodies can't be used,
- for example when posting a direct JSON payload to a server.  Use of this feature will automatically disable
- the setting of HTTP Content-Type and Content-Length headers, so it's the responsibility of the user of this
- property to update those headers accordingly.
+ for example when posting a direct JSON payload to a server.  This property is a block that returns an
+ `NSInputStream`, rather than an input stream itself, because an input stream cannot be re-used, which will
+ cause problems when replaying a request after refreshing authentication credentials.
+ 
+ Use of this feature will automatically disable the setting of HTTP Content-Type and Content-Length headers,
+ so it's the responsibility of the user of this property to update those headers accordingly.
  */
-@property (nonatomic, strong) NSInputStream *bodyStream;
+@property (nonatomic, copy) NSInputStream *(^bodyStreamBlock)(void);
 
 /**
  List of all the parameter keys that have been added to this instance.

--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Support/CSFParameterStorage.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Support/CSFParameterStorage.m
@@ -156,8 +156,8 @@
     BOOL result = YES;
     NSError *resultError = nil;
 
-    if (self.bodyStream) {
-        request.HTTPBodyStream = self.bodyStream;
+    if (self.bodyStreamBlock) {
+        request.HTTPBodyStream = self.bodyStreamBlock();
     } else {
         // Add explicit query string keys here, only if we are posting multipart or URLEncoded
         // bodies.  If we are doing a querystring request already, then simply wait for the

--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest+Internal.h
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest+Internal.h
@@ -26,7 +26,7 @@
 
 @interface SFRestRequest ()
 
-@property (nonatomic, strong) NSInputStream *requestBodyStream;
+@property (nonatomic, copy) NSInputStream *(^requestBodyStreamBlock)(void);
 @property (nonatomic, copy) NSString *requestContentType;
 
 @end

--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.h
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.h
@@ -189,10 +189,10 @@ extern NSString * const kSFDefaultRestEndpoint;
 
 /**
  * Sets a custom request body based on an NSInputStream representation.
- * @param bodyData The NSInputStream object representing the request body.
+ * @param bodyStreamBlock The block that will return an NSInputStream object representing the request body.
  * @param contentType The content type associated with this request.
  */
-- (void)setCustomRequestBodyStream:(NSInputStream *)bodyInputStream contentType:(NSString *)contentType;
+- (void)setCustomRequestBodyStream:(NSInputStream* (^)(void))bodyStreamBlock contentType:(NSString *)contentType;
 
 /**
  * Returns YES if error is a network error

--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.m
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.m
@@ -38,7 +38,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
 @synthesize delegate=_delegate;
 @synthesize action=_action;
 @synthesize queryParams=_queryParams;
-@synthesize requestBodyStream=_requestBodyStream;
+@synthesize requestBodyStreamBlock=_requestBodyStreamBlock;
 @synthesize requestContentType=_requestContentType;
 
 - (id)initWithMethod:(SFRestMethod)method path:(NSString *)path queryParams:(NSDictionary *)queryParams {
@@ -158,12 +158,15 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
 
 - (void)setCustomRequestBodyData:(NSData *)bodyData contentType:(NSString *)contentType {
     if (bodyData == nil) bodyData = [NSData data];
-    [self setCustomRequestBodyStream:[NSInputStream inputStreamWithData:bodyData] contentType:contentType];
+    NSInputStream *(^bodyStreamBlock)(void) = ^{
+        return [NSInputStream inputStreamWithData:bodyData];
+    };
+    [self setCustomRequestBodyStream:bodyStreamBlock contentType:contentType];
 }
 
-- (void)setCustomRequestBodyStream:(NSInputStream *)bodyInputStream contentType:(NSString *)contentType {
-    if (bodyInputStream != nil) {
-        self.requestBodyStream = bodyInputStream;
+- (void)setCustomRequestBodyStream:(NSInputStream* (^)(void))bodyInputStreamBlock contentType:(NSString *)contentType {
+    if (bodyInputStreamBlock != nil) {
+        self.requestBodyStreamBlock = bodyInputStreamBlock;
         if ([contentType length] > 0) {
             self.requestContentType = contentType;
         }
@@ -209,8 +212,8 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
     }
     
     // Custom request body overrides default behavior.
-    if (self.requestBodyStream != nil) {
-        self.action.parameters.bodyStream = self.requestBodyStream;
+    if (self.requestBodyStreamBlock != nil) {
+        self.action.parameters.bodyStreamBlock = self.requestBodyStreamBlock;
         if ([self.requestContentType length] > 0) {
             [self setHeaderValue:self.requestContentType forHeaderName:@"Content-Type"];
         }
@@ -235,7 +238,10 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
                  [[SFJsonUtils lastError] localizedDescription]];
                 return;
             }
-            self.action.parameters.bodyStream = [NSInputStream inputStreamWithData:bodyData];
+            NSInputStream *(^bodyStreamBlock)(void) = ^{
+                return [NSInputStream inputStreamWithData:bodyData];
+            };
+            self.action.parameters.bodyStreamBlock = bodyStreamBlock;
             [self setHeaderValue:@"application/json" forHeaderName:@"Content-Type"];
             [self setHeaderValue:[NSString stringWithFormat:@"%lu", bodyData.length] forHeaderName:@"Content-Length"];
         } else {


### PR DESCRIPTION
The issue is that POST bodies are represented as `NSInputStream` objects, which are used as the `NSURLRequest.HTTPBodyStream` in the initial request.  But once the input stream is read through once in the initial request, it's no longer valid.  This presents a problem if the request needs to be replayed after a 401 from the original request.

I changed the input stream inputs across the board, to a block that returns the `NSInputStream`.  That way, the stream can be regenerated from its source, with the initiation of each request.