### PR TITLE
Flattening dependencies for samples, to embed frameworks

### DIFF
--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer.xcodeproj/project.pbxproj
@@ -28,17 +28,212 @@
 		7DF4D3CD1472E3E0005CE144 /* RestAPIExplorerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF4D3C71472E3DF005CE144 /* RestAPIExplorerViewController.m */; };
 		7DF4D3CF1472E3E0005CE144 /* QueryListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DF4D3CA1472E3E0005CE144 /* QueryListViewController.m */; };
 		820275F21651787D00DB814C /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 820275F11651787D00DB814C /* MessageUI.framework */; };
+		8236AC171C4D9B55004B69B8 /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8236ABDD1C4D9AD5004B69B8 /* SalesforceSDKCore.framework */; };
+		8236AC181C4D9B55004B69B8 /* SalesforceSDKCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8236ABDD1C4D9AD5004B69B8 /* SalesforceSDKCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8236AC1C1C4D9B68004B69B8 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8236ABFC1C4D9AF4004B69B8 /* CocoaLumberjack.framework */; };
+		8236AC1D1C4D9B68004B69B8 /* CocoaLumberjack.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8236ABFC1C4D9AF4004B69B8 /* CocoaLumberjack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8236AC201C4D9B71004B69B8 /* SalesforceNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8236ABCF1C4D9ABE004B69B8 /* SalesforceNetwork.framework */; };
+		8236AC211C4D9B71004B69B8 /* SalesforceNetwork.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8236ABCF1C4D9ABE004B69B8 /* SalesforceNetwork.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8236AC241C4D9B84004B69B8 /* SalesforceRestAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 829DA2441C125E870040F5F1 /* SalesforceRestAPI.framework */; };
+		8236AC251C4D9B84004B69B8 /* SalesforceRestAPI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 829DA2441C125E870040F5F1 /* SalesforceRestAPI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8236AC5B1C4D9C66004B69B8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8236AC591C4D9C66004B69B8 /* LaunchScreen.storyboard */; };
 		8242E0CA15AB823400E9E6AF /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8242E0C915AB823400E9E6AF /* QuartzCore.framework */; };
-		829DA2491C125E9A0040F5F1 /* SalesforceRestAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 829DA2441C125E870040F5F1 /* SalesforceRestAPI.framework */; };
 		82E7F5AF17147BC400AC4E27 /* InitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 82E7F5AD17147BC400AC4E27 /* InitialViewController.m */; };
 		82E7F5B017147BC400AC4E27 /* InitialViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 82E7F5AE17147BC400AC4E27 /* InitialViewController.xib */; };
-		CE6AB3841C10C45A0012125E /* SalesforceNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3831C10C45A0012125E /* SalesforceNetwork.framework */; };
-		CE6AB38A1C10C46F0012125E /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3891C10C46F0012125E /* SalesforceSDKCore.framework */; };
 		CE6AB38C1C10C4880012125E /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB38B1C10C4880012125E /* libz.tbd */; };
 		CE6AB38E1C10C4940012125E /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB38D1C10C4940012125E /* libxml2.tbd */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		8236ABCE1C4D9ABE004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABC81C4D9ABE004B69B8 /* SalesforceNetwork.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CE4CE28C1C0E454F009F6029;
+			remoteInfo = SalesforceNetwork;
+		};
+		8236ABD01C4D9ABE004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABC81C4D9ABE004B69B8 /* SalesforceNetwork.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 825347F51A8ADD050019FE0B;
+			remoteInfo = SalesforceNetworkTests;
+		};
+		8236ABD21C4D9ABE004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABC81C4D9ABE004B69B8 /* SalesforceNetwork.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CEA883301C1910F6008D871B;
+			remoteInfo = SalesforceNetworkStatic;
+		};
+		8236ABDC1C4D9AD5004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABD41C4D9AD5004B69B8 /* SalesforceSDKCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CE4CE26B1C0E449C009F6029;
+			remoteInfo = SalesforceSDKCore;
+		};
+		8236ABDE1C4D9AD5004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABD41C4D9AD5004B69B8 /* SalesforceSDKCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 82D4642419C7C8170006BDFE;
+			remoteInfo = SalesforceSDKCoreTestApp;
+		};
+		8236ABE01C4D9AD5004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABD41C4D9AD5004B69B8 /* SalesforceSDKCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 4F7EB4151BFFC88200768720;
+			remoteInfo = SalesforceSDKCoreTests;
+		};
+		8236ABE21C4D9AD5004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABD41C4D9AD5004B69B8 /* SalesforceSDKCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CEA8825F1C18F722008D871B;
+			remoteInfo = SalesforceSDKCoreStatic;
+		};
+		8236ABF71C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = DCB3185114EB418E001CFBEE;
+			remoteInfo = CocoaLumberjack;
+		};
+		8236ABF91C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 18F3BF0F1A81D8B700692297;
+			remoteInfo = CocoaLumberjackSwift;
+		};
+		8236ABFB1C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19FF46021B8B4CF400B43179;
+			remoteInfo = "CocoaLumberjack-iOS";
+		};
+		8236ABFD1C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19FF460F1B8B4D1400B43179;
+			remoteInfo = "CocoaLumberjackSwift-iOS";
+		};
+		8236ABFF1C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 18F3BFD71A81E06E00692297;
+			remoteInfo = "CocoaLumberjack-iOS-Static";
+		};
+		8236AC011C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19190EDE1B84D812008D059E;
+			remoteInfo = "CocoaLumberjack-watchOS";
+		};
+		8236AC031C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19190EEB1B84D826008D059E;
+			remoteInfo = "CocoaLumberjackSwift-watchOS";
+		};
+		8236AC051C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19D90B261BBFA9DB00947169;
+			remoteInfo = "CocoaLumberjack-tvOS";
+		};
+		8236AC071C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19D90B351BBFAA7500947169;
+			remoteInfo = "CocoaLumberjackSwift-tvOS";
+		};
+		8236AC091C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = DCB318CA14ED6C3B001CFBEE;
+			remoteInfo = FmwkTest;
+		};
+		8236AC0B1C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 55CCBEFF19BA679200957A39;
+			remoteInfo = SwiftTest;
+		};
+		8236AC0D1C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 18F3BF5F1A81DD2E00692297;
+			remoteInfo = iOSSwiftTest;
+		};
+		8236AC0F1C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19EC14671B84D134000EC2E7;
+			remoteInfo = watchOSSwiftTest;
+		};
+		8236AC111C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19EC14731B84D134000EC2E7;
+			remoteInfo = "watchOSSwiftTest Extension";
+		};
+		8236AC131C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19406BE11BDBABFF001194DC;
+			remoteInfo = tvOSSwiftTest;
+		};
+		8236AC151C4D9AF4004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 18F3BFF21A81E0C700692297;
+			remoteInfo = iOSLibStaticTest;
+		};
+		8236AC191C4D9B55004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABD41C4D9AD5004B69B8 /* SalesforceSDKCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE26A1C0E449C009F6029;
+			remoteInfo = SalesforceSDKCore;
+		};
+		8236AC1E1C4D9B68004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 19FF46011B8B4CF400B43179;
+			remoteInfo = "CocoaLumberjack-iOS";
+		};
+		8236AC221C4D9B71004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8236ABC81C4D9ABE004B69B8 /* SalesforceNetwork.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE28B1C0E454F009F6029;
+			remoteInfo = SalesforceNetwork;
+		};
+		8236AC261C4D9B84004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE2A21C0E4569009F6029;
+			remoteInfo = SalesforceRestAPI;
+		};
 		829DA2431C125E870040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */;
