### PR TITLE
Fix to prevent crashing exception

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Queue/CSFNetwork.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Queue/CSFNetwork.m
@@ -258,6 +258,11 @@ static NSMutableDictionary *SharedInstances = nil;
     // performed in duplicateActionInFlight: will match.
     action.enqueuedNetwork = self;
     
+    
+    if (contributeProgress) {
+        [self.progress resignCurrent];
+    }
+    
     // bypass duplicate detection for POST and PUT
     if ([action.method isEqualToString:@"POST"] || [action.method isEqualToString:@"PUT"]) {
         [self.queue addOperation:action];

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/SalesforceSDKCommon.h
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/SalesforceSDKCommon.h
@@ -2,7 +2,7 @@
  SalesforceSDKCommon.h
  SalesforceSDKCommon
 
- Created by Kevin Hawkins on Thu Nov 12 15:07:58 PST 2015.
+ Created by Qingqing Liu on Tue Nov 10 09:55:29 PST 2015.
 
  Copyright (c) 2015, salesforce.com, inc. All rights reserved.
  
@@ -28,6 +28,7 @@
  */
 
 #import <SalesforceSDKCommon/NSData+SFSDKUtils.h>
+#import <SalesforceSDKCommon/SFDatasharingHelper.h>
 #import <SalesforceSDKCommon/SFSDKAsyncProcessListener.h>
 #import <SalesforceSDKCommon/SFSDKDatasharingHelper.h>
 #import <SalesforceSDKCommon/SFSDKReachability.h>

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/SalesforceSDKCommon.h
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/SalesforceSDKCommon.h
@@ -2,7 +2,7 @@
  SalesforceSDKCommon.h
  SalesforceSDKCommon
 
- Created by Qingqing Liu on Tue Nov 10 09:55:29 PST 2015.
+ Created by Kevin Hawkins on Thu Nov 12 15:07:58 PST 2015.
 
  Copyright (c) 2015, salesforce.com, inc. All rights reserved.
  
@@ -28,7 +28,6 @@
  */
 
 #import <SalesforceSDKCommon/NSData+SFSDKUtils.h>
-#import <SalesforceSDKCommon/SFDatasharingHelper.h>
 #import <SalesforceSDKCommon/SFSDKAsyncProcessListener.h>
 #import <SalesforceSDKCommon/SFSDKDatasharingHelper.h>
 #import <SalesforceSDKCommon/SFSDKReachability.h>


### PR DESCRIPTION
Fix to prevent crashing exception
 *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSProgress becomeCurrentWithPendingUnitCount:]: NSProgress object is already current on this thread <NSThread: 0x7fe4a1c046e0>{number = 1, name = main}'