### PR TITLE
Updating template so that Xcode 7 doesn't ask to convert swift to latest syntax

### DIFF
--- a/build/app_template_files/__NativeSwiftTemplateAppName__/__NativeSwiftTemplateAppName__.xcodeproj/project.pbxproj
+++ b/build/app_template_files/__NativeSwiftTemplateAppName__/__NativeSwiftTemplateAppName__.xcodeproj/project.pbxproj
@@ -80,7 +80,7 @@
 		4FD6C4A11B755265002F9F90 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				4FD6C49A1B755242002F9F90 /* __NativeSwiftTemplateAppName__-Bridging-Header.h */,
+				4FD6C49A1B755242002F9F90 /* Bridging-Header.h */,
 				4FD6C49B1B755242002F9F90 /* InitialViewController.xib */,
 				4FD6C49C1B755242002F9F90 /* RootViewController.swift */,
 				4FD6C49D1B755242002F9F90 /* InitialViewController.swift */,
@@ -134,6 +134,7 @@
 		4FD6C46C1B754AF1002F9F90 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0640;
 				ORGANIZATIONNAME = Salesforce;
 				TargetAttributes = {


### PR DESCRIPTION
@rwhitley pointed out that Xcode 7 was offering to convert swift syntax the first time app generated with forceios --apptype=native_swift were opened.