@@ -76,6 +271,23 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		8236AC1B1C4D9B56004B69B8 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				8236AC211C4D9B71004B69B8 /* SalesforceNetwork.framework in Embed Frameworks */,
+				8236AC1D1C4D9B68004B69B8 /* CocoaLumberjack.framework in Embed Frameworks */,
+				8236AC251C4D9B84004B69B8 /* SalesforceRestAPI.framework in Embed Frameworks */,
+				8236AC181C4D9B55004B69B8 /* SalesforceSDKCore.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		4F2147B8193D213A0010F9D3 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = Settings.bundle; path = ../../../../shared/resources/Settings.bundle; sourceTree = "<group>"; };
 		4F473D7117E26DFF000CCDF3 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
@@ -103,13 +315,15 @@
 		7DF4D3CA1472E3E0005CE144 /* QueryListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = QueryListViewController.m; path = Classes/QueryListViewController.m; sourceTree = "<group>"; };
 		7DF4D3CB1472E3E0005CE144 /* QueryListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = QueryListViewController.h; path = Classes/QueryListViewController.h; sourceTree = "<group>"; };
 		820275F11651787D00DB814C /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
+		8236ABC81C4D9ABE004B69B8 /* SalesforceNetwork.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceNetwork.xcodeproj; path = ../../../libs/SalesforceNetwork/SalesforceNetwork.xcodeproj; sourceTree = "<group>"; };
+		8236ABD41C4D9AD5004B69B8 /* SalesforceSDKCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceSDKCore.xcodeproj; path = ../../../libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj; sourceTree = "<group>"; };
+		8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Lumberjack.xcodeproj; path = ../../../external/CocoaLumberjack/Lumberjack.xcodeproj; sourceTree = "<group>"; };
+		8236AC5A1C4D9C66004B69B8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8242E0C915AB823400E9E6AF /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceRestAPI.xcodeproj; path = ../../../libs/SalesforceRestAPI/SalesforceRestAPI.xcodeproj; sourceTree = "<group>"; };
 		82E7F5AC17147BC400AC4E27 /* InitialViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = InitialViewController.h; path = Classes/InitialViewController.h; sourceTree = "<group>"; };
 		82E7F5AD17147BC400AC4E27 /* InitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = InitialViewController.m; path = Classes/InitialViewController.m; sourceTree = "<group>"; };
 		82E7F5AE17147BC400AC4E27 /* InitialViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = InitialViewController.xib; path = Classes/InitialViewController.xib; sourceTree = "<group>"; };
-		CE6AB3831C10C45A0012125E /* SalesforceNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SalesforceNetwork.framework; path = "../../../libs/SalesforceNetwork/build/Debug-iphoneos/SalesforceNetwork.framework"; sourceTree = "<group>"; };
-		CE6AB3891C10C46F0012125E /* SalesforceSDKCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SalesforceSDKCore.framework; path = "../../../libs/SalesforceSDKCore/build/Debug-iphoneos/SalesforceSDKCore.framework"; sourceTree = "<group>"; };
 		CE6AB38B1C10C4880012125E /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		CE6AB38D1C10C4940012125E /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -119,15 +333,16 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				829DA2491C125E9A0040F5F1 /* SalesforceRestAPI.framework in Frameworks */,
-				CE6AB3841C10C45A0012125E /* SalesforceNetwork.framework in Frameworks */,
-				CE6AB38A1C10C46F0012125E /* SalesforceSDKCore.framework in Frameworks */,
 				CE6AB38C1C10C4880012125E /* libz.tbd in Frameworks */,
 				CE6AB38E1C10C4940012125E /* libxml2.tbd in Frameworks */,
+				8236AC241C4D9B84004B69B8 /* SalesforceRestAPI.framework in Frameworks */,
 				7DF4D2EB1472E238005CE144 /* CFNetwork.framework in Frameworks */,
+				8236AC171C4D9B55004B69B8 /* SalesforceSDKCore.framework in Frameworks */,
 				7DF4D2DF1472E238005CE144 /* CoreData.framework in Frameworks */,
 				7DF4D2E91472E238005CE144 /* CoreGraphics.framework in Frameworks */,
 				7DF4D2E71472E238005CE144 /* Foundation.framework in Frameworks */,
+				8236AC1C1C4D9B68004B69B8 /* CocoaLumberjack.framework in Frameworks */,
+				8236AC201C4D9B71004B69B8 /* SalesforceNetwork.framework in Frameworks */,
 				820275F21651787D00DB814C /* MessageUI.framework in Frameworks */,
 				7DF4D2ED1472E238005CE144 /* MobileCoreServices.framework in Frameworks */,
 				8242E0CA15AB823400E9E6AF /* QuartzCore.framework in Frameworks */,
@@ -161,11 +376,12 @@
 		7DF4D2DD1472E238005CE144 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */,
+				8236ABD41C4D9AD5004B69B8 /* SalesforceSDKCore.xcodeproj */,
+				8236ABC81C4D9ABE004B69B8 /* SalesforceNetwork.xcodeproj */,
+				829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */,
 				CE6AB38D1C10C4940012125E /* libxml2.tbd */,
 				CE6AB38B1C10C4880012125E /* libz.tbd */,
-				CE6AB3891C10C46F0012125E /* SalesforceSDKCore.framework */,
-				CE6AB3831C10C45A0012125E /* SalesforceNetwork.framework */,
-				829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */,
 				7DF4D2EA1472E238005CE144 /* CFNetwork.framework */,
 				7DF4D2DE1472E238005CE144 /* CoreData.framework */,
 				7DF4D2E81472E238005CE144 /* CoreGraphics.framework */,
@@ -196,6 +412,7 @@
 		7DF4D2EF1472E238005CE144 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				8236AC591C4D9C66004B69B8 /* LaunchScreen.storyboard */,
 				7DF4D2F01472E238005CE144 /* RestAPIExplorer-Info.plist */,
 				7DF4D2F11472E238005CE144 /* InfoPlist.strings */,
 				7DF4D2F41472E238005CE144 /* main.m */,
@@ -238,12 +455,56 @@
 			name = NativeRestApp;
 			sourceTree = "<group>";
 		};
