### PR TITLE
The SFOAuthCredentials refactor missed the upgrade case.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -68,8 +68,13 @@ NSException * SFOAuthInvalidIdentifierException() {
 
 - (id)initWithCoder:(NSCoder *)coder {
     NSString *clusterClassName = [coder decodeObjectOfClass:[NSString class] forKey:kSFOAuthClusterImplementationKey];
-    Class clusterClass = NSClassFromString(clusterClassName) ?: self.class;
+    if (clusterClassName.length == 0) {
+        // Legacy credentials class (which doesn't have a persisted implementation class)
+        // should default to SFOAuthKeychainCredentials.
+        clusterClassName = @"SFOAuthKeychainCredentials";
+    }
     
+    Class clusterClass = NSClassFromString(clusterClassName) ?: self.class;
     if ([self isMemberOfClass:clusterClass])  {
         self = [super init];
         if (self) {


### PR DESCRIPTION
Since `SFOAuthCredentials` became a base class in the 4.x timeframe, the upgrade case from < 4.x to 4.x would not deserialize the credentials properly.