### PR TITLE
Swift support, use NS_ENUM since this enum is not intended for options

### DIFF
--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.h
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.h
@@ -31,14 +31,14 @@
 /**
  * HTTP methods for requests
  */
-typedef enum SFRestMethod {
+typedef NS_ENUM(NSInteger, SFRestMethod) {
     SFRestMethodGET = 0,
     SFRestMethodPOST,
     SFRestMethodPUT,
     SFRestMethodDELETE,
     SFRestMethodHEAD,
     SFRestMethodPATCH,
-} SFRestMethod;
+};
 
 
 /**


### PR DESCRIPTION
contribution to #1218