### PR TITLE
Encode (serialize) the access and refresh tokens in the user account

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -121,7 +121,9 @@ NSException * SFOAuthInvalidIdentifierException() {
     [coder encodeObject:self.issuedAt           forKey:@"SFOAuthIssuedAt"];
     [coder encodeObject:self.protocol           forKey:@"SFOAuthProtocol"];
     [coder encodeObject:kSFOAuthArchiveVersion  forKey:@"SFOAuthArchiveVersion"];
-    [coder encodeObject:@(self.isEncrypted)          forKey:@"SFOAuthEncrypted"];
+    [coder encodeObject:@(self.isEncrypted)     forKey:@"SFOAuthEncrypted"];
+    [coder encodeObject:self.refreshToken       forKey:@"SFOAuthRefreshToken"];
+    [coder encodeObject:self.accessToken        forKey:@"SFOAuthAccessToken"];
 }
 
 - (id)init {


### PR DESCRIPTION
Encode (serialize) the access and refresh tokens in the user account plist file to prevent repeated logins after upgrading from SDK 3.3.1 to SDK 4.1. Note that this repeated login problem does not occur if logging in "fresh" after a logout (the problem only occurs if logging in with an App such as Account Editor on SDK 3.3.1 first).