+		8236ABC91C4D9ABE004B69B8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8236ABCF1C4D9ABE004B69B8 /* SalesforceNetwork.framework */,
+				8236ABD11C4D9ABE004B69B8 /* SalesforceNetworkTests.xctest */,
+				8236ABD31C4D9ABE004B69B8 /* libSalesforceNetwork.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8236ABD51C4D9AD5004B69B8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8236ABDD1C4D9AD5004B69B8 /* SalesforceSDKCore.framework */,
+				8236ABDF1C4D9AD5004B69B8 /* SalesforceSDKCoreTestApp.app */,
+				8236ABE11C4D9AD5004B69B8 /* SalesforceSDKCoreTests.xctest */,
+				8236ABE31C4D9AD5004B69B8 /* libSalesforceSDKCore.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8236ABE51C4D9AF4004B69B8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8236ABF81C4D9AF4004B69B8 /* CocoaLumberjack.framework */,
+				8236ABFA1C4D9AF4004B69B8 /* CocoaLumberjackSwift.framework */,
+				8236ABFC1C4D9AF4004B69B8 /* CocoaLumberjack.framework */,
+				8236ABFE1C4D9AF4004B69B8 /* CocoaLumberjackSwift.framework */,
+				8236AC001C4D9AF4004B69B8 /* libCocoaLumberjack.a */,
+				8236AC021C4D9AF4004B69B8 /* CocoaLumberjack.framework */,
+				8236AC041C4D9AF4004B69B8 /* CocoaLumberjackSwift.framework */,
+				8236AC061C4D9AF4004B69B8 /* CocoaLumberjack.framework */,
+				8236AC081C4D9AF4004B69B8 /* CocoaLumberjackSwift.framework */,
+				8236AC0A1C4D9AF4004B69B8 /* FmwkTest.app */,
+				8236AC0C1C4D9AF4004B69B8 /* SwiftTest.app */,
+				8236AC0E1C4D9AF4004B69B8 /* iOSSwiftTest.app */,
+				8236AC101C4D9AF4004B69B8 /* watchOSSwiftTest.app */,
+				8236AC121C4D9AF4004B69B8 /* watchOSSwiftTest Extension.appex */,
+				8236AC141C4D9AF4004B69B8 /* tvOSSwiftTest.app */,
+				8236AC161C4D9AF4004B69B8 /* iOSLibStaticTest.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		829DA23D1C125E870040F5F1 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				829DA2441C125E870040F5F1 /* SalesforceRestAPI.framework */,
 				829DA2461C125E870040F5F1 /* SalesforceRestAPITestApp.app */,
-				829DA2481C125E870040F5F1 /* SalesforceRestAPITestAppTests.xctest */,
+				829DA2481C125E870040F5F1 /* SalesforceRestAPITests.xctest */,
 				82C5E3F51C1B631600376C00 /* libSalesforceRestAPI.a */,
 			);
 			name = Products;
@@ -259,11 +520,16 @@
 				7DF4D2D51472E238005CE144 /* Sources */,
 				7DF4D2D61472E238005CE144 /* Frameworks */,
 				7DF4D2D71472E238005CE144 /* Resources */,
+				8236AC1B1C4D9B56004B69B8 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				829DA24B1C125EBA0040F5F1 /* PBXTargetDependency */,
+				8236AC1A1C4D9B55004B69B8 /* PBXTargetDependency */,
+				8236AC1F1C4D9B68004B69B8 /* PBXTargetDependency */,
+				8236AC231C4D9B71004B69B8 /* PBXTargetDependency */,
+				8236AC271C4D9B84004B69B8 /* PBXTargetDependency */,
 			);
 			name = RestAPIExplorer;
 			productName = RestAPIExplorer;
@@ -277,11 +543,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0710;
-				TargetAttributes = {
-					7DF4D2D91472E238005CE144 = {
-						DevelopmentTeam = 62J96EUJ9N;
-					};
-				};
 			};
 			buildConfigurationList = 7DF4D2D31472E238005CE144 /* Build configuration list for PBXProject "RestAPIExplorer" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -289,14 +550,27 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 7DF4D2CE1472E238005CE144;
 			productRefGroup = 7DF4D2DB1472E238005CE144 /* Products */;
 			projectDirPath = "";
 			projectReferences = (
 				{
+					ProductGroup = 8236ABE51C4D9AF4004B69B8 /* Products */;
+					ProjectRef = 8236ABE41C4D9AF4004B69B8 /* Lumberjack.xcodeproj */;
+				},
+				{
+					ProductGroup = 8236ABC91C4D9ABE004B69B8 /* Products */;
+					ProjectRef = 8236ABC81C4D9ABE004B69B8 /* SalesforceNetwork.xcodeproj */;
+				},
+				{
 					ProductGroup = 829DA23D1C125E870040F5F1 /* Products */;
 					ProjectRef = 829DA23C1C125E870040F5F1 /* SalesforceRestAPI.xcodeproj */;
+				},
+				{
+					ProductGroup = 8236ABD51C4D9AD5004B69B8 /* Products */;
+					ProjectRef = 8236ABD41C4D9AD5004B69B8 /* SalesforceSDKCore.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -307,6 +581,167 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		8236ABCF1C4D9ABE004B69B8 /* SalesforceNetwork.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SalesforceNetwork.framework;
+			remoteRef = 8236ABCE1C4D9ABE004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236ABD11C4D9ABE004B69B8 /* SalesforceNetworkTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = SalesforceNetworkTests.xctest;
+			remoteRef = 8236ABD01C4D9ABE004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236ABD31C4D9ABE004B69B8 /* libSalesforceNetwork.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSalesforceNetwork.a;
+			remoteRef = 8236ABD21C4D9ABE004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236ABDD1C4D9AD5004B69B8 /* SalesforceSDKCore.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SalesforceSDKCore.framework;
+			remoteRef = 8236ABDC1C4D9AD5004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236ABDF1C4D9AD5004B69B8 /* SalesforceSDKCoreTestApp.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = SalesforceSDKCoreTestApp.app;
+			remoteRef = 8236ABDE1C4D9AD5004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236ABE11C4D9AD5004B69B8 /* SalesforceSDKCoreTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = SalesforceSDKCoreTests.xctest;
+			remoteRef = 8236ABE01C4D9AD5004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236ABE31C4D9AD5004B69B8 /* libSalesforceSDKCore.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSalesforceSDKCore.a;
+			remoteRef = 8236ABE21C4D9AD5004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236ABF81C4D9AF4004B69B8 /* CocoaLumberjack.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjack.framework;
+			remoteRef = 8236ABF71C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236ABFA1C4D9AF4004B69B8 /* CocoaLumberjackSwift.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjackSwift.framework;
+			remoteRef = 8236ABF91C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236ABFC1C4D9AF4004B69B8 /* CocoaLumberjack.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjack.framework;
+			remoteRef = 8236ABFB1C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236ABFE1C4D9AF4004B69B8 /* CocoaLumberjackSwift.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjackSwift.framework;
+			remoteRef = 8236ABFD1C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC001C4D9AF4004B69B8 /* libCocoaLumberjack.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libCocoaLumberjack.a;
+			remoteRef = 8236ABFF1C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC021C4D9AF4004B69B8 /* CocoaLumberjack.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjack.framework;
+			remoteRef = 8236AC011C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC041C4D9AF4004B69B8 /* CocoaLumberjackSwift.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjackSwift.framework;
+			remoteRef = 8236AC031C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC061C4D9AF4004B69B8 /* CocoaLumberjack.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjack.framework;
+			remoteRef = 8236AC051C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC081C4D9AF4004B69B8 /* CocoaLumberjackSwift.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjackSwift.framework;
+			remoteRef = 8236AC071C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC0A1C4D9AF4004B69B8 /* FmwkTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = FmwkTest.app;
+			remoteRef = 8236AC091C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC0C1C4D9AF4004B69B8 /* SwiftTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = SwiftTest.app;
+			remoteRef = 8236AC0B1C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC0E1C4D9AF4004B69B8 /* iOSSwiftTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = iOSSwiftTest.app;
+			remoteRef = 8236AC0D1C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC101C4D9AF4004B69B8 /* watchOSSwiftTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = watchOSSwiftTest.app;
+			remoteRef = 8236AC0F1C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC121C4D9AF4004B69B8 /* watchOSSwiftTest Extension.appex */ = {
+			isa = PBXReferenceProxy;
+			fileType = "wrapper.app-extension";
+			path = "watchOSSwiftTest Extension.appex";
+			remoteRef = 8236AC111C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC141C4D9AF4004B69B8 /* tvOSSwiftTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = tvOSSwiftTest.app;
+			remoteRef = 8236AC131C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236AC161C4D9AF4004B69B8 /* iOSLibStaticTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = iOSLibStaticTest.app;
+			remoteRef = 8236AC151C4D9AF4004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		829DA2441C125E870040F5F1 /* SalesforceRestAPI.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -321,10 +756,10 @@
 			remoteRef = 829DA2451C125E870040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		829DA2481C125E870040F5F1 /* SalesforceRestAPITestAppTests.xctest */ = {
+		829DA2481C125E870040F5F1 /* SalesforceRestAPITests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = SalesforceRestAPITestAppTests.xctest;
+			path = SalesforceRestAPITests.xctest;
 			remoteRef = 829DA2471C125E870040F5F1 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -342,6 +777,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8236AC5B1C4D9C66004B69B8 /* LaunchScreen.storyboard in Resources */,
 				7DF4D2F31472E238005CE144 /* InfoPlist.strings in Resources */,
 				7DF4D2F71472E238005CE144 /* RestAPIExplorer-Prefix.pch in Resources */,
 				4F2147B9193D213A0010F9D3 /* Settings.bundle in Resources */,
@@ -371,6 +807,26 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		8236AC1A1C4D9B55004B69B8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SalesforceSDKCore;
+			targetProxy = 8236AC191C4D9B55004B69B8 /* PBXContainerItemProxy */;
+		};
+		8236AC1F1C4D9B68004B69B8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "CocoaLumberjack-iOS";
+			targetProxy = 8236AC1E1C4D9B68004B69B8 /* PBXContainerItemProxy */;
+		};
+		8236AC231C4D9B71004B69B8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SalesforceNetwork;
+			targetProxy = 8236AC221C4D9B71004B69B8 /* PBXContainerItemProxy */;
+		};
+		8236AC271C4D9B84004B69B8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SalesforceRestAPI;
+			targetProxy = 8236AC261C4D9B84004B69B8 /* PBXContainerItemProxy */;
+		};
 		829DA24B1C125EBA0040F5F1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SalesforceRestAPI;
