### PR TITLE
Swift Support and nullability

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -183,12 +183,12 @@ extern NSString * const kSFAuthenticationManagerFinishedNotification;
 /**
  Alert view for displaying auth-related status messages.
  */
-@property (nonatomic, strong) UIAlertController *statusAlert;
+@property (nonatomic, strong, nullable) UIAlertController *statusAlert;
 
 /**
  The view controller used to present the authentication dialog.
  */
-@property (nonatomic, strong) SFLoginViewController *authViewController;
+@property (nonatomic, strong, nullable) SFLoginViewController *authViewController;
 
 /**
  Whether or not the application is currently in the process of authenticating.
@@ -300,7 +300,7 @@ extern NSString * const kSFAuthenticationManagerFinishedNotification;
  */
 - (BOOL)loginWithCompletion:(SFOAuthFlowSuccessCallbackBlock)completionBlock
                     failure:(SFOAuthFlowFailureCallbackBlock)failureBlock
-                    account:(SFUserAccount *)account;
+                    account:(nullable SFUserAccount *)account;
 
 /**
  Forces a logout from the current account, redirecting the user to the login process.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
@@ -27,6 +27,8 @@
 
 #import "SFUserAccountConstants.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class SFCommunityData;
 @class SFUserAccountIdentity;
 @class SFIdentityData;
@@ -39,7 +41,7 @@
 
 /** The access scopes for this user
  */
-@property (nonatomic, copy) NSSet *accessScopes;
+@property (nonatomic, copy, nullable) NSSet<NSString*> *accessScopes;
 
 /**
  The unique identifier for this account.
@@ -62,7 +64,7 @@
 
 /** The user's email
  */
-@property (nonatomic, copy) NSString *email;
+@property (nonatomic, copy, nullable) NSString *email;
 
 /** The user's organization name
  */
@@ -81,7 +83,7 @@
  because this class doesn't fetch it from the server but
  only stores it locally on the disk.
  */
-@property (nonatomic, strong) UIImage *photo;
+@property (nonatomic, strong, nullable) UIImage *photo;
 
 /** The access restriction associated with this user
  */
@@ -89,11 +91,11 @@
 
 /** The current community id the user is logged in
  */
-@property (nonatomic, copy) NSString *communityId;
+@property (nonatomic, copy, nullable) NSString *communityId;
 
 /** The list of communities (as SFCommunityData item)
  */
-@property (nonatomic, copy) NSArray *communities;
+@property (nonatomic, copy, nullable) NSArray<SFCommunityData *> *communities;
 
 /** Indicates whether or not the receiver represents a guest user account.
  */
@@ -146,11 +148,11 @@
  @communityId The id of the community
  @return The url of the API endpoint for that community
  */
-- (NSURL*)communityUrlWithId:(NSString *)communityId;
+- (nullable NSURL*)communityUrlWithId:(NSString *)communityId;
 
 /** Returns the community dictionary for the specified ID
  */
-- (SFCommunityData*)communityWithId:(NSString*)communityId;
+- (nullable SFCommunityData*)communityWithId:(NSString*)communityId;
 
 /** Set object in customData dictionary
  
@@ -168,7 +170,7 @@
 /** Retrieve the object stored in the custom data dictionary
  @return The object for a particular key
  */
-- (id)customDataObjectForKey:(id)key;
+- (nullable id)customDataObjectForKey:(id)key;
 
 /** Function that returns a key that uniquely identifies this user account for the
  given scope. Note that if you use SFUserAccountScopeGlobal,
@@ -178,6 +180,8 @@
  @scope The scope
  @return a key identifying this user account for the specified scope
  */
-NSString *SFKeyForUserAndScope(SFUserAccount *user, SFUserAccountScope scope);
+NSString *_Nullable SFKeyForUserAndScope(SFUserAccount * _Nullable user, SFUserAccountScope scope);
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -27,29 +27,30 @@
 #import "SFUserAccountIdentity.h"
 #import "SFUserAccountConstants.h"
 
+NS_ASSUME_NONNULL_BEGIN
 /** Notification sent when something has changed with the current user
  */
-extern NSString * const SFUserAccountManagerDidChangeCurrentUserNotification;
+FOUNDATION_EXTERN NSString * const SFUserAccountManagerDidChangeCurrentUserNotification;
 
 /** The key containing the type of change for the SFUserAccountManagerDidChangeCurrentUserNotification
  The value is a NSNumber that can be casted to the option SFUserAccountChange
  */
