### PR TITLE
Fix project dependencies, target references

### DIFF
--- a/hybrid/SampleApps/NoteSync/NoteSync.xcodeproj/project.pbxproj
+++ b/hybrid/SampleApps/NoteSync/NoteSync.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		824A9DBF1724CAF900C9BD79 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 824A9DBE1724CAF900C9BD79 /* SystemConfiguration.framework */; };
 		82638F0C19B8E1FD00FBB3C9 /* UIApplication+SalesforceHybridSDK.m in Sources */ = {isa = PBXBuildFile; fileRef = 82638F0B19B8E1FD00FBB3C9 /* UIApplication+SalesforceHybridSDK.m */; };
 		8272301C19D764160066A350 /* InitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8272301B19D764160066A350 /* InitialViewController.m */; };
+		829DA2791C1263320040F5F1 /* SalesforceHybridSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 829DA2721C1263010040F5F1 /* SalesforceHybridSDK.framework */; };
 		82AF5AA71A0DA9AD006C7A4B /* cordova_plugins.js in Copy Shared www Files */ = {isa = PBXBuildFile; fileRef = 82AF5AA51A0DA996006C7A4B /* cordova_plugins.js */; };
 		82AF5AE61A0DADA4006C7A4B /* CDVLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 82AF5AE01A0DADA4006C7A4B /* CDVLogger.m */; };
 		82AF5AEA1A0DAE72006C7A4B /* console-via-logger.js in Copy cordova-plugin-console plugin */ = {isa = PBXBuildFile; fileRef = 82AF5AE41A0DADA4006C7A4B /* console-via-logger.js */; };
@@ -68,7 +69,6 @@
 		CE6AB3B21C10CB850012125E /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3B11C10CB850012125E /* SalesforceSDKCore.framework */; };
 		CE6AB3B71C10CB8F0012125E /* SalesforceNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3B61C10CB8F0012125E /* SalesforceNetwork.framework */; };
 		CE6AB3B91C10CB950012125E /* SalesforceRestAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3B81C10CB950012125E /* SalesforceRestAPI.framework */; };
-		CE6AB3BA1C10CB9D0012125E /* SalesforceHybridSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FFEE60D1BFE914300B7AA8A /* SalesforceHybridSDK.framework */; };
 		CE6AB3BC1C10CBA50012125E /* SmartStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3BB1C10CBA50012125E /* SmartStore.framework */; };
 		CE6AB3BE1C10CBAE0012125E /* SmartSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3BD1C10CBAE0012125E /* SmartSync.framework */; };
 		CE6AB3C01C10CBB90012125E /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3BF1C10CBB90012125E /* libz.tbd */; };
@@ -78,26 +78,33 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		4FFEE60C1BFE914300B7AA8A /* PBXContainerItemProxy */ = {
+		829DA2711C1263010040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4FFEE6051BFE914200B7AA8A /* SalesforceHybridSDK.xcodeproj */;
+			containerPortal = 829DA26A1C1263010040F5F1 /* SalesforceHybridSDK.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = 82EFF2D016E7C57100A63CDF;
+			remoteGlobalIDString = CE4CE2E11C0E465B009F6029;
 			remoteInfo = SalesforceHybridSDK;
 		};
-		4FFEE60E1BFE914300B7AA8A /* PBXContainerItemProxy */ = {
+		829DA2731C1263010040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4FFEE6051BFE914200B7AA8A /* SalesforceHybridSDK.xcodeproj */;
+			containerPortal = 829DA26A1C1263010040F5F1 /* SalesforceHybridSDK.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 82EFF2FF16E8049500A63CDF;
-			remoteInfo = HybridPluginTestApp;
+			remoteInfo = SalesforceHybridSDKTestApp;
 		};
-		4FFEE6101BFE914300B7AA8A /* PBXContainerItemProxy */ = {
+		829DA2751C1263010040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4FFEE6051BFE914200B7AA8A /* SalesforceHybridSDK.xcodeproj */;
+			containerPortal = 829DA26A1C1263010040F5F1 /* SalesforceHybridSDK.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 8222729D19C39F4500FC537E;
-			remoteInfo = HybridPluginTestAppTests;
+			remoteInfo = SalesforceHybridSDKTestAppTests;
+		};
+		829DA2771C1263260040F5F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 829DA26A1C1263010040F5F1 /* SalesforceHybridSDK.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE2E01C0E465B009F6029;
+			remoteInfo = SalesforceHybridSDK;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -213,7 +220,6 @@
 		4FF15E671908852E00705FE0 /* com.salesforce.util.exec.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = com.salesforce.util.exec.js; sourceTree = "<group>"; };
 		4FF15E681908852E00705FE0 /* com.salesforce.util.logger.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = com.salesforce.util.logger.js; sourceTree = "<group>"; };
 		4FF15E9C1908860100705FE0 /* cordova.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = cordova.js; path = "../../../../external/cordova-ios/cordova-ios/CordovaLib/cordova.js"; sourceTree = "<group>"; };
-		4FFEE6051BFE914200B7AA8A /* SalesforceHybridSDK.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceHybridSDK.xcodeproj; path = ../../../libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj; sourceTree = "<group>"; };
 		8230E2451A24181500EFE764 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = ../../../../shared/resources/Images.xcassets; sourceTree = "<group>"; };
 		824A9BCE1721FCA400C9BD79 /* NoteSync.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NoteSync.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		824A9BD11721FCA400C9BD79 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -246,6 +252,7 @@
 		8272301A19D764160066A350 /* InitialViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InitialViewController.h; path = ../../../../shared/hybrid/InitialViewController.h; sourceTree = "<group>"; };
 		8272301B19D764160066A350 /* InitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = InitialViewController.m; path = ../../../../shared/hybrid/InitialViewController.m; sourceTree = "<group>"; };
 		828B294C174AE06400741BBE /* libCordova.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libCordova.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		829DA26A1C1263010040F5F1 /* SalesforceHybridSDK.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceHybridSDK.xcodeproj; path = ../../../libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj; sourceTree = "<group>"; };
 		82AF5AA51A0DA996006C7A4B /* cordova_plugins.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = cordova_plugins.js; path = ../../../../shared/hybrid/cordova_plugins.js; sourceTree = "<group>"; };
 		82AF5ADF1A0DADA4006C7A4B /* CDVLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVLogger.h; sourceTree = "<group>"; };
 		82AF5AE01A0DADA4006C7A4B /* CDVLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVLogger.m; sourceTree = "<group>"; };
@@ -267,7 +274,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CE6AB3BA1C10CB9D0012125E /* SalesforceHybridSDK.framework in Frameworks */,
+				829DA2791C1263320040F5F1 /* SalesforceHybridSDK.framework in Frameworks */,
 				CE6AB3BE1C10CBAE0012125E /* SmartSync.framework in Frameworks */,
 				CE6AB3BC1C10CBA50012125E /* SmartStore.framework in Frameworks */,
 				CE6AB3B91C10CB950012125E /* SalesforceRestAPI.framework in Frameworks */,
@@ -355,16 +362,6 @@
 			path = com.salesforce;
 			sourceTree = "<group>";
 		};
-		4FFEE6061BFE914200B7AA8A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				4FFEE60D1BFE914300B7AA8A /* SalesforceHybridSDK.framework */,
-				4FFEE60F1BFE914300B7AA8A /* SalesforceHybridSDKTestApp.app */,
-				4FFEE6111BFE914300B7AA8A /* SalesforceHybridSDKTestAppTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		824A9BC51721FCA400C9BD79 = {
 			isa = PBXGroup;
 			children = (
@@ -395,7 +392,7 @@
 				CE6AB3B81C10CB950012125E /* SalesforceRestAPI.framework */,
 				CE6AB3B61C10CB8F0012125E /* SalesforceNetwork.framework */,
 				CE6AB3B11C10CB850012125E /* SalesforceSDKCore.framework */,
-				4FFEE6051BFE914200B7AA8A /* SalesforceHybridSDK.xcodeproj */,
+				829DA26A1C1263010040F5F1 /* SalesforceHybridSDK.xcodeproj */,
 				4F22155E19DF549400FF2D26 /* ImageIO.framework */,
 				4FF15E25190884C600705FE0 /* AssetsLibrary.framework */,
 				828B294C174AE06400741BBE /* libCordova.a */,
@@ -486,6 +483,16 @@
 			name = Classes;
 			sourceTree = "<group>";
 		};
+		829DA26B1C1263010040F5F1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				829DA2721C1263010040F5F1 /* SalesforceHybridSDK.framework */,
+				829DA2741C1263010040F5F1 /* SalesforceHybridSDKTestApp.app */,
+				829DA2761C1263010040F5F1 /* SalesforceHybridSDKTestAppTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		82AF5ADD1A0DADA4006C7A4B /* cordova-plugin-console */ = {
 			isa = PBXGroup;
 			children = (
@@ -549,7 +556,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				CE4CE4D21C0E6838009F6029 /* PBXTargetDependency */,
+				829DA2781C1263260040F5F1 /* PBXTargetDependency */,
 			);
 			name = NoteSync;
 			productName = NoteSync;
@@ -577,8 +584,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 4FFEE6061BFE914200B7AA8A /* Products */;
-					ProjectRef = 4FFEE6051BFE914200B7AA8A /* SalesforceHybridSDK.xcodeproj */;
+					ProductGroup = 829DA26B1C1263010040F5F1 /* Products */;
+					ProjectRef = 829DA26A1C1263010040F5F1 /* SalesforceHybridSDK.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -589,25 +596,25 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		4FFEE60D1BFE914300B7AA8A /* SalesforceHybridSDK.framework */ = {
+		829DA2721C1263010040F5F1 /* SalesforceHybridSDK.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = SalesforceHybridSDK.framework;
-			remoteRef = 4FFEE60C1BFE914300B7AA8A /* PBXContainerItemProxy */;
+			remoteRef = 829DA2711C1263010040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4FFEE60F1BFE914300B7AA8A /* SalesforceHybridSDKTestApp.app */ = {
+		829DA2741C1263010040F5F1 /* SalesforceHybridSDKTestApp.app */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.application;
 			path = SalesforceHybridSDKTestApp.app;
-			remoteRef = 4FFEE60E1BFE914300B7AA8A /* PBXContainerItemProxy */;
+			remoteRef = 829DA2731C1263010040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4FFEE6111BFE914300B7AA8A /* SalesforceHybridSDKTestAppTests.xctest */ = {
+		829DA2761C1263010040F5F1 /* SalesforceHybridSDKTestAppTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = SalesforceHybridSDKTestAppTests.xctest;
-			remoteRef = 4FFEE6101BFE914300B7AA8A /* PBXContainerItemProxy */;
+			remoteRef = 829DA2751C1263010040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -645,9 +652,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		CE4CE4D21C0E6838009F6029 /* PBXTargetDependency */ = {
+		829DA2781C1263260040F5F1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SalesforceHybridSDK;
+			targetProxy = 829DA2771C1263260040F5F1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/hybrid/SampleApps/SmartSyncExplorerHybrid/SmartSyncExplorerHybrid.xcodeproj/project.pbxproj
+++ b/hybrid/SampleApps/SmartSyncExplorerHybrid/SmartSyncExplorerHybrid.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		824A9DBF1724CAF900C9BD79 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 824A9DBE1724CAF900C9BD79 /* SystemConfiguration.framework */; };
 		82638F0C19B8E1FD00FBB3C9 /* UIApplication+SalesforceHybridSDK.m in Sources */ = {isa = PBXBuildFile; fileRef = 82638F0B19B8E1FD00FBB3C9 /* UIApplication+SalesforceHybridSDK.m */; };
 		8272301C19D764160066A350 /* InitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8272301B19D764160066A350 /* InitialViewController.m */; };
+		829DA2931C1264FF0040F5F1 /* SalesforceHybridSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 829DA28C1C1264E40040F5F1 /* SalesforceHybridSDK.framework */; };
 		82AF5AA71A0DA9AD006C7A4B /* cordova_plugins.js in Copy Shared www Files */ = {isa = PBXBuildFile; fileRef = 82AF5AA51A0DA996006C7A4B /* cordova_plugins.js */; };
 		82AF5AE61A0DADA4006C7A4B /* CDVLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 82AF5AE01A0DADA4006C7A4B /* CDVLogger.m */; };
 		82AF5AEA1A0DAE72006C7A4B /* console-via-logger.js in Copy cordova-plugin-console plugin */ = {isa = PBXBuildFile; fileRef = 82AF5AE41A0DADA4006C7A4B /* console-via-logger.js */; };
@@ -69,7 +70,6 @@
 		CE6AB3CF1C10CDFE0012125E /* SalesforceRestAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3CE1C10CDFD0012125E /* SalesforceRestAPI.framework */; };
 		CE6AB3D11C10CE040012125E /* SmartStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3D01C10CE030012125E /* SmartStore.framework */; };
 		CE6AB3D31C10CE090012125E /* SmartSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3D21C10CE090012125E /* SmartSync.framework */; };
