### PR TITLE
True weak object collection support

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -59,6 +59,14 @@
 		4F7EB4AD1BFFCF2300768720 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7EB4A41BFFCEF600768720 /* ViewController.m */; };
 		4FE5332A1BFFE70600814D2A /* Main_iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB4981BFFCEF600768720 /* Main_iPad.storyboard */; };
 		4FE5332B1BFFE70600814D2A /* Main_iPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB49A1BFFCEF600768720 /* Main_iPhone.storyboard */; };
+		8206D6651CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8206D6631CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8206D6661CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 8206D6631CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8206D6671CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 8206D6641CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.m */; };
+		8206D6681CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 8206D6641CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.m */; };
+		8206D67F1CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8206D67D1CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8206D6801CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8206D67D1CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8206D6811CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8206D67E1CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.m */; };
+		8206D6821CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 8206D67E1CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.m */; };
 		829DA2951C1266340040F5F1 /* SalesforceSDKCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 829DA2941C1266340040F5F1 /* SalesforceSDKCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		82C5E3EE1C1B62AF00376C00 /* SalesforceSDKResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 82C5E3ED1C1B62AF00376C00 /* SalesforceSDKResources.bundle */; };
 		82D0AB891C49A4BD0081F833 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE00216D1C03DBB70079DCA4 /* CocoaLumberjack.framework */; };
@@ -822,6 +830,10 @@
 		6F8960741A9E96C400A48FF1 /* SalesforceSDKCore-Static-iOS-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "SalesforceSDKCore-Static-iOS-Debug.xcconfig"; sourceTree = "<group>"; };
 		6F8960751A9E96C400A48FF1 /* SalesforceSDKCore-Static-iOS-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "SalesforceSDKCore-Static-iOS-Release.xcconfig"; sourceTree = "<group>"; };
 		6F8960761A9E96C400A48FF1 /* SalesforceSDKCore-Test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "SalesforceSDKCore-Test.xcconfig"; sourceTree = "<group>"; };
+		8206D6631CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKWeakObjectContainer.h; sourceTree = "<group>"; };
+		8206D6641CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKWeakObjectContainer.m; sourceTree = "<group>"; };
+		8206D67D1CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableOrderedSet+SFSDKUtils.h"; sourceTree = "<group>"; };
+		8206D67E1CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMutableOrderedSet+SFSDKUtils.m"; sourceTree = "<group>"; };
 		8220B74F16D804CA00EC3921 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		8220B75316D804CA00EC3921 /* SalesforceSDKCore-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SalesforceSDKCore-Prefix.pch"; sourceTree = "<group>"; };
 		8280EBB316E14E9F00768DE8 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -963,6 +975,8 @@
 				4FF945BE1BFFF47D005368C5 /* NSData+SFAdditions.m */,
 				4FF945BF1BFFF47D005368C5 /* NSDictionary+SFAdditions.h */,
 				4FF945C01BFFF47D005368C5 /* NSDictionary+SFAdditions.m */,
+				8206D67D1CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.h */,
+				8206D67E1CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.m */,
 				4FF945C11BFFF47D005368C5 /* NSNotificationCenter+SFAdditions.h */,
 				4FF945C21BFFF47D005368C5 /* NSNotificationCenter+SFAdditions.m */,
 				4FF945C31BFFF47D005368C5 /* NSString+SFAdditions.h */,
@@ -1000,6 +1014,8 @@
 				4F96FC5E1BFD32130022F021 /* SFSDKDatasharingHelper.m */,
 				4F96FC5F1BFD32130022F021 /* SFSDKReachability.h */,
 				4F96FC601BFD32130022F021 /* SFSDKReachability.m */,
+				8206D6631CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.h */,
+				8206D6641CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.m */,
 				4F96FC611BFD32130022F021 /* SFUserActivityMonitor.h */,
 				4F96FC621BFD32130022F021 /* SFUserActivityMonitor.m */,
 			);
@@ -1395,6 +1411,7 @@
 				E1C80CF31C5AEE31001B3A21 /* SFSDKNewLoginHostViewController.h in Headers */,
 				CE4CE3751C0E526A009F6029 /* SFKeyStoreManager+Internal.h in Headers */,
 				CE4CE36E1C0E526A009F6029 /* SFGeneratedKeyStore.h in Headers */,
