### PR TITLE
Splitting out OAuth test flow and coordinator delegate

### DIFF
--- a/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
+++ b/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		82C2B71217BBF2EB0023218F /* SFOAuthCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = BEEA6CEF14C4E61A00487C9D /* SFOAuthCrypto.h */; };
 		82E0D880191AC65100A8FC23 /* libSalesforceSecurity.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82E0D87F191AC65100A8FC23 /* libSalesforceSecurity.a */; };
 		82F06EB117B5B05300F287A2 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 82F06EB017B5B05300F287A2 /* Default-568h@2x.png */; };
+		82F9A44C1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 82F9A44B1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.m */; };
 		BEEA6CF214C4E61B00487C9D /* SFOAuthCrypto.m in Sources */ = {isa = PBXBuildFile; fileRef = BEEA6CF014C4E61A00487C9D /* SFOAuthCrypto.m */; };
 		CF0886C113C397C30022C321 /* SalesforceOAuthTestViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CF0886BE13C397C30022C321 /* SalesforceOAuthTestViewController.xib */; };
 		CF19784A13B510EC00AFCA56 /* SFOAuthCredentials.m in Sources */ = {isa = PBXBuildFile; fileRef = CF19784613B510EC00AFCA56 /* SFOAuthCredentials.m */; };
@@ -152,6 +153,8 @@
 		82B0FC1415F5AE420054B066 /* SFOAuthInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFOAuthInfo.m; path = SalesforceOAuth/Classes/SFOAuthInfo.m; sourceTree = SOURCE_ROOT; };
 		82E0D87F191AC65100A8FC23 /* libSalesforceSecurity.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libSalesforceSecurity.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		82F06EB017B5B05300F287A2 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		82F9A44A1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFOAuthTestFlowCoordinatorDelegate.h; sourceTree = "<group>"; };
+		82F9A44B1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFOAuthTestFlowCoordinatorDelegate.m; sourceTree = "<group>"; };
 		BEEA6CEF14C4E61A00487C9D /* SFOAuthCrypto.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFOAuthCrypto.h; path = SalesforceOAuth/Classes/SFOAuthCrypto.h; sourceTree = SOURCE_ROOT; };
 		BEEA6CF014C4E61A00487C9D /* SFOAuthCrypto.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFOAuthCrypto.m; path = SalesforceOAuth/Classes/SFOAuthCrypto.m; sourceTree = SOURCE_ROOT; };
 		CF0886BF13C397C30022C321 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/SalesforceOAuthTestViewController.xib; sourceTree = "<group>"; };
@@ -251,6 +254,8 @@
 				8293A8D91A43573800ABC43C /* SFOAuthCoordinatorFlowTests.m */,
 				8293A8D61A40FD1100ABC43C /* SFOAuthTestFlow.h */,
 				8293A8D71A40FD1100ABC43C /* SFOAuthTestFlow.m */,
+				82F9A44A1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.h */,
+				82F9A44B1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.m */,
 				829A08741A3235DE00DC17A5 /* Supporting Files */,
 			);
 			path = SalesforceOAuthUnitTests;
@@ -605,6 +610,7 @@
 			files = (
 				829A08801A32362C00DC17A5 /* SalesforceOAuthUnitTestsCoordinatorDelegate.m in Sources */,
 				8293A8DA1A43573800ABC43C /* SFOAuthCoordinatorFlowTests.m in Sources */,
+				82F9A44C1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.m in Sources */,
 				8293A8D81A40FD1100ABC43C /* SFOAuthTestFlow.m in Sources */,
 				829A08771A3235DE00DC17A5 /* SalesforceOAuthUnitTests.m in Sources */,
 			);

--- a/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
+++ b/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		827C82DA17DD86CE0011BBA1 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 827C82D917DD86CE0011BBA1 /* MessageUI.framework */; };
 		827C82DC17DD86D60011BBA1 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 827C82DB17DD86D60011BBA1 /* QuartzCore.framework */; };
 		827C82DE17DD86E10011BBA1 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 827C82DD17DD86E10011BBA1 /* libz.dylib */; };
