### PR TITLE
Fixing an issue with the recent moving of some header files

### DIFF
--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/RestAPIExplorerViewController.m
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/RestAPIExplorerViewController.m
@@ -34,6 +34,7 @@
 #import <SalesforceSDKCore/SFSecurityLockout.h>
 #import <SalesforceSDKCore/SFAuthenticationManager.h>
 #import <SalesforceSDKCore/SFDefaultUserManagementViewController.h>
+#import <SalesforceSDKCore/SFIdentityData.h>
 
 @interface RestAPIExplorerViewController ()
 


### PR DESCRIPTION
RestAPIExplorer was relying on an indirect import.