### PR TITLE
Moving to SQLCipher 3.4 with JSON1 support

### DIFF
--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -103,12 +103,14 @@
 
     XCTAssertTrue([options containsObject:@"ENABLE_FTS4"]);
     XCTAssertTrue([options containsObject:@"ENABLE_FTS3_PARENTHESIS"]);
+    XCTAssertTrue([options containsObject:@"ENABLE_FTS5"]);
+    XCTAssertTrue([options containsObject:@"ENABLE_JSON1"]);
 }
 
 - (void) testSqliteVersion
 {
     NSString* version = [NSString stringWithUTF8String:sqlite3_libversion()];
-    XCTAssertEqualObjects(version, @"3.8.8.3");
+    XCTAssertEqualObjects(version, @"3.11.0");
 }
 
 /**


### PR DESCRIPTION
All native and hybrid smartstore tests are passing.