-		8293A8D81A40FD1100ABC43C /* SFOAuthFlowAndDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8293A8D71A40FD1100ABC43C /* SFOAuthFlowAndDelegate.m */; };
+		8293A8D81A40FD1100ABC43C /* SFOAuthTestFlow.m in Sources */ = {isa = PBXBuildFile; fileRef = 8293A8D71A40FD1100ABC43C /* SFOAuthTestFlow.m */; };
 		8293A8DA1A43573800ABC43C /* SFOAuthCoordinatorFlowTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8293A8D91A43573800ABC43C /* SFOAuthCoordinatorFlowTests.m */; };
 		8293A8E21A43AFE700ABC43C /* libSalesforceSDKCommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8293A8E11A43AFE700ABC43C /* libSalesforceSDKCommon.a */; };
 		829A08771A3235DE00DC17A5 /* SalesforceOAuthUnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 829A08761A3235DE00DC17A5 /* SalesforceOAuthUnitTests.m */; };
@@ -81,6 +81,27 @@
 			remoteGlobalIDString = 82D53D301A3618CD00E46F8F;
 			remoteInfo = SalesforceSDKCommon;
 		};
+		82507F9F1BF574310096D73C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82507F991BF574300096D73C /* SalesforceSecurity.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 820AB72418E230EC00E25E1D;
+			remoteInfo = SalesforceSecurity;
+		};
+		82507FA11BF574310096D73C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82507F991BF574300096D73C /* SalesforceSecurity.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 820AB73418E230EC00E25E1D;
+			remoteInfo = SalesforceSecurityTests;
+		};
+		82507FA31BF5744E0096D73C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82507F991BF574300096D73C /* SalesforceSecurity.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 820AB72318E230EC00E25E1D;
+			remoteInfo = SalesforceSecurity;
+		};
 		829A08781A3235DE00DC17A5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CFA9ADCB13AA86D80024260E /* Project object */;
@@ -112,12 +133,13 @@
 		6FFCCF9E13BD832C00F4B22B /* SFOAuthCoordinator+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SFOAuthCoordinator+Internal.h"; path = "SalesforceOAuth/Classes/SFOAuthCoordinator+Internal.h"; sourceTree = SOURCE_ROOT; };
 		8201F1AA1A310AED00C6696A /* SFOAuthOrgAuthConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFOAuthOrgAuthConfiguration.h; path = SalesforceOAuth/Classes/SFOAuthOrgAuthConfiguration.h; sourceTree = SOURCE_ROOT; };
 		8201F1AB1A310AED00C6696A /* SFOAuthOrgAuthConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFOAuthOrgAuthConfiguration.m; path = SalesforceOAuth/Classes/SFOAuthOrgAuthConfiguration.m; sourceTree = SOURCE_ROOT; };
+		82507F991BF574300096D73C /* SalesforceSecurity.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceSecurity.xcodeproj; path = ../SalesforceSecurity/SalesforceSecurity.xcodeproj; sourceTree = "<group>"; };
 		827C82D717DD86AD0011BBA1 /* libSalesforceCommonUtils.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libSalesforceCommonUtils.a; path = ../../external/ThirdPartyDependencies/SalesforceCommonUtils/libSalesforceCommonUtils.a; sourceTree = "<group>"; };
 		827C82D917DD86CE0011BBA1 /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		827C82DB17DD86D60011BBA1 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		827C82DD17DD86E10011BBA1 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
-		8293A8D61A40FD1100ABC43C /* SFOAuthFlowAndDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFOAuthFlowAndDelegate.h; sourceTree = "<group>"; };
-		8293A8D71A40FD1100ABC43C /* SFOAuthFlowAndDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFOAuthFlowAndDelegate.m; sourceTree = "<group>"; };
+		8293A8D61A40FD1100ABC43C /* SFOAuthTestFlow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFOAuthTestFlow.h; sourceTree = "<group>"; };
+		8293A8D71A40FD1100ABC43C /* SFOAuthTestFlow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFOAuthTestFlow.m; sourceTree = "<group>"; };
 		8293A8D91A43573800ABC43C /* SFOAuthCoordinatorFlowTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFOAuthCoordinatorFlowTests.m; sourceTree = "<group>"; };
 		8293A8E11A43AFE700ABC43C /* libSalesforceSDKCommon.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libSalesforceSDKCommon.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		829A08721A3235DE00DC17A5 /* SalesforceOAuthUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SalesforceOAuthUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -210,6 +232,15 @@
 			path = Configuration;
 			sourceTree = "<group>";
 		};
+		82507F9A1BF574300096D73C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				82507FA01BF574310096D73C /* libSalesforceSecurity.a */,
+				82507FA21BF574310096D73C /* SalesforceSecurityTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		829A08731A3235DE00DC17A5 /* SalesforceOAuthUnitTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -218,8 +249,8 @@
 				829A087E1A32362C00DC17A5 /* SalesforceOAuthUnitTestsCoordinatorDelegate.h */,
 				829A087F1A32362C00DC17A5 /* SalesforceOAuthUnitTestsCoordinatorDelegate.m */,
 				8293A8D91A43573800ABC43C /* SFOAuthCoordinatorFlowTests.m */,
