### PR TITLE
Fixes for iOS 7 bodyStream/Content-Length issues

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Support/CSFParameterStorage.h
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Support/CSFParameterStorage.h
@@ -52,6 +52,8 @@
  */
 @property (nonatomic, strong) NSInputStream *bodyStream;
 
+@property (nonatomic, strong) NSData *bodyData;
+
 /**
  List of all the parameter keys that have been added to this instance.
  */

--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Support/CSFParameterStorage.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Support/CSFParameterStorage.m
@@ -158,6 +158,8 @@
 
     if (self.bodyStream) {
         request.HTTPBodyStream = self.bodyStream;
+    } else if (self.bodyData) {
+        request.HTTPBody = self.bodyData;
     } else {
         // Add explicit query string keys here, only if we are posting multipart or URLEncoded
         // bodies.  If we are doing a querystring request already, then simply wait for the

--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.m
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.m
@@ -235,8 +235,15 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
                  [[SFJsonUtils lastError] localizedDescription]];
                 return;
             }
-            self.action.parameters.bodyStream = [NSInputStream inputStreamWithData:bodyData];
+
+            if (IS_EQUAL_IOS7) {
+                self.action.parameters.bodyData = bodyData;
+            } else {
+                self.action.parameters.bodyStream = [NSInputStream inputStreamWithData:bodyData];
+            }
+
             [self setHeaderValue:@"application/json" forHeaderName:@"Content-Type"];
+            [self setHeaderValue:[NSString stringWithFormat:@"%lu", (unsigned long)bodyData.length] forHeaderName:@"Content-Length"];
         } else {
             [self convertQueryParamsToActionParams];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKConstants.h
@@ -29,6 +29,8 @@
 #define __SALESFORCE_SDK_3_3_0 30300
 #define __SALESFORCE_SDK_3_3_1 30301
 
+#define IS_EQUAL_IOS7 [[UIDevice currentDevice].systemVersion hasPrefix:@"7"]
+
 #define SALESFORCE_SDK_VERSION_MIN_REQUIRED __SALESFORCE_SDK_3_3_1
 
 #define SALESFORCE_SDK_VERSION [NSString stringWithFormat:@"%d.%d.%d%@",              \


### PR DESCRIPTION
Even though v3.3 is working great ton iOS 8/9 devices, theres an issue on iOS 7. As soon as you use HTTPBodyStream, it will clear Content-Length header, even if you set it after the bodyStream. This is considered functioning as designed for iOS 7. 

These are the fixes I had to use to get our app working on iOS 7/8/9 properly.