### PR TITLE
New tests 

### DIFF
--- a/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
+++ b/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		4FEE44881BFD5CD900F09C43 /* SFSmartStoreFullTextSearchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F96015A1BFD33B30022F021 /* SFSmartStoreFullTextSearchTests.m */; };
 		4FEE44891BFD5CDC00F09C43 /* SFSmartStoreTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F96015C1BFD33B30022F021 /* SFSmartStoreTestCase.m */; };
 		4FEE448A1BFD5CE500F09C43 /* SFSmartStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F96015E1BFD33B30022F021 /* SFSmartStoreTests.m */; };
+		4FF4DC671CF51D9300385C2C /* SFQuerySpecTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FF4DC661CF51D9300385C2C /* SFQuerySpecTests.m */; };
 		4FFEE6351BFE98E100B7AA8A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CEAAAE61195911E600CBBFE9 /* InfoPlist.strings */; };
 		6F96F9A01CB824EF00B2A120 /* libsqlcipher.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 828917AC1C52DB6B002F9981 /* libsqlcipher.a */; };
 		828917841C52B705002F9981 /* FMDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 8289177A1C52B705002F9981 /* FMDatabase.h */; };
@@ -260,6 +261,8 @@
 		4F96FC501BFD31EF0022F021 /* SmartStore-Test.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = "SmartStore-Test.xcconfig"; path = "Configuration/SmartStore-Test.xcconfig"; sourceTree = "<group>"; };
 		4F99B53B1CEA81A6007BC4D2 /* SFSmartStoreLoadTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSmartStoreLoadTests.m; sourceTree = "<group>"; };
 		4F99B5401CEA81C6007BC4D2 /* SFSmartStoreLoadTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSmartStoreLoadTests.h; sourceTree = "<group>"; };
+		4FF4DC651CF51D9300385C2C /* SFQuerySpecTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFQuerySpecTests.h; sourceTree = "<group>"; };
+		4FF4DC661CF51D9300385C2C /* SFQuerySpecTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFQuerySpecTests.m; sourceTree = "<group>"; };
 		4FFEE6341BFE98B600B7AA8A /* SmartStoreTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "SmartStoreTests-Info.plist"; path = "SmartStoreTests/SmartStoreTests-Info.plist"; sourceTree = SOURCE_ROOT; };
 		8289177A1C52B705002F9981 /* FMDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FMDatabase.h; path = ../../../../external/fmdb/src/fmdb/FMDatabase.h; sourceTree = "<group>"; };
 		8289177B1C52B705002F9981 /* FMDatabase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FMDatabase.m; path = ../../../../external/fmdb/src/fmdb/FMDatabase.m; sourceTree = "<group>"; };
@@ -483,6 +486,8 @@
 		CEAAAE5E195911E600CBBFE9 /* SmartStoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				4FF4DC651CF51D9300385C2C /* SFQuerySpecTests.h */,
+				4FF4DC661CF51D9300385C2C /* SFQuerySpecTests.m */,
 				4F99B5401CEA81C6007BC4D2 /* SFSmartStoreLoadTests.h */,
 				4F9601531BFD33B30022F021 /* SFSmartSqlTests.h */,
 				4F9601541BFD33B30022F021 /* SFSmartSqlTests.m */,
@@ -888,6 +893,7 @@
 			files = (
 				4FEE44891BFD5CDC00F09C43 /* SFSmartStoreTestCase.m in Sources */,
 				4FEE44851BFD5CCC00F09C43 /* SFSmartSqlTests.m in Sources */,
+				4FF4DC671CF51D9300385C2C /* SFQuerySpecTests.m in Sources */,
 				4FEE44861BFD5CD200F09C43 /* SFSmartStoreAlterTests.m in Sources */,
 				4F99B53C1CEA81A6007BC4D2 /* SFSmartStoreLoadTests.m in Sources */,
 				4FEE44881BFD5CD900F09C43 /* SFSmartStoreFullTextSearchTests.m in Sources */,

--- a/libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.m
@@ -119,10 +119,10 @@ static SFSmartSqlHelper *sharedInstance = nil;
     }
     
     // With json1 support, the column name could be an expression of the form json_extract(soup, '$.x.y.z')
-    // We can't have TABLE_x.json_extract(soup, ...) in the sql query
+    // We can't have TABLE_x.json_extract(soup, ...) or table_alias.json_extract(soup, ...) in the sql query
     // Instead we should have json_extract(TABLE_x.soup, ...)
     NSError *error = nil;
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"(TABLE_[0-9]+)\\.json_extract\\(soup" options:0 error:&error];
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"([^ ]+)\\.json_extract\\(soup" options:0 error:&error];
     [regex replaceMatchesInString:sql options:0 range:NSMakeRange(0, [sql length]) withTemplate:@"json_extract($1.soup"];
     
     return sql;

