### PR TITLE
Remove unnecessary finalizeCrypt call when closing decrypt stream

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.m
@@ -152,7 +152,6 @@
 }
 
 - (void)close {
-    [self.cryptChunks finalizeCrypt];
     [self.inStream close];
 }
 


### PR DESCRIPTION
This is not a big deal, but if the stream is closed before finished reading, it could potentially cause a crash. Also this call is unnecessary.
@bhariharan 