### PR TITLE
Making native-ish app template schemes shared

### DIFF
--- a/build/app_template_files/__NativeSwiftTemplateAppName__/__NativeSwiftTemplateAppName__.xcodeproj/xcshareddata/xcschemes/__NativeSwiftTemplateAppName__.xcscheme
+++ b/build/app_template_files/__NativeSwiftTemplateAppName__/__NativeSwiftTemplateAppName__.xcodeproj/xcshareddata/xcschemes/__NativeSwiftTemplateAppName__.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4FD6C4731B754AF1002F9F90"
+               BuildableName = "__NativeSwiftTemplateAppName__.app"
+               BlueprintName = "__NativeSwiftTemplateAppName__"
+               ReferencedContainer = "container:__NativeSwiftTemplateAppName__.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4FD6C4731B754AF1002F9F90"
+            BuildableName = "__NativeSwiftTemplateAppName__.app"
+            BlueprintName = "__NativeSwiftTemplateAppName__"
+            ReferencedContainer = "container:__NativeSwiftTemplateAppName__.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4FD6C4731B754AF1002F9F90"
+            BuildableName = "__NativeSwiftTemplateAppName__.app"
+            BlueprintName = "__NativeSwiftTemplateAppName__"
+            ReferencedContainer = "container:__NativeSwiftTemplateAppName__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4FD6C4731B754AF1002F9F90"
+            BuildableName = "__NativeSwiftTemplateAppName__.app"
+            BlueprintName = "__NativeSwiftTemplateAppName__"
+            ReferencedContainer = "container:__NativeSwiftTemplateAppName__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/build/app_template_files/__NativeTemplateAppName__/__NativeTemplateAppName__.xcodeproj/xcshareddata/xcschemes/__NativeTemplateAppName__.xcscheme
+++ b/build/app_template_files/__NativeTemplateAppName__/__NativeTemplateAppName__.xcodeproj/xcshareddata/xcschemes/__NativeTemplateAppName__.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4F8D5E9C1B6C0568005E64D4"
+               BuildableName = "__NativeTemplateAppName__.app"
+               BlueprintName = "__NativeTemplateAppName__"
+               ReferencedContainer = "container:__NativeTemplateAppName__.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4F8D5E9C1B6C0568005E64D4"
+            BuildableName = "__NativeTemplateAppName__.app"
+            BlueprintName = "__NativeTemplateAppName__"
+            ReferencedContainer = "container:__NativeTemplateAppName__.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4F8D5E9C1B6C0568005E64D4"
+            BuildableName = "__NativeTemplateAppName__.app"
+            BlueprintName = "__NativeTemplateAppName__"
+            ReferencedContainer = "container:__NativeTemplateAppName__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4F8D5E9C1B6C0568005E64D4"
+            BuildableName = "__NativeTemplateAppName__.app"
+            BlueprintName = "__NativeTemplateAppName__"
+            ReferencedContainer = "container:__NativeTemplateAppName__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/build/app_template_files/__ReactNativeTemplateAppName__/__ReactNativeTemplateAppName__.xcodeproj/project.pbxproj
+++ b/build/app_template_files/__ReactNativeTemplateAppName__/__ReactNativeTemplateAppName__.xcodeproj/project.pbxproj
@@ -308,7 +308,6 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = __ReactNativeTemplateAppName__/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "__CompanyIdentifier__.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -321,7 +320,6 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				INFOPLIST_FILE = __ReactNativeTemplateAppName__/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "__CompanyIdentifier__.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/build/app_template_files/__ReactNativeTemplateAppName__/__ReactNativeTemplateAppName__.xcodeproj/xcshareddata/xcschemes/__ReactNativeTemplateAppName__.xcscheme
+++ b/build/app_template_files/__ReactNativeTemplateAppName__/__ReactNativeTemplateAppName__.xcodeproj/xcshareddata/xcschemes/__ReactNativeTemplateAppName__.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4F8D5E9C1B6C0568005E64D4"
+               BuildableName = "__ReactNativeTemplateAppName__.app"
+               BlueprintName = "__ReactNativeTemplateAppName__"
+               ReferencedContainer = "container:__ReactNativeTemplateAppName__.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4F8D5E9C1B6C0568005E64D4"
+            BuildableName = "__ReactNativeTemplateAppName__.app"
+            BlueprintName = "__ReactNativeTemplateAppName__"
+            ReferencedContainer = "container:__ReactNativeTemplateAppName__.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4F8D5E9C1B6C0568005E64D4"
+            BuildableName = "__ReactNativeTemplateAppName__.app"
+            BlueprintName = "__ReactNativeTemplateAppName__"
+            ReferencedContainer = "container:__ReactNativeTemplateAppName__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4F8D5E9C1B6C0568005E64D4"
+            BuildableName = "__ReactNativeTemplateAppName__.app"
+            BlueprintName = "__ReactNativeTemplateAppName__"
+            ReferencedContainer = "container:__ReactNativeTemplateAppName__.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/build/app_template_files/__ReactNativeTemplateAppName__/__ReactNativeTemplateAppName__/Info.plist
+++ b/build/app_template_files/__ReactNativeTemplateAppName__/__ReactNativeTemplateAppName__/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleIcons~ipad</key>
 	<dict/>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>__CompanyIdentifier__.${PRODUCT_NAME:rfc1034identifier}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/build/app_template_files/createApp.sh
