### PR TITLE
Remove NSUnderlyingErrorKey to fix crash

### DIFF
--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+Blocks.m
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+Blocks.m
@@ -38,8 +38,8 @@ static char CompleteBlockKey;
 #pragma mark - error handling
 
 + (NSError *)errorWithDescription:(NSString *)description {    
-    NSArray *objArray = @[description, @"", @""];
-    NSArray *keyArray = @[NSLocalizedDescriptionKey, NSUnderlyingErrorKey, NSFilePathErrorKey];
+    NSArray *objArray = @[description, @""];
+    NSArray *keyArray = @[NSLocalizedDescriptionKey, NSFilePathErrorKey];
     
     NSDictionary *eDict = [NSDictionary dictionaryWithObjects:objArray
                                                       forKeys:keyArray];


### PR DESCRIPTION
Fix #1448.