### PR TITLE
Better swift support per #1218

### DIFF
--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+QueryBuilder.h
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+QueryBuilder.h
@@ -49,6 +49,8 @@
 #import <Foundation/Foundation.h>
 #import "SFRestAPI.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 // Reserved characters that must be escaped in SOSL search terms
 extern NSString * const kSOSLReservedCharacters;
 extern NSString * const kSOSLEscapeCharacter;
@@ -72,9 +74,10 @@ extern NSInteger const kMaxSOSLSearchLimit;
  * @param objectScope - nil to search all searchable objects, or a dictionary where each key is an sObject name
  * and each value is a string with the fieldlist and (optional) where, order by, and limit clause for that object.
  * or NSNull to not specify any fields/clauses for that object
+ * @returns query or nil if a query could not be generated
  */
-+ (NSString *) SOSLSearchWithSearchTerm:(NSString *)term 
-                            objectScope:(NSDictionary *)objectScope;
++ (nullable NSString *) SOSLSearchWithSearchTerm:(NSString *)term
+                            objectScope:(nullable NSDictionary<NSString*, NSString*> *)objectScope;
 
 /**
  * Generate a SOSL search.
@@ -84,10 +87,11 @@ extern NSInteger const kMaxSOSLSearchLimit;
  * and each value is a string with the fieldlist and (optional) where, order by, and limit clause for that object.
  * or NSNull to not specify any fields/clauses for that object
  * @param limit - overall search limit (max 200)
+ * @returns query or nil if a query could not be generated
  */
-+ (NSString *) SOSLSearchWithSearchTerm:(NSString *)term 
-                             fieldScope:(NSString *)fieldScope 
-                            objectScope:(NSDictionary *)objectScope 
++ (nullable NSString *) SOSLSearchWithSearchTerm:(NSString *)term
+                             fieldScope:(nullable NSString *)fieldScope
+                            objectScope:(nullable NSDictionary<NSString*, NSString*> *)objectScope
                                   limit:(NSInteger)limit;
 
 /**
@@ -96,10 +100,11 @@ extern NSInteger const kMaxSOSLSearchLimit;
  * @param sObject - object to query
  * @param where - nil OR where clause
  * @param limit - limit count, or 0 for no limit (for use with query locators)
+ * @returns query or nil if a query could not be generated
  */
-+ (NSString *) SOQLQueryWithFields:(NSArray *)fields 
++ (nullable NSString *) SOQLQueryWithFields:(NSArray<NSString*> *)fields
                            sObject:(NSString *)sObject 
-                             whereClause:(NSString *)whereClause
+                             whereClause:(nullable NSString *)whereClause
                              limit:(NSInteger)limit;
 
 /**
@@ -111,13 +116,16 @@ extern NSInteger const kMaxSOSLSearchLimit;
  * @param having - nil OR having clause
  * @param orderBy - nil OR NSArray of strings, each string is an individual order by clause
  * @param limit - limit count, or 0 for no limit (for use with query locators)
+ * @returns query or nil if a query could not be generated
  */
-+ (NSString *) SOQLQueryWithFields:(NSArray *)fields 
++ (nullable NSString *) SOQLQueryWithFields:(NSArray<NSString*> *)fields
                            sObject:(NSString *)sObject 
-                             whereClause:(NSString *)whereClause
-                           groupBy:(NSArray *)groupBy 
-                            having:(NSString *)having
-                           orderBy:(NSArray *)orderBy 
+                             whereClause:(nullable NSString *)whereClause
+                           groupBy:(nullable NSArray<NSString*> *)groupBy
+                            having:(nullable NSString *)having
+                           orderBy:(nullable NSArray<NSString*> *)orderBy
                              limit:(NSInteger)limit;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.h
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(NSInteger, SFRestMethod) {
     SFRestMethodPATCH,
 };
 
+NS_ASSUME_NONNULL_BEGIN
 
 /**
  The default REST endpoint used by requests.
@@ -112,13 +113,13 @@ extern NSString * const kSFDefaultRestEndpoint;
  * The query parameters of the request (could be nil).
  * Note that URL encoding of the parameters will automatically happen when the request is sent.
  */
-@property (nonatomic, strong) NSDictionary *queryParams;
+@property (nullable, nonatomic, strong) NSDictionary<NSString*, NSString*> *queryParams;
 
 /**
  * Dictionary of any custom HTTP headers you wish to add to your request.  You can also use
  * `setHeaderValue:forHeaderName:` to add headers to this property.
  */
-@property (nonatomic, strong) NSDictionary *customHeaders;
+@property (nonatomic, strong) NSDictionary<NSString*, NSString*> *customHeaders;
 
 /**
  * Underlying SFRestAPISalesforceAction through which the network call is carried out
@@ -128,7 +129,7 @@ extern NSString * const kSFDefaultRestEndpoint;
 /**
  * The delegate for this request. Notified of request status.
  */
-@property (nonatomic, weak) id<SFRestDelegate> delegate;
+@property (nullable, nonatomic, weak) id<SFRestDelegate> delegate;
 
 
 /**
@@ -161,7 +162,7 @@ extern NSString * const kSFDefaultRestEndpoint;
  * from the collection of headers.
  * @param name The name of the HTTP header to set.
  */
-- (void)setHeaderValue:(NSString *)value forHeaderName:(NSString *)name;
+- (void)setHeaderValue:(nullable NSString *)value forHeaderName:(NSString *)name;
 
 /**
  * Cancels this request if it is running
@@ -215,6 +216,8 @@ extern NSString * const kSFDefaultRestEndpoint;
  * @param path the request path
  * @param queryParams the parameters of the request (could be nil)
  */
-+ (instancetype)requestWithMethod:(SFRestMethod)method path:(NSString *)path queryParams:(NSDictionary *)queryParams;
++ (instancetype)requestWithMethod:(SFRestMethod)method path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, NSString*> *)queryParams;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Better swift support per #1218

* Set nullability to reduce the number of optional checks or ensure that swift programmers have to check for optionals in several cases where `nil` could result
* Use Objective-C lightweight generics to restrict the types that a swift programmer can pass to the API
* Update documentation to reflect nullability on return values