-		CE6AB3D41C10CE0F0012125E /* SalesforceHybridSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FFEE61C1BFE916F00B7AA8A /* SalesforceHybridSDK.framework */; };
 		CE6AB3D61C10CE160012125E /* libCordova.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3D51C10CE160012125E /* libCordova.a */; };
 		CE6AB3D81C10CE210012125E /* libFMDB-IOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3D71C10CE210012125E /* libFMDB-IOS.a */; };
 		CE6AB3DA1C10CE2A0012125E /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3D91C10CE2A0012125E /* libz.tbd */; };
@@ -77,26 +77,33 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		4FFEE61B1BFE916F00B7AA8A /* PBXContainerItemProxy */ = {
+		829DA28B1C1264E40040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4FFEE6141BFE916F00B7AA8A /* SalesforceHybridSDK.xcodeproj */;
+			containerPortal = 829DA2841C1264E40040F5F1 /* SalesforceHybridSDK.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = 82EFF2D016E7C57100A63CDF;
+			remoteGlobalIDString = CE4CE2E11C0E465B009F6029;
 			remoteInfo = SalesforceHybridSDK;
 		};
-		4FFEE61D1BFE916F00B7AA8A /* PBXContainerItemProxy */ = {
+		829DA28D1C1264E40040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4FFEE6141BFE916F00B7AA8A /* SalesforceHybridSDK.xcodeproj */;
+			containerPortal = 829DA2841C1264E40040F5F1 /* SalesforceHybridSDK.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 82EFF2FF16E8049500A63CDF;
-			remoteInfo = HybridPluginTestApp;
+			remoteInfo = SalesforceHybridSDKTestApp;
 		};
-		4FFEE61F1BFE916F00B7AA8A /* PBXContainerItemProxy */ = {
+		829DA28F1C1264E40040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4FFEE6141BFE916F00B7AA8A /* SalesforceHybridSDK.xcodeproj */;
+			containerPortal = 829DA2841C1264E40040F5F1 /* SalesforceHybridSDK.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 8222729D19C39F4500FC537E;
-			remoteInfo = HybridPluginTestAppTests;
+			remoteInfo = SalesforceHybridSDKTestAppTests;
+		};
+		829DA2911C1264F40040F5F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 829DA2841C1264E40040F5F1 /* SalesforceHybridSDK.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE2E01C0E465B009F6029;
+			remoteInfo = SalesforceHybridSDK;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -210,7 +217,6 @@
 		4FF15E671908852E00705FE0 /* com.salesforce.util.exec.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = com.salesforce.util.exec.js; sourceTree = "<group>"; };
 		4FF15E681908852E00705FE0 /* com.salesforce.util.logger.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = com.salesforce.util.logger.js; sourceTree = "<group>"; };
 		4FF15E9C1908860100705FE0 /* cordova.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = cordova.js; path = "../../../../external/cordova-ios/cordova-ios/CordovaLib/cordova.js"; sourceTree = "<group>"; };
-		4FFEE6141BFE916F00B7AA8A /* SalesforceHybridSDK.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceHybridSDK.xcodeproj; path = ../../../libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj; sourceTree = "<group>"; };
 		8230E2451A24181500EFE764 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = ../../../../shared/resources/Images.xcassets; sourceTree = "<group>"; };
 		824A9BCE1721FCA400C9BD79 /* SmartSyncExplorerHybrid.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SmartSyncExplorerHybrid.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		824A9BD11721FCA400C9BD79 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -243,6 +249,7 @@
 		8272301A19D764160066A350 /* InitialViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InitialViewController.h; path = ../../../../shared/hybrid/InitialViewController.h; sourceTree = "<group>"; };
 		8272301B19D764160066A350 /* InitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = InitialViewController.m; path = ../../../../shared/hybrid/InitialViewController.m; sourceTree = "<group>"; };
 		828B294C174AE06400741BBE /* libCordova.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libCordova.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		829DA2841C1264E40040F5F1 /* SalesforceHybridSDK.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceHybridSDK.xcodeproj; path = ../../../libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj; sourceTree = "<group>"; };
 		82AF5AA51A0DA996006C7A4B /* cordova_plugins.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = cordova_plugins.js; path = ../../../../shared/hybrid/cordova_plugins.js; sourceTree = "<group>"; };
 		82AF5ADF1A0DADA4006C7A4B /* CDVLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVLogger.h; sourceTree = "<group>"; };
 		82AF5AE01A0DADA4006C7A4B /* CDVLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVLogger.m; sourceTree = "<group>"; };
@@ -264,7 +271,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CE6AB3D41C10CE0F0012125E /* SalesforceHybridSDK.framework in Frameworks */,
+				829DA2931C1264FF0040F5F1 /* SalesforceHybridSDK.framework in Frameworks */,
 				CE6AB3D31C10CE090012125E /* SmartSync.framework in Frameworks */,
 				CE6AB3D11C10CE040012125E /* SmartStore.framework in Frameworks */,
 				CE6AB3CF1C10CDFE0012125E /* SalesforceRestAPI.framework in Frameworks */,
@@ -352,16 +359,6 @@
 			path = com.salesforce;
 			sourceTree = "<group>";
 		};
-		4FFEE6151BFE916F00B7AA8A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				4FFEE61C1BFE916F00B7AA8A /* SalesforceHybridSDK.framework */,
-				4FFEE61E1BFE916F00B7AA8A /* SalesforceHybridSDKTestApp.app */,
-				4FFEE6201BFE916F00B7AA8A /* SalesforceHybridSDKTestAppTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		824A9BC51721FCA400C9BD79 = {
 			isa = PBXGroup;
 			children = (
@@ -392,7 +389,7 @@
 				CE6AB3CE1C10CDFD0012125E /* SalesforceRestAPI.framework */,
 				CE6AB3CC1C10CDF70012125E /* SalesforceNetwork.framework */,
 				CE6AB3C71C10CDF10012125E /* SalesforceSDKCore.framework */,
-				4FFEE6141BFE916F00B7AA8A /* SalesforceHybridSDK.xcodeproj */,
+				829DA2841C1264E40040F5F1 /* SalesforceHybridSDK.xcodeproj */,
 				4F22155E19DF549400FF2D26 /* ImageIO.framework */,
 				4FF15E25190884C600705FE0 /* AssetsLibrary.framework */,
 				828B294C174AE06400741BBE /* libCordova.a */,
@@ -481,6 +478,16 @@
 			name = Classes;
 			sourceTree = "<group>";
 		};
+		829DA2851C1264E40040F5F1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				829DA28C1C1264E40040F5F1 /* SalesforceHybridSDK.framework */,
+				829DA28E1C1264E40040F5F1 /* SalesforceHybridSDKTestApp.app */,
+				829DA2901C1264E40040F5F1 /* SalesforceHybridSDKTestAppTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		82AF5ADD1A0DADA4006C7A4B /* cordova-plugin-console */ = {
 			isa = PBXGroup;
 			children = (
@@ -544,7 +551,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				CE4CE4DB1C0E685F009F6029 /* PBXTargetDependency */,
+				829DA2921C1264F40040F5F1 /* PBXTargetDependency */,
 			);
 			name = SmartSyncExplorerHybrid;
 			productName = SmartSyncExplorerHybrid;
@@ -572,8 +579,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 4FFEE6151BFE916F00B7AA8A /* Products */;
-					ProjectRef = 4FFEE6141BFE916F00B7AA8A /* SalesforceHybridSDK.xcodeproj */;
+					ProductGroup = 829DA2851C1264E40040F5F1 /* Products */;
+					ProjectRef = 829DA2841C1264E40040F5F1 /* SalesforceHybridSDK.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -584,25 +591,25 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		4FFEE61C1BFE916F00B7AA8A /* SalesforceHybridSDK.framework */ = {
+		829DA28C1C1264E40040F5F1 /* SalesforceHybridSDK.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = SalesforceHybridSDK.framework;
-			remoteRef = 4FFEE61B1BFE916F00B7AA8A /* PBXContainerItemProxy */;
+			remoteRef = 829DA28B1C1264E40040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4FFEE61E1BFE916F00B7AA8A /* SalesforceHybridSDKTestApp.app */ = {
+		829DA28E1C1264E40040F5F1 /* SalesforceHybridSDKTestApp.app */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.application;
 			path = SalesforceHybridSDKTestApp.app;
-			remoteRef = 4FFEE61D1BFE916F00B7AA8A /* PBXContainerItemProxy */;
+			remoteRef = 829DA28D1C1264E40040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4FFEE6201BFE916F00B7AA8A /* SalesforceHybridSDKTestAppTests.xctest */ = {
+		829DA2901C1264E40040F5F1 /* SalesforceHybridSDKTestAppTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = SalesforceHybridSDKTestAppTests.xctest;
-			remoteRef = 4FFEE61F1BFE916F00B7AA8A /* PBXContainerItemProxy */;
+			remoteRef = 829DA28F1C1264E40040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -639,9 +646,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		CE4CE4DB1C0E685F009F6029 /* PBXTargetDependency */ = {
+		829DA2921C1264F40040F5F1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SalesforceHybridSDK;
+			targetProxy = 829DA2911C1264F40040F5F1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
@@ -190,6 +190,13 @@
 			remoteGlobalIDString = 82EFF2FE16E8049500A63CDF;
 			remoteInfo = SalesforceHybridSDKTestApp;
 		};
+		829DA2301C125D2F0040F5F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4F70CA091C03DF6D00D26B3F /* SmartSync.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE2C81C0E463C009F6029;
+			remoteInfo = SmartSync;
+		};
 		82A8C6E81C122998006BBDFE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 82EFF2C816E7C57100A63CDF /* Project object */;
@@ -1100,6 +1107,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				829DA2311C125D2F0040F5F1 /* PBXTargetDependency */,
 				CE4CE4A61C0E609C009F6029 /* PBXTargetDependency */,
 			);
 			name = SalesforceHybridSDK;
@@ -1283,6 +1291,11 @@
 			isa = PBXTargetDependency;
 			target = 82EFF2FE16E8049500A63CDF /* SalesforceHybridSDKTestApp */;
 			targetProxy = 822272AB19C39F4500FC537E /* PBXContainerItemProxy */;
+		};
+		829DA2311C125D2F0040F5F1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SmartSync;
+			targetProxy = 829DA2301C125D2F0040F5F1 /* PBXContainerItemProxy */;
 		};
 		CE4CE2E71C0E465B009F6029 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		822272CE19C3A3E500FC537E /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8251CA1516EC3AF900BD1EA2 /* SystemConfiguration.framework */; };
 		822272CF19C3A3FC00FC537E /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8251CA1116EC3AC100BD1EA2 /* MobileCoreServices.framework */; };
 		822272E519C3A84E00FC537E /* libsqlcipher.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 822272E419C3A84E00FC537E /* libsqlcipher.a */; };
