### PR TITLE
Make SFCryptChunks compatible with SFCrypto

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFCryptChunks.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFCryptChunks.h
@@ -31,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 extern size_t const SFCryptChunksCipherBlockSize;
 // The cipher algorithm used by SFCryptChunks.
 extern uint32_t const SFCryptChunksCipherAlgorithm;
+// The cipher key size used by SFCryptChunks.
+extern size_t const SFCryptChunksCipherKeySize;
 // The cipher options used in the cipher algorithm used by SFCryptChunks.
 extern uint32_t const SFCryptChunksCipherOptions;
 


### PR DESCRIPTION
SFCrypto fills/truncate the key passed if the size is not correct. Applying the same logic in SFCryptChunks will guarantee interchangeability between SFCrypto and SFCryptChunks (SFEncryptStream and SFDecryptStream too).

Files encrypted/decrypted with SFCrypto can be encrypted/decrypted by SFCryptChunks and vice-versa.

@bhariharan @dbreese 