### PR TITLE
more swift support

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -36,6 +36,7 @@ typedef NS_ENUM(NSUInteger, SFAppType) {
     kSFAppTypeReactNative
 };
 
+NS_ASSUME_NONNULL_BEGIN
 
 @protocol SalesforceSDKManagerDelegate <NSObject>
 
@@ -78,9 +79,9 @@ typedef NS_ENUM(NSUInteger, SFAppType) {
 /**
  @return The singleton instance of the SDK Manager.
  */
-+ (instancetype)sharedManager;
++ (nonnull instancetype)sharedManager;
 
-@property (nonatomic, strong) SFSDKAppConfig *appConfig;
+@property (nonatomic, strong, nullable) SFSDKAppConfig *appConfig;
 
 /**
  Whether or not the SDK is currently in the middle of a launch process.
@@ -96,17 +97,17 @@ typedef NS_ENUM(NSUInteger, SFAppType) {
 /**
  The Connected App ID configured for this application.
  */
-@property (nonatomic, copy) NSString *connectedAppId;
+@property (nonatomic, copy, nullable) NSString *connectedAppId;
 
 /**
  The Connected App Callback URI configured for this application.
  */
-@property (nonatomic, copy) NSString *connectedAppCallbackUri;
+@property (nonatomic, copy, nullable) NSString *connectedAppCallbackUri;
 
 /**
  The OAuth scopes configured for this application.
  */
-@property (nonatomic, strong) NSArray *authScopes;
+@property (nonatomic, strong, nullable) NSArray<NSString*> *authScopes;
 
 /**
  Whether or not to attempt authentication as part of the launch process.  Default
@@ -117,27 +118,27 @@ typedef NS_ENUM(NSUInteger, SFAppType) {
 /**
  The configured post launch action block to execute when launch completes.
  */
-@property (nonatomic, copy) SFSDKPostLaunchCallbackBlock postLaunchAction;
+@property (nonatomic, copy, nullable) SFSDKPostLaunchCallbackBlock postLaunchAction;
 
 /**
  The configured launch error action block to execute in the event of an error during launch.
  */
-@property (nonatomic, copy) SFSDKLaunchErrorCallbackBlock launchErrorAction;
+@property (nonatomic, copy, nullable) SFSDKLaunchErrorCallbackBlock launchErrorAction;
 
 /**
  The post logout action block to execute after the current user has been logged out.
  */
-@property (nonatomic, copy) SFSDKLogoutCallbackBlock postLogoutAction;
+@property (nonatomic, copy, nullable) SFSDKLogoutCallbackBlock postLogoutAction;
 
 /**
  The switch user action block to execute when switching from one user to another.
  */
-@property (nonatomic, copy) SFSDKSwitchUserCallbackBlock switchUserAction;
+@property (nonatomic, copy, nullable) SFSDKSwitchUserCallbackBlock switchUserAction;
 
 /**
  The block to execute after the app has entered the foreground.
  */
-@property (nonatomic, copy) SFSDKAppForegroundCallbackBlock postAppForegroundAction;
+@property (nonatomic, copy, nullable) SFSDKAppForegroundCallbackBlock postAppForegroundAction;
 
 /**
  Whether or not to use a security snapshot view when the app is backgrounded, to prevent
@@ -158,7 +159,7 @@ typedef NS_ENUM(NSUInteger, SFAppType) {
          [SFPasscodeProviderManager addPasscodeProvider:myProvider];
          [SalesforceSDKManager setPreferredPasscodeProvider:myProviderName];
  */
-@property (nonatomic, copy) NSString *preferredPasscodeProvider;
+@property (nonatomic, nullable, copy) NSString *preferredPasscodeProvider;
 
 /**
  Gets or sets a block that will return a user agent string, created with an optional qualifier.
@@ -194,3 +195,5 @@ typedef NS_ENUM(NSUInteger, SFAppType) {
 + (NSString *)launchActionsStringRepresentation:(SFSDKLaunchAction)launchActions;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -35,7 +35,7 @@
 @class SFAuthErrorHandlerList;
 @class SFLoginHostUpdateResult;
 @class SFLoginViewController;
-
+NS_ASSUME_NONNULL_BEGIN
 /**
  Callback block definition for OAuth completion callback.
  */
@@ -353,7 +353,7 @@ extern NSString * const kSFAuthenticationManagerFinishedNotification;
  @param cookieNames The names of the cookies to remove.
  @param domainNames The names of the domains where the cookies are set.
  */
-+ (void)removeCookies:(NSArray *)cookieNames fromDomains:(NSArray *)domainNames;
++ (void)removeCookies:(NSArray<NSString*> *)cookieNames fromDomains:(NSArray<NSString*> *)domainNames;
 
 /**
  Remove all cookies from the cookie store.
@@ -367,3 +367,5 @@ extern NSString * const kSFAuthenticationManagerFinishedNotification;
 + (void)addSidCookieForDomain:(NSString*)domain;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SalesforceSDKCoreDefines.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SalesforceSDKCoreDefines.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 @class SFUserAccount;
-
+NS_ASSUME_NONNULL_BEGIN
 // Errors
 extern NSString * const kSalesforceSDKManagerErrorDomain;
 extern NSString * const kSalesforceSDKManagerErrorDetailsKey;
@@ -19,13 +19,13 @@ enum {
 };
 
 // Launch actions taken
-typedef enum {
+typedef NS_OPTIONS(NSInteger, SFSDKLaunchAction) {
     SFSDKLaunchActionNone                 = 0,
     SFSDKLaunchActionAuthenticated        = 1 << 0,
     SFSDKLaunchActionAlreadyAuthenticated = 1 << 1,
     SFSDKLaunchActionAuthBypassed         = 1 << 2,
     SFSDKLaunchActionPasscodeVerified     = 1 << 3
-} SFSDKLaunchAction;
+};
 
 /**
  Callback block to implement for post launch actions.
@@ -55,4 +55,6 @@ typedef void (^SFSDKAppForegroundCallbackBlock)(void);
 /**
  Block to return a user agent string, with an optional qualifier.
  */
-typedef NSString* (^SFSDKUserAgentCreationBlock)(NSString *qualifier);
+typedef NSString*_Nonnull (^SFSDKUserAgentCreationBlock)(NSString *qualifier);
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
[implicit unwrapping should be avoided at all costs](https://developer.apple.com/swift/blog/?id=25) as it can introduce dangerous bugs. Default to nullable unless provable otherwise.

Concerns:
==========

* Several things I've marked as `nullable` probably shouldn't be but are because the implementation can return `nil` in pre `launch()` states (IMO calling these then without first assigning to them should be undefined behavior or should fail explicitly).
* There should probably be a tracking issue for all of the implicit unwrapping issues
* Changing nullability is technically a breaking change for swift users