### PR TITLE
Reverting changes from PR 1428

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -121,9 +121,7 @@ NSException * SFOAuthInvalidIdentifierException() {
     [coder encodeObject:self.issuedAt           forKey:@"SFOAuthIssuedAt"];
     [coder encodeObject:self.protocol           forKey:@"SFOAuthProtocol"];
     [coder encodeObject:kSFOAuthArchiveVersion  forKey:@"SFOAuthArchiveVersion"];
-    [coder encodeObject:@(self.isEncrypted)     forKey:@"SFOAuthEncrypted"];
-    [coder encodeObject:self.refreshToken       forKey:@"SFOAuthRefreshToken"];
-    [coder encodeObject:self.accessToken        forKey:@"SFOAuthAccessToken"];
+    [coder encodeObject:@(self.isEncrypted)          forKey:@"SFOAuthEncrypted"];
 }
 
 - (id)init {


### PR DESCRIPTION
This is in anticipation of a more appropriate fix for the issue of users being logged out between upgrades from Mobile SDK 3.3 to 4.x.