-				8293A8D61A40FD1100ABC43C /* SFOAuthFlowAndDelegate.h */,
-				8293A8D71A40FD1100ABC43C /* SFOAuthFlowAndDelegate.m */,
+				8293A8D61A40FD1100ABC43C /* SFOAuthTestFlow.h */,
+				8293A8D71A40FD1100ABC43C /* SFOAuthTestFlow.m */,
 				829A08741A3235DE00DC17A5 /* Supporting Files */,
 			);
 			path = SalesforceOAuthUnitTests;
@@ -312,6 +343,7 @@
 			isa = PBXGroup;
 			children = (
 				6F644D0F1A9FD846009BF92A /* SalesforceSDKCommon.xcodeproj */,
+				82507F991BF574300096D73C /* SalesforceSecurity.xcodeproj */,
 				8293A8E11A43AFE700ABC43C /* libSalesforceSDKCommon.a */,
 				82E0D87F191AC65100A8FC23 /* libSalesforceSecurity.a */,
 				827C82DD17DD86E10011BBA1 /* libz.dylib */,
@@ -422,6 +454,7 @@
 			);
 			dependencies = (
 				6F7EAABE1B6191D000F4C242 /* PBXTargetDependency */,
+				82507FA41BF5744E0096D73C /* PBXTargetDependency */,
 			);
 			name = SalesforceOAuth;
 			productName = SalesforceOAuth;
@@ -458,6 +491,10 @@
 					ProductGroup = 6F644D101A9FD846009BF92A /* Products */;
 					ProjectRef = 6F644D0F1A9FD846009BF92A /* SalesforceSDKCommon.xcodeproj */;
 				},
+				{
+					ProductGroup = 82507F9A1BF574300096D73C /* Products */;
+					ProjectRef = 82507F991BF574300096D73C /* SalesforceSecurity.xcodeproj */;
+				},
 			);
 			projectRoot = "";
 			targets = (
@@ -482,6 +519,20 @@
 			fileType = wrapper.cfbundle;
 			path = SalesforceSDKCommonTests.xctest;
 			remoteRef = 6F644D191A9FD847009BF92A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82507FA01BF574310096D73C /* libSalesforceSecurity.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSalesforceSecurity.a;
+			remoteRef = 82507F9F1BF574310096D73C /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82507FA21BF574310096D73C /* SalesforceSecurityTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = SalesforceSecurityTests.xctest;
+			remoteRef = 82507FA11BF574310096D73C /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -554,7 +605,7 @@
 			files = (
 				829A08801A32362C00DC17A5 /* SalesforceOAuthUnitTestsCoordinatorDelegate.m in Sources */,
 				8293A8DA1A43573800ABC43C /* SFOAuthCoordinatorFlowTests.m in Sources */,
-				8293A8D81A40FD1100ABC43C /* SFOAuthFlowAndDelegate.m in Sources */,
+				8293A8D81A40FD1100ABC43C /* SFOAuthTestFlow.m in Sources */,
 				829A08771A3235DE00DC17A5 /* SalesforceOAuthUnitTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -589,6 +640,11 @@
 			isa = PBXTargetDependency;
 			name = SalesforceSDKCommon;
 			targetProxy = 6F7EAABD1B6191D000F4C242 /* PBXContainerItemProxy */;
+		};
+		82507FA41BF5744E0096D73C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SalesforceSecurity;
+			targetProxy = 82507FA31BF5744E0096D73C /* PBXContainerItemProxy */;
 		};
 		829A08791A3235DE00DC17A5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/xcshareddata/xcschemes/SalesforceOAuth.xcscheme
