### PR TITLE
Sync Manager logout issue

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore+Internal.h
@@ -34,7 +34,6 @@
 @interface SFSmartStore () <SFAuthenticationManagerDelegate>
 
 @property (nonatomic, strong) FMDatabaseQueue *storeQueue;
-@property (nonatomic, strong) SFUserAccount *user;
 @property (nonatomic, strong) SFSmartStoreDatabaseManager *dbMgr;
 @property (nonatomic, assign) BOOL isGlobal;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStore.h
@@ -122,6 +122,10 @@ extern NSString *const SOUP_LAST_MODIFIED_DATE;
  */
 @property (nonatomic, readonly, strong) NSString *storePath;
 
+/**
+ User for this store - nil for global stores
+ */
+@property (nonatomic, strong) SFUserAccount *user;
 
 /**
  Use this method to obtain a shared store instance with a particular name for the current user.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/SmartStore/SFSmartStoreDatabaseManager.m
@@ -28,7 +28,6 @@
 #import <SalesforceCommonUtils/NSString+SFAdditions.h>
 #import "SFSmartStoreUtils.h"
 #import "SFUserAccountManager.h"
-#import "SFAuthenticationManager.h"
 #import "SFUserAccount.h"
 #import "SFDirectoryManager.h"
 #import "FMDatabase.h"
@@ -53,10 +52,6 @@ static NSInteger  const kSFSmartStoreVerifyDbErrorCode     = 6;
 static NSString * const kSFSmartStoreVerifyDbErrorDesc     = @"Could not open database at path '%@' for verification: %@";
 static NSInteger  const kSFSmartStoreVerifyReadDbErrorCode = 7;
 static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read from database at path '%@', for verification: %@";
-
-@interface SFSmartStoreDatabaseManager () <SFAuthenticationManagerDelegate>
-
-@end
 
 @implementation SFSmartStoreDatabaseManager
 
@@ -118,9 +113,6 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     if (self) {
         self.user = ([user.accountIdentity isEqual:[SFUserAccountManager sharedInstance].temporaryUserIdentity] ? nil : user);
         self.isGlobalManager = NO;
-        if (self.user) {
-            [[SFAuthenticationManager sharedManager] addDelegate:self];
-        }
     }
     return self;
 }
@@ -132,12 +124,6 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
         self.isGlobalManager = YES;
     }
     return self;
-}
-
-- (void)dealloc {
-    if (self.user) {
-        [[SFAuthenticationManager sharedManager] removeDelegate:self];
-    }
 }
 
 #pragma mark - Database management methods
@@ -472,12 +458,5 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     }
     return allStoreNames;
 }
-
-#pragma mark - SFAuthenticationManagerDelegate
-
-- (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user {
-    [[self class] removeSharedManagerForUser:user];
-}
-
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -90,11 +90,11 @@ static NSMutableDictionary *syncMgrList = nil;
     @synchronized ([SFSmartSyncSyncManager class]) {
         if (store == nil || store.storePath == nil) return nil;
         
-        NSString *storePath = store.storePath;
-        id syncMgr = [syncMgrList objectForKey:storePath];
+        NSString *key = [SFSmartSyncSyncManager keyForStore:store];
+        id syncMgr = [syncMgrList objectForKey:key];
         if (syncMgr == nil) {
             syncMgr = [[self alloc] initWithStore:store];
-            syncMgrList[storePath] = syncMgr;
+            syncMgrList[key] = syncMgr;
         }
         return syncMgr;
     }
@@ -107,18 +107,31 @@ static NSMutableDictionary *syncMgrList = nil;
 + (void)removeSharedInstanceForUser:(SFUserAccount *)user storeName:(NSString *)storeName {
     if (user == nil) return;
     if (storeName.length == 0) storeName = kDefaultSmartStoreName;
-    SFSmartStore *store = [SFSmartStore sharedStoreWithName:storeName user:user];
-    [self removeSharedInstanceForStore:store];
+    NSString* key = [SFSmartSyncSyncManager keyForUser:user storeName:storeName];
+    [SFSmartSyncSyncManager removeSharedInstanceForKey:key];
 }
 
-+ (void)removeSharedInstanceForStore:(SFSmartStore *)store {
++ (void)removeSharedInstanceForStore:(SFSmartStore*) store {
+    NSString* key = [SFSmartSyncSyncManager keyForStore:store];
+    [SFSmartSyncSyncManager removeSharedInstanceForKey:key];
+}
+
++ (void)removeSharedInstanceForKey:(NSString*) key {
     @synchronized([SFSmartSyncSyncManager class]) {
-        if (store.storePath.length > 0) {
-            NSString *key = store.storePath;
-            [syncMgrList removeObjectForKey:key];
-        }
+        [syncMgrList removeObjectForKey:key];
     }
 }
+
++ (NSString*)keyForStore:(SFSmartStore*)store {
+    return [SFSmartSyncSyncManager keyForUser:store.user storeName:store.storeName];
+}
+
++ (NSString*)keyForUser:(SFUserAccount*)user storeName:(NSString*)storeName {
+    NSString* keyPrefix = user == nil ? SFKeyForUserAndScope(nil, SFUserAccountScopeGlobal) : SFKeyForUserAndScope(user, SFUserAccountScopeUser);
+    return [NSString  stringWithFormat:@"%@-%@", keyPrefix, storeName];
+}
+
+
 
 #pragma mark - init / dealloc
 
@@ -133,6 +146,7 @@ static NSMutableDictionary *syncMgrList = nil;
     }
     return self;
 }
+
 
 
 - (void)dealloc {

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -127,7 +127,7 @@ static NSMutableDictionary *syncMgrList = nil;
 }
 
 + (NSString*)keyForUser:(SFUserAccount*)user storeName:(NSString*)storeName {
-    NSString* keyPrefix = user == nil ? SFKeyForUserAndScope(nil, SFUserAccountScopeGlobal) : SFKeyForUserAndScope(user, SFUserAccountScopeUser);
+    NSString* keyPrefix = user == nil ? SFKeyForUserAndScope(nil, SFUserAccountScopeGlobal) : SFKeyForUserAndScope(user, SFUserAccountScopeCommunity);
     return [NSString  stringWithFormat:@"%@-%@", keyPrefix, storeName];
 }
 


### PR DESCRIPTION
Revealed by smart sync react native sample app.

On logout: sync manager's removeSharedInstanceForUser was calling SFSmartStore's sharedStoreWithName in order to get the store path (which was the key in the map of sync managers).
As a result a SFSmartStore instance was recreated and would linger after the logout.

Now: sync manager's can figure out the key from the store name / user and doesn't actually need the store object.