### PR TITLE
Adding ability for SFIdentityCoordinator to refresh on expired credentials

### DIFF
--- a/SalesforceMobileSDK-iOS.podspec
+++ b/SalesforceMobileSDK-iOS.podspec
@@ -58,7 +58,7 @@ Pod::Spec.new do |s|
       oauth.dependency 'SalesforceMobileSDK-iOS/SalesforceSDKCommon'
       oauth.dependency 'SalesforceMobileSDK-iOS/SalesforceSecurity'
       oauth.source_files = 'libs/SalesforceOAuth/SalesforceOAuth/Classes/**/*.{h,m}', 'libs/SalesforceOAuth/SalesforceOAuth/SalesforceOAuth.h'
-      oauth.public_header_files = 'libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.h', 'libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCredentials.h', 'libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthInfo.h', 'libs/SalesforceOAuth/SalesforceOAuth/SalesforceOAuth.h'
+      oauth.public_header_files = 'libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.h', 'libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCredentials.h', 'libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthInfo.h', 'libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthSessionRefresher.h', 'libs/SalesforceOAuth/SalesforceOAuth/SalesforceOAuth.h'
       oauth.header_dir = 'Headers/SalesforceOAuth'
       oauth.prefix_header_contents = '#import <SalesforceCommonUtils/SFLogger.h>'
       oauth.xcconfig = { 'HEADER_SEARCH_PATHS' => "${PODS_ROOT}/Headers/Public/#{s.name}/Headers" }

--- a/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
+++ b/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		82C2B71117BBF2EB0023218F /* SFOAuthCredentials+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FFCCF9C13BD82B000F4B22B /* SFOAuthCredentials+Internal.h */; };
 		82C2B71217BBF2EB0023218F /* SFOAuthCrypto.h in Headers */ = {isa = PBXBuildFile; fileRef = BEEA6CEF14C4E61A00487C9D /* SFOAuthCrypto.h */; };
 		82E0D880191AC65100A8FC23 /* libSalesforceSecurity.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82E0D87F191AC65100A8FC23 /* libSalesforceSecurity.a */; };
+		82E96E471BFC496000A8A4D0 /* SFOAuthSessionRefresherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 82E96E461BFC496000A8A4D0 /* SFOAuthSessionRefresherTests.m */; };
+		82E96E4D1BFC4C1800A8A4D0 /* SFOAuthSessionRefresher+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 82E96E4C1BFC4C1800A8A4D0 /* SFOAuthSessionRefresher+Internal.h */; };
 		82F06EB117B5B05300F287A2 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 82F06EB017B5B05300F287A2 /* Default-568h@2x.png */; };
 		82F9A44C1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 82F9A44B1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.m */; };
 		BEEA6CF214C4E61B00487C9D /* SFOAuthCrypto.m in Sources */ = {isa = PBXBuildFile; fileRef = BEEA6CF014C4E61A00487C9D /* SFOAuthCrypto.m */; };
@@ -156,6 +158,8 @@
 		82B0FC1315F5AE420054B066 /* SFOAuthInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFOAuthInfo.h; path = SalesforceOAuth/Classes/SFOAuthInfo.h; sourceTree = SOURCE_ROOT; };
 		82B0FC1415F5AE420054B066 /* SFOAuthInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFOAuthInfo.m; path = SalesforceOAuth/Classes/SFOAuthInfo.m; sourceTree = SOURCE_ROOT; };
 		82E0D87F191AC65100A8FC23 /* libSalesforceSecurity.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libSalesforceSecurity.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		82E96E461BFC496000A8A4D0 /* SFOAuthSessionRefresherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFOAuthSessionRefresherTests.m; sourceTree = "<group>"; };
+		82E96E4C1BFC4C1800A8A4D0 /* SFOAuthSessionRefresher+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SFOAuthSessionRefresher+Internal.h"; path = "SalesforceOAuth/Classes/SFOAuthSessionRefresher+Internal.h"; sourceTree = SOURCE_ROOT; };
 		82F06EB017B5B05300F287A2 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
 		82F9A44A1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFOAuthTestFlowCoordinatorDelegate.h; sourceTree = "<group>"; };
 		82F9A44B1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFOAuthTestFlowCoordinatorDelegate.m; sourceTree = "<group>"; };
@@ -256,6 +260,7 @@
 				829A087E1A32362C00DC17A5 /* SalesforceOAuthUnitTestsCoordinatorDelegate.h */,
 				829A087F1A32362C00DC17A5 /* SalesforceOAuthUnitTestsCoordinatorDelegate.m */,
 				8293A8D91A43573800ABC43C /* SFOAuthCoordinatorFlowTests.m */,