+		829DA2B11C12677B0040F5F1 /* SalesforceHybridSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 829DA2B01C12677B0040F5F1 /* SalesforceHybridSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		82AF5A6B1A0D911D006C7A4B /* CDVLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 82AF5A651A0D911D006C7A4B /* CDVLogger.m */; };
 		82AF5A6F1A0D9277006C7A4B /* console-via-logger.js in Copy cordova-plugin-console plugin */ = {isa = PBXBuildFile; fileRef = 82AF5A691A0D911D006C7A4B /* console-via-logger.js */; };
 		82AF5A701A0D9277006C7A4B /* logger.js in Copy cordova-plugin-console plugin */ = {isa = PBXBuildFile; fileRef = 82AF5A6A1A0D911D006C7A4B /* logger.js */; };
@@ -416,6 +417,7 @@
 		8251CA3616ED007000BD1EA2 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		8251CA3816ED008200BD1EA2 /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
 		8251CA3A16ED009700BD1EA2 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
+		829DA2B01C12677B0040F5F1 /* SalesforceHybridSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SalesforceHybridSDK.h; sourceTree = "<group>"; };
 		82AF5A641A0D911D006C7A4B /* CDVLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVLogger.h; sourceTree = "<group>"; };
 		82AF5A651A0D911D006C7A4B /* CDVLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVLogger.m; sourceTree = "<group>"; };
 		82AF5A691A0D911D006C7A4B /* console-via-logger.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "console-via-logger.js"; sourceTree = "<group>"; };
@@ -863,6 +865,7 @@
 		82EFF2D516E7C57100A63CDF /* SalesforceHybridSDK */ = {
 			isa = PBXGroup;
 			children = (
+				829DA2B01C12677B0040F5F1 /* SalesforceHybridSDK.h */,
 				82EFF2E116E7C84900A63CDF /* Classes */,
 				82EFF2F916E7FFDB00A63CDF /* Resources */,
 				82EFF2D616E7C57100A63CDF /* Supporting Files */,
@@ -1042,6 +1045,7 @@
 				CE4CE4641C0E5B2A009F6029 /* SFHybridViewConfig.h in Headers */,
 				CE4CE45C1C0E5B1F009F6029 /* SFSmartStorePlugin.h in Headers */,
 				CE4CE4541C0E5AEE009F6029 /* SFSDKInfoPlugin.h in Headers */,
+				829DA2B11C12677B0040F5F1 /* SalesforceHybridSDK.h in Headers */,
 				CE4CE45E1C0E5B2A009F6029 /* SFLocalhostSubstitutionCache.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/libs/SalesforceNetwork/SalesforceNetwork.xcodeproj/project.pbxproj
+++ b/libs/SalesforceNetwork/SalesforceNetwork.xcodeproj/project.pbxproj
@@ -153,6 +153,13 @@
 			remoteGlobalIDString = D31108AD1828DB8700737925;
 			remoteInfo = OCMockLibTests;
 		};
+		829DA21B1C125BED0040F5F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6F7EAA941B61917700F4C242 /* SalesforceSDKCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE26A1C0E449C009F6029;
+			remoteInfo = SalesforceSDKCore;
+		};
 		CE0AB0341C10D1BA00BFAEED /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 6F7EAAF71B6299BA00F4C242 /* OCMock.xcodeproj */;
@@ -700,6 +707,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				829DA21C1C125BED0040F5F1 /* PBXTargetDependency */,
 			);
 			name = SalesforceNetwork;
 			productName = SalesforceNetwork;
@@ -911,6 +919,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		829DA21C1C125BED0040F5F1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SalesforceSDKCore;
+			targetProxy = 829DA21B1C125BED0040F5F1 /* PBXContainerItemProxy */;
+		};
 		CE0AB0351C10D1BA00BFAEED /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = OCMockLib;