--- a/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.h
+++ b/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.h
@@ -1,0 +1,31 @@
+/*
+ Copyright (c) 2016, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+//  Logic unit tests contain unit test code that is designed to be linked into an independent test executable.
+//  See Also: http://developer.apple.com/iphone/library/documentation/Xcode/Conceptual/iphone_development/135-Unit_Testing_Applications/unit_testing_applications.html
+
+#import "SFSmartStoreTestCase.h"
+
+@interface SFQuerySpecTests : SFSmartStoreTestCase
+@end

--- a/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
@@ -1,0 +1,146 @@
+/*
+ Copyright (c) 2016, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFQuerySpecTests.h"
+#import "SFQuerySpec.h"
+
+
+@implementation SFQuerySpecTests
+
+
+#pragma mark - setup and teardown
+
+- (void) setUp
+{
+    [super setUp];
+    [SFLogger setLogLevel:SFLogLevelDebug];
+}
+
+
+#pragma mark - tests
+- (void) testAllQuerySmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newAllQuerySpec:@"employees" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderDescending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.smartSql, @"Wrong smart sql for all query spec");
+}
+
+- (void) testAllQueryCountSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newAllQuerySpec:@"employees" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderDescending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT count(*) FROM {employees} ", querySpec.countSmartSql, @"Wrong count smart sql for all query spec");
+}
+
+- (void) testAllQueryIdsSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newAllQuerySpec:@"employees" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderDescending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT id FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.idsSmartSql, @"Wrong ids smart sql for all query spec");
+}
+
+- (void) testRangeQuerySmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newRangeQuerySpec:@"employees" withPath:@"lastName" withBeginKey:@"Bond" withEndKey:@"Smith" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for range query spec");
+}
+
+- (void) testRangeQueryCountSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newRangeQuerySpec:@"employees" withPath:@"lastName" withBeginKey:@"Bond" withEndKey:@"Smith" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT count(*) FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ", querySpec.countSmartSql, @"Wrong count smart sql for range query spec");
+}
+
+- (void) testRangeQueryIdsSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newRangeQuerySpec:@"employees" withPath:@"lastName" withBeginKey:@"Bond" withEndKey:@"Smith" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for range query spec");
+}
+
+- (void) testExactQuerySmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newExactQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for exact query spec");
+}
+
+- (void) testExactQueryCountSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newExactQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT count(*) FROM {employees} WHERE {employees:lastName} = ? ", querySpec.countSmartSql, @"Wrong count smart sql for exact query spec");
+}
+
+- (void) testExactQueryIdsSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newExactQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for exact query spec");
+}
+
+- (void) testMatchQuerySmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec");
+}
+
+- (void) testMatchQueryCountSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT count(*) FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ", querySpec.countSmartSql, @"Wrong count smart sql for match query spec");
+}
+
+- (void) testMatchQueryIdsSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT id FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for match query spec");
+}
+
+
+
+- (void) testLikeQuerySmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newLikeQuerySpec:@"employees" withPath:@"lastName" withLikeKey:@"Bon%" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for like query spec");
+}
+
+- (void) testLikeQueryCountSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newLikeQuerySpec:@"employees" withPath:@"lastName" withLikeKey:@"Bon%" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT count(*) FROM {employees} WHERE {employees:lastName} LIKE ? ", querySpec.countSmartSql, @"Wrong count smart sql for like query spec");
+}
+
+- (void) testLikeQueryIdsSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newLikeQuerySpec:@"employees" withPath:@"lastName" withLikeKey:@"Bon%" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for like query spec");
+}
+
+- (void) testSmartQueryCountSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newSmartQuerySpec:@"select {employees:salary} from {employees} where {employees:lastName} = 'Haas'" withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT count(*) FROM (select {employees:salary} from {employees} where {employees:lastName} = 'Haas')", querySpec.countSmartSql, @"Wrong count smart sql");
+}
+
+- (void) testSmartQueryIdsSmartSql
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newSmartQuerySpec:@"select {employees:salary} from {employees} where {employees:lastName} = 'Haas'" withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT id FROM (select {employees:salary} from {employees} where {employees:lastName} = 'Haas')", querySpec.idsSmartSql, @"Wrong ids smart sql");
+}
+
+@end

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
@@ -48,6 +48,8 @@
 #define kSalary               @"salary"
 #define kBudget               @"budget"
 #define kName                 @"name"
+#define kEducation            @"education"
+#define kBuilding             @"building"
 
 #pragma mark - setup and teardown
 
@@ -58,23 +60,27 @@
     self.store = [SFSmartStore sharedStoreWithName:kTestStore user:[SFUserAccountManager sharedInstance].currentUser];
     
     // Employees soup
-    [self.store registerSoup:kEmployeesSoup                              // should be TABLE_1
-          withIndexSpecs:[SFSoupIndex asArraySoupIndexes:
-                          @[[self createStringIndexSpec:kFirstName],
-                           [self createStringIndexSpec:kLastName],    // should be TABLE_1_0
-                           [self createStringIndexSpec:kDeptCode],    // should be TABLE_1_1
-                           [self createStringIndexSpec:kEmployeeId],  // should be TABLE_1_2
-                           [self createStringIndexSpec:kManagerId],   // should be TABLE_1_3
-                           [self createFloatingIndexSpec:kSalary]]]
-                   error:nil];
+    [self.store registerSoup:kEmployeesSoup                               // should be TABLE_1
+              withIndexSpecs:[SFSoupIndex asArraySoupIndexes:
+                              @[[self createStringIndexSpec:kFirstName],   // should be TABLE_1_0
+                                [self createStringIndexSpec:kLastName],    // should be TABLE_1_1
+                                [self createStringIndexSpec:kDeptCode],    // should be TABLE_1_2
+                                [self createStringIndexSpec:kEmployeeId],  // should be TABLE_1_3
+                                [self createStringIndexSpec:kManagerId],   // should be TABLE_1_4
+                                [self createFloatingIndexSpec:kSalary],    // should be TABLE_1_5
+                                [self createJSON1IndexSpec:kEducation]     // should be json_extract(soup, '$.education')
+                                ]]
+                       error:nil];
 
     // Departments soup
-    [self.store registerSoup:kDepartmentsSoup                            // should be TABLE_2
-          withIndexSpecs:[SFSoupIndex asArraySoupIndexes:
-                          @[[self createStringIndexSpec:kDeptCode],    // should be TABLE_2_0
-                           [self createStringIndexSpec:kName],        // should be TABLE_2_1
-                           [self createIntegerIndexSpec:kBudget]]]
-                   error:nil];
+    [self.store registerSoup:kDepartmentsSoup                              // should be TABLE_2
+              withIndexSpecs:[SFSoupIndex asArraySoupIndexes:
+                              @[[self createStringIndexSpec:kDeptCode],    // should be TABLE_2_0
+                                [self createStringIndexSpec:kName],        // should be TABLE_2_1
+                                [self createIntegerIndexSpec:kBudget],     // should be TABLE_2_2
+                                [self createJSON1IndexSpec:kBuilding]      // should be json_extract(soup, '$.building')
+                                ]]
+                       error:nil];
 }
 
 - (void) tearDown
@@ -166,6 +172,27 @@
     XCTAssertEqualObjects(@"select mgr.id, e.id from TABLE_1 as mgr, TABLE_1 as e", 
                          [self.store convertSmartSql:@"select mgr.{employees:_soupEntryId}, e.{employees:_soupEntryId} from {employees} as mgr, {employees} as e"], @"Bad conversion");
 }
+
+- (void) testConvertSmartSqlWithJSON1
+{
+    XCTAssertEqualObjects(@"select TABLE_1_1, json_extract(soup, '$.education') from TABLE_1 where json_extract(soup, '$.education') = 'MIT'",
+                          [self.store convertSmartSql:@"select {employees:lastName}, {employees:education} from {employees} where {employees:education} = 'MIT'"], @"Bad conversion");
+}
+
+- (void) testConvertSmartSqlWithJSON1AndTableQualifiedColumn
+{
+    XCTAssertEqualObjects(@"select json_extract(TABLE_1.soup, '$.education') from TABLE_1 order by json_extract(TABLE_1.soup, '$.education')",
+                          [self.store convertSmartSql:@"select {employees}.{employees:education} from {employees} order by {employees}.{employees:education}"], @"Bad conversion");
+}
+
+- (void) testConvertSmartSqlWithJSON1AndTableAliases
+{
+    XCTAssertEqualObjects(@"select json_extract(e.soup, '$.education'), json_extract(soup, '$.building') from TABLE_1 as e, TABLE_2",
+                          [self.store convertSmartSql:@"select e.{employees:education}, {departments:building} from {employees} as e, {departments}"], @"Bad conversion");
+    
+    // XXX join query with json1 will only run if all the json1 columns are qualified by table or alias
+}
+
 
 - (void) testSmartQueryDoingCount 
 {

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.h
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.h
@@ -37,6 +37,7 @@
 - (NSDictionary*) createIntegerIndexSpec:(NSString*) path;
 - (NSDictionary*) createFloatingIndexSpec:(NSString*) path;
 - (NSDictionary*) createFullTextIndexSpec:(NSString*) path;
+- (NSDictionary*) createJSON1IndexSpec:(NSString*) path;
 - (NSDictionary*) createSimpleIndexSpec:(NSString*) path withType:(NSString*) pathType;
 
 - (BOOL) hasTable:(NSString*)tableName store:(SFSmartStore*)store;

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
@@ -111,6 +111,11 @@
     return [self createSimpleIndexSpec:path withType:kSoupIndexTypeString];
 }
 
+- (NSDictionary*) createJSON1IndexSpec:(NSString*) path
+{
+    return [self createSimpleIndexSpec:path withType:kSoupIndexTypeJSON1];
+}
+
 - (NSDictionary*) createSimpleIndexSpec:(NSString*) path withType:(NSString*) pathType
 {
     return @{@"path": path, @"type": pathType};


### PR DESCRIPTION
Around the calculated fields for a query spec and smart sql to sql generation
Tests apply to recent changes (json1 / remove by query) but also older code.

One issue found and fixed (table alias for json1 columns in smart sql - same fix will need to be done on Android).
One issue found not yet fixed (joins with json1 columns that are not table/alias qualified - I'll try to fix this one before merging this pull request - the same fix will have to be done on Android).