+++ b/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/xcshareddata/xcschemes/SalesforceOAuth.xcscheme
@@ -51,10 +51,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -66,15 +66,18 @@
             ReferencedContainer = "container:../SalesforceSecurity/SalesforceSecurity.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -89,10 +92,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/xcshareddata/xcschemes/SalesforceOAuthTest.xcscheme
+++ b/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/xcshareddata/xcschemes/SalesforceOAuthTest.xcscheme
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:SalesforceOAuth.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
@@ -86,10 +89,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthCoordinatorFlowTests.m
+++ b/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthCoordinatorFlowTests.m
@@ -28,11 +28,13 @@
 
 #import "SFOAuthCoordinator+Internal.h"
 #import "SFOAuthTestFlow.h"
+#import "SFOAuthTestFlowCoordinatorDelegate.h"
 
 @interface SFOAuthCoordinatorFlowTests : XCTestCase
 
 @property (nonatomic, strong) SFOAuthCoordinator *coordinator;
 @property (nonatomic, strong) SFOAuthTestFlow *oauthTestFlow;
+@property (nonatomic, strong) SFOAuthTestFlowCoordinatorDelegate *testFlowDelegate;
 
 @end
 
@@ -53,7 +55,7 @@
     [self.coordinator authenticate];
     SFSDKAsyncProcessListener *listener = [[SFSDKAsyncProcessListener alloc] initWithExpectedStatus:@YES
                                                                                   actualStatusBlock:^id{
-                                                                                      return [NSNumber numberWithBool:self.oauthTestFlow.didAuthenticateCalled];
+                                                                                      return [NSNumber numberWithBool:self.testFlowDelegate.didAuthenticateCalled];
                                                                                   }
                                                                                             timeout:(self.oauthTestFlow.timeBeforeUserAgentCompletion + 0.5)];
     BOOL userAgentFlowSucceeded = [[listener waitForCompletion] boolValue];
@@ -68,7 +70,7 @@
     [self.coordinator authenticate];
     SFSDKAsyncProcessListener *listener = [[SFSDKAsyncProcessListener alloc] initWithExpectedStatus:@YES
                                                                                   actualStatusBlock:^id{
-                                                                                      return [NSNumber numberWithBool:self.oauthTestFlow.didAuthenticateCalled];
+                                                                                      return [NSNumber numberWithBool:self.testFlowDelegate.didAuthenticateCalled];
                                                                                   }
                                                                                             timeout:(self.oauthTestFlow.timeBeforeUserAgentCompletion + 0.5)];
     BOOL refreshFlowSucceeded = [[listener waitForCompletion] boolValue];
@@ -104,14 +106,16 @@
 
 - (void)configureFlowAndDelegate {
     self.oauthTestFlow = [[SFOAuthTestFlow alloc] initWithCoordinator:self.coordinator];
+    self.testFlowDelegate = [[SFOAuthTestFlowCoordinatorDelegate alloc] init];
     self.coordinator.oauthCoordinatorFlow = self.oauthTestFlow;
-    self.coordinator.delegate = self.oauthTestFlow;
+    self.coordinator.delegate = self.testFlowDelegate;
 }
 
 - (void)tearDownCoordinatorFlow {
     [self.coordinator.credentials revoke];
     self.coordinator.delegate = nil;
     self.coordinator.oauthCoordinatorFlow = nil;
+    self.testFlowDelegate = nil;
     self.oauthTestFlow = nil;
     self.coordinator = nil;
 }