-extern NSString * const SFUserAccountManagerUserChangeKey;
+FOUNDATION_EXTERN NSString * const SFUserAccountManagerUserChangeKey;
 
 /**
  Identifies the notification for the login host changing in the app's settings.
  */
-extern NSString * const kSFLoginHostChangedNotification;
+FOUNDATION_EXTERN NSString * const kSFLoginHostChangedNotification;
 
 /**
  The key for the original host in a login host change notification.
  */
-extern NSString * const kSFLoginHostChangedNotificationOriginalHostKey;
+FOUNDATION_EXTERN NSString * const kSFLoginHostChangedNotificationOriginalHostKey;
 
 /**
  The key for the updated host in a login host change notification.
  */
-extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
+FOUNDATION_EXTERN NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
 
 @class SFUserAccountManager;
 
@@ -69,7 +70,7 @@ extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
  */
 - (void)userAccountManager:(SFUserAccountManager *)userAccountManager
         willSwitchFromUser:(SFUserAccount *)fromUser
-                    toUser:(SFUserAccount *)toUser;
+                    toUser:(nullable SFUserAccount *)toUser;
 
 /**
  Called after the user account manager switches from one user to another.
@@ -80,7 +81,7 @@ extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
  */
 - (void)userAccountManager:(SFUserAccountManager *)userAccountManager
          didSwitchFromUser:(SFUserAccount *)fromUser
-                    toUser:(SFUserAccount *)toUser;
+                    toUser:(nullable SFUserAccount *)toUser;
 
 @end
 
@@ -92,15 +93,15 @@ extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
 /** The current user account.  This property may be nil if the user
  has never logged in.
  */
-@property (nonatomic, strong) SFUserAccount *currentUser;
+@property (nonatomic, strong, nullable) SFUserAccount *currentUser;
 
 /** The user identity for the temporary user account.
  */
-@property (nonatomic, readonly) SFUserAccountIdentity *temporaryUserIdentity;
+@property (nonatomic, readonly, nullable) SFUserAccountIdentity *temporaryUserIdentity;
 
 /** The "temporary" account user.  Useful for determining whether there's a valid user context.
  */
-@property (nonatomic, readonly) SFUserAccount *temporaryUser;
+@property (nonatomic, readonly, nullable) SFUserAccount *temporaryUser;
 
 /** Returns YES if the application supports anonymous user, no otherwise.
  
@@ -119,7 +120,7 @@ extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
 
 /** Returns the anonymous user or nil if none exists
   */
-@property (nonatomic, strong, readonly) SFUserAccount *anonymousUser;
+@property (nonatomic, strong, readonly, nullable) SFUserAccount *anonymousUser;
 
 /** Returns YES if the current user is anonymous, no otherwise
   */
@@ -127,36 +128,36 @@ extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
 
 /**  Convenience property to retrieve the current user's identity.
  */
-@property (nonatomic, readonly) SFUserAccountIdentity *currentUserIdentity;
+@property (nonatomic, readonly, nullable) SFUserAccountIdentity *currentUserIdentity;
 
 /**  Convenience property to retrieve the current user's communityId.
  This property is an alias for `currentUser.communityId`
  */
-@property (nonatomic, readonly) NSString *currentCommunityId;
+@property (nonatomic, readonly, nullable) NSString *currentCommunityId;
 
 /** An NSArray of all the SFUserAccount instances for the app.
  */
-@property (nonatomic, readonly) NSArray *allUserAccounts;
+@property (nonatomic, readonly) NSArray<SFUserAccount*> *allUserAccounts;
 
 /** Returns all the user identities sorted by Org ID and User ID.
  */
-@property (nonatomic, readonly) NSArray *allUserIdentities;
+@property (nonatomic, readonly) NSArray<SFUserAccountIdentity*> *allUserIdentities;
 
 /** The most recently active user identity. Note that this may be temporarily
  different from currentUser if the user associated with the activeUserIdentity
  is removed from the accounts list.
  */