+				82E96E461BFC496000A8A4D0 /* SFOAuthSessionRefresherTests.m */,
 				8293A8D61A40FD1100ABC43C /* SFOAuthTestFlow.h */,
 				8293A8D71A40FD1100ABC43C /* SFOAuthTestFlow.m */,
 				82F9A44A1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.h */,
@@ -291,6 +296,7 @@
 				8201F1AA1A310AED00C6696A /* SFOAuthOrgAuthConfiguration.h */,
 				8201F1AB1A310AED00C6696A /* SFOAuthOrgAuthConfiguration.m */,
 				82A170DB1BFBFF3A00528401 /* SFOAuthSessionRefresher.h */,
+				82E96E4C1BFC4C1800A8A4D0 /* SFOAuthSessionRefresher+Internal.h */,
 				82A170DC1BFBFF3A00528401 /* SFOAuthSessionRefresher.m */,
 			);
 			path = Classes;
@@ -407,6 +413,7 @@
 				82BBB58D1790A2D000374DD8 /* SFOAuthInfo.h in Headers */,
 				82C2B71017BBF2EB0023218F /* SFOAuthCoordinator+Internal.h in Headers */,
 				82C2B71117BBF2EB0023218F /* SFOAuthCredentials+Internal.h in Headers */,
+				82E96E4D1BFC4C1800A8A4D0 /* SFOAuthSessionRefresher+Internal.h in Headers */,
 				82C2B71217BBF2EB0023218F /* SFOAuthCrypto.h in Headers */,
 				6F1A48AC1B5CAC1400826955 /* SFOAuthKeychainCredentials.h in Headers */,
 				8201F1AC1A310AED00C6696A /* SFOAuthOrgAuthConfiguration.h in Headers */,
@@ -615,6 +622,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				82E96E471BFC496000A8A4D0 /* SFOAuthSessionRefresherTests.m in Sources */,
 				829A08801A32362C00DC17A5 /* SalesforceOAuthUnitTestsCoordinatorDelegate.m in Sources */,
 				8293A8DA1A43573800ABC43C /* SFOAuthCoordinatorFlowTests.m in Sources */,
 				82F9A44C1BFAB2080074BD55 /* SFOAuthTestFlowCoordinatorDelegate.m in Sources */,

--- a/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
+++ b/libs/SalesforceOAuth/SalesforceOAuth.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		8293A8E21A43AFE700ABC43C /* libSalesforceSDKCommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8293A8E11A43AFE700ABC43C /* libSalesforceSDKCommon.a */; };
 		829A08771A3235DE00DC17A5 /* SalesforceOAuthUnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 829A08761A3235DE00DC17A5 /* SalesforceOAuthUnitTests.m */; };
 		829A08801A32362C00DC17A5 /* SalesforceOAuthUnitTestsCoordinatorDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 829A087F1A32362C00DC17A5 /* SalesforceOAuthUnitTestsCoordinatorDelegate.m */; };