--- a/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthCoordinatorFlowTests.m
+++ b/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthCoordinatorFlowTests.m
@@ -27,12 +27,12 @@
 #import <SalesforceSDKCommon/SFSDKAsyncProcessListener.h>
 
 #import "SFOAuthCoordinator+Internal.h"
-#import "SFOAuthFlowAndDelegate.h"
+#import "SFOAuthTestFlow.h"
 
 @interface SFOAuthCoordinatorFlowTests : XCTestCase
 
 @property (nonatomic, strong) SFOAuthCoordinator *coordinator;
-@property (nonatomic, strong) SFOAuthFlowAndDelegate *flowAndDelegate;
+@property (nonatomic, strong) SFOAuthTestFlow *oauthTestFlow;
 
 @end
 
@@ -53,14 +53,14 @@
     [self.coordinator authenticate];
     SFSDKAsyncProcessListener *listener = [[SFSDKAsyncProcessListener alloc] initWithExpectedStatus:@YES
                                                                                   actualStatusBlock:^id{
-                                                                                      return [NSNumber numberWithBool:self.flowAndDelegate.didAuthenticateCalled];
+                                                                                      return [NSNumber numberWithBool:self.oauthTestFlow.didAuthenticateCalled];
                                                                                   }
-                                                                                            timeout:(self.flowAndDelegate.timeBeforeUserAgentCompletion + 0.5)];
+                                                                                            timeout:(self.oauthTestFlow.timeBeforeUserAgentCompletion + 0.5)];
     BOOL userAgentFlowSucceeded = [[listener waitForCompletion] boolValue];
     XCTAssertTrue(userAgentFlowSucceeded, @"User agent flow should have completed successfully.");
-    XCTAssertTrue(self.flowAndDelegate.beginUserAgentFlowCalled, @"User agent flow should have been called in first authenticate.");
-    XCTAssertFalse(self.flowAndDelegate.beginTokenEndpointFlowCalled, @"Token endpoint should not have been called in first authenticate.");
-    XCTAssertEqual(self.flowAndDelegate.tokenEndpointFlowType, SFOAuthTokenEndpointFlowNone, @"Should be no token endpoint flow type configured.");
+    XCTAssertTrue(self.oauthTestFlow.beginUserAgentFlowCalled, @"User agent flow should have been called in first authenticate.");
+    XCTAssertFalse(self.oauthTestFlow.beginTokenEndpointFlowCalled, @"Token endpoint should not have been called in first authenticate.");
+    XCTAssertEqual(self.oauthTestFlow.tokenEndpointFlowType, SFOAuthTokenEndpointFlowNone, @"Should be no token endpoint flow type configured.");
 }
 
 - (void)testRefreshFlowInitiated {
@@ -68,27 +68,27 @@
     [self.coordinator authenticate];
     SFSDKAsyncProcessListener *listener = [[SFSDKAsyncProcessListener alloc] initWithExpectedStatus:@YES
                                                                                   actualStatusBlock:^id{
-                                                                                      return [NSNumber numberWithBool:self.flowAndDelegate.didAuthenticateCalled];
+                                                                                      return [NSNumber numberWithBool:self.oauthTestFlow.didAuthenticateCalled];
                                                                                   }
-                                                                                            timeout:(self.flowAndDelegate.timeBeforeUserAgentCompletion + 0.5)];
+                                                                                            timeout:(self.oauthTestFlow.timeBeforeUserAgentCompletion + 0.5)];
     BOOL refreshFlowSucceeded = [[listener waitForCompletion] boolValue];
     XCTAssertTrue(refreshFlowSucceeded, @"Refresh flow should have completed successfully.");
