### PR TITLE
Fix for crasher

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Queue/CSFNetwork.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Queue/CSFNetwork.m
@@ -256,8 +256,9 @@ static NSMutableDictionary *SharedInstances = nil;
         action.duplicateParentAction = duplicateAction;
         [action addDependency:duplicateAction];
     }
-
-    [self.queue addOperation:action];
+    if (!(action.isCancelled || action.isFinished)) {
+        [self.queue addOperation:action];
+    }
 }
 
 - (void)executeActions:(NSArray *)actions completionBlock:(void(^)(NSArray *actions, NSArray *errors))completionBlock {
@@ -283,8 +284,9 @@ static NSMutableDictionary *SharedInstances = nil;
             [self executeAction:action];
         }
     }
-
-    [self.queue addOperation:parentOperation];
+    if (!(parentOperation.isCancelled || parentOperation.isFinished)) {
+        [self.queue addOperation:parentOperation];
+    }
 }
 
 - (NSArray*)actionsWithContext:(id)context {


### PR DESCRIPTION
Adding an operation to an operation queue that is finished is always a crasher. This can occur in a quick enqueue and cancel, since enqueuing can be async. From the docs for addOperation:

> An operation object can be in at most one operation queue at a time and this method throws an NSInvalidArgumentException exception if the operation is already in another queue. Similarly, this method throws an NSInvalidArgumentException exception if the operation is currently executing or has already finished executing.