+				8206D6651CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.h in Headers */,
 				CE4CE33E1C0E524B009F6029 /* SFInstrumentation.h in Headers */,
 				4F06AF811C49A16A00F70798 /* SFOAuthTestFlowCoordinatorDelegate.h in Headers */,
 				4F06AF7F1C49A16A00F70798 /* SFOAuthTestFlow.h in Headers */,
@@ -1473,6 +1490,7 @@
 				CE4CE3911C0E526A009F6029 /* SFUserAccountConstants.h in Headers */,
 				E1C80CEF1C5AEE31001B3A21 /* SFSDKLoginHostListViewController.h in Headers */,
 				CE4CE3A31C0E5279009F6029 /* SalesforceSDKCoreDefines.h in Headers */,
+				8206D67F1CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.h in Headers */,
 				CE4CE3651C0E526A009F6029 /* SFDefaultUserManagementDetailViewController.h in Headers */,
 				CE4CE3231C0E523B009F6029 /* UIDevice+SFHardware.h in Headers */,
 				CE4CE3591C0E526A009F6029 /* SFAuthenticationManager.h in Headers */,
@@ -1530,6 +1548,7 @@
 				CEA882A11C18FAAB008D871B /* NSData+SFSDKUtils_Internal.h in Headers */,
 				CEA8830D1C18FB8E008D871B /* SFUserAccountManager.h in Headers */,
 				CEA882A81C18FAAB008D871B /* SFSDKAppConfig.h in Headers */,
+				8206D6801CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.h in Headers */,
 				E1C80D291C5C3672001B3A21 /* SFSDKLoginHostDelegate.h in Headers */,
 				CEA882D11C18FB8E008D871B /* SFAuthenticationManager.h in Headers */,
 				CEA8830A1C18FB8E008D871B /* SFUserAccountIdentity.h in Headers */,
@@ -1561,6 +1580,7 @@
 				CEA882F81C18FB8E008D871B /* SFPasscodeViewController.h in Headers */,
 				CEA8828D1C18FAAB008D871B /* SFCrypto.h in Headers */,
 				CEA882BD1C18FB4D008D871B /* SFOAuthCredentials+Internal.h in Headers */,
+				8206D6661CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.h in Headers */,
 				CEA882B81C18FB3D008D871B /* SFMethodInterceptor.h in Headers */,
 				CEA883151C18FC2C008D871B /* SFSDKTestRequestListener.h in Headers */,
 				E1C80D2E1C5C3683001B3A21 /* SFSDKNewLoginHostViewController.h in Headers */,
@@ -1971,11 +1991,13 @@
 				CE4CE3311C0E523B009F6029 /* SFSDKAppConfig.m in Sources */,
 				CE4CE3881C0E526A009F6029 /* SFSDKCryptoUtils.m in Sources */,
 				CE4CE3201C0E523B009F6029 /* SFPathUtil.m in Sources */,
+				8206D6811CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.m in Sources */,
 				CE4CE3261C0E523B009F6029 /* UIScreen+SFAdditions.m in Sources */,
 				CE4CE37C1C0E526A009F6029 /* SFPasscodeManager.m in Sources */,
 				CE4CE30A1C0E523B009F6029 /* NSURL+SFAdditions.m in Sources */,
 				CE4CE3601C0E526A009F6029 /* SFAuthErrorHandlerList.m in Sources */,
 				CE4CE3AA1C0E5279009F6029 /* SFManagedPreferences.m in Sources */,
+				8206D6671CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.m in Sources */,
 				CE4CE35E1C0E526A009F6029 /* SFAuthErrorHandler.m in Sources */,
 				CE4CE37F1C0E526A009F6029 /* SFPasscodeProviderManager.m in Sources */,
 				CE4CE3411C0E524B009F6029 /* SFMethodInterceptor.m in Sources */,
@@ -2059,11 +2081,13 @@
 				CEA882A91C18FAAB008D871B /* SFSDKAppConfig.m in Sources */,
 				CEA883001C18FB8E008D871B /* SFSDKCryptoUtils.m in Sources */,
 				CEA882981C18FAAB008D871B /* SFPathUtil.m in Sources */,