+++ b/build/app_template_files/createApp.sh
@@ -223,6 +223,7 @@ function replaceTokens()
   inputPrefixFile="${appNameToken}/${appNameToken}/Prefix.pch"
   inputInfoFile="${appNameToken}/${appNameToken}/Info.plist"
   inputProjectFile="${appNameToken}/${appNameToken}.xcodeproj/project.pbxproj"
+  inputSharedSchemeFile="${appNameToken}/${appNameToken}.xcodeproj/xcshareddata/xcschemes/${appNameToken}.xcscheme"
 
 
   # Make the output folder.
@@ -252,6 +253,7 @@ function replaceTokens()
   # App name
   tokenSubstituteInFile "${inputPodfile}" "${appNameToken}" "${OPT_APP_NAME}"
   tokenSubstituteInFile "${inputProjectFile}" "${appNameToken}" "${OPT_APP_NAME}"
+  tokenSubstituteInFile "${inputSharedSchemeFile}" "${appNameToken}" "${OPT_APP_NAME}"
   tokenSubstituteInFile "${inputPrefixFile}" "${appNameToken}" "${OPT_APP_NAME}"
   tokenSubstituteInFile "${inputIndexiosFile}" "${appNameToken}" "${OPT_APP_NAME}"
   tokenSubstituteInFile "${inputConnectedAppFile}" "${appNameToken}" "${OPT_APP_NAME}"
@@ -271,6 +273,7 @@ function replaceTokens()
   
   # Rename files, move to destination folder.
   echoColor $TERM_COLOR_YELLOW "Creating app in ${outputFolderAbsPath}/${OPT_APP_NAME}"
+  mv "${appNameToken}/${appNameToken}.xcodeproj/xcshareddata/xcschemes/${appNameToken}.xcscheme" "${appNameToken}/${appNameToken}.xcodeproj/xcshareddata/xcschemes/${OPT_APP_NAME}.xcscheme"
   mv "${appNameToken}/${appNameToken}.xcodeproj" "${appNameToken}/${OPT_APP_NAME}.xcodeproj"
   mv "${appNameToken}/${appNameToken}" "${appNameToken}/${OPT_APP_NAME}"
   mv "${appNameToken}" "${outputFolderAbsPath}/${OPT_APP_NAME}"


### PR DESCRIPTION
I found a way for the test script to be able to build the app schemes created from `forceios`: make the schemes shared.  Shared schemes will be recognized by `xcodebuild` without having to open the CocoaPods-created workspace first.