### PR TITLE
Occasional crash during logout or user switching

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFSalesforceAction.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFSalesforceAction.m
@@ -61,6 +61,7 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
 }
 
 - (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
     self.enqueuedNetwork = nil;
 }
 


### PR DESCRIPTION
Fixing exc_bad_access on post notification
Went looking for objects doing addObserver without doing removeObserver - and found at least one
http://stackoverflow.com/questions/15995138/nsnotificationcenter-postnotificationname-exec-badaccess