### PR TITLE
New app type in SalesforceSDKManager for react native

### DIFF
--- a/libs/SalesforceReact/SalesforceReact/Classes/SFNetReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFNetReactBridge.m
@@ -36,10 +36,6 @@ NSString * const kPathArg         = @"path";
 NSString * const kQueryParams     = @"queryParams";
 NSString * const kHeaderParams    = @"headerParams";
 
-// User agent
-NSString * const kUserAgentReact  = @"User-Agent";
-NSString * const kReactNative     = @"React";
-
 @implementation SFNetReactBridge
 
 RCT_EXPORT_MODULE();
@@ -55,7 +51,6 @@ RCT_EXPORT_METHOD(sendRequest:(NSDictionary *)argsDict callback:(RCTResponseSend
     
     SFRestRequest* request = [SFRestRequest requestWithMethod:method path:path queryParams:queryParams];
     [request setCustomHeaders:headerParams];
-    [request setHeaderValue:[SFRestAPI userAgentString:kReactNative] forHeaderName:kUserAgentReact];
     
     [[SFRestAPI sharedInstance] sendRESTRequest:request
                                       failBlock:^(NSError *e) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -28,7 +28,7 @@
     NSMutableOrderedSet *_delegates;
 }
 
-@property (nonatomic, assign) BOOL isNative;
+@property (nonatomic, assign) SFAppType appType;
 @property (nonatomic, weak) id<SalesforceSDKManagerFlow> sdkManagerFlow;
 @property (nonatomic, assign) BOOL hasVerifiedPasscodeAtStartup;
 @property (nonatomic, assign) SFSDKLaunchAction launchActions;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -29,6 +29,13 @@
 
 @class SFUserAccount, SFSDKAppConfig;
 
+typedef NS_ENUM(NSUInteger, SFAppType) {
+    kSFAppTypeNative,
+    kSFAppTypeHybrid,
+    kSFAppTypeReactNative
+};
+
+
 @protocol SalesforceSDKManagerDelegate <NSObject>
 
 @optional
@@ -74,10 +81,11 @@
  */
 @property (nonatomic, readonly) BOOL isLaunching;
 
+
 /**
- Whether or not the SDK is currently in the middle of a launch process.
+ App type (native, hybrid or react native)
  */
-@property (nonatomic, readonly) BOOL isNative;
+@property (nonatomic, readonly) SFAppType appType;
 
 /**
  The Connected App ID configured for this application.


### PR DESCRIPTION
 - user agent for react native will show the correct app type regardless of whether SFNetReactBridge is used or not
- smartsync calls from react native app should show: ReactNativeSmartSync