-    XCTAssertFalse(self.flowAndDelegate.beginUserAgentFlowCalled, @"User agent flow should not have been called with a refresh token.");
-    XCTAssertTrue(self.flowAndDelegate.beginTokenEndpointFlowCalled, @"Token endpoint should have been called with a refresh token.");
-    XCTAssertEqual(self.flowAndDelegate.tokenEndpointFlowType, SFOAuthTokenEndpointFlowRefresh, @"Token endpoint flow type should be refresh.");
+    XCTAssertFalse(self.oauthTestFlow.beginUserAgentFlowCalled, @"User agent flow should not have been called with a refresh token.");
+    XCTAssertTrue(self.oauthTestFlow.beginTokenEndpointFlowCalled, @"Token endpoint should have been called with a refresh token.");
+    XCTAssertEqual(self.oauthTestFlow.tokenEndpointFlowType, SFOAuthTokenEndpointFlowRefresh, @"Token endpoint flow type should be refresh.");
 }
 
 - (void)testMultipleAuthenticationRequests {
     [self.coordinator authenticate];
-    XCTAssertTrue(self.flowAndDelegate.beginUserAgentFlowCalled, @"User agent flow should have been called in first authenticate.");
-    XCTAssertFalse(self.flowAndDelegate.beginTokenEndpointFlowCalled, @"Token endpoint should not have been called in first authenticate.");
-    XCTAssertEqual(self.flowAndDelegate.tokenEndpointFlowType, SFOAuthTokenEndpointFlowNone, @"Should be no token endpoint flow type configured.");
+    XCTAssertTrue(self.oauthTestFlow.beginUserAgentFlowCalled, @"User agent flow should have been called in first authenticate.");
+    XCTAssertFalse(self.oauthTestFlow.beginTokenEndpointFlowCalled, @"Token endpoint should not have been called in first authenticate.");
+    XCTAssertEqual(self.oauthTestFlow.tokenEndpointFlowType, SFOAuthTokenEndpointFlowNone, @"Should be no token endpoint flow type configured.");
     
     [self configureFlowAndDelegate];
     [self.coordinator authenticate];
-    XCTAssertFalse(self.flowAndDelegate.beginUserAgentFlowCalled, @"User agent flow should not have been called in second authenticate.");
-    XCTAssertFalse(self.flowAndDelegate.beginTokenEndpointFlowCalled, @"Token endpoint should not have been called in second authenticate.");
-    XCTAssertEqual(self.flowAndDelegate.tokenEndpointFlowType, SFOAuthTokenEndpointFlowNone, @"Should be no token endpoint flow type configured.");
+    XCTAssertFalse(self.oauthTestFlow.beginUserAgentFlowCalled, @"User agent flow should not have been called in second authenticate.");
+    XCTAssertFalse(self.oauthTestFlow.beginTokenEndpointFlowCalled, @"Token endpoint should not have been called in second authenticate.");
+    XCTAssertEqual(self.oauthTestFlow.tokenEndpointFlowType, SFOAuthTokenEndpointFlowNone, @"Should be no token endpoint flow type configured.");
 }
 
 #pragma mark - Private methods
@@ -103,16 +103,16 @@
 }
 
 - (void)configureFlowAndDelegate {
-    self.flowAndDelegate = [[SFOAuthFlowAndDelegate alloc] initWithCoordinator:self.coordinator];
-    self.coordinator.oauthCoordinatorFlow = self.flowAndDelegate;
-    self.coordinator.delegate = self.flowAndDelegate;
+    self.oauthTestFlow = [[SFOAuthTestFlow alloc] initWithCoordinator:self.coordinator];
+    self.coordinator.oauthCoordinatorFlow = self.oauthTestFlow;
+    self.coordinator.delegate = self.oauthTestFlow;
 }
 
 - (void)tearDownCoordinatorFlow {
     [self.coordinator.credentials revoke];
     self.coordinator.delegate = nil;
     self.coordinator.oauthCoordinatorFlow = nil;
-    self.flowAndDelegate = nil;
+    self.oauthTestFlow = nil;
     self.coordinator = nil;
 }
 

--- a/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthTestFlow.h
+++ b/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthTestFlow.h
@@ -28,7 +28,7 @@
 @class SFOAuthOrgAuthConfiguration;
 @class SFOAuthInfo;
 
-@interface SFOAuthFlowAndDelegate : NSObject <SFOAuthCoordinatorDelegate, SFOAuthCoordinatorFlow>
+@interface SFOAuthTestFlow : NSObject <SFOAuthCoordinatorDelegate, SFOAuthCoordinatorFlow>
 
 @property (nonatomic, assign) BOOL beginUserAgentFlowCalled;
 @property (nonatomic, assign) BOOL beginTokenEndpointFlowCalled;