@@ -385,6 +841,14 @@
 				7DF4D2F21472E238005CE144 /* en */,
 			);
 			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		8236AC591C4D9C66004B69B8 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				8236AC5A1C4D9C66004B69B8 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
@@ -488,6 +952,7 @@
 				GCC_PREFIX_HEADER = "RestAPIExplorer/RestAPIExplorer-Prefix.pch";
 				INFOPLIST_FILE = "RestAPIExplorer/RestAPIExplorer-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_PREFIX}.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -511,6 +976,7 @@
 				GCC_PREFIX_HEADER = "RestAPIExplorer/RestAPIExplorer-Prefix.pch";
 				INFOPLIST_FILE = "RestAPIExplorer/RestAPIExplorer-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_PREFIX}.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Base.lproj/LaunchScreen.storyboard
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/RestAPIExplorer-Info.plist
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/RestAPIExplorer-Info.plist
@@ -24,6 +24,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer.xcodeproj/project.pbxproj
@@ -32,15 +32,36 @@
 		8284055619EA09E40079AB60 /* ContactDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8284055519EA09E40079AB60 /* ContactDetailViewController.m */; };
 		8284055819EAFB610079AB60 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 8284055719EAFB610079AB60 /* Settings.bundle */; };
 		8284055A19EAFD9C0079AB60 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8284055919EAFD9C0079AB60 /* Images.xcassets */; };
-		829DA2621C1260AE0040F5F1 /* SmartSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 829DA25D1C1260960040F5F1 /* SmartSync.framework */; };
-		CE6AB3901C10C4C90012125E /* SmartStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB38F1C10C4C90012125E /* SmartStore.framework */; };
-		CE6AB3951C10C4D60012125E /* SalesforceRestAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3941C10C4D60012125E /* SalesforceRestAPI.framework */; };
-		CE6AB3971C10C4DC0012125E /* SalesforceNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3961C10C4DC0012125E /* SalesforceNetwork.framework */; };
-		CE6AB3991C10C4E20012125E /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB3981C10C4E20012125E /* SalesforceSDKCore.framework */; };
+		82D0AC011C49A7A10081F833 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82D0ABE61C49A7710081F833 /* CocoaLumberjack.framework */; };
+		82D0AC021C49A7A10081F833 /* CocoaLumberjack.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 82D0ABE61C49A7710081F833 /* CocoaLumberjack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		82D0AC061C49A7BE0081F833 /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82D0ABC51C49A7550081F833 /* SalesforceSDKCore.framework */; };
+		82D0AC071C49A7BE0081F833 /* SalesforceSDKCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 82D0ABC51C49A7550081F833 /* SalesforceSDKCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		82D0AC0A1C49A7D10081F833 /* SalesforceNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82D0ABB61C49A73D0081F833 /* SalesforceNetwork.framework */; };
+		82D0AC0B1C49A7D10081F833 /* SalesforceNetwork.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 82D0ABB61C49A73D0081F833 /* SalesforceNetwork.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		82D0AC0E1C49A7E10081F833 /* SalesforceRestAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82D0ABA81C49A7290081F833 /* SalesforceRestAPI.framework */; };
+		82D0AC0F1C49A7E10081F833 /* SalesforceRestAPI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 82D0ABA81C49A7290081F833 /* SalesforceRestAPI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		82D0AC121C49A7F60081F833 /* SmartStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82D0AB9A1C49A6FB0081F833 /* SmartStore.framework */; };
+		82D0AC131C49A7F60081F833 /* SmartStore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 82D0AB9A1C49A6FB0081F833 /* SmartStore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		82D0AC161C49A8120081F833 /* SmartSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 829DA25D1C1260960040F5F1 /* SmartSync.framework */; };
+		82D0AC171C49A8120081F833 /* SmartSync.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 829DA25D1C1260960040F5F1 /* SmartSync.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CE6AB39B1C10C4F50012125E /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6AB39A1C10C4F50012125E /* libz.tbd */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		8236ABB51C4D9922004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0AB921C49A6FB0081F833 /* SmartStore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 4F06AF091C499EB600F70798;
+			remoteInfo = SmartStoreTestApp;
+		};
+		8236ABBB1C4D9922004B69B8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 4F06AF2E1C499FD100F70798;
+			remoteInfo = SmartSyncTestApp;
+		};
 		829DA25C1C1260960040F5F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */;
@@ -69,7 +90,278 @@
 			remoteGlobalIDString = CEA883EE1C19160E008D871B;
 			remoteInfo = SmartSyncStatic;
 		};
