### PR TITLE
Should handle nil response without crashing

### DIFF
--- a/libs/SalesforceReact/SalesforceReact/Classes/SFNetReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFNetReactBridge.m
@@ -62,7 +62,7 @@ RCT_EXPORT_METHOD(sendRequest:(NSDictionary *)argsDict callback:(RCTResponseSend
                                           callback(@[RCTMakeError(@"sendRequest failed", e, nil)]);
                                       }
                                   completeBlock:^(id response) {
-                                      callback(@[[NSNull null], response]);
+                                      callback(@[[NSNull null], response == nil ? [NSNull null] : response]);
                                   }
      ];
 }


### PR DESCRIPTION
Response can be nil (e.g. in the case of a delete)

Fix for https://github.com/forcedotcom/SmartSyncExplorerReactNative/issues/29