--- a/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthTestFlow.m
+++ b/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthTestFlow.m
@@ -22,14 +22,14 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "SFOAuthFlowAndDelegate.h"
+#import "SFOAuthTestFlow.h"
 #import "SFOAuthOrgAuthConfiguration.h"
 #import "SFOAuthInfo.h"
 
 static NSString * const kWebNotSupportedExceptionName = @"com.salesforce.oauth.tests.WebNotSupported";
 static NSString * const kWebNotSupportedReasonFormat  = @"%@ UIWebView transactions not supported in unit test framework.";
 
-@interface SFOAuthFlowAndDelegate ()
+@interface SFOAuthTestFlow ()
 
 @property (nonatomic, weak) SFOAuthCoordinator *coordinator;
 @property (nonatomic, strong) SFOAuthOrgAuthConfiguration *retrieveOrgConf;
@@ -37,7 +37,7 @@ static NSString * const kWebNotSupportedReasonFormat  = @"%@ UIWebView transacti
 
 @end
 
-@implementation SFOAuthFlowAndDelegate
+@implementation SFOAuthTestFlow
 
 @synthesize coordinator = _coordinator;
 

--- a/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthTestFlow.m
+++ b/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthTestFlow.m
@@ -26,9 +26,6 @@
 #import "SFOAuthOrgAuthConfiguration.h"
 #import "SFOAuthInfo.h"
 
-static NSString * const kWebNotSupportedExceptionName = @"com.salesforce.oauth.tests.WebNotSupported";
-static NSString * const kWebNotSupportedReasonFormat  = @"%@ UIWebView transactions not supported in unit test framework.";
-
 @interface SFOAuthTestFlow ()
 
 @property (nonatomic, weak) SFOAuthCoordinator *coordinator;
@@ -45,7 +42,6 @@ static NSString * const kWebNotSupportedReasonFormat  = @"%@ UIWebView transacti
     self = [super init];
     if (self) {
         self.coordinator = coordinator;
-        self.isNetworkAvailable = YES;  // Network is available by default.
         self.timeBeforeUserAgentCompletion = 1.0;  // 1s default before user agent flow "completes".
         self.timeBeforeRefreshTokenCompletion = 1.0;
         self.userAgentFlowIsSuccessful = YES;
@@ -150,57 +146,6 @@ static NSString * const kWebNotSupportedReasonFormat  = @"%@ UIWebView transacti
 - (void)handleTokenEndpointResponse:(NSMutableData *) data{
     [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     self.handleTokenEndpointResponseCalled = YES;
-}
-
-#pragma mark - SFOAuthCoordinatorDelegate
-
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(UIWebView *)view {
-    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
-    @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
-}
-
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator willBeginAuthenticationWithView:(UIWebView *)view {
-    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
-    @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
-}
-
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didStartLoad:(UIWebView *)view {
-    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
-    @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
-}
-
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFinishLoad:(UIWebView *)view error:(NSError*)errorOrNil {
-    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
-    @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
-}
-
-- (void)oauthCoordinatorWillBeginAuthentication:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)info {
-    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    self.willBeginAuthenticationCalled = YES;
-    self.authInfo = info;
-}
-
-- (void)oauthCoordinatorDidAuthenticate:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)info {
-    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    self.didAuthenticateCalled = YES;
-    self.authInfo = info;
-}
-
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFailWithError:(NSError *)error authInfo:(SFOAuthInfo *)info {
-    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    self.didFailWithErrorCalled = YES;
-    self.didFailWithError = error;
-    self.authInfo = info;
-}
-
-- (BOOL)oauthCoordinatorIsNetworkAvailable:(SFOAuthCoordinator*)coordinator {
-    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    self.isNetworkAvailableCalled = YES;
-    return self.isNetworkAvailable;
 }
 
 @end

--- a/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthTestFlowCoordinatorDelegate.h
+++ b/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthTestFlowCoordinatorDelegate.h
@@ -23,25 +23,18 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "SFOAuthCoordinator+Internal.h"
+#import "SFOAuthCoordinator.h"
 
