### PR TITLE
Making up for xcodebuild's deficiencies

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1,7 +1,9 @@
 <project name="SalesforceMobileSDK-iOS" basedir="." default="all">
     <property name="artifactsDir" location="artifacts" />
     <property name="deviceBuildName" value="iphoneos" />
+    <property name="deviceCompileArguments" value="PLATFORM_NAME=iphoneos" />
     <property name="simulatorBuildName" value="iphonesimulator" />
+    <property name="simulatorCompileArguments" value="PLATFORM_NAME=iphonesimulator" />
     <property name="thirdPartyLibDir" location="../external/ThirdPartyDependencies" />
     <property name="sharedResourcesDir" location="../shared/resources" />
     <property name="sdkResourcesBundleName" value="SalesforceSDKResources.bundle" />
@@ -220,6 +222,7 @@
             <param name="sdk" value="${deviceBuildName}" />
             <param name="buildOutputDir" value="${baseBuildOutputDir}/${deviceBuildName}" />
             <param name="action" value="build" />
+            <param name="additionalCompileArguments" value="${deviceCompileArguments}" />
         </antcall>
 
         <!-- Simulator -->
@@ -227,6 +230,7 @@
             <param name="sdk" value="${simulatorBuildName}" />
             <param name="buildOutputDir" value="${baseBuildOutputDir}/${simulatorBuildName}" />
             <param name="action" value="build" />
+            <param name="additionalCompileArguments" value="${simulatorCompileArguments}" />
         </antcall>
     </target>
 
@@ -277,6 +281,7 @@
             <param name="sdk" value="${deviceBuildName}" />
             <param name="buildOutputDir" value="${baseBuildOutputDir}/${deviceBuildName}" />
             <param name="action" value="clean" />
+            <param name="additionalCompileArguments" value="${deviceCompileArguments}" />
         </antcall>
         
         <!-- Simulator -->
@@ -284,6 +289,7 @@
             <param name="sdk" value="${simulatorBuildName}" />
             <param name="buildOutputDir" value="${baseBuildOutputDir}/${simulatorBuildName}" />
             <param name="action" value="clean" />
+            <param name="additionalCompileArguments" value="${simulatorCompileArguments}" />
         </antcall>
         
         <delete file="${baseBuildOutputDir}/${deviceBuildName}/${libName}" />
@@ -314,6 +320,7 @@
             <arg value="${action}" />
             <arg value="CONFIGURATION_BUILD_DIR=${buildOutputDir}" />
             <arg value="ONLY_ACTIVE_ARCH=NO" />
+            <arg value="${additionalCompileArguments}" />
         </exec>
     </target>
     


### PR DESCRIPTION
In Xcode 7.2 and later, xcodebuild will not build simulator builds without a further hint as to what the platform is that it's building against.  This PR adds the hint.  NB: I add it for device too, just so that there's not wonky conditional logic in the ant script.