### PR TITLE
Setting default user agent

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFSalesforceAction.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFSalesforceAction.m
@@ -109,11 +109,12 @@ static void * kObservingKey = &kObservingKey;
             NSDictionary *errorDict = jsonArray[0];
             if ([errorDict isKindOfClass:[NSDictionary class]] && errorDict[@"errorCode"]) {
                 msgObj = errorDict[@"message"] ?: errorDict[@"msg"];
-                errorCode = errorDict[@"errorCode"] ;
+                errorCode = errorDict[@"errorCode"];
             }
         } else if (response.statusCode >= 400 && [content isKindOfClass:[NSDictionary class]]) {
             NSDictionary *errorDict = (NSDictionary*)content;
             msgObj = errorDict[@"msg"];
+            errorCode = errorDict[@"errorCode"];
         }
         
         CSFNetwork *network = self.enqueuedNetwork;

--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Queue/CSFNetwork.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Queue/CSFNetwork.m
@@ -151,7 +151,8 @@ static NSMutableDictionary *SharedInstances = nil;
     self = [self init];
     if (self) {
         self.account = account;
-        [[SFAuthenticationManager sharedManager] addDelegate:self];        
+        [[SFAuthenticationManager sharedManager] addDelegate:self];
+        self.userAgent = [SalesforceSDKManager sharedManager].userAgentString(@"");
     }
     return self;
 }


### PR DESCRIPTION
We weren't setting any user agent on ```CSFNetwork```. All outgoing requests through ```RestApiExplorer``` currently have ```User-Agent``` set to ```nil```.