### PR TITLE
add tint color support nav bar

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -109,12 +109,11 @@
     self.navBar.items = @[item];
     if(self.showSettingsIcon) {
         // setup right bar button
-        UIImage *image = [SFSDKResourceUtils imageNamed:@"login-window-gear"];
+        UIImage *image = [[SFSDKResourceUtils imageNamed:@"login-window-gear"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
         UIBarButtonItem *rightButton = [[UIBarButtonItem alloc] initWithImage:image style:UIBarButtonItemStylePlain target:self action:@selector(showLoginHost:)];
         rightButton.accessibilityLabel = [SFSDKResourceUtils localizedString:@"LOGIN_CHOOSE_SERVER"];
         self.navBar.topItem.rightBarButtonItem = rightButton;
     }
-    self.navBar.tintColor = [UIColor whiteColor];
     [self styleNavigationBar:self.navBar];
     [self.view addSubview:self.navBar];
     [self setNeedsStatusBarAppearanceUpdate];
@@ -124,7 +123,7 @@
 - (void)setupBackButton {
     // setup left bar button
     if ([self shouldShowBackButton]) {
-        UIImage *image = [SFSDKResourceUtils imageNamed:@"globalheader-back-arrow"];
+        UIImage *image = [[SFSDKResourceUtils imageNamed:@"globalheader-back-arrow"]  imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
         self.navBar.topItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithImage:image style:UIBarButtonItemStylePlain target:self action:@selector(backToPreviousHost:)];
     } else {
         self.navBar.topItem.leftBarButtonItem = nil;
@@ -209,6 +208,7 @@
         [navigationBar setBackgroundImage:backgroundImage forBarMetrics:UIBarMetricsDefault];
     }
     if (self.navBarTextColor) {
+        navigationBar.tintColor = self.navBarTextColor;
         [navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName: self.navBarTextColor}];
     }
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -210,6 +210,9 @@
     if (self.navBarTextColor) {
         navigationBar.tintColor = self.navBarTextColor;
         [navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName: self.navBarTextColor}];
+    } else {
+        // default color
+        navigationBar.tintColor = [UIColor whiteColor];
     }
     
     if (self.navBarFont && self.navBarTextColor) {


### PR DESCRIPTION
@bhariharan @wmathurin @kchitalia 

Navigation bar tint color should be driven by navigation bar text color and image on navigation bar should be used as a template color so that tint color can be applied.

With this change, navigation bar color can be set to any color (even white) and image will still work