### PR TITLE
Fixing another compilation error

### DIFF
--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer.xcodeproj/project.pbxproj
@@ -1212,6 +1212,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
+				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = SmartSyncExplorerUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1232,6 +1233,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
+				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = SmartSyncExplorerUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1372,6 +1374,7 @@
 				4F1DA6931C84FD7E0014FAD3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		827C630C19E6018C00027484 /* Build configuration list for PBXProject "SmartSyncExplorer" */ = {
 			isa = XCConfigurationList;

--- a/shared/test/test/SalesforceTestCase.swift
+++ b/shared/test/test/SalesforceTestCase.swift
@@ -46,7 +46,6 @@ class SalesforceTestCase: XCTestCase {
     }
     
     func loginThroughUI() {
-        // TODO move credentials to external file similar to test_credentials.json
         let loginInfo: NSDictionary = TestSetupUtils.populateUILoginInfoFromConfigFileForClass(self.dynamicType)
         loginDelegate.loginToSalesforce(String(loginInfo.valueForKey("username")), password:(String(loginInfo.valueForKey("password"))), host:Host.sandbox)
     }


### PR DESCRIPTION
Something changed in ```Xcode 7.1``` and greater. Header search paths should now be empty for frameworks to work properly with ```Swift```. Everything compiles fine now.