### PR TITLE
The same version of sqlcipher should be used regardless on how you consume the SDK

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,6 @@ external/cordova-ios
 external/fmdb
 external/ocmock
 external/react-native
-external/ThirdPartyDependencies
 external/shared/doc/
 external/shared/gen/
 external/shared/test/

--- a/SalesforceMobileSDK-iOS.podspec
+++ b/SalesforceMobileSDK-iOS.podspec
@@ -47,11 +47,17 @@ Pod::Spec.new do |s|
 
   end
 
+  s.subspec 'SQLCipher' do |sqlcipher|
+
+      sqlcipher.preserve_paths = 'external/ThirdPartyDependencies/sqlcipher/LICENSE'
+      sqlcipher.vendored_libraries = 'external/ThirdPartyDependencies/sqlcipher/libsqlcipher.a'
+
+  end
+
   s.subspec 'SmartStore' do |smartstore|
 
       smartstore.dependency 'SalesforceMobileSDK-iOS/SalesforceSDKCore'
-      smartstore.dependency 'SQLCipher', '~> 3.1'
-      smartstore.dependency 'SQLCipher/fts', '~> 3.1'
+      smartstore.dependency 'SalesforceMobileSDK-iOS/SQLCipher'
       smartstore.dependency 'FMDB', '~> 2.5'
       smartstore.source_files = 'libs/Smartstore/Smartstore/Classes/**/*.{h,m}', 'libs/Smartstore/Smartstore/Smartstore.h'
       smartstore.public_header_files = 'libs/SmartStore/SmartStore/Classes/SFAlterSoupLongOperation.h', 'libs/SmartStore/SmartStore/Classes/SFQuerySpec.h', 'libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStore.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreInspectorViewController.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreUtils.h', 'libs/SmartStore/SmartStore/Classes/SFSoupIndex.h', 'libs/SmartStore/SmartStore/Classes/SFStoreCursor.h', 'libs/SmartStore/SmartStore/SmartStore.h', 'libs/SmartStore/SmartStore/Classes/sqlite/SqliteAdditions.h'


### PR DESCRIPTION
Zetetic has not updated their pod spec since April 2014, so you get sqlcipher 3.1 when you use cocoapod and 3.3 otherwise.
Before 4.0, forceios generated apps didn't use cocoapod, now they do (unless you generate an hybrid application).

The same version of sqlcipher should be used regardless on how you consume the SDK (native vs hybrid, cocoapod or not).
