### PR TITLE
Everything scheme builds again

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
@@ -1506,6 +1506,7 @@
 			baseConfigurationReference = CE8F13091AD4A87200233F2F /* SalesforceHybridSDK-Test.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/SalesforceHybridSDKTestApp.app/SalesforceHybridSDKTestApp";
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -1539,6 +1540,7 @@
 			baseConfigurationReference = CE8F13091AD4A87200233F2F /* SalesforceHybridSDK-Test.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/SalesforceHybridSDKTestApp.app/SalesforceHybridSDKTestApp";
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -1621,6 +1623,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CE8F13091AD4A87200233F2F /* SalesforceHybridSDK-Test.xcconfig */;
 			buildSettings = {
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SalesforceHybridSDKTestApp/SalesforceHybridSDKTestApp-Prefix.pch";
@@ -1642,6 +1645,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CE8F13091AD4A87200233F2F /* SalesforceHybridSDK-Test.xcconfig */;
 			buildSettings = {
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SalesforceHybridSDKTestApp/SalesforceHybridSDKTestApp-Prefix.pch";
@@ -1664,6 +1668,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CECB662E1C1BB8CB008038AE /* SalesforceHybridSDK-Dynamic-iOS-Debug.xcconfig */;
 			buildSettings = {
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
@@ -1701,6 +1706,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CECB662F1C1BB8CB008038AE /* SalesforceHybridSDK-Dynamic-iOS-Release.xcconfig */;
 			buildSettings = {
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Classes/AppDelegate.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Classes/AppDelegate.m
@@ -23,14 +23,9 @@
  */
 
 #import "AppDelegate.h"
-#import "SFHybridViewConfig.h"
-#import <SalesforceSDKCore/SFJsonUtils.h>
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
+#import <SalesforceHybridSDK/SalesforceHybridSDK.h>
 #import "SFTestRunnerPlugin.h"
-#import <SalesforceSDKCore/TestSetupUtils.h>
-#import <SalesforceSDKCore/SFSDKTestCredentialsData.h>
-#import <SalesforceSDKCore/SFAuthenticationManager.h>
-#import <SalesforceSDKCore/SFUserAccountManager.h>
-#import <SalesforceSDKCore/SFDefaultUserManagementViewController.h>
 
 @interface AppDelegate () <SFAuthenticationManagerDelegate, SFUserAccountManagerDelegate>
 

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTestAppTests/SFPluginTestSuite.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTestAppTests/SFPluginTestSuite.m
@@ -24,12 +24,11 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <SmartStore/SmartStore.h>
+#import <SalesforceHybridSDK/SalesforceHybridSDK.h>
 #import "SFPluginTestSuite.h"
 #import "AppDelegate.h"
-#import "SFHybridViewController.h"
 #import "SFTestRunnerPlugin.h"
-#import <SmartStore/SFSmartStore.h>
-#import "SFSmartStorePlugin.h"
 
 @implementation SFPluginTestSuite
 

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTestAppTests/SmartStoreLoadTestSuite.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTestAppTests/SmartStoreLoadTestSuite.m
@@ -24,14 +24,12 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <SmartStore/Smartstore.h>
+#import <SalesforceHybridSDK/SalesforceHybridSDK.h>
 
 #import "SmartStoreLoadTestSuite.h"
-
 #import "AppDelegate.h"
 #import "SFTestRunnerPlugin.h"
-#import <SmartStore/SFSmartStore.h>
-#import "SFSmartStorePlugin.h"
-#import "SFHybridViewController.h"
 
 
 @implementation SmartStoreLoadTestSuite

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTestAppTests/SmartStoreTestSuite.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTestAppTests/SmartStoreTestSuite.m
@@ -24,15 +24,12 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <SmartStore/SmartStore.h>
+#import <SalesforceHybridSDK/SalesforceHybridSDK.h>
 
 #import "SmartStoreTestSuite.h"
-
 #import "AppDelegate.h"
 #import "SFTestRunnerPlugin.h"
-#import <SmartStore/SFSmartStore.h>
-#import "SFSmartStorePlugin.h"
-#import "SFHybridViewController.h"
-
 
 @implementation SmartStoreTestSuite
 

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTestAppTests/SmartSyncTestSuite.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTestAppTests/SmartSyncTestSuite.m
@@ -23,15 +23,12 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <SmartStore/SmartStore.h>
+#import <SalesforceHybridSDK/SalesforceHybridSDK.h>
 
 #import "SmartSyncTestSuite.h"
-
 #import "AppDelegate.h"
 #import "SFTestRunnerPlugin.h"
-#import <SmartStore/SFSmartStore.h>
-#import "SFSmartStorePlugin.h"
-#import "SFSmartSyncPlugin.h"
-#import "SFHybridViewController.h"
 
 @implementation SmartSyncTestSuite
 

--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetworkTests/CSFActionParameterStorageTests.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetworkTests/CSFActionParameterStorageTests.m
@@ -24,6 +24,7 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import <SalesforceNetwork/SalesforceNetwork.h>
 #import "CSFParameterStorage_Internal.h"
 
 @interface CSFParameterStorageTests : XCTestCase

--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetworkTests/CSFInputTests.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetworkTests/CSFInputTests.m
@@ -25,7 +25,7 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "CSFInput.h"
+#import <SalesforceNetwork/SalesforceNetwork.h>
 #import "CSFInput_Internal.h"
 
 @interface TestInputWithMutable : CSFInput

--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetworkTests/CSFOutputTests.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetworkTests/CSFOutputTests.m
@@ -24,7 +24,7 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
-
+#import <SalesforceNetwork/SalesforceNetwork.h>
 #import "CSFOutput_Internal.h"
 
 ////////////

--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetworkTests/CSFSalesforceOAuthRefreshTests.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetworkTests/CSFSalesforceOAuthRefreshTests.m
@@ -10,8 +10,8 @@
 #import <XCTest/XCTest.h>
 
 #import <SalesforceSDKCore/SalesforceSDKCore.h>
+#import <SalesforceNetwork/SalesforceNetwork.h>
 
-#import "CSFSalesforceAction.h"
 #import "CSFSalesforceOAuthRefresh.h"
 #import "CSFAuthRefresh+Internal.h"
 #import "CSFNetwork+Internal.h"

--- a/libs/SalesforceRestAPI/SalesforceRestAPITestAppTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceRestAPI/SalesforceRestAPITestAppTests/SalesforceRestAPITests.m
@@ -24,21 +24,11 @@
 
 #import "SalesforceRestAPITests.h"
 
-#import <SalesforceNetwork/CSFDefines.h>
-#import <SalesforceSDKCore/SFJsonUtils.h>
-#import <SalesforceSDKCore/SFOAuthCoordinator.h>
-#import <SalesforceSDKCore/SFOAuthCredentials.h>
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
+#import <SalesforceNetwork/SalesforceNetwork.h>
+#import <SalesforceRestAPI/SalesforceRestAPI.h>
 #import "SFRestAPI+Internal.h"
-#import "SFRestRequest.h"
 #import "SFNativeRestRequestListener.h"
-#import <SalesforceSDKCore/TestSetupUtils.h>
-#import "SFRestAPI+Blocks.h"
-#import "SFRestAPI+QueryBuilder.h"
-#import <SalesforceSDKCore/SFAuthenticationManager.h>
-#import <SalesforceSDKCore/SFUserAccountManager.h>
-#import <SalesforceSDKCore/SFUserAccount.h>
-#import <SalesforceSDKCore/SFLogger.h>
-#import "SFRestAPI+Files.h"
 
 @interface SalesforceRestAPITests ()
 {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/SalesforceSDKCore.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/SalesforceSDKCore.h
@@ -2,9 +2,9 @@
  SalesforceSDKCore.h
  SalesforceSDKCore
 
- Created by Wolfgang Mathurin on Tue Nov 24 17:26:01 PST 2015.
+ Created by Wolfgang Mathurin on Thu Jan 14 15:44:17 PST 2016.
 
- Copyright (c) 2015, salesforce.com, inc. All rights reserved.
+ Copyright (c) 2016, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -109,4 +109,3 @@
 #import <SalesforceSDKCore/TestSetupUtils.h>
 #import <SalesforceSDKCore/UIDevice+SFHardware.h>
 #import <SalesforceSDKCore/UIScreen+SFAdditions.h>
-

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTestAppTests/SFOAuthCoordinatorFlowTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTestAppTests/SFOAuthCoordinatorFlowTests.m
@@ -24,8 +24,7 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
-#import "SFSDKAsyncProcessListener.h"
-
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import "SFOAuthCoordinator+Internal.h"
 #import "SFOAuthTestFlow.h"
 #import "SFOAuthTestFlowCoordinatorDelegate.h"

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTestAppTests/SFOAuthSessionRefresherTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTestAppTests/SFOAuthSessionRefresherTests.m
@@ -23,9 +23,9 @@
  */
 
 #import <XCTest/XCTest.h>
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import "SFOAuthSessionRefresher+Internal.h"
 #import "SFOAuthCoordinator+Internal.h"
-#import "SFOAuthCredentials.h"
 #import "SFOAuthTestFlow.h"
 
 @interface SFOAuthSessionRefresherTests : XCTestCase

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTestAppTests/SFOAuthTestFlow.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTestAppTests/SFOAuthTestFlow.h
@@ -23,6 +23,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import "SFOAuthCoordinator+Internal.h"
 
 @class SFOAuthOrgAuthConfiguration;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTestAppTests/SFTestSDKManagerFlow.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTestAppTests/SFTestSDKManagerFlow.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import "SalesforceSDKManager+Internal.h"
 
 @interface SFTestSDKManagerFlow : NSObject <SalesforceSDKManagerFlow>

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTestAppTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTestAppTests/SFUserAccountManagerTests.m
@@ -23,10 +23,8 @@
  */
 
 #import <XCTest/XCTest.h>
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import "SFUserAccountManager+Internal.h"
-#import "SFUserAccount.h"
-#import "SFDirectoryManager.h"
-#import "SFIdentityData.h"
 
 static NSString * const kUserIdFormatString = @"005R0000000Dsl%lu";
 static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SDKCommonNSDataTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SDKCommonNSDataTests.m
@@ -24,6 +24,7 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import "NSData+SFSDKUtils_Internal.h"
 
 @interface SDKCommonNSDataTests : XCTestCase

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFKeyStoreManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFKeyStoreManagerTests.m
@@ -24,7 +24,7 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
-#import <SalesforceSDKCore/NSData+SFAdditions.h>
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import "SFKeyStoreManager+Internal.h"
 
 @interface SFKeyStoreManagerTests : XCTestCase

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFKeyStoreTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFKeyStoreTests.m
@@ -22,10 +22,9 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #import <XCTest/XCTest.h>
-#import "SFEncryptionKey.h"
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import "SFKeyStore+Internal.h"
 #import "SFKeyStoreManager+Internal.h"
-#import <SalesforceSDKCore/NSData+SFAdditions.h>
 
 @interface SFKeyStoreTests : XCTestCase
 {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSecurityTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSecurityTests.m
@@ -24,13 +24,9 @@
 
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
-#import "SFKeyStoreKey.h"
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import "SFKeyStoreManager+Internal.h"
-#import "SFSDKCryptoUtils.h"
-#import "SFPasscodeProviderManager.h"
-#import "SFEncryptionKey.h"
 #import "SFKeyStore+Internal.h"
-#import <SalesforceSDKCore/NSData+SFAdditions.h>
 
 static NSUInteger const kNumThreadsInSafetyTest = 100;
 

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.h
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.h
@@ -23,7 +23,7 @@
  */
 
 #import <XCTest/XCTest.h>
-#import "SFSmartStore.h"
+#import <SmartStore/SmartStore.h>
 #import <fmdb/FMResultSet.h>
 #import <SalesforceSDKCore/SFUserAccountManager.h>
 


### PR DESCRIPTION
For some reason, import of project header in a test file without first importing public headers referenced in the project header caused compilation errors
Now in tests, we import the framework master header before any project header

Had to enable import of non-modular headers in SalesforceHybridSDK because it was choking on the #import <Cordova/xxx.h>