--- a/libs/SalesforceNetwork/SalesforceNetwork.xcodeproj/project.pbxproj
+++ b/libs/SalesforceNetwork/SalesforceNetwork.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		8253486B1A8ADD220019FE0B /* InternalFunctionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8253480B1A8ADD220019FE0B /* InternalFunctionTests.m */; };
 		825348BC1A8ADD220019FE0B /* TestDataAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 825348621A8ADD220019FE0B /* TestDataAction.m */; };
 		825348D01A8AF55B0019FE0B /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 825348CF1A8AF55B0019FE0B /* MessageUI.framework */; };
+		829DA2A61C1266870040F5F1 /* SalesforceNetwork.h in Headers */ = {isa = PBXBuildFile; fileRef = 829DA2A51C1266870040F5F1 /* SalesforceNetwork.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		82A0C3B51A990FD600243931 /* MockNetworkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 82A0C3A31A990E8A00243931 /* MockNetworkTests.m */; };
 		82A0C3B61A990FDB00243931 /* ValueTransformerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 82A0C3A51A990EBF00243931 /* ValueTransformerTests.m */; };
 		82A0C3D91A99115300243931 /* CSFActionParameterStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 82A0C3D51A99115300243931 /* CSFActionParameterStorageTests.m */; };
@@ -251,6 +252,7 @@
 		827DD4811A7C006F00519F03 /* CSFURLValueTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CSFURLValueTransformer.h; sourceTree = "<group>"; };
 		827DD4821A7C006F00519F03 /* CSFURLValueTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CSFURLValueTransformer.m; sourceTree = "<group>"; };
 		827DD5071A7C086800519F03 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		829DA2A51C1266870040F5F1 /* SalesforceNetwork.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SalesforceNetwork.h; sourceTree = "<group>"; };
 		82A0C3A31A990E8A00243931 /* MockNetworkTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MockNetworkTests.m; sourceTree = "<group>"; };
 		82A0C3A51A990EBF00243931 /* ValueTransformerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ValueTransformerTests.m; sourceTree = "<group>"; };
 		82A0C3A71A990F0000243931 /* NSMutableURLRequest+SalesforceNetwork.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+SalesforceNetwork.h"; sourceTree = "<group>"; };
@@ -388,6 +390,7 @@
 		827DD3F11A7BF72E00519F03 /* SalesforceNetwork */ = {
 			isa = PBXGroup;
 			children = (
+				829DA2A51C1266870040F5F1 /* SalesforceNetwork.h */,
 				827DD3F21A7C006E00519F03 /* SalesforceNetwork */,
 				825348041A8ADD220019FE0B /* SalesforceNetworkTests */,
 			);
@@ -638,6 +641,7 @@
 				CE4CE3CB1C0E5562009F6029 /* CSFOAuthTokenRefreshOutput.h in Headers */,
 				CE4CE3C81C0E5540009F6029 /* CSFOutput_Internal.h in Headers */,
 				CE4CE3E71C0E5687009F6029 /* CSFDefines.h in Headers */,
+				829DA2A61C1266870040F5F1 /* SalesforceNetwork.h in Headers */,
 				CE4CE3C91C0E5557009F6029 /* CSFOAuthTokenRefreshInput.h in Headers */,
 				CE4CE3CD1C0E5577009F6029 /* CSFAuthRefresh+Internal.h in Headers */,
 				CE4CE3BE1C0E552C009F6029 /* CSFAction.h in Headers */,

--- a/libs/SalesforceRestAPI/SalesforceRestAPI.xcodeproj/project.pbxproj
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI.xcodeproj/project.pbxproj
@@ -100,6 +100,13 @@
 			remoteGlobalIDString = 82C0C75C16E07DEB0006B3C0;
 			remoteInfo = SalesforceRestAPITestApp;
 		};
+		829DA2171C125BAE0040F5F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4FE8ACE01C03E4DD00A4AE68 /* SalesforceNetwork.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE28B1C0E454F009F6029;
+			remoteInfo = SalesforceNetwork;
+		};
 		82A8C6E31C122998006BBDFE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 82C0C72616E076DE0006B3C0 /* Project object */;
@@ -485,6 +492,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				829DA2181C125BAE0040F5F1 /* PBXTargetDependency */,
 			);
 			name = SalesforceRestAPI;
 			productName = SalesforceRestAPI;
@@ -658,6 +666,11 @@
 			isa = PBXTargetDependency;
 			target = 82C0C75C16E07DEB0006B3C0 /* SalesforceRestAPITestApp */;
 			targetProxy = 829A088B1A323DDF00DC17A5 /* PBXContainerItemProxy */;