+		82D0AB991C49A6FB0081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0AB921C49A6FB0081F833 /* SmartStore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CE4CE2B91C0E4581009F6029;
+			remoteInfo = SmartStore;
+		};
+		82D0AB9B1C49A6FB0081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0AB921C49A6FB0081F833 /* SmartStore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CEAAAE55195911E600CBBFE9;
+			remoteInfo = SmartStoreTests;
+		};
+		82D0AB9D1C49A6FB0081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0AB921C49A6FB0081F833 /* SmartStore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CEA883BA1C1914DE008D871B;
+			remoteInfo = SmartStoreStatic;
+		};
+		82D0ABA71C49A7290081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0AB9F1C49A7280081F833 /* SalesforceRestAPI.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CE4CE2A31C0E4569009F6029;
+			remoteInfo = SalesforceRestAPI;
+		};
+		82D0ABA91C49A7290081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0AB9F1C49A7280081F833 /* SalesforceRestAPI.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 82C0C75D16E07DEB0006B3C0;
+			remoteInfo = SalesforceRestAPITestApp;
+		};
+		82D0ABAB1C49A7290081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0AB9F1C49A7280081F833 /* SalesforceRestAPI.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 829A08851A323DDF00DC17A5;
+			remoteInfo = SalesforceRestAPITestAppTests;
+		};
+		82D0ABAD1C49A7290081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0AB9F1C49A7280081F833 /* SalesforceRestAPI.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CEA883921C19135D008D871B;
+			remoteInfo = SalesforceRestAPIStatic;
+		};
+		82D0ABB51C49A73D0081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABAF1C49A73D0081F833 /* SalesforceNetwork.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CE4CE28C1C0E454F009F6029;
+			remoteInfo = SalesforceNetwork;
+		};
+		82D0ABB71C49A73D0081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABAF1C49A73D0081F833 /* SalesforceNetwork.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 825347F51A8ADD050019FE0B;
+			remoteInfo = SalesforceNetworkTests;
+		};
+		82D0ABB91C49A73D0081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABAF1C49A73D0081F833 /* SalesforceNetwork.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CEA883301C1910F6008D871B;
+			remoteInfo = SalesforceNetworkStatic;
+		};
+		82D0ABC41C49A7550081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABBB1C49A7540081F833 /* SalesforceSDKCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CE4CE26B1C0E449C009F6029;
+			remoteInfo = SalesforceSDKCore;
+		};
+		82D0ABC61C49A7550081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABBB1C49A7540081F833 /* SalesforceSDKCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 4F7EB4151BFFC88200768720;
+			remoteInfo = SalesforceSDKCoreTests;
+		};
+		82D0ABC81C49A7550081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABBB1C49A7540081F833 /* SalesforceSDKCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 82D4642419C7C8170006BDFE;
+			remoteInfo = SalesforceSDKCoreTestApp;
+		};
+		82D0ABCC1C49A7550081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABBB1C49A7540081F833 /* SalesforceSDKCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = CEA8825F1C18F722008D871B;
+			remoteInfo = SalesforceSDKCoreStatic;
+		};
+		82D0ABE11C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = DCB3185114EB418E001CFBEE;
+			remoteInfo = CocoaLumberjack;
+		};
+		82D0ABE31C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 18F3BF0F1A81D8B700692297;
+			remoteInfo = CocoaLumberjackSwift;
+		};
+		82D0ABE51C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19FF46021B8B4CF400B43179;
+			remoteInfo = "CocoaLumberjack-iOS";
+		};
+		82D0ABE71C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19FF460F1B8B4D1400B43179;
+			remoteInfo = "CocoaLumberjackSwift-iOS";
+		};
+		82D0ABE91C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 18F3BFD71A81E06E00692297;
+			remoteInfo = "CocoaLumberjack-iOS-Static";
+		};
+		82D0ABEB1C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19190EDE1B84D812008D059E;
+			remoteInfo = "CocoaLumberjack-watchOS";
+		};
+		82D0ABED1C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19190EEB1B84D826008D059E;
+			remoteInfo = "CocoaLumberjackSwift-watchOS";
+		};
+		82D0ABEF1C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19D90B261BBFA9DB00947169;
+			remoteInfo = "CocoaLumberjack-tvOS";
+		};
+		82D0ABF11C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19D90B351BBFAA7500947169;
+			remoteInfo = "CocoaLumberjackSwift-tvOS";
+		};
+		82D0ABF31C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = DCB318CA14ED6C3B001CFBEE;
+			remoteInfo = FmwkTest;
+		};
+		82D0ABF51C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 55CCBEFF19BA679200957A39;
+			remoteInfo = SwiftTest;
+		};
+		82D0ABF71C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 18F3BF5F1A81DD2E00692297;
+			remoteInfo = iOSSwiftTest;
+		};
+		82D0ABF91C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19EC14671B84D134000EC2E7;
+			remoteInfo = watchOSSwiftTest;
+		};
+		82D0ABFB1C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19EC14731B84D134000EC2E7;
+			remoteInfo = "watchOSSwiftTest Extension";
+		};
+		82D0ABFD1C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 19406BE11BDBABFF001194DC;
+			remoteInfo = tvOSSwiftTest;
+		};
+		82D0ABFF1C49A7710081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 18F3BFF21A81E0C700692297;
+			remoteInfo = iOSLibStaticTest;
+		};
+		82D0AC031C49A7A10081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 19FF46011B8B4CF400B43179;
+			remoteInfo = "CocoaLumberjack-iOS";
+		};
+		82D0AC081C49A7BE0081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABBB1C49A7540081F833 /* SalesforceSDKCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE26A1C0E449C009F6029;
+			remoteInfo = SalesforceSDKCore;
+		};
+		82D0AC0C1C49A7D10081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0ABAF1C49A73D0081F833 /* SalesforceNetwork.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE28B1C0E454F009F6029;
+			remoteInfo = SalesforceNetwork;
+		};
+		82D0AC101C49A7E10081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0AB9F1C49A7280081F833 /* SalesforceRestAPI.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE2A21C0E4569009F6029;
+			remoteInfo = SalesforceRestAPI;
+		};
+		82D0AC141C49A7F60081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 82D0AB921C49A6FB0081F833 /* SmartStore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE2B81C0E4581009F6029;
+			remoteInfo = SmartStore;
+		};
+		82D0AC181C49A8120081F833 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = CE4CE2C81C0E463C009F6029;
+			remoteInfo = SmartSync;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		82D0AC051C49A7A10081F833 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				82D0AC131C49A7F60081F833 /* SmartStore.framework in Embed Frameworks */,
+				82D0AC0B1C49A7D10081F833 /* SalesforceNetwork.framework in Embed Frameworks */,
+				82D0AC021C49A7A10081F833 /* CocoaLumberjack.framework in Embed Frameworks */,
+				82D0AC171C49A8120081F833 /* SmartSync.framework in Embed Frameworks */,
+				82D0AC0F1C49A7E10081F833 /* SalesforceRestAPI.framework in Embed Frameworks */,
+				82D0AC071C49A7BE0081F833 /* SalesforceSDKCore.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		4F60B2271B9A2C2900923174 /* WYPopoverController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WYPopoverController.h; path = ../../../../../external/wypopovercontroller/WYPopoverController/WYPopoverController.h; sourceTree = "<group>"; };
@@ -114,10 +406,11 @@
 		8284055719EAFB610079AB60 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = Settings.bundle; path = ../../../../shared/resources/Settings.bundle; sourceTree = "<group>"; };
 		8284055919EAFD9C0079AB60 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = ../../../../shared/resources/Images.xcassets; sourceTree = "<group>"; };
 		829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SmartSync.xcodeproj; path = ../../../libs/SmartSync/SmartSync.xcodeproj; sourceTree = "<group>"; };
-		CE6AB38F1C10C4C90012125E /* SmartStore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SmartStore.framework; path = "../../../libs/SmartStore/build/Debug-iphoneos/SmartStore.framework"; sourceTree = "<group>"; };
-		CE6AB3941C10C4D60012125E /* SalesforceRestAPI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SalesforceRestAPI.framework; path = "../../../libs/SalesforceRestAPI/build/Debug-iphoneos/SalesforceRestAPI.framework"; sourceTree = "<group>"; };
-		CE6AB3961C10C4DC0012125E /* SalesforceNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SalesforceNetwork.framework; path = "../../../libs/SalesforceNetwork/build/Debug-iphoneos/SalesforceNetwork.framework"; sourceTree = "<group>"; };
-		CE6AB3981C10C4E20012125E /* SalesforceSDKCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SalesforceSDKCore.framework; path = "../../../libs/SalesforceSDKCore/build/Debug-iphoneos/SalesforceSDKCore.framework"; sourceTree = "<group>"; };
+		82D0AB921C49A6FB0081F833 /* SmartStore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SmartStore.xcodeproj; path = ../../../libs/SmartStore/SmartStore.xcodeproj; sourceTree = "<group>"; };
+		82D0AB9F1C49A7280081F833 /* SalesforceRestAPI.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceRestAPI.xcodeproj; path = ../../../libs/SalesforceRestAPI/SalesforceRestAPI.xcodeproj; sourceTree = "<group>"; };
+		82D0ABAF1C49A73D0081F833 /* SalesforceNetwork.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceNetwork.xcodeproj; path = ../../../libs/SalesforceNetwork/SalesforceNetwork.xcodeproj; sourceTree = "<group>"; };
+		82D0ABBB1C49A7540081F833 /* SalesforceSDKCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceSDKCore.xcodeproj; path = ../../../libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj; sourceTree = "<group>"; };
+		82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Lumberjack.xcodeproj; path = ../../../external/CocoaLumberjack/Lumberjack.xcodeproj; sourceTree = "<group>"; };
 		CE6AB39A1C10C4F50012125E /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -126,19 +419,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				829DA2621C1260AE0040F5F1 /* SmartSync.framework in Frameworks */,