-@property (nonatomic, copy) SFUserAccountIdentity *activeUserIdentity;
+@property (nonatomic, copy, nullable) SFUserAccountIdentity *activeUserIdentity;
 
 /** The most recently active community ID. Set when a user
  is changed and stored to disk for retrieval after bootup
  */
-@property (nonatomic, copy) NSString *activeCommunityId;
+@property (nonatomic, copy, nullable) NSString *activeCommunityId;
 
 /** A convenience property to store the previous community
  id as it may change during early oAuth flow and we want to retain it
  */
-@property (nonatomic, strong) NSString *previousCommunityId;
+@property (nonatomic, strong, nullable) NSString *previousCommunityId;
 
 /** The host that will be used for login.
  */
@@ -171,7 +172,7 @@ extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
  value is determined by the SFDCOAuthClientIdPreference 
  configured via the settings bundle.
  */
-@property (nonatomic, copy) NSString *oauthClientId;
+@property (nonatomic, copy, nullable) NSString *oauthClientId;
 
 /** Oauth callback url to use for the oauth login process.
  Apps may customize this by setting this property before login.
@@ -179,12 +180,12 @@ extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
  bundle property SFDCOAuthRedirectUri
  default: @"sfdc:///axm/detect/oauth/done")
  */
-@property (nonatomic, copy) NSString *oauthCompletionUrl;
+@property (nonatomic, copy, nullable) NSString *oauthCompletionUrl;
 
 /**
  The OAuth scopes associated with the app.
  */
-@property (nonatomic, copy) NSSet *scopes;
+@property (nonatomic, copy) NSSet<NSString*> *scopes;
 
 /** Shared singleton
  */
@@ -240,19 +241,19 @@ extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
 
 /** Allows you to lookup the user account associated with a given user identity.
  */
-- (SFUserAccount *)userAccountForUserIdentity:(SFUserAccountIdentity *)userIdentity;
+- (nullable SFUserAccount *)userAccountForUserIdentity:(SFUserAccountIdentity *)userIdentity;
 
 /** Returns all accounts that have access to a particular org
  @param orgId The org to match accounts against
  @return An array of accounts that can access that org
  */
-- (NSArray *)accountsForOrgId:(NSString *)orgId;
+- (NSArray<SFUserAccount*> *)accountsForOrgId:(NSString *)orgId;
 
 /** Returns all accounts that match a particular instance URL
  @param instanceURL The host parameter of a given instance URL
  @return An array of accounts that match that instance URL
  */
-- (NSArray *)accountsForInstanceURL:(NSString *)instanceURL;
+- (NSArray<SFUserAccount*> *)accountsForInstanceURL:(NSString *)instanceURL;
 
 /** Adds a user account
  */
@@ -314,7 +315,7 @@ extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
  Switches away from the current user, to the given user account.
  @param newCurrentUser The user to switch to.
  */
-- (void)switchToUser:(SFUserAccount *)newCurrentUser;
+- (void)switchToUser:(nullable SFUserAccount *)newCurrentUser;
 
 /** Invoke this method to inform this manager
  that something has changed for the current user.
@@ -325,3 +326,5 @@ extern NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
 - (void)userChanged:(SFUserAccountChange)change;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -209,7 +209,7 @@ static const NSUInteger SFUserAccountManagerCannotRetrieveUserData = 10003;
 
 #pragma mark - Default Values
 
-- (NSSet *)scope
+- (NSSet *)scopes
 {
     NSUserDefaults *defs = [NSUserDefaults standardUserDefaults];
     NSArray *scopesArray = [defs objectForKey:kOAuthScopesKey] ?: [NSArray array];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -209,10 +209,10 @@ static const NSUInteger SFUserAccountManagerCannotRetrieveUserData = 10003;
 
 #pragma mark - Default Values
 
-- (NSSet *)scopes
+- (NSSet *)scope
 {
     NSUserDefaults *defs = [NSUserDefaults standardUserDefaults];
-    NSArray *scopesArray = [defs objectForKey:kOAuthScopesKey];
+    NSArray *scopesArray = [defs objectForKey:kOAuthScopesKey] ?: [NSArray array];
     return [NSSet setWithArray:scopesArray];
 }
 


### PR DESCRIPTION
yet more work on #1412 and #1413 

Also switching from using `extern` to `FOUNDATION_EXTERN` on the very odd chance someone is using objective-c++, better to be compatible than sorry.