+		};
+		829DA2181C125BAE0040F5F1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SalesforceNetwork;
+			targetProxy = 829DA2171C125BAE0040F5F1 /* PBXContainerItemProxy */;
 		};
 		CE4CE2A91C0E456A009F6029 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/libs/SalesforceRestAPI/SalesforceRestAPI.xcodeproj/project.pbxproj
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		829A088A1A323DDF00DC17A5 /* SalesforceRestAPITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 829A08891A323DDF00DC17A5 /* SalesforceRestAPITests.m */; };
 		829A08911A323E8B00DC17A5 /* test_credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 829A08901A323E8B00DC17A5 /* test_credentials.json */; };
 		829A08951A32417F00DC17A5 /* SFNativeRestRequestListener.m in Sources */ = {isa = PBXBuildFile; fileRef = 829A08941A32417F00DC17A5 /* SFNativeRestRequestListener.m */; };
+		829DA2A81C1266C20040F5F1 /* SalesforceRestAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 829DA2A71C1266C20040F5F1 /* SalesforceRestAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		82C0C75E16E07DEB0006B3C0 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82C0C74216E076DE0006B3C0 /* UIKit.framework */; };
 		82C0C75F16E07DEB0006B3C0 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82C0C73116E076DE0006B3C0 /* Foundation.framework */; };
 		82C0C76116E07DEB0006B3C0 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82C0C76016E07DEB0006B3C0 /* CoreGraphics.framework */; };
@@ -179,6 +180,7 @@
 		829A08921A32417F00DC17A5 /* SalesforceRestAPITests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SalesforceRestAPITests.h; sourceTree = "<group>"; };
 		829A08931A32417F00DC17A5 /* SFNativeRestRequestListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFNativeRestRequestListener.h; sourceTree = "<group>"; };
 		829A08941A32417F00DC17A5 /* SFNativeRestRequestListener.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFNativeRestRequestListener.m; sourceTree = "<group>"; };
+		829DA2A71C1266C20040F5F1 /* SalesforceRestAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SalesforceRestAPI.h; sourceTree = "<group>"; };
 		82C0C73116E076DE0006B3C0 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		82C0C74216E076DE0006B3C0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		82C0C75D16E07DEB0006B3C0 /* SalesforceRestAPITestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SalesforceRestAPITestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -346,6 +348,7 @@
 		82C0C73316E076DE0006B3C0 /* SalesforceRestAPI */ = {
 			isa = PBXGroup;
 			children = (
+				829DA2A71C1266C20040F5F1 /* SalesforceRestAPI.h */,
 				82C0C78516E080780006B3C0 /* Classes */,
 				8201678916E17D65002F4066 /* Resources */,
 				82C0C73416E076DE0006B3C0 /* Supporting Files */,
@@ -430,6 +433,7 @@
 			files = (
 				CE4CE3FD1C0E594E009F6029 /* SFRestAPI+Blocks.h in Headers */,
 				CE4CE3FF1C0E594E009F6029 /* SFRestAPI+Files.h in Headers */,
+				829DA2A81C1266C20040F5F1 /* SalesforceRestAPI.h in Headers */,
 				CE4CE4061C0E594E009F6029 /* SFRestRequest.h in Headers */,
 				CE4CE4021C0E594E009F6029 /* SFRestAPI+QueryBuilder.h in Headers */,
 				CE4CE3FB1C0E594E009F6029 /* SFRestAPI.h in Headers */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		4FE5332A1BFFE70600814D2A /* Main_iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB4981BFFCEF600768720 /* Main_iPad.storyboard */; };
 		4FE5332B1BFFE70600814D2A /* Main_iPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB49A1BFFCEF600768720 /* Main_iPhone.storyboard */; };
 		4FFDAD491C068FC5009BCD6D /* test_credentials.json in Resources */ = {isa = PBXBuildFile; fileRef = 4FFDAD381C068E8F009BCD6D /* test_credentials.json */; };
+		829DA2951C1266340040F5F1 /* SalesforceSDKCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 829DA2941C1266340040F5F1 /* SalesforceSDKCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		82D4642519C7C8170006BDFE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8220B74F16D804CA00EC3921 /* Foundation.framework */; };
 		82D4642619C7C8170006BDFE /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280EBCC16E14F7000768DE8 /* CoreGraphics.framework */; };
 		82D4642719C7C8170006BDFE /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280EBB516E14E9F00768DE8 /* UIKit.framework */; };
@@ -635,6 +636,7 @@
 		8280EC1916E1600200768DE8 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		8280EC1C16E1604900768DE8 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		8280EC1E16E1605A00768DE8 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		829DA2941C1266340040F5F1 /* SalesforceSDKCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SalesforceSDKCore.h; sourceTree = "<group>"; };
 		82D4642419C7C8170006BDFE /* SalesforceSDKCoreTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SalesforceSDKCoreTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		82D4644319C7C8180006BDFE /* SalesforceSDKCoreTestAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SalesforceSDKCoreTestAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		82D4644419C7C8180006BDFE /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -1039,6 +1041,7 @@
 		8220B75116D804CA00EC3921 /* SalesforceSDKCore */ = {
 			isa = PBXGroup;
 			children = (
+				829DA2941C1266340040F5F1 /* SalesforceSDKCore.h */,
 				82AF840C16DFD95F008912EF /* Classes */,
 				8220B75216D804CA00EC3921 /* Supporting Files */,
 			);
@@ -1151,6 +1154,7 @@
 				CE4CE39D1C0E5272009F6029 /* SFSDKTestRequestListener.h in Headers */,
 				CE4CE3131C0E523B009F6029 /* NSString+SFAdditions.h in Headers */,
 				CE4CE38C1C0E526A009F6029 /* SFSHA256PasscodeProvider.h in Headers */,
+				829DA2951C1266340040F5F1 /* SalesforceSDKCore.h in Headers */,
 				CE4CE3151C0E523B009F6029 /* SFCrypto.h in Headers */,
 				CE4CE3701C0E526A009F6029 /* SFKeyStore+Internal.h in Headers */,
 				CE4CE3501C0E5252009F6029 /* SFOAuthSessionRefresher+Internal.h in Headers */,

--- a/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
+++ b/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		4FEE44891BFD5CDC00F09C43 /* SFSmartStoreTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F96015C1BFD33B30022F021 /* SFSmartStoreTestCase.m */; };
 		4FEE448A1BFD5CE500F09C43 /* SFSmartStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F96015E1BFD33B30022F021 /* SFSmartStoreTests.m */; };
 		4FFEE6351BFE98E100B7AA8A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CEAAAE61195911E600CBBFE9 /* InfoPlist.strings */; };
+		829DA2AA1C1266F70040F5F1 /* SmartStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 829DA2A91C1266F70040F5F1 /* SmartStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE0AB0751C10D39900BFAEED /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0AB0741C10D39900BFAEED /* SalesforceSDKCore.framework */; };
 		CE0AB0761C10D3AF00BFAEED /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE4CE5841C0FB648009F6029 /* libz.tbd */; };
 		CE0AB0781C10D3B500BFAEED /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0AB0771C10D3B500BFAEED /* libxml2.tbd */; };