-				CE6AB3901C10C4C90012125E /* SmartStore.framework in Frameworks */,
-				CE6AB3951C10C4D60012125E /* SalesforceRestAPI.framework in Frameworks */,
-				CE6AB3971C10C4DC0012125E /* SalesforceNetwork.framework in Frameworks */,
-				CE6AB3991C10C4E20012125E /* SalesforceSDKCore.framework in Frameworks */,
+				82D0AC0A1C49A7D10081F833 /* SalesforceNetwork.framework in Frameworks */,
 				820C8B2F19E6096800E9BE5C /* libsqlcipher.a in Frameworks */,
 				CE6AB39B1C10C4F50012125E /* libz.tbd in Frameworks */,
+				82D0AC011C49A7A10081F833 /* CocoaLumberjack.framework in Frameworks */,
 				827C631719E6018C00027484 /* CoreGraphics.framework in Frameworks */,
 				820C8B1F19E6081C00E9BE5C /* ImageIO.framework in Frameworks */,
+				82D0AC061C49A7BE0081F833 /* SalesforceSDKCore.framework in Frameworks */,
 				820C8B2319E6088400E9BE5C /* MessageUI.framework in Frameworks */,
 				8258804B1AA4222A000C551E /* MobileCoreServices.framework in Frameworks */,
+				82D0AC161C49A8120081F833 /* SmartSync.framework in Frameworks */,
+				82D0AC0E1C49A7E10081F833 /* SalesforceRestAPI.framework in Frameworks */,
 				820C8B2719E6091100E9BE5C /* SystemConfiguration.framework in Frameworks */,
 				827C631919E6018C00027484 /* UIKit.framework in Frameworks */,
+				82D0AC121C49A7F60081F833 /* SmartStore.framework in Frameworks */,
 				827C631519E6018C00027484 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -224,12 +518,13 @@
 		827C631319E6018C00027484 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CE6AB39A1C10C4F50012125E /* libz.tbd */,
-				CE6AB3981C10C4E20012125E /* SalesforceSDKCore.framework */,
-				CE6AB3961C10C4DC0012125E /* SalesforceNetwork.framework */,
-				CE6AB3941C10C4D60012125E /* SalesforceRestAPI.framework */,
-				CE6AB38F1C10C4C90012125E /* SmartStore.framework */,
 				829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */,
+				82D0AB921C49A6FB0081F833 /* SmartStore.xcodeproj */,
+				82D0AB9F1C49A7280081F833 /* SalesforceRestAPI.xcodeproj */,
+				82D0ABAF1C49A73D0081F833 /* SalesforceNetwork.xcodeproj */,
+				82D0ABBB1C49A7540081F833 /* SalesforceSDKCore.xcodeproj */,
+				82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */,
+				CE6AB39A1C10C4F50012125E /* libz.tbd */,
 				8258804A1AA4222A000C551E /* MobileCoreServices.framework */,
 				820C8B2E19E6096800E9BE5C /* libsqlcipher.a */,
 				827C631419E6018C00027484 /* Foundation.framework */,
@@ -267,8 +562,75 @@
 			isa = PBXGroup;
 			children = (
 				829DA25D1C1260960040F5F1 /* SmartSync.framework */,
+				8236ABBC1C4D9922004B69B8 /* SmartSyncTestApp.app */,
 				829DA25F1C1260960040F5F1 /* SmartSyncTests.xctest */,
 				82C5E3FA1C1B633F00376C00 /* libSmartSync.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		82D0AB931C49A6FB0081F833 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				82D0AB9A1C49A6FB0081F833 /* SmartStore.framework */,
+				8236ABB61C4D9922004B69B8 /* SmartStoreTestApp.app */,
+				82D0AB9C1C49A6FB0081F833 /* SmartStoreTests.xctest */,
+				82D0AB9E1C49A6FB0081F833 /* libSmartStore.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		82D0ABA01C49A7280081F833 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				82D0ABA81C49A7290081F833 /* SalesforceRestAPI.framework */,
+				82D0ABAA1C49A7290081F833 /* SalesforceRestAPITestApp.app */,
+				82D0ABAC1C49A7290081F833 /* SalesforceRestAPITestAppTests.xctest */,
+				82D0ABAE1C49A7290081F833 /* libSalesforceRestAPI.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		82D0ABB01C49A73D0081F833 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				82D0ABB61C49A73D0081F833 /* SalesforceNetwork.framework */,
+				82D0ABB81C49A73D0081F833 /* SalesforceNetworkTests.xctest */,
+				82D0ABBA1C49A73D0081F833 /* libSalesforceNetwork.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		82D0ABBC1C49A7540081F833 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				82D0ABC51C49A7550081F833 /* SalesforceSDKCore.framework */,
+				82D0ABC91C49A7550081F833 /* SalesforceSDKCoreTestApp.app */,
+				82D0ABC71C49A7550081F833 /* SalesforceSDKCoreTests.xctest */,
+				82D0ABCD1C49A7550081F833 /* libSalesforceSDKCore.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		82D0ABCF1C49A7710081F833 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				82D0ABE21C49A7710081F833 /* CocoaLumberjack.framework */,
+				82D0ABE41C49A7710081F833 /* CocoaLumberjackSwift.framework */,
+				82D0ABE61C49A7710081F833 /* CocoaLumberjack.framework */,
+				82D0ABE81C49A7710081F833 /* CocoaLumberjackSwift.framework */,
+				82D0ABEA1C49A7710081F833 /* libCocoaLumberjack.a */,
+				82D0ABEC1C49A7710081F833 /* CocoaLumberjack.framework */,
+				82D0ABEE1C49A7710081F833 /* CocoaLumberjackSwift.framework */,
+				82D0ABF01C49A7710081F833 /* CocoaLumberjack.framework */,
+				82D0ABF21C49A7710081F833 /* CocoaLumberjackSwift.framework */,
+				82D0ABF41C49A7710081F833 /* FmwkTest.app */,
+				82D0ABF61C49A7710081F833 /* SwiftTest.app */,
+				82D0ABF81C49A7710081F833 /* iOSSwiftTest.app */,
+				82D0ABFA1C49A7710081F833 /* watchOSSwiftTest.app */,
+				82D0ABFC1C49A7710081F833 /* watchOSSwiftTest Extension.appex */,
+				82D0ABFE1C49A7710081F833 /* tvOSSwiftTest.app */,
+				82D0AC001C49A7710081F833 /* iOSLibStaticTest.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -283,11 +645,18 @@
 				827C630D19E6018C00027484 /* Sources */,
 				827C630E19E6018C00027484 /* Frameworks */,
 				827C630F19E6018C00027484 /* Resources */,
+				82D0AC051C49A7A10081F833 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				829DA2611C1260A50040F5F1 /* PBXTargetDependency */,
+				82D0AC041C49A7A10081F833 /* PBXTargetDependency */,
+				82D0AC091C49A7BE0081F833 /* PBXTargetDependency */,
+				82D0AC0D1C49A7D10081F833 /* PBXTargetDependency */,
+				82D0AC111C49A7E10081F833 /* PBXTargetDependency */,
+				82D0AC151C49A7F60081F833 /* PBXTargetDependency */,
+				82D0AC191C49A8120081F833 /* PBXTargetDependency */,
 			);
 			name = SmartSyncExplorer;
 			productName = SmartSyncExplorer;
