### PR TITLE
Query params map can have non-string values.

### DIFF
--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.h
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.h
@@ -113,7 +113,7 @@ extern NSString * const kSFDefaultRestEndpoint;
  * The query parameters of the request (could be nil).
  * Note that URL encoding of the parameters will automatically happen when the request is sent.
  */
-@property (nullable, nonatomic, strong) NSDictionary<NSString*, NSString*> *queryParams;
+@property (nullable, nonatomic, strong) NSDictionary<NSString*, NSObject*> *queryParams;
 
 /**
  * Dictionary of any custom HTTP headers you wish to add to your request.  You can also use

--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.m
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestRequest.m
@@ -35,12 +35,6 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
 
 @implementation SFRestRequest
 
-@synthesize delegate=_delegate;
-@synthesize action=_action;
-@synthesize queryParams=_queryParams;
-@synthesize requestBodyStreamBlock=_requestBodyStreamBlock;
-@synthesize requestContentType=_requestContentType;
-
 - (id)initWithMethod:(SFRestMethod)method path:(NSString *)path queryParams:(NSDictionary *)queryParams {
     SFRestAPISalesforceAction *action = [self actionFromMethod:method path:path];
     return [self initWithSalesforceAction:action queryParams:queryParams];


### PR DESCRIPTION
Query params property is also used for post / patch requests: in which case, it gets serialized to a string using [SFJsonUtils JSONRepresentation:self.queryParams] and ends up in the body.

Addressing regressions reported here: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/1430