@@ -167,6 +168,7 @@
 		4F96FC4F1BFD31EF0022F021 /* SmartStore-Static-iOS-Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "SmartStore-Static-iOS-Release.xcconfig"; path = "Configuration/SmartStore-Static-iOS-Release.xcconfig"; sourceTree = "<group>"; };
 		4F96FC501BFD31EF0022F021 /* SmartStore-Test.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "SmartStore-Test.xcconfig"; path = "Configuration/SmartStore-Test.xcconfig"; sourceTree = "<group>"; };
 		4FFEE6341BFE98B600B7AA8A /* SmartStoreTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "SmartStoreTests-Info.plist"; path = "SmartStoreTests/SmartStoreTests-Info.plist"; sourceTree = SOURCE_ROOT; };
+		829DA2A91C1266F70040F5F1 /* SmartStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmartStore.h; sourceTree = "<group>"; };
 		CE0021A81C06694D0079DCA4 /* fmdb.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = fmdb.xcodeproj; path = ../../external/fmdb/fmdb.xcodeproj; sourceTree = "<group>"; };
 		CE0AB0741C10D39900BFAEED /* SalesforceSDKCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SalesforceSDKCore.framework; path = "../SalesforceSDKCore/build/Debug-iphoneos/SalesforceSDKCore.framework"; sourceTree = "<group>"; };
 		CE0AB0771C10D3B500BFAEED /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
@@ -309,6 +311,7 @@
 		CEAAAE4A195911E600CBBFE9 /* SmartStore */ = {
 			isa = PBXGroup;
 			children = (
+				829DA2A91C1266F70040F5F1 /* SmartStore.h */,
 				CEF50A79196B3EB60076264C /* Classes */,
 				CEAAAE4B195911E600CBBFE9 /* Supporting Files */,
 			);
@@ -396,6 +399,7 @@
 				CE4CE4161C0E59DA009F6029 /* SFSmartStoreDatabaseManager+Internal.h in Headers */,
 				CE4CE41B1C0E59DA009F6029 /* SFSmartStoreUpgrade+Internal.h in Headers */,
 				CE4CE40F1C0E59DA009F6029 /* SFSmartSqlHelper.h in Headers */,
+				829DA2AA1C1266F70040F5F1 /* SmartStore.h in Headers */,
 				CE4CE4111C0E59DA009F6029 /* SFSmartStore.h in Headers */,
 				CE4CE40A1C0E59C5009F6029 /* SqliteAdditions.h in Headers */,
 				CE4CE4191C0E59DA009F6029 /* SFSmartStoreUpgrade.h in Headers */,

--- a/libs/SmartSync/SmartSync.xcodeproj/project.pbxproj
+++ b/libs/SmartSync/SmartSync.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		4F9079811A82EDF600E32659 /* SFSyncUpdateCallbackQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9079801A82EDF600E32659 /* SFSyncUpdateCallbackQueue.m */; };
 		4F9732D61A816C2D006E2A86 /* SyncManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9732D51A816C2D006E2A86 /* SyncManagerTests.m */; };
 		828E0E541AB398AA004E0AF2 /* TestSyncUpTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 828E0E531AB398AA004E0AF2 /* TestSyncUpTarget.m */; };
+		829DA2AF1C12674D0040F5F1 /* SmartSync.h in Headers */ = {isa = PBXBuildFile; fileRef = 829DA2AE1C12674D0040F5F1 /* SmartSync.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE0AB0401C10D20B00BFAEED /* SalesforceNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0AB03F1C10D20B00BFAEED /* SalesforceNetwork.framework */; };
 		CE0AB07D1C10D3FE00BFAEED /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE0AB07C1C10D3FE00BFAEED /* libxml2.tbd */; };
 		CE0AB07E1C10D41100BFAEED /* SmartStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FFEE5BD1BFE8F8800B7AA8A /* SmartStore.framework */; };
@@ -193,6 +194,7 @@
 		828E0E451AAFD171004E0AF2 /* SFSmartSyncNetworkUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSmartSyncNetworkUtils.m; sourceTree = "<group>"; };
 		828E0E521AB398AA004E0AF2 /* TestSyncUpTarget.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TestSyncUpTarget.h; path = Targets/TestSyncUpTarget.h; sourceTree = "<group>"; };
 		828E0E531AB398AA004E0AF2 /* TestSyncUpTarget.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TestSyncUpTarget.m; path = Targets/TestSyncUpTarget.m; sourceTree = "<group>"; };
+		829DA2AE1C12674D0040F5F1 /* SmartSync.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmartSync.h; sourceTree = "<group>"; };
 		CE0AB03F1C10D20B00BFAEED /* SalesforceNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SalesforceNetwork.framework; path = "../SalesforceNetwork/build/Debug-iphoneos/SalesforceNetwork.framework"; sourceTree = "<group>"; };
 		CE0AB07C1C10D3FE00BFAEED /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
 		CE0AB07F1C10D41700BFAEED /* libFMDB-IOS.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libFMDB-IOS.a"; path = "../../external/fmdb/build/Debug-iphoneos/libFMDB-IOS.a"; sourceTree = "<group>"; };
@@ -386,6 +388,7 @@
 		CEAAAE4A195911E600CBBFE9 /* SmartSync */ = {
 			isa = PBXGroup;
 			children = (
+				829DA2AE1C12674D0040F5F1 /* SmartSync.h */,
 				CEF50A79196B3EB60076264C /* Classes */,
 				CEAAAE4B195911E600CBBFE9 /* Supporting Files */,
 			);
@@ -530,6 +533,7 @@
 				CE4CE4221C0E5A35009F6029 /* SFSmartSyncSyncManager.h in Headers */,
 				CE4CE4241C0E5A35009F6029 /* SFSmartSyncMetadataManager.h in Headers */,
 				CE4CE4461C0E5A75009F6029 /* SFSyncOptions.h in Headers */,
+				829DA2AF1C12674D0040F5F1 /* SmartSync.h in Headers */,
 				CE4CE4481C0E5A75009F6029 /* SFSyncUpTarget.h in Headers */,
 				CE4CE42C1C0E5A49009F6029 /* SFObjectType.h in Headers */,
 			);

--- a/libs/SmartSync/SmartSync.xcodeproj/project.pbxproj
+++ b/libs/SmartSync/SmartSync.xcodeproj/project.pbxproj
@@ -139,6 +139,20 @@
 			remoteGlobalIDString = 829A08851A323DDF00DC17A5;
 			remoteInfo = SalesforceRestAPITests;
 		};
+		829DA2251C125C980040F5F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4FFEE5B31BFE8F8800B7AA8A /* SmartStore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE2B81C0E4581009F6029;
+			remoteInfo = SmartStore;
+		};
+		829DA22E1C125CAE0040F5F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6F7EAACF1B61920A00F4C242 /* SalesforceRestAPI.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE2A21C0E4569009F6029;
+			remoteInfo = SalesforceRestAPI;
+		};
 		82A8C6E71C122998006BBDFE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CEAAAE3D195911E600CBBFE9 /* Project object */;
@@ -537,6 +551,8 @@
 			buildRules = (
 			);
 			dependencies = (
+				829DA2261C125C980040F5F1 /* PBXTargetDependency */,
+				829DA22F1C125CAE0040F5F1 /* PBXTargetDependency */,
 			);
 			name = SmartSync;
 			productName = SmartSync;
@@ -740,6 +756,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		829DA2261C125C980040F5F1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SmartStore;
+			targetProxy = 829DA2251C125C980040F5F1 /* PBXContainerItemProxy */;
+		};
+		829DA22F1C125CAE0040F5F1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SalesforceRestAPI;
+			targetProxy = 829DA22E1C125CAE0040F5F1 /* PBXContainerItemProxy */;
+		};
 		CE4CE49B1C0E6011009F6029 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = CE4CE2C81C0E463C009F6029 /* SmartSync */;

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer.xcodeproj/project.pbxproj
@@ -30,36 +30,43 @@
 		7DF4D3CF1472E3E0005CE144 /* QueryListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF4D3CA1472E3E0005CE144 /* QueryListViewController.m */; };
 		820275F21651787D00DB814C /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 820275F11651787D00DB814C /* MessageUI.framework */; };
 		8242E0CA15AB823400E9E6AF /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8242E0C915AB823400E9E6AF /* QuartzCore.framework */; };
+		829DA2491C125E9A0040F5F1 /* SalesforceRestAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 829DA2441C125E870040F5F1 /* SalesforceRestAPI.framework */; };
 		82E7F5AF17147BC400AC4E27 /* InitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 82E7F5AD17147BC400AC4E27 /* InitialViewController.m */; };
 		82E7F5B017147BC400AC4E27 /* InitialViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 82E7F5AE17147BC400AC4E27 /* InitialViewController.xib */; };
 		CE6AB3841C10C45A0012125E /* SalesforceNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3831C10C45A0012125E /* SalesforceNetwork.framework */; };
-		CE6AB3881C10C4680012125E /* SalesforceRestAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FFEE5E31BFE90CA00B7AA8A /* SalesforceRestAPI.framework */; };
 		CE6AB38A1C10C46F0012125E /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3891C10C46F0012125E /* SalesforceSDKCore.framework */; };
 		CE6AB38C1C10C4880012125E /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB38B1C10C4880012125E /* libz.tbd */; };
 		CE6AB38E1C10C4940012125E /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB38D1C10C4940012125E /* libxml2.tbd */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		4FFEE5E21BFE90CA00B7AA8A /* PBXContainerItemProxy */ = {
+		829DA2431C125E870040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4FFEE5DB1BFE90CA00B7AA8A /* SalesforceRestAPI.xcodeproj */;
+			containerPortal = 829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = 82C0C72E16E076DE0006B3C0;
+			remoteGlobalIDString = CE4CE2A31C0E4569009F6029;
 			remoteInfo = SalesforceRestAPI;
 		};