-@class SFOAuthOrgAuthConfiguration;
 @class SFOAuthInfo;
 
-@interface SFOAuthTestFlow : NSObject <SFOAuthCoordinatorFlow>
+@interface SFOAuthTestFlowCoordinatorDelegate : NSObject <SFOAuthCoordinatorDelegate>
 
-@property (nonatomic, assign) BOOL beginUserAgentFlowCalled;
-@property (nonatomic, assign) BOOL beginTokenEndpointFlowCalled;
-@property (nonatomic, assign) BOOL beginNativeBrowserFlowCalled;
-@property (nonatomic, assign) SFOAuthTokenEndpointFlow tokenEndpointFlowType;
-@property (nonatomic, assign) BOOL handleTokenEndpointResponseCalled;
-
-@property (nonatomic, assign) NSTimeInterval timeBeforeUserAgentCompletion;
-@property (nonatomic, assign) NSTimeInterval timeBeforeRefreshTokenCompletion;
-@property (nonatomic, assign) BOOL userAgentFlowIsSuccessful;
-@property (nonatomic, assign) BOOL refreshTokenFlowIsSuccessful;
-
-- (id)initWithCoordinator:(SFOAuthCoordinator *)coordinator;
-- (void)setRetrieveOrgAuthConfigurationData:(SFOAuthOrgAuthConfiguration *)config error:(NSError *)error;
+@property (nonatomic, assign) BOOL willBeginAuthenticationCalled;
+@property (nonatomic, assign) BOOL didAuthenticateCalled;
+@property (nonatomic, strong) SFOAuthInfo *authInfo;
+@property (nonatomic, assign) BOOL didFailWithErrorCalled;
+@property (nonatomic, assign) BOOL isNetworkAvailableCalled;
+@property (nonatomic, strong) NSError *didFailWithError;
+@property (nonatomic, assign) BOOL isNetworkAvailable;
 
 @end

--- a/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthTestFlowCoordinatorDelegate.m
+++ b/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthTestFlowCoordinatorDelegate.m
@@ -1,0 +1,92 @@
+/*
+ Copyright (c) 2015, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFOAuthTestFlowCoordinatorDelegate.h"
+#import "SFOAuthInfo.h"
+
+static NSString * const kWebNotSupportedExceptionName = @"com.salesforce.oauth.tests.WebNotSupported";
+static NSString * const kWebNotSupportedReasonFormat  = @"%@ UIWebView transactions not supported in unit test framework.";
+
+@implementation SFOAuthTestFlowCoordinatorDelegate
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        self.isNetworkAvailable = YES;  // Network is available by default.
+    }
+    return self;
+}
+
+#pragma mark - SFOAuthCoordinatorDelegate
+
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(UIWebView *)view {
+    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
+    @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
+}
+
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator willBeginAuthenticationWithView:(UIWebView *)view {
+    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
+    @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
+}
+
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didStartLoad:(UIWebView *)view {
+    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
+    @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
+}
+
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFinishLoad:(UIWebView *)view error:(NSError*)errorOrNil {
+    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
+    @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
+}
+
+- (void)oauthCoordinatorWillBeginAuthentication:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)info {
+    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    self.willBeginAuthenticationCalled = YES;
+    self.authInfo = info;
+}
+
+- (void)oauthCoordinatorDidAuthenticate:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)info {
+    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    self.didAuthenticateCalled = YES;
+    self.authInfo = info;
+}
+
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFailWithError:(NSError *)error authInfo:(SFOAuthInfo *)info {
+    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    self.didFailWithErrorCalled = YES;
+    self.didFailWithError = error;
+    self.authInfo = info;
+}
+
+- (BOOL)oauthCoordinatorIsNetworkAvailable:(SFOAuthCoordinator*)coordinator {
+    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    self.isNetworkAvailableCalled = YES;
+    return self.isNetworkAvailable;
+}
+
+@end


### PR DESCRIPTION
In anticipation of testing a session refresher, which will have its own `SFOAuthCoordinator` delegate implementation.