+		82A170DD1BFBFF3A00528401 /* SFOAuthSessionRefresher.h in Headers */ = {isa = PBXBuildFile; fileRef = 82A170DB1BFBFF3A00528401 /* SFOAuthSessionRefresher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82A170DE1BFBFF3A00528401 /* SFOAuthSessionRefresher.m in Sources */ = {isa = PBXBuildFile; fileRef = 82A170DC1BFBFF3A00528401 /* SFOAuthSessionRefresher.m */; };
 		82B0FC1615F5AE420054B066 /* SFOAuthInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 82B0FC1415F5AE420054B066 /* SFOAuthInfo.m */; };
 		82BBB58B1790A2D000374DD8 /* SFOAuthCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FFCCF8F13BD7C0100F4B22B /* SFOAuthCoordinator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		82BBB58C1790A2D000374DD8 /* SFOAuthCredentials.h in Headers */ = {isa = PBXBuildFile; fileRef = CF19784513B510EC00AFCA56 /* SFOAuthCredentials.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -149,6 +151,8 @@
 		829A087D1A32362C00DC17A5 /* SalesforceOAuthUnitTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SalesforceOAuthUnitTests.h; sourceTree = "<group>"; };
 		829A087E1A32362C00DC17A5 /* SalesforceOAuthUnitTestsCoordinatorDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SalesforceOAuthUnitTestsCoordinatorDelegate.h; sourceTree = "<group>"; };
 		829A087F1A32362C00DC17A5 /* SalesforceOAuthUnitTestsCoordinatorDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SalesforceOAuthUnitTestsCoordinatorDelegate.m; sourceTree = "<group>"; };
+		82A170DB1BFBFF3A00528401 /* SFOAuthSessionRefresher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFOAuthSessionRefresher.h; path = SalesforceOAuth/Classes/SFOAuthSessionRefresher.h; sourceTree = SOURCE_ROOT; };
+		82A170DC1BFBFF3A00528401 /* SFOAuthSessionRefresher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFOAuthSessionRefresher.m; path = SalesforceOAuth/Classes/SFOAuthSessionRefresher.m; sourceTree = SOURCE_ROOT; };
 		82B0FC1315F5AE420054B066 /* SFOAuthInfo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFOAuthInfo.h; path = SalesforceOAuth/Classes/SFOAuthInfo.h; sourceTree = SOURCE_ROOT; };
 		82B0FC1415F5AE420054B066 /* SFOAuthInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFOAuthInfo.m; path = SalesforceOAuth/Classes/SFOAuthInfo.m; sourceTree = SOURCE_ROOT; };
 		82E0D87F191AC65100A8FC23 /* libSalesforceSecurity.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libSalesforceSecurity.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -286,6 +290,8 @@
 				82B0FC1415F5AE420054B066 /* SFOAuthInfo.m */,
 				8201F1AA1A310AED00C6696A /* SFOAuthOrgAuthConfiguration.h */,
 				8201F1AB1A310AED00C6696A /* SFOAuthOrgAuthConfiguration.m */,
+				82A170DB1BFBFF3A00528401 /* SFOAuthSessionRefresher.h */,
+				82A170DC1BFBFF3A00528401 /* SFOAuthSessionRefresher.m */,
 			);
 			path = Classes;
 			sourceTree = SOURCE_ROOT;
@@ -397,6 +403,7 @@
 			files = (
 				82BBB58B1790A2D000374DD8 /* SFOAuthCoordinator.h in Headers */,
 				82BBB58C1790A2D000374DD8 /* SFOAuthCredentials.h in Headers */,
+				82A170DD1BFBFF3A00528401 /* SFOAuthSessionRefresher.h in Headers */,
 				82BBB58D1790A2D000374DD8 /* SFOAuthInfo.h in Headers */,
 				82C2B71017BBF2EB0023218F /* SFOAuthCoordinator+Internal.h in Headers */,
 				82C2B71117BBF2EB0023218F /* SFOAuthCredentials+Internal.h in Headers */,
@@ -634,6 +641,7 @@
 				8201F1AD1A310AED00C6696A /* SFOAuthOrgAuthConfiguration.m in Sources */,
 				6FFCCF9213BD7C0100F4B22B /* SFOAuthCoordinator.m in Sources */,
 				6F1A48AD1B5CAC1400826955 /* SFOAuthKeychainCredentials.m in Sources */,
+				82A170DE1BFBFF3A00528401 /* SFOAuthSessionRefresher.m in Sources */,
 				BEEA6CF214C4E61B00487C9D /* SFOAuthCrypto.m in Sources */,
 				82B0FC1615F5AE420054B066 /* SFOAuthInfo.m in Sources */,
 			);

--- a/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthSessionRefresher+Internal.h
+++ b/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthSessionRefresher+Internal.h
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) 2015, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFOAuthSessionRefresher.h"
+#import "SFOAuthCoordinator.h"
+
+@interface SFOAuthSessionRefresher () <SFOAuthCoordinatorDelegate>
+
+@property (nonatomic, strong) SFOAuthCoordinator *coordinator;
+@property (nonatomic, copy) void (^completionBlock)(SFOAuthCredentials *);
+@property (nonatomic, copy) void (^errorBlock)(NSError *);
+
+@end

