### PR TITLE
Updates to the LLVM module map to account for unannounced changes in Xcode 7.3

### DIFF
--- a/libs/SalesforceKit/SalesforceKit.modulemap
+++ b/libs/SalesforceKit/SalesforceKit.modulemap
@@ -16,8 +16,6 @@ framework module SalesforceKit {
         
         export *
         module * { export * }
-        
-        use SalesforceSDKCore
     }
     
     framework module SalesforceRestAPI {
@@ -25,9 +23,6 @@ framework module SalesforceKit {
         
         export *
         module * { export * }
-        
-        use SalesforceSDKCore
-        use SalesforceNetwork
     }
 
     framework module SmartStore {
@@ -35,8 +30,6 @@ framework module SalesforceKit {
 
         export *
         module * { export * }
-
-        use SalesforceRestAPI
     }
 
     framework module SmartSync {
@@ -44,11 +37,13 @@ framework module SalesforceKit {
         
         export *
         module * { export * }
-        
-        use SalesforceRestAPI
     }
 
     link "z"
     link "sqlite3"
     link framework "MobileCoreServices"
+        
+    use SalesforceSDKCore
+    use SalesforceNetwork
+    use SalesforceRestAPI
 }


### PR DESCRIPTION
Xcode 7.3 made changes to how LLVM manages library dependencies, so these changes are made to allow backwards compatibility to earlier versions of Xcode, while still working against Xcode 7.3.