+				8206D6821CA600D700F0AECD /* NSMutableOrderedSet+SFSDKUtils.m in Sources */,
 				E1C80D281C5C366F001B3A21 /* SFSDKLoginHost.m in Sources */,
 				CEA8829E1C18FAAB008D871B /* UIScreen+SFAdditions.m in Sources */,
 				CEA882F41C18FB8E008D871B /* SFPasscodeManager.m in Sources */,
 				CEA882821C18FAAB008D871B /* NSURL+SFAdditions.m in Sources */,
 				CEA882D81C18FB8E008D871B /* SFAuthErrorHandlerList.m in Sources */,
+				8206D6681CA5BDEB00F0AECD /* SFSDKWeakObjectContainer.m in Sources */,
 				CEA883221C18FC40008D871B /* SFManagedPreferences.m in Sources */,
 				CEA882D61C18FB8E008D871B /* SFAuthErrorHandler.m in Sources */,
 				CEA882F71C18FB8E008D871B /* SFPasscodeProviderManager.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		82D4642519C7C8170006BDFE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8220B74F16D804CA00EC3921 /* Foundation.framework */; };
 		82D4642619C7C8170006BDFE /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280EBCC16E14F7000768DE8 /* CoreGraphics.framework */; };
 		82D4642719C7C8170006BDFE /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280EBB516E14E9F00768DE8 /* UIKit.framework */; };
+		82DC4E841CA6184A00C95187 /* NSMutableOrderedSet+SFSDKUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 82DC4E831CA6184A00C95187 /* NSMutableOrderedSet+SFSDKUtilsTests.m */; settings = {ASSET_TAGS = (); }; };
 		CE4CE2721C0E449C009F6029 /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE4CE26B1C0E449C009F6029 /* SalesforceSDKCore.framework */; };
 		CE4CE2731C0E449C009F6029 /* SalesforceSDKCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE4CE26B1C0E449C009F6029 /* SalesforceSDKCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CE4CE3051C0E5229009F6029 /* SFCocoaLumberJackCustomFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FF946081BFFF4D9005368C5 /* SFCocoaLumberJackCustomFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -851,6 +852,7 @@
 		82D0AB191C497F410081F833 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		82D4642419C7C8170006BDFE /* SalesforceSDKCoreTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SalesforceSDKCoreTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		82D4644419C7C8180006BDFE /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		82DC4E831CA6184A00C95187 /* NSMutableOrderedSet+SFSDKUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableOrderedSet+SFSDKUtilsTests.m"; path = "SalesforceSDKCoreTests/NSMutableOrderedSet+SFSDKUtilsTests.m"; sourceTree = SOURCE_ROOT; };
 		CE0021551C03DBB70079DCA4 /* Lumberjack.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Lumberjack.xcodeproj; path = ../../external/CocoaLumberjack/Lumberjack.xcodeproj; sourceTree = "<group>"; };
 		CE4CE26B1C0E449C009F6029 /* SalesforceSDKCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SalesforceSDKCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEA8825F1C18F722008D871B /* libSalesforceSDKCore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSalesforceSDKCore.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -921,6 +923,7 @@
 		4F7EB3F61BFFC84700768720 /* SalesforceSDKCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				82DC4E831CA6184A00C95187 /* NSMutableOrderedSet+SFSDKUtilsTests.m */,
 				4F06AF5D1C49A16A00F70798 /* NSURL+SFStringUtilsTests.h */,
 				4F06AF5E1C49A16A00F70798 /* NSURL+SFStringUtilsTests.m */,
 				4F06AF5F1C49A16A00F70798 /* SalesforceOAuthUnitTests.h */,
@@ -1961,6 +1964,7 @@
 				4F06AF901C49A18E00F70798 /* SFOAuthTestFlow.m in Sources */,
 				4F06AF8B1C49A18E00F70798 /* SalesforceOAuthUnitTestsCoordinatorDelegate.m in Sources */,
 				4F7EB41C1BFFC8D700768720 /* SFSecurityTests.m in Sources */,
+				82DC4E841CA6184A00C95187 /* NSMutableOrderedSet+SFSDKUtilsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSMutableOrderedSet+SFSDKUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSMutableOrderedSet+SFSDKUtils.h
@@ -26,10 +26,46 @@
 
 @interface NSMutableOrderedSet (SFSDKWeakObjects)
 
+/**
+ Adds a weakified object to the ordered set.
+ @param obj The object to hold a weak reference to.
+ */
 - (void)msdkAddObjectToWeakify:(id)obj;