--- a/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthSessionRefresher.h
+++ b/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthSessionRefresher.h
@@ -1,9 +1,4 @@
 /*
- SalesforceOAuth.h
- SalesforceOAuth
-
- Created by Kevin Hawkins on Tue Nov 17 16:37:27 PST 2015.
-
  Copyright (c) 2015, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
@@ -27,7 +22,30 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <SalesforceOAuth/SFOAuthCoordinator.h>
-#import <SalesforceOAuth/SFOAuthCredentials.h>
-#import <SalesforceOAuth/SFOAuthInfo.h>
-#import <SalesforceOAuth/SFOAuthSessionRefresher.h>
+#import <Foundation/Foundation.h>
+
+@class SFOAuthCredentials;
+
+/**
+ * Error codes for refresh failures.
+ */
+typedef NS_ENUM(NSUInteger, SFOAuthSessionRefreshErrorCode) {
+    SFOAuthSessionRefreshErrorCodeInvalidCredentials = 766,
+};
+
+@interface SFOAuthSessionRefresher : NSObject
+
+/**
+ * Initializes the object with the given credentials.
+ * @param credentials The OAuth credentials used to refresh the session.
+ */
+- (instancetype)initWithCredentials:(SFOAuthCredentials *)credentials NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Refreshes the expired session, with the given completion and error handler blocks.
+ * @param completionBlock Called once the session has been refreshed.
+ * @param errorBlock Called if there was an error refreshing the session.
+ */
+- (void)refreshSessionWithCompletion:(void (^) (SFOAuthCredentials *))completionBlock error:(void (^) (NSError *))errorBlock;
+
+@end

