### PR TITLE
Soup table will now have db indexes on created and last modified

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.m
@@ -90,6 +90,11 @@ static SFSmartSqlHelper *sharedInstance = nil;
                     [sql appendString:tableQualifier];
                     [sql appendString:@"id"];
                 }
+                // {soupName:_soupCreatedDate}
+                else if ([path isEqualToString:@"_soupCreatedDate"]) {
+                    [sql appendString:tableQualifier];
+                    [sql appendString:@"created"];
+                }
                 // {soupName:_soupLastModifiedDate}
                 else if ([path isEqualToString:@"_soupLastModifiedDate"]) {
                     [sql appendString:tableQualifier];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -1007,10 +1007,9 @@ NSString *const EXPLAIN_ROWS = @"rows";
     NSMutableArray *columnsForFts = [NSMutableArray new];
     
     // Indexes on created and lastModified
+    NSString* createIndexFormat = @"CREATE INDEX IF NOT EXISTS %@_%@_idx ON %@ ( %@ )";
     for (NSString* col in @[CREATED_COL, LAST_MODIFIED_COL]) {
-        [createIndexStmts addObject:
-         [NSString stringWithFormat:@"CREATE INDEX IF NOT EXISTS %@ ON %@ ( %@ )",[NSString stringWithFormat:@"%@_%@_idx",soupTableName,col], soupTableName, col]
-         ];
+        [createIndexStmts addObject:[NSString stringWithFormat:createIndexFormat, soupTableName, col, soupTableName, col]];
     }
     
     for (NSUInteger i = 0; i < [indexSpecs count]; i++) {
@@ -1041,10 +1040,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
         [soupIndexMapInserts addObject:values];
         
         // for creating an index on the soup table
-        NSString *indexName = [NSString stringWithFormat:@"%@_%lu_idx",soupTableName,(unsigned long)i];
-        [createIndexStmts addObject:
-         [NSString stringWithFormat:@"CREATE INDEX IF NOT EXISTS %@ ON %@ ( %@ )",indexName, soupTableName, columnName]
-         ];
+        [createIndexStmts addObject:[NSString stringWithFormat:createIndexFormat, soupTableName, [NSString stringWithFormat:@"%u", i], soupTableName, columnName]];
     }
     
     [createTableStmt appendString:@")"];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -1006,6 +1006,13 @@ NSString *const EXPLAIN_ROWS = @"rows";
     NSMutableString *createFtsStmt = [NSMutableString new];
     NSMutableArray *columnsForFts = [NSMutableArray new];
     
+    // Indexes on created and lastModified
+    for (NSString* col in @[CREATED_COL, LAST_MODIFIED_COL]) {
+        [createIndexStmts addObject:
+         [NSString stringWithFormat:@"CREATE INDEX IF NOT EXISTS %@ ON %@ ( %@ )",[NSString stringWithFormat:@"%@_%@_idx",soupTableName,col], soupTableName, col]
+         ];
+    }
+    
     for (NSUInteger i = 0; i < [indexSpecs count]; i++) {
         SFSoupIndex *indexSpec = (SFSoupIndex*) indexSpecs[i];
         

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
@@ -151,8 +151,8 @@
 
 - (void) testConvertSmartSqlWithSpecialColumns
 {
-    XCTAssertEqualObjects(@"select TABLE_1.id, TABLE_1.lastModified, TABLE_1.soup from TABLE_1", 
-                         [self.store convertSmartSql:@"select {employees:_soupEntryId}, {employees:_soupLastModifiedDate}, {employees:_soup} from {employees}"], @"Bad conversion");
+    XCTAssertEqualObjects(@"select TABLE_1.id, TABLE_1.created, TABLE_1.lastModified, TABLE_1.soup from TABLE_1",
+                         [self.store convertSmartSql:@"select {employees:_soupEntryId}, {employees:_soupCreatedDate}, {employees:_soupLastModifiedDate}, {employees:_soup} from {employees}"], @"Bad conversion");
 }
 	
 - (void) testConvertSmartSqlWithSpecialColumnsAndJoin

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -247,10 +247,12 @@
                          store:store];
             
             // Check db indexes
-            NSString* indexSqlFormat = @"CREATE INDEX %@_%2$u_idx ON %1$@ ( %3$@ )";
+            NSString* indexSqlFormat = @"CREATE INDEX %@_%@_idx ON %1$@ ( %3$@ )";
             [self checkDatabaseIndexes:soupTableName
-                 expectedSqlStatements:@[ [NSString stringWithFormat:indexSqlFormat, soupTableName, 0, expectedColumnName0],
-                                          [NSString stringWithFormat:indexSqlFormat, soupTableName, 1, expectedColumnName1]
+                 expectedSqlStatements:@[ [NSString stringWithFormat:indexSqlFormat, soupTableName, @"0", expectedColumnName0],
+                                          [NSString stringWithFormat:indexSqlFormat, soupTableName, @"1", expectedColumnName1],
+                                          [NSString stringWithFormat:indexSqlFormat, soupTableName, @"created", @"created"],
+                                          [NSString stringWithFormat:indexSqlFormat, soupTableName, @"lastModified", @"lastModified"]
                                          ]
                                  store:store];
             


### PR DESCRIPTION
To get them for an existing soup, simply alter the soup passing in the original set of index specs