### PR TITLE
Removing questionable cleansing methods from SalesforceSDKCore

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSArray+SFAdditions.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSArray+SFAdditions.h
@@ -47,9 +47,4 @@
  */
 - (NSArray*)filteredArrayExcludingValue:(id)value forKeyPath:(NSString*)key;
 
-/**
- Returns an array cleansed of any nil objects
- */
-- (NSArray *)cleansedArray;
-
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSArray+SFAdditions.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSArray+SFAdditions.m
@@ -50,25 +50,4 @@
     }]];
 }
 
-- (NSArray *)cleansedArray {
-    if ([self containsObject:nil]) {
-        NSMutableArray *cleansedArray = [NSMutableArray array];
-        for (id arrayObject in self) {
-            if (nil != arrayObject) {
-                if ([arrayObject isKindOfClass:[NSArray class]]) {
-                    NSArray *newArray = [self cleansedArray];
-                    [cleansedArray addObject:newArray];
-                } else {
-                    [cleansedArray addObject:arrayObject];
-                }
-            } else {
-                [self log:SFLogLevelWarning format:@"nil object found in array"];
-            }
-        }
-        return cleansedArray;
-    }
-    
-    return self;
-}
-
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSDictionary+SFAdditions.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSDictionary+SFAdditions.h
@@ -42,12 +42,6 @@
  */
 - (id)nonNullObjectForKey:(id)key;
 
-/**
- Cleans the dictionary of any "<nil>" "<null>" or "NSNull" values.
- @return A new dictionary with nil/null/NSNull key/values removed
- */
-- (id)cleansedDictionary;
-
 - (NSString*)jsonString;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSDictionary+SFAdditions.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSDictionary+SFAdditions.m
@@ -63,30 +63,6 @@
     return result;
 }
 
-- (id)cleansedDictionary {
-    NSArray *allKeys = [self allKeys];
-    NSMutableDictionary *updatedDict = [NSMutableDictionary dictionaryWithCapacity:allKeys.count];
-    
-    for (NSString *key in allKeys) {
-        id value = [self nonNullObjectForKey:key];
-        if ([value isKindOfClass:[NSDictionary class]]) {
-            value = [(NSDictionary *)value cleansedDictionary];
-        }
-        if ([value isKindOfClass:[NSArray class]]) {
-            // Log a warning if we find a nil object
-            if ([value containsObject:nil]) {
-                [self log:SFLogLevelWarning format:@"array in cleansedDictionary contains nill object for key: %@", key];
-            }
-            
-            value = [(NSArray *)value cleansedArray];
-        }
-        if (value) {
-            [updatedDict setValue:value forKey:key];
-        }
-    }
-    return updatedDict;
-}
-
 - (NSString*)jsonString {
     NSError *error = nil;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:self


### PR DESCRIPTION
The `cleansedArray` method does nothing.  The `cleansedDictionary` method isn't comprehensive in its data structure considerations, which seems like it would do more harm than good.  Neither method is used in the SDK.