### PR TITLE
Updating test to fix failure

### DIFF
--- a/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SalesforceOAuthUnitTests.m
+++ b/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SalesforceOAuthUnitTests.m
@@ -253,7 +253,7 @@ static NSString * const kClientId   = @"SfdcMobileChatteriOS";
  */
 - (void)testTokenEncryptionDecryption
 {
-    NSString *accessToken = @"gimmeAccess!";
+    NSString *accessToken = @"gimmeAccess!!!";
     NSString *refreshToken = @"IWannaRefresh!";
     SFOAuthKeychainCredentials *credentials = [[SFOAuthKeychainCredentials alloc] initWithIdentifier:kIdentifier clientId:kClientId encrypted:YES];
     


### PR DESCRIPTION
There seems to be an issue in the legacy encryption/decryption process, for strings that are too short.  However, a) that's not ever going to be an issue with access and refresh tokens, and b) I don't want to muck with the legacy logic to make sure it can be fixed without breaking its previous functionality, because c) I doubt that functionality is hardly ever leveraged anymore (we're a long time past those legacy token encryption schemes).