### PR TITLE
Headers in SalesforceSDKCore should not import from <SalesforceSDKCore/...>

### DIFF
--- a/SalesforceMobileSDK-iOS.podspec
+++ b/SalesforceMobileSDK-iOS.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
                      :submodules => true }
   
   s.requires_arc = true
+  s.default_subspec  = 'SalesforceSDKCore'
 
   s.subspec 'SalesforceSDKCore' do |sdkcore|
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFUserActivityMonitor.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFUserActivityMonitor.m
@@ -24,7 +24,7 @@
 
 #import "SFUserActivityMonitor.h"
 #import "SFApplication.h"
-#import <SalesforceSDKCore/SFInactivityTimerCenter.h>
+#import "SFInactivityTimerCenter.h"
 
 // Singleton instance
 static SFUserActivityMonitor *_instance;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFGeneratedKeyStore.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFGeneratedKeyStore.m
@@ -25,7 +25,7 @@
 #import "SFGeneratedKeyStore.h"
 #import "SFKeyStore+Internal.h"
 #import "SFKeyStoreKey.h"
-#import <SalesforceSDKCore/SFKeychainItemWrapper.h>
+#import "SFKeychainItemWrapper.h"
 
 // Keychain and NSCoding constants
 static NSString * const kGeneratedKeyStoreKeychainIdentifier = @"com.salesforce.keystore.generatedKeystoreKeychainId";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStore.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStore.m
@@ -23,8 +23,8 @@
  */
 
 #import "SFKeyStore+Internal.h"
-#import <SalesforceSDKCore/SFCrypto.h>
-#import <SalesforceSDKCore/SFKeychainItemWrapper.h>
+#import "SFCrypto.h"
+#import "SFKeychainItemWrapper.h"
 #import "SFSDKCryptoUtils.h"
 
 @implementation SFKeyStore

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.m
@@ -26,8 +26,8 @@
 
 #import "SFKeyStoreManager+Internal.h"
 #import "SFSDKCryptoUtils.h"
-#import <SalesforceSDKCore/SFKeychainItemWrapper.h>
-#import <SalesforceSDKCore/SFCrypto.h>
+#import "SFKeychainItemWrapper.h"
+#import "SFCrypto.h"
 
 // Keychain and NSCoding constants
 static NSString * const kKeyStoreKeychainIdentifier = @"com.salesforce.keystore.keystoreKeychainId";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPBKDF2PasscodeProvider.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPBKDF2PasscodeProvider.m
@@ -23,10 +23,10 @@
  */
 
 #import "SFPBKDF2PasscodeProvider.h"
-#import <SalesforceSDKCore/SFKeychainItemWrapper.h>
+#import "SFKeychainItemWrapper.h"
 #import "SFPBKDFData.h"
 #import "SFSDKCryptoUtils.h"
-#import <SalesforceSDKCore/NSData+SFAdditions.h>
+#import "NSData+SFAdditions.h"
 
 static NSString * const kKeychainIdentifierPasscodeVerify = @"com.salesforce.security.passcode.pbkdf2.verify";
 static NSString * const kKeychainIdentifierPasscodeEncrypt = @"com.salesforce.security.passcode.pbkdf2.encrypt";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeKeyStore.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeKeyStore.m
@@ -27,7 +27,7 @@
 #import "SFKeyStoreKey.h"
 #import "SFPasscodeManager.h"
 #import "SFKeyStoreManager+Internal.h"
-#import <SalesforceSDKCore/SFKeychainItemWrapper.h>
+#import "SFKeychainItemWrapper.h"
 
 // Keychain and NSCoding constants
 static NSString * const kPasscodeKeyStoreKeychainIdentifier = @"com.salesforce.keystore.passcodeKeystoreKeychainId";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
@@ -25,7 +25,7 @@
 #import "SFSDKCryptoUtils.h"
 #import "SFPBKDFData.h"
 #import <CommonCrypto/CommonCrypto.h>
-#import <SalesforceSDKCore/NSData+SFAdditions.h>
+#import "NSData+SFAdditions.h"
 #import <Security/Security.h>
 
 // Public constants

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSHA256PasscodeProvider.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSHA256PasscodeProvider.m
@@ -23,7 +23,7 @@
  */
 
 #import "SFSHA256PasscodeProvider.h"
-#import <SalesforceSDKCore/SFKeychainItemWrapper.h>
+#import "SFKeychainItemWrapper.h"
 
 static NSString * const kKeychainIdentifierPasscode = @"com.salesforce.security.passcode";
 

--- a/shared/hybrid/AppDelegate.m
+++ b/shared/hybrid/AppDelegate.m
@@ -26,8 +26,6 @@
 //
 
 #import "AppDelegate.h"
-// #import "MainViewController.h"
-
 #import <Cordova/CDVPlugin.h>
 
 @implementation AppDelegate


### PR DESCRIPTION
Added default subspec so that when you "pod 'SalesforceMobileSDK-iOS'", you only get core