--- a/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthSessionRefresher.m
@@ -1,0 +1,131 @@
+/*
+ Copyright (c) 2015, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFOAuthSessionRefresher.h"
+#import "SFOAuthCoordinator.h"
+#import "SFOAuthCredentials.h"
+
+@interface SFOAuthSessionRefresher () <SFOAuthCoordinatorDelegate>
+
+@property (nonatomic, strong) SFOAuthCredentials *credentials;
+@property (nonatomic, strong) SFOAuthCoordinator *coordinator;
+@property (nonatomic, copy) void (^completionBlock)(SFOAuthCredentials *);
+@property (nonatomic, copy) void (^errorBlock)(NSError *);
+
+@end
+
+@implementation SFOAuthSessionRefresher
+
+- (instancetype)initWithCredentials:(SFOAuthCredentials *)credentials {
+    self = [super init];
+    if (self) {
+        self.credentials = credentials;
+    }
+    return self;
+}
+
+- (instancetype)init {
+    return [self initWithCredentials:nil];
+}
+
+- (void)dealloc {
+    [self.coordinator stopAuthentication];
+    self.coordinator.delegate = nil;
+}
+
+- (void)refreshSessionWithCompletion:(void (^)(SFOAuthCredentials *))completionBlock error:(void (^)(NSError *))errorBlock {
+    self.completionBlock = completionBlock;
+    self.errorBlock = errorBlock;
+    if (self.credentials.instanceUrl == nil) {
+        NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain
+                                             code:SFOAuthSessionRefreshErrorCodeInvalidCredentials
+                                         userInfo:@{ NSLocalizedDescriptionKey: @"Credentials do not contain an instanceUrl" }];
+        [self completeWithError:error];
+        return;
+    }
+    
+    if (self.credentials.clientId.length == 0) {
+        NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain
+                                             code:SFOAuthSessionRefreshErrorCodeInvalidCredentials
+                                         userInfo:@{ NSLocalizedDescriptionKey: @"Credentials do not have an OAuth2 client_id set" }];
+        [self completeWithError:error];
+        return;
+    }
+    
+    if (self.credentials.refreshToken.length == 0) {
+        NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain
+                                             code:SFOAuthSessionRefreshErrorCodeInvalidCredentials
+                                         userInfo:@{ NSLocalizedDescriptionKey: @"Credentials do not have an OAuth2 refresh_token set" }];
+        [self completeWithError:error];
+        return;
+    }
+    
+    self.coordinator = [[SFOAuthCoordinator alloc] initWithCredentials:self.credentials];
+    self.coordinator.delegate = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.coordinator authenticate];
+    });
+}
+
+#pragma mark - Private methods
+
+- (void)completeWithSuccess:(SFOAuthCredentials *)credentials {
+    [self log:SFLogLevelInfo format:@"%@ Session was successfully refreshed.", NSStringFromSelector(_cmd)];
+    if (self.completionBlock) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            self.completionBlock(credentials);
+        });
+    }
+}
+
+- (void)completeWithError:(NSError *)error {
+    [self log:SFLogLevelError format:@"%@ Refresh failed with error: %@", NSStringFromSelector(_cmd), error];
+    if (self.errorBlock) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            self.errorBlock(error);
+        });
+    }
+}
+
+#pragma mark - SFOAuthCoordinatorDelegate
+
+- (void)oauthCoordinatorDidAuthenticate:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)info {
+    [self completeWithSuccess:coordinator.credentials];
+}
+
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFailWithError:(NSError *)error authInfo:(SFOAuthInfo *)info {
+    [self completeWithError:error];
+}
+
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(UIWebView *)view {
+    // Shouldn't happen (refreshSessionWithCompletion:error: is guarded by the presence of a refresh token), but....
+    NSString *errorString = [NSString stringWithFormat:@"%@: User Agent flow not supported for token refresh.", NSStringFromClass([self class])];
+    NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain
+                                         code:SFOAuthSessionRefreshErrorCodeInvalidCredentials
+                                     userInfo:@{ NSLocalizedDescriptionKey: errorString }];
+    [coordinator stopAuthentication];
+    [self completeWithError:error];
+}
+
+@end

--- a/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthSessionRefresherTests.m
+++ b/libs/SalesforceOAuth/SalesforceOAuthUnitTests/SFOAuthSessionRefresherTests.m
@@ -1,0 +1,174 @@
+/*
+ Copyright (c) 2015, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "SFOAuthSessionRefresher+Internal.h"
+#import "SFOAuthCoordinator+Internal.h"
+#import "SFOAuthCredentials.h"
+#import "SFOAuthTestFlow.h"
+
+@interface SFOAuthSessionRefresherTests : XCTestCase
+
+@property (nonatomic, strong) SFOAuthSessionRefresher *oauthSessionRefresher;
+@property (nonatomic, strong) SFOAuthTestFlow *oauthTestFlow;
+
+@end
+
+@implementation SFOAuthSessionRefresherTests
+
+- (void)setUp {
+    [super setUp];
+    [self setupCoordinatorFlow];
+}
+
+- (void)tearDown {
+    [self tearDownCoordinatorFlow];
+    [super tearDown];
+}
+
+- (void)testSuccessfulRefresh {
+    __block NSError *unexpectedRefreshError = nil;
+    __block SFOAuthCredentials *newCreds = nil;
+    XCTestExpectation *refreshAccessTokenExpectation = [self expectationWithDescription:@"Refresh Access Token"];
+    NSString *origAccessToken = self.oauthSessionRefresher.coordinator.credentials.accessToken;
+    self.oauthSessionRefresher.coordinator.credentials.accessToken = nil;
+    [self.oauthSessionRefresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
+        newCreds = updatedCredentials;
+        [refreshAccessTokenExpectation fulfill];
+    } error:^(NSError *refreshError) {
+        unexpectedRefreshError = refreshError;
+        [refreshAccessTokenExpectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError *error) {
+        XCTAssertNil(error, @"Error waiting for completion: %@", error);;
+        XCTAssertNil(unexpectedRefreshError, @"Should not have received an error refreshing the access token.");
+        XCTAssertNotNil(newCreds.accessToken, @"Should have received a refreshed access token.");
+        self.oauthSessionRefresher.coordinator.credentials.accessToken = origAccessToken;
+    }];
+}
+
+- (void)testBadInputData {
+    __block NSError *inputError = nil;
+    
+    // Invalid Instance URL
+    XCTestExpectation *invalidInputExpectation = [self expectationWithDescription:@"Refresh with invalid Instance URL"];
+    NSURL *origUrl = self.oauthSessionRefresher.coordinator.credentials.instanceUrl;
+    self.oauthSessionRefresher.coordinator.credentials.instanceUrl = nil;
+    [self.oauthSessionRefresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
+        [invalidInputExpectation fulfill];
+    } error:^(NSError *refreshError) {
+        inputError = refreshError;
+        [invalidInputExpectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError *error) {
+        XCTAssertNil(error, @"Error waiting for completion: %@", error);;
+        XCTAssertNotNil(inputError, @"Should have received an input error for bad Instance URL.");
+        XCTAssertTrue(inputError.code == SFOAuthSessionRefreshErrorCodeInvalidCredentials, @"Wrong error code for input error");
+        self.oauthSessionRefresher.coordinator.credentials.instanceUrl = origUrl;
+    }];
+    
+    // Invalid Client ID
+    inputError = nil;
+    invalidInputExpectation = [self expectationWithDescription:@"Refresh with invalid Client ID"];
+    NSString *origClientId = self.oauthSessionRefresher.coordinator.credentials.clientId;
+    self.oauthSessionRefresher.coordinator.credentials.clientId = nil;
+    [self.oauthSessionRefresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
+        [invalidInputExpectation fulfill];
+    } error:^(NSError *refreshError) {
+        inputError = refreshError;
+        [invalidInputExpectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError *error) {
+        XCTAssertNil(error, @"Error waiting for completion: %@", error);;
+        XCTAssertNotNil(inputError, @"Should have received an input error for bad Client ID.");
+        XCTAssertTrue(inputError.code == SFOAuthSessionRefreshErrorCodeInvalidCredentials, @"Wrong error code for input error");
+        self.oauthSessionRefresher.coordinator.credentials.clientId = origClientId;
+    }];
+    
+    // Invalid Refresh Token
+    inputError = nil;
+    invalidInputExpectation = [self expectationWithDescription:@"Refresh with invalid Refresh Token"];
+    NSString *origRefreshToken = self.oauthSessionRefresher.coordinator.credentials.refreshToken;
+    self.oauthSessionRefresher.coordinator.credentials.refreshToken = nil;
+    self.oauthSessionRefresher.coordinator.credentials.instanceUrl = origUrl;  // Nil'ed out as side effect of nil refresh token in SFOAuthCredentials.
+    [self.oauthSessionRefresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
+        [invalidInputExpectation fulfill];
+    } error:^(NSError *refreshError) {
+        inputError = refreshError;
+        [invalidInputExpectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError *error) {
+        XCTAssertNil(error, @"Error waiting for completion: %@", error);;
+        XCTAssertNotNil(inputError, @"Should have received an input error for bad Refresh Token.");
+        XCTAssertTrue(inputError.code == SFOAuthSessionRefreshErrorCodeInvalidCredentials, @"Wrong error code for input error");
+        self.oauthSessionRefresher.coordinator.credentials.refreshToken = origRefreshToken;
+    }];
+}
+
+- (void)testFailedRefresh {
+    __block NSError *refreshFailsError = nil;
+    self.oauthTestFlow.refreshTokenFlowIsSuccessful = NO;
+    XCTestExpectation *refreshAccessTokenExpectation = [self expectationWithDescription:@"Refresh Access Token fails"];
+    [self.oauthSessionRefresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
+        [refreshAccessTokenExpectation fulfill];
+    } error:^(NSError *refreshError) {
+        refreshFailsError = refreshError;
+        [refreshAccessTokenExpectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError *error) {
+        XCTAssertNil(error, @"Error waiting for completion: %@", error);;
+        XCTAssertNotNil(refreshFailsError, @"Should have received an error refreshing the access token.");
+    }];
+}
+
+#pragma mark - Private methods
+
+- (void)setupCoordinatorFlow {
+    NSString *credsIdentifier = [NSString stringWithFormat:@"CredsIdentifier_%u", arc4random()];
+    NSString *credsClientId = [NSString stringWithFormat:@"CredsClientId_%u", arc4random()];
+    NSString *credsAccessToken = [NSString stringWithFormat:@"CredsAccessToken_%u", arc4random()];
+    NSString *credsRefreshToken = [NSString stringWithFormat:@"CredsRefreshToken_%u", arc4random()];
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:credsIdentifier clientId:credsClientId encrypted:YES];
+    creds.redirectUri = [NSString stringWithFormat:@"sfdcUnitTest:///redirect_uri_%u", arc4random()];
+    creds.instanceUrl = [NSURL URLWithString:@"https://cs1.salesforce.com"];
+    creds.accessToken = credsAccessToken;
+    creds.refreshToken = credsRefreshToken;
+    self.oauthSessionRefresher = [[SFOAuthSessionRefresher alloc] initWithCredentials:creds];
+    self.oauthTestFlow = [[SFOAuthTestFlow alloc] initWithCoordinator:self.oauthSessionRefresher.coordinator];
+    self.oauthSessionRefresher.coordinator.oauthCoordinatorFlow = self.oauthTestFlow;
+}
+
+- (void)tearDownCoordinatorFlow {
+    [self.oauthSessionRefresher.coordinator.credentials revoke];
+    self.oauthSessionRefresher.coordinator.oauthCoordinatorFlow = nil;
+    self.oauthSessionRefresher = nil;
+    self.oauthTestFlow = nil;
+}
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator+Internal.h
@@ -26,16 +26,12 @@
 #import "SFIdentityCoordinator.h"
 
 @class SFIdentityData;
+@class SFOAuthSessionRefresher;
 
 /**
  * Internal interface for the SFIdentityCoordinator.
  */
 @interface SFIdentityCoordinator ()