+
+/**
+ Removes a weakified object from the ordered set.  If the object doesn't exist in the
+ ordered set, no action is takend.
+ @param obj The object whose weak reference should be removed from the ordered set.
+ */
 - (void)msdkRemoveWeakifiedObject:(id)obj;
-- (void)msdkEnumerateWeakifiedObjectsWithBlock:(void (^)(id))block;
+
+/**
+ Enumerates the ordered set to take action against weakified objects.
+ @param block The block to execute against each weakified object.
+ */
+- (void)msdkEnumerateWeakifiedObjectsWithBlock:(void (^)(id weakifiedObj))block;
+
+/**
+ Whether or not the ordered set contains the weakified object.
+ @param obj The object to query in the ordered set.
+ @return YES if the set contains a weakified reference to the object, NO otherwise.
+ */
 - (BOOL)msdkContainsWeakifiedObject:(id)obj;
+
+/**
+ Get the index of the weakified object in the ordered set.
+ @param obj The object to query in the set.
+ @return The index of the object in the ordered set, or NSNotFound if the object does have a weakified
+ reference in the ordered set.
+ */
 - (NSUInteger)msdkIndexOfWeakifiedObject:(id)obj;
+
+/**
+ Returns the weakified object at the given index.
+ @param index The index in the ordered set where the object exists.
+ @return The weakified object, or nil if the object at that index is not in a weakified form.
+ @throw NSRangeException if the index does not exist in the range of objects in the ordered set.
+ */
+- (id)msdkWeakifiedObjectAtIndex:(NSUInteger)index;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSMutableOrderedSet+SFSDKUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSMutableOrderedSet+SFSDKUtils.h
@@ -1,0 +1,35 @@
+/*
+ Copyright (c) 2016, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface NSMutableOrderedSet (SFSDKWeakObjects)
+
+- (void)msdkAddObjectToWeakify:(id)obj;
+- (void)msdkRemoveWeakifiedObject:(id)obj;
+- (void)msdkEnumerateWeakifiedObjectsWithBlock:(void (^)(id))block;
+- (BOOL)msdkContainsWeakifiedObject:(id)obj;
+- (NSUInteger)msdkIndexOfWeakifiedObject:(id)obj;
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSMutableOrderedSet+SFSDKUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSMutableOrderedSet+SFSDKUtils.m
@@ -1,0 +1,79 @@
+/*
+ Copyright (c) 2016, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFSDKWeakObjectContainer.h"
+
+@implementation NSMutableOrderedSet (SFSDKWeakObjects)
+
+- (void)msdkAddObjectToWeakify:(id)obj {
+    if (obj != nil && ![self msdkContainsWeakifiedObject:obj]) {
+        
+        SFSDKWeakObjectContainer *weakDelegateContainer = [[SFSDKWeakObjectContainer alloc] initWithObject:obj];
+        [self addObject:weakDelegateContainer];
+    }
+}
+
+- (void)msdkRemoveWeakifiedObject:(id)obj {
+    if (obj != nil) {
+        NSUInteger objectIndex = [self msdkIndexOfWeakifiedObject:obj];
+        if (objectIndex != NSNotFound) {
+            [self removeObjectAtIndex:objectIndex];
+        }
+    }
+}
+
+- (void)msdkEnumerateWeakifiedObjectsWithBlock:(void (^)(id))block {
+    if (block != NULL) {
+        [self enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+            if (![obj isKindOfClass:[SFSDKWeakObjectContainer class]]) {
+                [self log:SFLogLevelWarning format:@"%@ obj expected to be '%@', actually '%@'.  No action taken.", NSStringFromSelector(_cmd), NSStringFromClass([SFSDKWeakObjectContainer class]), NSStringFromClass([obj class])];
+            } else {
+                id internalObj = ((SFSDKWeakObjectContainer *)obj).object;
+                if (internalObj != nil) {
+                    block(internalObj);
+                }
+            }
+        }];
+    }
+}
+
+
+- (BOOL)msdkContainsWeakifiedObject:(id)obj {
+    NSUInteger objIndex = [self msdkIndexOfWeakifiedObject:obj];
+    return (objIndex != NSNotFound);
+}
+
+- (NSUInteger)msdkIndexOfWeakifiedObject:(id)obj {
+    if (obj == nil) return NSNotFound;
+    NSUInteger objIndex = [self indexOfObjectPassingTest:^BOOL(id  _Nonnull setObj, NSUInteger idx, BOOL * _Nonnull stop) {
+        if (![setObj isKindOfClass:[SFSDKWeakObjectContainer class]]) {
+            return NO;
+        } else {
+            return (((SFSDKWeakObjectContainer*)setObj).object == obj);
+        }
+    }];
+    return objIndex;
+}
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSMutableOrderedSet+SFSDKUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSMutableOrderedSet+SFSDKUtils.m
@@ -76,4 +76,13 @@
     return objIndex;
 }
 
+- (id)msdkWeakifiedObjectAtIndex:(NSUInteger)index {
+    id weakObjectContainerObj = [self objectAtIndex:index];
+    if (weakObjectContainerObj == nil || ![weakObjectContainerObj isKindOfClass:[SFSDKWeakObjectContainer class]]) {
+        return nil;
+    }
+    SFSDKWeakObjectContainer *weakObjectContainer = (SFSDKWeakObjectContainer *)weakObjectContainerObj;
+    return weakObjectContainer.object;
+}
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWeakObjectContainer.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWeakObjectContainer.h
@@ -1,0 +1,33 @@
+/*
+ Copyright (c) 2016, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface SFSDKWeakObjectContainer : NSObject
+
+@property (nonatomic, readonly, weak) id object;
+
+- (instancetype)initWithObject:(id)object NS_DESIGNATED_INITIALIZER;
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWeakObjectContainer.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWeakObjectContainer.m
@@ -1,0 +1,41 @@
+/*
+ Copyright (c) 2016, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFSDKWeakObjectContainer.h"
+
+@implementation SFSDKWeakObjectContainer
+
+- (instancetype)init {
+    return [self initWithObject:nil];
+}
+
+- (instancetype)initWithObject:(id)object {
+    self = [super init];
+    if (self) {
+        _object = object;
+    }
+    return self;
+}
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -1030,7 +1030,7 @@ static Class InstanceClass = nil;
     }
 }
 
-- (void)removeDelegate:(id<SalesforceSDKManagerDelegate>)delegate
+- (void)removeDelegate:(id<SFAuthenticationManagerDelegate>)delegate
 {
     @synchronized(self) {
         if (delegate) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -35,6 +35,7 @@
 #import "SFPreferences.h"
 #import "SFUserActivityMonitor.h"
 #import "SFIdentityData.h"
+#import "NSMutableOrderedSet+SFSDKUtils.h"
 
 // Private constants
 
@@ -149,33 +150,33 @@ static BOOL _showPasscode = YES;
 
 + (void)addDelegate:(id<SFSecurityLockoutDelegate>)delegate
 {
-    @synchronized (self) {
+    @synchronized(self) {
         if (delegate) {
-            NSValue *nonretainedDelegate = [NSValue valueWithNonretainedObject:delegate];
-            [sDelegates addObject:nonretainedDelegate];
+            [sDelegates msdkAddObjectToWeakify:delegate];
         }
     }
 }
 
 + (void)removeDelegate:(id<SFSecurityLockoutDelegate>)delegate
 {
-    @synchronized (self) {
+    @synchronized(self) {
         if (delegate) {
-            NSValue *nonretainedDelegate = [NSValue valueWithNonretainedObject:delegate];
-            [sDelegates removeObject:nonretainedDelegate];
+            [sDelegates msdkRemoveWeakifiedObject:delegate];
         }
     }
 }
 
 + (void)enumerateDelegates:(void (^)(id<SFSecurityLockoutDelegate>))block
 {
-    @synchronized (self) {
-        [sDelegates enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-            id<SFSecurityLockoutDelegate> delegate = [obj nonretainedObjectValue];
-            if (delegate) {
-                if (block) block(delegate);
-            }
-        }];
+    @synchronized(self) {
+        if (block != NULL) {
+            [sDelegates msdkEnumerateWeakifiedObjectsWithBlock:^(id delegateObj) {
+                if ([delegateObj conformsToProtocol:@protocol(SFSecurityLockoutDelegate)]) {
+                    id<SFSecurityLockoutDelegate> delegate = (id<SFSecurityLockoutDelegate>)delegateObj;
+                    block(delegate);
+                }
+            }];
+        }
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/SalesforceSDKCore.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/SalesforceSDKCore.h
@@ -2,7 +2,7 @@
  SalesforceSDKCore.h
  SalesforceSDKCore
 
- Created by Kunal Chitalia on Fri Jan 29 17:58:02 PST 2016.
+ Created by Kevin Hawkins on Fri Mar 25 17:12:46 PDT 2016.
 
  Copyright (c) 2016, salesforce.com, inc. All rights reserved.
  
@@ -31,6 +31,7 @@
 #import <SalesforceSDKCore/NSData+SFAdditions.h>
 #import <SalesforceSDKCore/NSData+SFSDKUtils.h>
 #import <SalesforceSDKCore/NSDictionary+SFAdditions.h>
+#import <SalesforceSDKCore/NSMutableOrderedSet+SFSDKUtils.h>
 #import <SalesforceSDKCore/NSNotificationCenter+SFAdditions.h>
 #import <SalesforceSDKCore/NSString+SFAdditions.h>
 #import <SalesforceSDKCore/NSURL+SFAdditions.h>
@@ -95,6 +96,7 @@
 #import <SalesforceSDKCore/SFSDKResourceUtils.h>
 #import <SalesforceSDKCore/SFSDKTestCredentialsData.h>
 #import <SalesforceSDKCore/SFSDKTestRequestListener.h>
+#import <SalesforceSDKCore/SFSDKWeakObjectContainer.h>
 #import <SalesforceSDKCore/SFSDKWebUtils.h>
 #import <SalesforceSDKCore/SFSecurityLockout+Internal.h>
 #import <SalesforceSDKCore/SFSecurityLockout.h>

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/NSMutableOrderedSet+SFSDKUtilsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/NSMutableOrderedSet+SFSDKUtilsTests.m
@@ -1,0 +1,144 @@
+/*
+ Copyright (c) 2016, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "NSMutableOrderedSet+SFSDKUtils.h"
+
+@interface NSMutableOrderedSet_SFSDKUtilsTests : XCTestCase
+
+@property (nonatomic, strong) NSMutableOrderedSet *set;
+
+@end
+
+@implementation NSMutableOrderedSet_SFSDKUtilsTests
+
+- (void)setUp {
+    [super setUp];
+    self.set = [NSMutableOrderedSet orderedSet];
+}
+
+- (void)tearDown {
+    self.set = nil;
+    [super tearDown];
+}
+
+- (void)testAddWeakifiedObjectSingleReference {
+    NSArray *ary1 = @[ @"One", @"Two", @"Three" ];
+    NSArray *ary2 = @[ @"One", @"Two", @"Three" ];
+    [self.set msdkAddObjectToWeakify:ary1];
+    [self.set msdkAddObjectToWeakify:ary1];
+    [self.set msdkAddObjectToWeakify:ary2];
+    __block NSUInteger ary1ObjectsCount = 0;
+    __block NSUInteger ary2ObjectsCount = 0;
+    [self.set msdkEnumerateWeakifiedObjectsWithBlock:^(id aryObj) {
+        if (aryObj == ary1) {
+            ary1ObjectsCount++;
+        } else if (aryObj == ary2) {
+            ary2ObjectsCount++;
+        }
+    }];
+    XCTAssertEqual(self.set.count, 2, @"Should be two elements in the ordered set.");
+    XCTAssertEqual(ary1ObjectsCount, 1, @"A given object reference should only be stored once.");
+    XCTAssertEqual(ary2ObjectsCount, 1, @"A given object reference should only be stored once.");
+}
+
+- (void)testRemoveWeakifiedObject {
+    NSDictionary *dict = @{ @1: @"One", @2: @"Two", @3: @"Three" };
+    [self.set msdkAddObjectToWeakify:dict];
+    XCTAssertEqual(self.set.count, 1, @"Object should have been added to the ordered set.");
+    NSUInteger objIdx = [self.set msdkIndexOfWeakifiedObject:dict];
+    XCTAssertEqual(objIdx, 0, @"Dict should be the first object in the ordered set.");
+    id dictObj = [self.set msdkWeakifiedObjectAtIndex:objIdx];
+    XCTAssertEqual(dict, dictObj, @"Dict objects should be the same.");
+    
+    [self.set msdkRemoveWeakifiedObject:dict];
+    XCTAssertEqual(self.set.count, 0, @"Should no longer be items in the ordered set.");
+    objIdx = [self.set msdkIndexOfWeakifiedObject:dict];
+    XCTAssertEqual(objIdx, NSNotFound, @"Index for non-existent object should be NSNotFound.");
+}
+
+- (void)testWeakifiedObjectIndex {
+    __strong NSArray *ary;
+    @autoreleasepool {
+        ary = @[ @"One", @"Two", @"Three" ];
+        [self.set msdkAddObjectToWeakify:ary];
+        NSUInteger objIdx = [self.set msdkIndexOfWeakifiedObject:ary];
+        XCTAssertEqual(objIdx, 0, @"Weakified object not found in ordered set.");
+        
+        // Set strong array reference to a different object/value.
+        ary = @[ ];
+    }
+    
+    NSArray *weakifiedArray = [self.set msdkWeakifiedObjectAtIndex:0];
+    XCTAssertNil(weakifiedArray, @"Once released, weakified object should be nil.");
+    NSUInteger indexForNonExistentObj = [self.set msdkIndexOfWeakifiedObject:ary];
+    XCTAssertEqual(indexForNonExistentObj, NSNotFound, @"Should return NSNotFound for object not in set.");
+}
+
+- (void)testEnumerateWeakifiedObjects {
+    NSDictionary *obj1 = @{ @"key1": @"value1" };
+    NSArray *obj2 = @[ @1, @2, @3 ];
+    NSString *obj3 = @"Test String";
+    [self.set msdkAddObjectToWeakify:obj1];
+    [self.set msdkAddObjectToWeakify:obj2];
+    [self.set msdkAddObjectToWeakify:obj3];
+    __block BOOL obj1Occurs = NO;
+    __block BOOL obj2Occurs = NO;
+    __block BOOL obj3Occurs = NO;
+    [self.set msdkEnumerateWeakifiedObjectsWithBlock:^(id weakObj) {
+        if (weakObj == obj1) {
+            obj1Occurs = YES;
+        } else if (weakObj == obj2) {
+            obj2Occurs = YES;
+        } else if (weakObj == obj3) {
+            obj3Occurs = YES;
+        } else {
+            XCTFail(@"Object '%@' should not occur in the ordered set.", weakObj);
+        }
+    }];
+    XCTAssertTrue(obj1Occurs, @"Didn't find obj1 in the ordered set.");
+    XCTAssertTrue(obj2Occurs, @"Didn't find obj2 in the ordered set.");
+    XCTAssertTrue(obj3Occurs, @"Didn't find obj3 in the ordered set.");
+}
+
+- (void)testContainsWeakifiedObject {
+    XCTAssertFalse([self.set msdkContainsWeakifiedObject:nil], @"Nil should never be 'contained' (acknoweldged) in the ordered set.");
+    NSArray *ary = @[ @"hello", @"world" ];
+    NSDictionary *dict = @{ @"key": @"value" };
+    [self.set msdkAddObjectToWeakify:ary];
+    XCTAssertTrue([self.set msdkContainsWeakifiedObject:ary], @"Array should be contained in the ordered set.");
+    XCTAssertFalse([self.set msdkContainsWeakifiedObject:dict], @"Dictionary should not be contained in the ordered set.");
+}
+
+- (void)testWeakifiedObjectAtIndex {
+    [self.set addObject:@"Non-weakified string"];
+    XCTAssertNil([self.set msdkWeakifiedObjectAtIndex:0], @"Non-weakified objects should report as nil in this case.");
+    NSArray *ary = @[ @"Test", @"Array" ];
+    [self.set msdkAddObjectToWeakify:ary];
+    id weakifiedObj = [self.set msdkWeakifiedObjectAtIndex:1];
+    XCTAssertEqual(weakifiedObj, ary, @"Weakified array and input array should be equal.");
+    XCTAssertThrows([self.set msdkWeakifiedObjectAtIndex:2], @"Indexes out of range should throw an NSRangeException.");
+}
+
+@end


### PR DESCRIPTION
Something that's been bugging me for a while.  `[NSValue valueWithNonretainedObject:]`, which we use to hold "weak" values in our multicast delegate support, does not actually provide weak values, i.e. values that go to `nil` when their reference count is exhausted.  It holds Unsafe Unretained values, which end up pointing at garbage when their reference count is exhausted.  This can lead to indeterminate behavior, including crashes, when enumerating these objects after they no longer exist.

This PR creates a container object for weak-referenced objects, and a category on `NSOrderedSet` to manipulate them in our delegate support.  That way, if/when the strong counterparts to delegate objects go away, enumerating these delegates will simply result in a no-op.