-		4FFEE5E41BFE90CA00B7AA8A /* PBXContainerItemProxy */ = {
+		829DA2451C125E870040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4FFEE5DB1BFE90CA00B7AA8A /* SalesforceRestAPI.xcodeproj */;
+			containerPortal = 829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 82C0C75D16E07DEB0006B3C0;
-			remoteInfo = SalesforceRestAPIUnitTestApp;
+			remoteInfo = SalesforceRestAPITestApp;
 		};
-		4FFEE5E61BFE90CA00B7AA8A /* PBXContainerItemProxy */ = {
+		829DA2471C125E870040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4FFEE5DB1BFE90CA00B7AA8A /* SalesforceRestAPI.xcodeproj */;
+			containerPortal = 829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 829A08851A323DDF00DC17A5;
-			remoteInfo = SalesforceRestAPITests;
+			remoteInfo = SalesforceRestAPITestAppTests;
+		};
+		829DA24A1C125EBA0040F5F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE2A21C0E4569009F6029;
+			remoteInfo = SalesforceRestAPI;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -68,7 +75,6 @@
 		4F473D7117E26DFF000CCDF3 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		4F53F6E91683D9C600CF1C17 /* SalesforceSDKResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = SalesforceSDKResources.bundle; path = ../../../../shared/resources/SalesforceSDKResources.bundle; sourceTree = "<group>"; };
 		4F84FDFD18DD07D0006A7699 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
-		4FFEE5DB1BFE90CA00B7AA8A /* SalesforceRestAPI.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceRestAPI.xcodeproj; path = ../../../libs/SalesforceRestAPI/SalesforceRestAPI.xcodeproj; sourceTree = "<group>"; };
 		7DF4D2DA1472E238005CE144 /* RestAPIExplorer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RestAPIExplorer.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7DF4D2DE1472E238005CE144 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		7DF4D2E01472E238005CE144 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
@@ -93,6 +99,7 @@
 		7DF4D3CB1472E3E0005CE144 /* QueryListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = QueryListViewController.h; path = Classes/QueryListViewController.h; sourceTree = "<group>"; };
 		820275F11651787D00DB814C /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		8242E0C915AB823400E9E6AF /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceRestAPI.xcodeproj; path = ../../../libs/SalesforceRestAPI/SalesforceRestAPI.xcodeproj; sourceTree = "<group>"; };
 		82E7F5AC17147BC400AC4E27 /* InitialViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InitialViewController.h; path = Classes/InitialViewController.h; sourceTree = "<group>"; };
 		82E7F5AD17147BC400AC4E27 /* InitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = InitialViewController.m; path = Classes/InitialViewController.m; sourceTree = "<group>"; };
 		82E7F5AE17147BC400AC4E27 /* InitialViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = InitialViewController.xib; path = Classes/InitialViewController.xib; sourceTree = "<group>"; };
@@ -107,7 +114,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CE6AB3881C10C4680012125E /* SalesforceRestAPI.framework in Frameworks */,
+				829DA2491C125E9A0040F5F1 /* SalesforceRestAPI.framework in Frameworks */,
 				CE6AB3841C10C45A0012125E /* SalesforceNetwork.framework in Frameworks */,
 				CE6AB38A1C10C46F0012125E /* SalesforceSDKCore.framework in Frameworks */,
 				CE6AB38C1C10C4880012125E /* libz.tbd in Frameworks */,
@@ -129,16 +136,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		4FFEE5DC1BFE90CA00B7AA8A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				4FFEE5E31BFE90CA00B7AA8A /* SalesforceRestAPI.framework */,
-				4FFEE5E51BFE90CA00B7AA8A /* SalesforceRestAPITestApp.app */,
-				4FFEE5E71BFE90CA00B7AA8A /* SalesforceRestAPITestAppTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		7DF4D2CE1472E238005CE144 = {
 			isa = PBXGroup;
 			children = (
@@ -163,7 +160,7 @@
 				CE6AB38B1C10C4880012125E /* libz.tbd */,
 				CE6AB3891C10C46F0012125E /* SalesforceSDKCore.framework */,
 				CE6AB3831C10C45A0012125E /* SalesforceNetwork.framework */,
-				4FFEE5DB1BFE90CA00B7AA8A /* SalesforceRestAPI.xcodeproj */,
+				829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */,
 				7DF4D2EA1472E238005CE144 /* CFNetwork.framework */,
 				7DF4D2DE1472E238005CE144 /* CoreData.framework */,
 				7DF4D2E81472E238005CE144 /* CoreGraphics.framework */,
@@ -237,6 +234,16 @@
 			name = NativeRestApp;
 			sourceTree = "<group>";
 		};
+		829DA23D1C125E870040F5F1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				829DA2441C125E870040F5F1 /* SalesforceRestAPI.framework */,
+				829DA2461C125E870040F5F1 /* SalesforceRestAPITestApp.app */,
+				829DA2481C125E870040F5F1 /* SalesforceRestAPITestAppTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -251,7 +258,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				CE4CE4B61C0E67BD009F6029 /* PBXTargetDependency */,
+				829DA24B1C125EBA0040F5F1 /* PBXTargetDependency */,
 			);
 			name = RestAPIExplorer;
 			productName = RestAPIExplorer;
@@ -283,8 +290,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 4FFEE5DC1BFE90CA00B7AA8A /* Products */;
-					ProjectRef = 4FFEE5DB1BFE90CA00B7AA8A /* SalesforceRestAPI.xcodeproj */;
+					ProductGroup = 829DA23D1C125E870040F5F1 /* Products */;
+					ProjectRef = 829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -295,25 +302,25 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		4FFEE5E31BFE90CA00B7AA8A /* SalesforceRestAPI.framework */ = {
+		829DA2441C125E870040F5F1 /* SalesforceRestAPI.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = SalesforceRestAPI.framework;
-			remoteRef = 4FFEE5E21BFE90CA00B7AA8A /* PBXContainerItemProxy */;
+			remoteRef = 829DA2431C125E870040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4FFEE5E51BFE90CA00B7AA8A /* SalesforceRestAPITestApp.app */ = {
+		829DA2461C125E870040F5F1 /* SalesforceRestAPITestApp.app */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.application;
 			path = SalesforceRestAPITestApp.app;
-			remoteRef = 4FFEE5E41BFE90CA00B7AA8A /* PBXContainerItemProxy */;
+			remoteRef = 829DA2451C125E870040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4FFEE5E71BFE90CA00B7AA8A /* SalesforceRestAPITestAppTests.xctest */ = {
+		829DA2481C125E870040F5F1 /* SalesforceRestAPITestAppTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = SalesforceRestAPITestAppTests.xctest;
-			remoteRef = 4FFEE5E61BFE90CA00B7AA8A /* PBXContainerItemProxy */;
+			remoteRef = 829DA2471C125E870040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -353,9 +360,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		CE4CE4B61C0E67BD009F6029 /* PBXTargetDependency */ = {
+		829DA24B1C125EBA0040F5F1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SalesforceRestAPI;
+			targetProxy = 829DA24A1C125EBA0040F5F1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer.xcodeproj/project.pbxproj
@@ -33,8 +33,8 @@
 		8284055619EA09E40079AB60 /* ContactDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8284055519EA09E40079AB60 /* ContactDetailViewController.m */; };
 		8284055819EAFB610079AB60 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8284055719EAFB610079AB60 /* Settings.bundle */; };
 		8284055A19EAFD9C0079AB60 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8284055919EAFD9C0079AB60 /* Images.xcassets */; };
+		829DA2621C1260AE0040F5F1 /* SmartSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 829DA25D1C1260960040F5F1 /* SmartSync.framework */; };
 		CE6AB3901C10C4C90012125E /* SmartStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB38F1C10C4C90012125E /* SmartStore.framework */; };