-
-/**
- * The data from the service response will be populated here.
- */
-@property (nonatomic, strong) NSMutableData *responseData;
 
 /**
  * Whether or not a request is already in progress.
@@ -48,14 +44,14 @@
 @property (nonatomic, strong) NSURLSession *session;
 
 /**
+ * The OAuth sesssion refresher to use if the identity request fails with expired credentials.
+ */
+@property (nonatomic, strong) SFOAuthSessionRefresher *oauthSessionRefresher;
+
+/**
  * Dictionary mapping error codes to their respective types.
  */
 @property (strong, nonatomic, readonly) NSDictionary *typeToCodeDict;
-
-/**
- * If there's an error in the HTTP transaction, set it in this property.
- */
-@property (nonatomic, strong) NSError *httpError;
 
 /**
  * Triggers the success notifictation to the delegate.
@@ -68,9 +64,14 @@
 - (void)notifyDelegateOfFailure:(NSError *)error;
 
 /**
+ * Sends the request to the identity service, and processes the response.
+ */
+- (void)sendRequest;
+
+/**
  * Process a completed response from the service, populating the ID data.
  */
-- (void)processResponse;
+- (void)processResponse:(NSData *)responseData;
 
 /**
  * Cleans up the in-process properties and vars, once a request is completed.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator.h
@@ -46,7 +46,8 @@ enum {
     kSFIdentityErrorNoData,
     kSFIdentityErrorDataMalformed,
     kSFIdentityErrorBadHttpResponse,
-    kSFIdentityErrorMissingParameters
+    kSFIdentityErrorMissingParameters,
+    kSFIdentityErrorAlreadyRetrieving,
 };
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKIdentityTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKIdentityTests.m
@@ -123,6 +123,28 @@ static NSException *authException = nil;
     idCoord.credentials.identityUrl = origIdentityUrl;
 }
 
+- (void)testIdentityAuthRefreshSuccess
+{
+    [SFAuthenticationManager sharedManager].idCoordinator.idData = nil;
+    [SFAuthenticationManager sharedManager].idCoordinator.credentials.accessToken = @"BadToken";
+    [self sendSyncIdentityRequest];
+    XCTAssertEqualObjects(_requestListener.returnStatus, kTestRequestStatusDidLoad, @"Identity request failed.");
+    [self validateIdentityData];
+}
+
+- (void)testIdentityAuthRefreshFailure
+{
+    [SFAuthenticationManager sharedManager].idCoordinator.idData = nil;
+    NSString *origAccessToken = [SFAuthenticationManager sharedManager].idCoordinator.credentials.accessToken;
+    NSString *origRefreshToken = [SFAuthenticationManager sharedManager].idCoordinator.credentials.refreshToken;
+    [SFAuthenticationManager sharedManager].idCoordinator.credentials.accessToken = @"BadToken";
+    [SFAuthenticationManager sharedManager].idCoordinator.credentials.refreshToken = @"BadRefreshToken";
+    [self sendSyncIdentityRequest];
+    XCTAssertEqualObjects(_requestListener.returnStatus, kTestRequestStatusDidFail, @"Identity request should have failed.");
+    [SFAuthenticationManager sharedManager].idCoordinator.credentials.accessToken = origAccessToken;
+    [SFAuthenticationManager sharedManager].idCoordinator.credentials.refreshToken = origRefreshToken;
+}
+
 #pragma mark - Private helper methods
 
 - (void)validateIdentityData


### PR DESCRIPTION
- Added `SFOAuthSessionRefresher` to SalesforceOAuth, that can be used by any low-level components that care to fire off a refresh process.
- Updated `SFIdentityCoordinator` to refresh credentials in the event of an expired/invalid session response.
- Unit tests.