### PR TITLE
We need the split up specs at the root of the repo to be able to do:

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "external/CocoaLumberjack"]
 	path = external/CocoaLumberjack
 url=https://github.com/forcedotcom/CocoaLumberjack.git
+[submodule "external/ios-specs"]
+	path = external/ios-specs
+	url = https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs

--- a/FMDB.podspec
+++ b/FMDB.podspec
@@ -1,0 +1,1 @@
+external/ios-specs/FMDB/4.0.1/FMDB.podspec

--- a/SalesforceNetwork.podspec
+++ b/SalesforceNetwork.podspec
@@ -1,0 +1,1 @@
+external/ios-specs/SalesforceNetwork/4.0.1/SalesforceNetwork.podspec

--- a/SalesforceReact.podspec
+++ b/SalesforceReact.podspec
@@ -1,0 +1,1 @@
+external/ios-specs/SalesforceReact/4.0.1/SalesforceReact.podspec

--- a/SalesforceRestAPI.podspec
+++ b/SalesforceRestAPI.podspec
@@ -1,0 +1,1 @@
+external/ios-specs/SalesforceRestAPI/4.0.1/SalesforceRestAPI.podspec

--- a/SalesforceSDKCore.podspec
+++ b/SalesforceSDKCore.podspec
@@ -1,0 +1,1 @@
+external/ios-specs/SalesforceSDKCore/4.0.1/SalesforceSDKCore.podspec

--- a/SmartStore.podspec
+++ b/SmartStore.podspec
@@ -1,0 +1,1 @@
+external/ios-specs/SmartStore/4.0.1/SmartStore.podspec

--- a/SmartSync.podspec
+++ b/SmartSync.podspec
@@ -1,0 +1,1 @@
+external/ios-specs/SmartSync/4.0.1/SmartSync.podspec


### PR DESCRIPTION
pod 'SalesforceSDKCore', :path => 'some clone of the repo'
or
pod 'SalesforceSDKCore', :git => 'some git version of the repo'