@@ -316,6 +685,26 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
+					ProductGroup = 82D0ABCF1C49A7710081F833 /* Products */;
+					ProjectRef = 82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */;
+				},
+				{
+					ProductGroup = 82D0ABB01C49A73D0081F833 /* Products */;
+					ProjectRef = 82D0ABAF1C49A73D0081F833 /* SalesforceNetwork.xcodeproj */;
+				},
+				{
+					ProductGroup = 82D0ABA01C49A7280081F833 /* Products */;
+					ProjectRef = 82D0AB9F1C49A7280081F833 /* SalesforceRestAPI.xcodeproj */;
+				},
+				{
+					ProductGroup = 82D0ABBC1C49A7540081F833 /* Products */;
+					ProjectRef = 82D0ABBB1C49A7540081F833 /* SalesforceSDKCore.xcodeproj */;
+				},
+				{
+					ProductGroup = 82D0AB931C49A6FB0081F833 /* Products */;
+					ProjectRef = 82D0AB921C49A6FB0081F833 /* SmartStore.xcodeproj */;
+				},
+				{
 					ProductGroup = 829DA2571C1260960040F5F1 /* Products */;
 					ProjectRef = 829DA2561C1260960040F5F1 /* SmartSync.xcodeproj */;
 				},
@@ -328,6 +717,20 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		8236ABB61C4D9922004B69B8 /* SmartStoreTestApp.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = SmartStoreTestApp.app;
+			remoteRef = 8236ABB51C4D9922004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		8236ABBC1C4D9922004B69B8 /* SmartSyncTestApp.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = SmartSyncTestApp.app;
+			remoteRef = 8236ABBB1C4D9922004B69B8 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		829DA25D1C1260960040F5F1 /* SmartSync.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -347,6 +750,216 @@
 			fileType = archive.ar;
 			path = libSmartSync.a;
 			remoteRef = 82C5E3F91C1B633F00376C00 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0AB9A1C49A6FB0081F833 /* SmartStore.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SmartStore.framework;
+			remoteRef = 82D0AB991C49A6FB0081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0AB9C1C49A6FB0081F833 /* SmartStoreTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = SmartStoreTests.xctest;
+			remoteRef = 82D0AB9B1C49A6FB0081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0AB9E1C49A6FB0081F833 /* libSmartStore.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSmartStore.a;
+			remoteRef = 82D0AB9D1C49A6FB0081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABA81C49A7290081F833 /* SalesforceRestAPI.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SalesforceRestAPI.framework;
+			remoteRef = 82D0ABA71C49A7290081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABAA1C49A7290081F833 /* SalesforceRestAPITestApp.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = SalesforceRestAPITestApp.app;
+			remoteRef = 82D0ABA91C49A7290081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABAC1C49A7290081F833 /* SalesforceRestAPITestAppTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = SalesforceRestAPITests.xctest;
+			remoteRef = 82D0ABAB1C49A7290081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABAE1C49A7290081F833 /* libSalesforceRestAPI.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSalesforceRestAPI.a;
+			remoteRef = 82D0ABAD1C49A7290081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABB61C49A73D0081F833 /* SalesforceNetwork.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SalesforceNetwork.framework;
+			remoteRef = 82D0ABB51C49A73D0081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABB81C49A73D0081F833 /* SalesforceNetworkTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = SalesforceNetworkTests.xctest;
+			remoteRef = 82D0ABB71C49A73D0081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABBA1C49A73D0081F833 /* libSalesforceNetwork.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSalesforceNetwork.a;
+			remoteRef = 82D0ABB91C49A73D0081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABC51C49A7550081F833 /* SalesforceSDKCore.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = SalesforceSDKCore.framework;
+			remoteRef = 82D0ABC41C49A7550081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABC71C49A7550081F833 /* SalesforceSDKCoreTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = SalesforceSDKCoreTests.xctest;
+			remoteRef = 82D0ABC61C49A7550081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABC91C49A7550081F833 /* SalesforceSDKCoreTestApp.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = SalesforceSDKCoreTestApp.app;
+			remoteRef = 82D0ABC81C49A7550081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABCD1C49A7550081F833 /* libSalesforceSDKCore.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libSalesforceSDKCore.a;
+			remoteRef = 82D0ABCC1C49A7550081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABE21C49A7710081F833 /* CocoaLumberjack.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjack.framework;
+			remoteRef = 82D0ABE11C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABE41C49A7710081F833 /* CocoaLumberjackSwift.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjackSwift.framework;
+			remoteRef = 82D0ABE31C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABE61C49A7710081F833 /* CocoaLumberjack.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjack.framework;
+			remoteRef = 82D0ABE51C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABE81C49A7710081F833 /* CocoaLumberjackSwift.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjackSwift.framework;
+			remoteRef = 82D0ABE71C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABEA1C49A7710081F833 /* libCocoaLumberjack.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libCocoaLumberjack.a;
+			remoteRef = 82D0ABE91C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABEC1C49A7710081F833 /* CocoaLumberjack.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjack.framework;
+			remoteRef = 82D0ABEB1C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABEE1C49A7710081F833 /* CocoaLumberjackSwift.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjackSwift.framework;
+			remoteRef = 82D0ABED1C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABF01C49A7710081F833 /* CocoaLumberjack.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjack.framework;
+			remoteRef = 82D0ABEF1C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABF21C49A7710081F833 /* CocoaLumberjackSwift.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CocoaLumberjackSwift.framework;
+			remoteRef = 82D0ABF11C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABF41C49A7710081F833 /* FmwkTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = FmwkTest.app;
+			remoteRef = 82D0ABF31C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABF61C49A7710081F833 /* SwiftTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = SwiftTest.app;
+			remoteRef = 82D0ABF51C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABF81C49A7710081F833 /* iOSSwiftTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = iOSSwiftTest.app;
+			remoteRef = 82D0ABF71C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABFA1C49A7710081F833 /* watchOSSwiftTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = watchOSSwiftTest.app;
+			remoteRef = 82D0ABF91C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABFC1C49A7710081F833 /* watchOSSwiftTest Extension.appex */ = {
+			isa = PBXReferenceProxy;
+			fileType = "wrapper.app-extension";
+			path = "watchOSSwiftTest Extension.appex";
+			remoteRef = 82D0ABFB1C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0ABFE1C49A7710081F833 /* tvOSSwiftTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = tvOSSwiftTest.app;
+			remoteRef = 82D0ABFD1C49A7710081F833 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		82D0AC001C49A7710081F833 /* iOSLibStaticTest.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = iOSLibStaticTest.app;
+			remoteRef = 82D0ABFF1C49A7710081F833 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -393,6 +1006,36 @@
 			isa = PBXTargetDependency;
 			name = SmartSync;
 			targetProxy = 829DA2601C1260A50040F5F1 /* PBXContainerItemProxy */;
+		};
+		82D0AC041C49A7A10081F833 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "CocoaLumberjack-iOS";
+			targetProxy = 82D0AC031C49A7A10081F833 /* PBXContainerItemProxy */;
+		};
+		82D0AC091C49A7BE0081F833 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SalesforceSDKCore;
+			targetProxy = 82D0AC081C49A7BE0081F833 /* PBXContainerItemProxy */;
+		};
+		82D0AC0D1C49A7D10081F833 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SalesforceNetwork;
+			targetProxy = 82D0AC0C1C49A7D10081F833 /* PBXContainerItemProxy */;
+		};
+		82D0AC111C49A7E10081F833 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SalesforceRestAPI;
+			targetProxy = 82D0AC101C49A7E10081F833 /* PBXContainerItemProxy */;
+		};
+		82D0AC151C49A7F60081F833 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SmartStore;
+			targetProxy = 82D0AC141C49A7F60081F833 /* PBXContainerItemProxy */;
+		};
+		82D0AC191C49A8120081F833 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = SmartSync;
+			targetProxy = 82D0AC181C49A8120081F833 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -500,10 +1143,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CODE_SIGN_RESOURCE_RULES_PATH = "$(SDKROOT)/ResourceRules.plist";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SmartSyncExplorer/SmartSyncExplorer-Prefix.pch";
 				INFOPLIST_FILE = "SmartSyncExplorer/SmartSyncExplorer-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.salesforce.mobilesdk.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -516,10 +1159,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
