### PR TITLE
Fix issues about not having 'full bitcode enabled' due to only sqlcip…

### DIFF
--- a/libs/SalesforceKit/scripts/build-universal.sh
+++ b/libs/SalesforceKit/scripts/build-universal.sh
@@ -71,6 +71,7 @@ xcodebuild -project ${PROJECT_NAME}.xcodeproj \
     -sdk iphoneos \
     -scheme ${FRAMEWORK_SCHEME} \
     -configuration ${CONFIGURATION} \
+    BITCODE_GENERATION_MODE=bitcode \
     ONLY_ACTIVE_ARCH=NO \
     ARCHS="armv7 armv7s arm64" \
     VALID_ARCHS="armv7 armv7s arm64" \

--- a/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
+++ b/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
@@ -1051,7 +1051,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = (
-					"-ObjC",
+					"$(inherited)",
 					"-lz",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.salesforce.mobilesdk.SmartStore;
@@ -1073,7 +1073,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
-					"-ObjC",
+					"$(inherited)",
 					"-lz",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.salesforce.mobilesdk.SmartStore;


### PR DESCRIPTION
…her having bitcode symbols on i386/x86_64.

Note this is the diff for the sqlcipher build_for_sdk.sh script:

```
diff --git a/build_for_sdk.sh b/build_for_sdk.sh
index 8cf0ffb..9c108c0 100755
--- a/build_for_sdk.sh
+++ b/build_for_sdk.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-xcodebuild ARCHS="armv7 armv7s arm64" ONLY_ACTIVE_ARCH=NO PLATFORM_NAME=iphoneos -configuration Release -project sqlcipher.xcodeproj -target sqlcipher clean install
+xcodebuild BITCODE_GENERATION_MODE=bitcode OTHER_CFLAGS="\$(inherited) -fembed-bitcode" ARCHS="armv7 armv7s arm64" ONLY_ACTIVE_ARCH=NO PLATFORM_NAME=iphoneos -configuration Release -project sqlcipher.xcodeproj -target sqlcipher clean install
 if [ -f "build/UninstalledProducts/libsqlcipher.a" ]; then
 	mkdir -p build/UninstalledProducts/iphoneos
 	mv build/UninstalledProducts/libsqlcipher.a build/UninstalledProducts/iphoneos/libsqlcipher.a
```