-		CE6AB3931C10C4D10012125E /* SmartSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FFEE5F11BFE90FC00B7AA8A /* SmartSync.framework */; };
 		CE6AB3951C10C4D60012125E /* SalesforceRestAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3941C10C4D60012125E /* SalesforceRestAPI.framework */; };
 		CE6AB3971C10C4DC0012125E /* SalesforceNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3961C10C4DC0012125E /* SalesforceNetwork.framework */; };
 		CE6AB3991C10C4E20012125E /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3981C10C4E20012125E /* SalesforceSDKCore.framework */; };
@@ -42,19 +42,26 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		4FFEE5F01BFE90FC00B7AA8A /* PBXContainerItemProxy */ = {
+		829DA25C1C1260960040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4FFEE5EA1BFE90FB00B7AA8A /* SmartSync.xcodeproj */;
+			containerPortal = 829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = CEAAAE45195911E600CBBFE9;
+			remoteGlobalIDString = CE4CE2C91C0E463C009F6029;
 			remoteInfo = SmartSync;
 		};
-		4FFEE5F21BFE90FC00B7AA8A /* PBXContainerItemProxy */ = {
+		829DA25E1C1260960040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4FFEE5EA1BFE90FB00B7AA8A /* SmartSync.xcodeproj */;
+			containerPortal = 829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = CEAAAE55195911E600CBBFE9;
 			remoteInfo = SmartSyncTests;
+		};
+		829DA2601C1260A50040F5F1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE2C81C0E463C009F6029;
+			remoteInfo = SmartSync;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -64,7 +71,6 @@
 		4FADBCB41BA0CEDA00D01855 /* ImagesSmartSyncExplorer.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ImagesSmartSyncExplorer.xcassets; sourceTree = "<group>"; };
 		4FEAC2421B97C65C00B08512 /* ActionsPopupController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ActionsPopupController.m; sourceTree = "<group>"; };
 		4FEAC2431B97C65C00B08512 /* ActionsPopupController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ActionsPopupController.h; sourceTree = "<group>"; };
-		4FFEE5EA1BFE90FB00B7AA8A /* SmartSync.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SmartSync.xcodeproj; path = ../../../libs/SmartSync/SmartSync.xcodeproj; sourceTree = "<group>"; };
 		820163C219FF029A00F5F1A7 /* SalesforceSDKResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = SalesforceSDKResources.bundle; path = ../../../../shared/resources/SalesforceSDKResources.bundle; sourceTree = "<group>"; };
 		820C8B0C19E6054E00E9BE5C /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		820C8B0D19E6054E00E9BE5C /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -102,6 +108,7 @@
 		8284055519EA09E40079AB60 /* ContactDetailViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContactDetailViewController.m; sourceTree = "<group>"; };
 		8284055719EAFB610079AB60 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = Settings.bundle; path = ../../../../shared/resources/Settings.bundle; sourceTree = "<group>"; };
 		8284055919EAFD9C0079AB60 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = ../../../../shared/resources/Images.xcassets; sourceTree = "<group>"; };
+		829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SmartSync.xcodeproj; path = ../../../libs/SmartSync/SmartSync.xcodeproj; sourceTree = "<group>"; };
 		CE6AB38F1C10C4C90012125E /* SmartStore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SmartStore.framework; path = "../../../libs/SmartStore/build/Debug-iphoneos/SmartStore.framework"; sourceTree = "<group>"; };
 		CE6AB3941C10C4D60012125E /* SalesforceRestAPI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SalesforceRestAPI.framework; path = "../../../libs/SalesforceRestAPI/build/Debug-iphoneos/SalesforceRestAPI.framework"; sourceTree = "<group>"; };
 		CE6AB3961C10C4DC0012125E /* SalesforceNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SalesforceNetwork.framework; path = "../../../libs/SalesforceNetwork/build/Debug-iphoneos/SalesforceNetwork.framework"; sourceTree = "<group>"; };
@@ -114,7 +121,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CE6AB3931C10C4D10012125E /* SmartSync.framework in Frameworks */,
+				829DA2621C1260AE0040F5F1 /* SmartSync.framework in Frameworks */,
 				CE6AB3901C10C4C90012125E /* SmartStore.framework in Frameworks */,
 				CE6AB3951C10C4D60012125E /* SalesforceRestAPI.framework in Frameworks */,
 				CE6AB3971C10C4DC0012125E /* SalesforceNetwork.framework in Frameworks */,
@@ -141,15 +148,6 @@
 				4F60B2281B9A2C2900923174 /* WYPopoverController.m */,
 			);
 			name = WYPopoverController;
-			sourceTree = "<group>";
-		};
-		4FFEE5EB1BFE90FB00B7AA8A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				4FFEE5F11BFE90FC00B7AA8A /* SmartSync.framework */,
-				4FFEE5F31BFE90FC00B7AA8A /* SmartSyncTests.xctest */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		820C8B0B19E6054E00E9BE5C /* Classes */ = {
@@ -227,7 +225,7 @@
 				CE6AB3961C10C4DC0012125E /* SalesforceNetwork.framework */,
 				CE6AB3941C10C4D60012125E /* SalesforceRestAPI.framework */,
 				CE6AB38F1C10C4C90012125E /* SmartStore.framework */,
-				4FFEE5EA1BFE90FB00B7AA8A /* SmartSync.xcodeproj */,
+				829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */,
 				8258804A1AA4222A000C551E /* MobileCoreServices.framework */,
 				820C8B2E19E6096800E9BE5C /* libsqlcipher.a */,
 				827C631419E6018C00027484 /* Foundation.framework */,
@@ -261,6 +259,15 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		829DA2571C1260960040F5F1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				829DA25D1C1260960040F5F1 /* SmartSync.framework */,
+				829DA25F1C1260960040F5F1 /* SmartSyncTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -275,7 +282,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				CE4CE4C11C0E67E8009F6029 /* PBXTargetDependency */,
+				829DA2611C1260A50040F5F1 /* PBXTargetDependency */,
 			);
 			name = SmartSyncExplorer;
 			productName = SmartSyncExplorer;
@@ -304,8 +311,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 4FFEE5EB1BFE90FB00B7AA8A /* Products */;
-					ProjectRef = 4FFEE5EA1BFE90FB00B7AA8A /* SmartSync.xcodeproj */;
+					ProductGroup = 829DA2571C1260960040F5F1 /* Products */;
+					ProjectRef = 829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -316,18 +323,18 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		4FFEE5F11BFE90FC00B7AA8A /* SmartSync.framework */ = {
+		829DA25D1C1260960040F5F1 /* SmartSync.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = SmartSync.framework;
-			remoteRef = 4FFEE5F01BFE90FC00B7AA8A /* PBXContainerItemProxy */;
+			remoteRef = 829DA25C1C1260960040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4FFEE5F31BFE90FC00B7AA8A /* SmartSyncTests.xctest */ = {
+		829DA25F1C1260960040F5F1 /* SmartSyncTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = SmartSyncTests.xctest;
-			remoteRef = 4FFEE5F21BFE90FC00B7AA8A /* PBXContainerItemProxy */;
+			remoteRef = 829DA25E1C1260960040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -371,9 +378,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		CE4CE4C11C0E67E8009F6029 /* PBXTargetDependency */ = {
+		829DA2611C1260A50040F5F1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SmartSync;
+			targetProxy = 829DA2601C1260A50040F5F1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 


### PR DESCRIPTION
As with all Xcode project file updates, I'm not 100% sure why the previous iterations weren't working.  There are clearly some net-new configuration sections added to the project files where dependencies weren't showing up, so I can only assume that those must have been the missing components.  Anyway, the following should apply:

- All library and sample app targets should build from scratch.  I.e. all target dependencies are lined up.
- All warnings about missing target dependencies should be gone.
- Umbrella header files have been added to their respective projects, so warnings about umbrella headers should be gone too, except for SalesforceReact.  Looking at that next.

@bhariharan and @wmathurin : Could you try this out clean in your environments, and make sure everything builds and runs as expected for you?  That's the best validation test I know of for these crazy configuration changes. :)