-				CODE_SIGN_RESOURCE_RULES_PATH = "$(SDKROOT)/ResourceRules.plist";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SmartSyncExplorer/SmartSyncExplorer-Prefix.pch";
 				INFOPLIST_FILE = "SmartSyncExplorer/SmartSyncExplorer-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.salesforce.mobilesdk.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		820C8B1F19E6081C00E9BE5C /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 820C8B1E19E6081C00E9BE5C /* ImageIO.framework */; };
 		820C8B2319E6088400E9BE5C /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 820C8B2219E6088400E9BE5C /* MessageUI.framework */; };
 		820C8B2719E6091100E9BE5C /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 820C8B2619E6091100E9BE5C /* SystemConfiguration.framework */; };
-		820C8B2F19E6096800E9BE5C /* libsqlcipher.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 820C8B2E19E6096800E9BE5C /* libsqlcipher.a */; };
 		820C8B3219E60BDE00E9BE5C /* ContactListViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 820C8B3119E60BDE00E9BE5C /* ContactListViewController.m */; };
 		820C8B3E19E71A3800E9BE5C /* SObjectDataSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 820C8B3D19E71A3800E9BE5C /* SObjectDataSpec.m */; };
 		820C8B4119E71C3F00E9BE5C /* ContactSObjectDataSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 820C8B4019E71C3F00E9BE5C /* ContactSObjectDataSpec.m */; };
@@ -376,7 +375,6 @@
 		820C8B1E19E6081C00E9BE5C /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
 		820C8B2219E6088400E9BE5C /* MessageUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		820C8B2619E6091100E9BE5C /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
-		820C8B2E19E6096800E9BE5C /* libsqlcipher.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libsqlcipher.a; path = ../../../external/ThirdPartyDependencies/sqlcipher/libsqlcipher.a; sourceTree = "<group>"; };
 		820C8B3019E60BDE00E9BE5C /* ContactListViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContactListViewController.h; sourceTree = "<group>"; };
 		820C8B3119E60BDE00E9BE5C /* ContactListViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ContactListViewController.m; sourceTree = "<group>"; };
 		820C8B3C19E71A3800E9BE5C /* SObjectDataSpec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SObjectDataSpec.h; path = Data/SObjectDataSpec.h; sourceTree = "<group>"; };
@@ -420,7 +418,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				82D0AC0A1C49A7D10081F833 /* SalesforceNetwork.framework in Frameworks */,
-				820C8B2F19E6096800E9BE5C /* libsqlcipher.a in Frameworks */,
 				CE6AB39B1C10C4F50012125E /* libz.tbd in Frameworks */,
 				82D0AC011C49A7A10081F833 /* CocoaLumberjack.framework in Frameworks */,
 				827C631719E6018C00027484 /* CoreGraphics.framework in Frameworks */,
@@ -526,7 +523,6 @@
 				82D0ABCE1C49A7710081F833 /* Lumberjack.xcodeproj */,
 				CE6AB39A1C10C4F50012125E /* libz.tbd */,
 				8258804A1AA4222A000C551E /* MobileCoreServices.framework */,
-				820C8B2E19E6096800E9BE5C /* libsqlcipher.a */,
 				827C631419E6018C00027484 /* Foundation.framework */,
 				820C8B1E19E6081C00E9BE5C /* ImageIO.framework */,
 				820C8B2219E6088400E9BE5C /* MessageUI.framework */,
@@ -585,7 +581,7 @@
 			children = (
 				82D0ABA81C49A7290081F833 /* SalesforceRestAPI.framework */,
 				82D0ABAA1C49A7290081F833 /* SalesforceRestAPITestApp.app */,
-				82D0ABAC1C49A7290081F833 /* SalesforceRestAPITestAppTests.xctest */,
+				82D0ABAC1C49A7290081F833 /* SalesforceRestAPITests.xctest */,
 				82D0ABAE1C49A7290081F833 /* libSalesforceRestAPI.a */,
 			);
 			name = Products;
@@ -787,7 +783,7 @@
 			remoteRef = 82D0ABA91C49A7290081F833 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		82D0ABAC1C49A7290081F833 /* SalesforceRestAPITestAppTests.xctest */ = {
+		82D0ABAC1C49A7290081F833 /* SalesforceRestAPITests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = SalesforceRestAPITests.xctest;


### PR DESCRIPTION
To summarize the awful project file updates:

- App targets need to embed the (non-system) frameworks they depend on, to form a proper app bundle, i.e. one that can be installed and run on a device.
- In order to embed a framework in an app bundle, it must be directly present—either as an Xcode project target or compiled framework library—in the app's project.

This necessitated flattening the Xcode project references for the sample app targets, which is the reason for all the flux in the project files.

Hybrid apps to follow sometime after this PR.