### PR TITLE
New optional parameter (selectPaths) for query specs

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
@@ -44,7 +44,7 @@
     
     for (NSUInteger i = 0; i < numDataStrings; i++) {
         for (NSUInteger j = i + 1; j < numDataStrings; j++) {
-            XCTAssertFalse([[dataStringArray objectAtIndex:i] isEqualToData:[dataStringArray objectAtIndex:j]], @"Random data strings at index %lu and %d are equal.  Not enough entropy!", (unsigned long)i, j);
+            XCTAssertFalse([[dataStringArray objectAtIndex:i] isEqualToData:[dataStringArray objectAtIndex:j]], @"Random data strings at index %lu and %luu are equal.  Not enough entropy!", (unsigned long)i, (unsigned long)j);
         }
     }
 }

--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2012-2014, salesforce.com, inc. All rights reserved.
+ Copyright (c) 2012-present, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -38,6 +38,7 @@ extern NSString * const kQuerySpecTypeLike;
 extern NSString * const kQuerySpecTypeSmart;
 extern NSString * const kQuerySpecTypeMatch;
 
+extern NSString * const kQuerySpecParamSelectPaths;
 extern NSString * const kQuerySpecParamIndexPath;
 extern NSString * const kQuerySpecParamOrder;
 extern NSString * const kQuerySpecParamPageSize;
@@ -98,6 +99,11 @@ typedef NS_ENUM(NSUInteger, SFSoupQuerySortOrder) {
 @property (nonatomic, strong) NSString *soupName;
 
 /**
+ The paths to return in an array. nil means return the entire soup element.
+ */
+@property (nonatomic, strong) NSArray *selectPaths;
+
+/**
  The indexPath to use for the query. Compound paths must be dot-delimited ie parent.child.grandchild.field .
  */
 @property (nonatomic, strong) NSString *path;
@@ -142,6 +148,7 @@ typedef NS_ENUM(NSUInteger, SFSoupQuerySortOrder) {
  * Factory method to build an exact query spec
  * Note: caller is responsible for releaseing the query spec
  * @param soupName The target soup name.
+ * @param selectPaths The paths to return - if nil the entire soup element is returned.
  * @param path The path to filter on.
  * @param matchKey The exact value to match.
  * @param orderPath The path to sort by.
@@ -149,12 +156,14 @@ typedef NS_ENUM(NSUInteger, SFSoupQuerySortOrder) {
  * @param pageSize The page size.
  * @return A query spec object.
  */
++ (SFQuerySpec*) newExactQuerySpec:(NSString*)soupName withSelectPaths:(NSArray*)selectPaths withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
 + (SFQuerySpec*) newExactQuerySpec:(NSString*)soupName withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
 
 /**
  * Factory method to build an like query spec
  * Note: caller is responsible for releaseing the query spec
  * @param soupName The target soup name.
+ * @param selectPaths The paths to return - if nil the entire soup element is returned.
  * @param path The path to filter on.
  * @param likeKey The value to match on.
  * @param orderPath The path to sort by.
@@ -162,12 +171,14 @@ typedef NS_ENUM(NSUInteger, SFSoupQuerySortOrder) {
  * @param pageSize The page size.
  * @return A query spec object.
  */
++ (SFQuerySpec*) newLikeQuerySpec:(NSString*)soupName withSelectPaths:(NSArray*)selectPaths withPath:(NSString*)path withLikeKey:(NSString*)likeKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
 + (SFQuerySpec*) newLikeQuerySpec:(NSString*)soupName withPath:(NSString*)path withLikeKey:(NSString*)likeKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
 
 /**
  * Factory method to build an range query spec
  * Note: caller is responsible for releaseing the query spec
  * @param soupName The target soup name.
+ * @param selectPaths The paths to return - if nil the entire soup element is returned.
  * @param path The path to filter on.
  * @param beginKey The start of the range.
  * @param endKey The end of the range.
@@ -176,16 +187,34 @@ typedef NS_ENUM(NSUInteger, SFSoupQuerySortOrder) {
  * @param pageSize The page size.
  * @return A query spec object.
  */
++ (SFQuerySpec*) newRangeQuerySpec:(NSString*)soupName withSelectPaths:(NSArray*)selectPaths withPath:(NSString*)path withBeginKey:(NSString*)beginKey withEndKey:(NSString*)endKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
 + (SFQuerySpec*) newRangeQuerySpec:(NSString*)soupName withPath:(NSString*)path withBeginKey:(NSString*)beginKey withEndKey:(NSString*)endKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
 
 /**
  * Factory method to build a query spec to return all data from a soup.
  * @param soupName The target soup name.
+ * @param selectPaths The paths to return - if nil the entire soup element is returned.
  * @param orderPath The path to sort by.
  * @param order The sort order.
  * @param pageSize The page size.
  */
++ (SFQuerySpec*) newAllQuerySpec:(NSString*)soupName withSelectPaths:(NSArray*)selectPaths withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
 + (SFQuerySpec*) newAllQuerySpec:(NSString*)soupName withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
+
+/**
+ * Factory method to build a match query spec (full-text search)
+ * Note: caller is responsible for releaseing the query spec
+ * @param soupName The target soup name.
+ * @param selectPaths The paths to return - if nil the entire soup element is returned.
+ * @param path The path to filter on - can be nil to match against any full-text indexed paths.
+ * @param matchKey The match query string.
+ * @param orderPath The path to sort by.
+ * @param order The sort order.
+ * @param pageSize The page size.
+ * @return A query spec object.
+ */
++ (SFQuerySpec*) newMatchQuerySpec:(NSString*)soupName withSelectPaths:(NSArray*)selectPaths withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
++ (SFQuerySpec*) newMatchQuerySpec:(NSString*)soupName withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
 
 /**
  * Factory method to build a smart query spec
@@ -196,18 +225,6 @@ typedef NS_ENUM(NSUInteger, SFSoupQuerySortOrder) {
  */
 + (SFQuerySpec*) newSmartQuerySpec:(NSString*)smartSql withPageSize:(NSUInteger)pageSize;
 
-/**
- * Factory method to build a match query spec (full-text search)
- * Note: caller is responsible for releaseing the query spec
- * @param soupName The target soup name.
- * @param path The path to filter on - can be nil to match against any full-text indexed paths
- * @param matchKey The match query string.
- * @param orderPath The path to sort by.
- * @param order The sort order.
- * @param pageSize The page size.
- * @return A query spec object.
- */
-+ (SFQuerySpec*) newMatchQuerySpec:(NSString*)soupName withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
 /**
  * Initializes the object with the given query spec.
  * @param querySpec the name/value pairs defining the query spec.

--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
@@ -37,6 +37,7 @@ NSString * const kQuerySpecTypeSmart = @"smart";
 NSString * const kQuerySpecTypeMatch = @"match";
 
 NSString * const kQuerySpecParamQueryType = @"queryType";
+NSString * const kQuerySpecParamSelectPaths = @"selectPaths";
 NSString * const kQuerySpecParamIndexPath = @"indexPath";
 NSString * const kQuerySpecParamOrderPath = @"orderPath";
 NSString * const kQuerySpecParamOrder = @"order";
@@ -52,10 +53,15 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
 @implementation SFQuerySpec
 
 + (SFQuerySpec*) newExactQuerySpec:(NSString*)soupName withPath:(NSString*)path withMatchKey:(NSString*)matchKey  withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize {
+    return [SFQuerySpec newExactQuerySpec:soupName withSelectPaths:nil withPath:path withMatchKey:matchKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
+}
+
++ (SFQuerySpec*) newExactQuerySpec:(NSString*)soupName withSelectPaths:(NSArray*)selectPaths withPath:(NSString*)path withMatchKey:(NSString*)matchKey  withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize {
     SFQuerySpec* querySpec = [[super alloc] init];
     if (nil != querySpec) {
         querySpec.queryType = kSFSoupQueryTypeExact;
         querySpec.path = path;
+        querySpec.selectPaths = selectPaths;
         querySpec.soupName = soupName;
         querySpec.path = path;
         querySpec.matchKey = matchKey;
@@ -68,11 +74,16 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
 }
 
 + (SFQuerySpec*) newLikeQuerySpec:(NSString*)soupName withPath:(NSString*)path withLikeKey:(NSString*)likeKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize {
+    return [SFQuerySpec newLikeQuerySpec:soupName withSelectPaths:nil withPath:path withLikeKey:likeKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
+}
+
++ (SFQuerySpec*) newLikeQuerySpec:(NSString*)soupName withSelectPaths:(NSArray*)selectPaths withPath:(NSString*)path withLikeKey:(NSString*)likeKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize {
     SFQuerySpec* querySpec = [[super alloc] init];
     if (nil != querySpec) {
         querySpec.queryType = kSFSoupQueryTypeLike;
         querySpec.soupName = soupName;
         querySpec.path = path;
+        querySpec.selectPaths = selectPaths;
         querySpec.likeKey = likeKey;
         querySpec.orderPath = orderPath;
         querySpec.order = order;
@@ -83,11 +94,16 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
 }
 
 + (SFQuerySpec*) newRangeQuerySpec:(NSString*)soupName withPath:(NSString*)path withBeginKey:(NSString*)beginKey withEndKey:(NSString*)endKey  withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize {
+    return [SFQuerySpec newRangeQuerySpec:soupName withSelectPaths:nil withPath:path withBeginKey:beginKey withEndKey:endKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
+}
+
++ (SFQuerySpec*) newRangeQuerySpec:(NSString*)soupName withSelectPaths:(NSArray*)selectPaths withPath:(NSString*)path withBeginKey:(NSString*)beginKey withEndKey:(NSString*)endKey  withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize {
     SFQuerySpec* querySpec = [[super alloc] init];
     if (nil != querySpec) {
         querySpec.queryType = kSFSoupQueryTypeRange;
         querySpec.soupName = soupName;
         querySpec.path = path;
+        querySpec.selectPaths = selectPaths;
         querySpec.beginKey = beginKey;
         querySpec.endKey = endKey;
         querySpec.orderPath = orderPath;
@@ -99,7 +115,32 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
 }
 
 + (SFQuerySpec*) newAllQuerySpec:(NSString *)soupName withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize {
-    return [self newRangeQuerySpec:soupName withPath:nil withBeginKey:nil withEndKey:nil withOrderPath:orderPath withOrder:order withPageSize:pageSize];
+    return [SFQuerySpec newAllQuerySpec:soupName withSelectPaths:nil withOrderPath:orderPath withOrder:order withPageSize:pageSize];
+}
+
++ (SFQuerySpec*) newAllQuerySpec:(NSString *)soupName withSelectPaths:(NSArray*)selectPaths withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize {
+    return [self newRangeQuerySpec:soupName withSelectPaths:selectPaths withPath:nil withBeginKey:nil withEndKey:nil withOrderPath:orderPath withOrder:order withPageSize:pageSize];
+}
+
++ (SFQuerySpec*) newMatchQuerySpec:(NSString*)soupName withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize {
+    return [SFQuerySpec newMatchQuerySpec:soupName withSelectPaths:nil withPath:path withMatchKey:matchKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
+}
+
++ (SFQuerySpec*) newMatchQuerySpec:(NSString*)soupName withSelectPaths:(NSArray*)selectPaths withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize {
+    SFQuerySpec* querySpec = [[super alloc] init];
+    if (nil != querySpec) {
+        querySpec.queryType = kSFSoupQueryTypeMatch;
+        querySpec.path = path;
+        querySpec.soupName = soupName;
+        querySpec.selectPaths = selectPaths;
+        querySpec.path = path;
+        querySpec.matchKey = matchKey;
+        querySpec.orderPath = orderPath;
+        querySpec.order = order;
+        querySpec.pageSize = pageSize;
+        [querySpec computeSmartAndCountAndIdsSql];
+    }
+    return querySpec;
 }
 
 + (SFQuerySpec*) newSmartQuerySpec:(NSString*)smartSql withPageSize:(NSUInteger)pageSize {
@@ -114,27 +155,11 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
     return querySpec;
 }
 
-+ (SFQuerySpec*) newMatchQuerySpec:(NSString*)soupName withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize {
-    SFQuerySpec* querySpec = [[super alloc] init];
-    if (nil != querySpec) {
-        querySpec.queryType = kSFSoupQueryTypeMatch;
-        querySpec.path = path;
-        querySpec.soupName = soupName;
-        querySpec.path = path;
-        querySpec.matchKey = matchKey;
-        querySpec.orderPath = orderPath;
-        querySpec.order = order;
-        querySpec.pageSize = pageSize;
-        [querySpec computeSmartAndCountAndIdsSql];
-    }
-    return querySpec;
-}
-
-
 - (id)initWithDictionary:(NSDictionary*)querySpec withSoupName:(NSString*) targetSoupName {
     
     NSString* rawQueryType = [querySpec nonNullObjectForKey:kQuerySpecParamQueryType];
     NSString* path = [querySpec nonNullObjectForKey:kQuerySpecParamIndexPath];
+    NSArray* selectPaths = [querySpec nonNullObjectForKey:kQuerySpecParamSelectPaths];
     NSString* beginKey = [querySpec nonNullObjectForKey:kQuerySpecParamBeginKey];
     NSString* endKey = [querySpec nonNullObjectForKey:kQuerySpecParamEndKey];
     NSString* matchKey = [querySpec nonNullObjectForKey:kQuerySpecParamMatchKey];
@@ -154,15 +179,15 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
     NSUInteger pageSize = ([rawPageSize integerValue] > 0 ? [rawPageSize integerValue] : kQuerySpecDefaultPageSize);
     
     if ([rawQueryType isEqualToString:kQuerySpecTypeRange]) {
-        self = [SFQuerySpec newRangeQuerySpec:targetSoupName withPath:path withBeginKey:beginKey withEndKey:endKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
+        self = [SFQuerySpec newRangeQuerySpec:targetSoupName withSelectPaths:selectPaths withPath:path withBeginKey:beginKey withEndKey:endKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
     } else if ([rawQueryType isEqualToString:kQuerySpecTypeLike]) {
-        self = [SFQuerySpec newLikeQuerySpec:targetSoupName withPath:path withLikeKey:likeKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
+        self = [SFQuerySpec newLikeQuerySpec:targetSoupName withSelectPaths:selectPaths withPath:path withLikeKey:likeKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
     } else if ([rawQueryType isEqualToString:kQuerySpecTypeExact]) {
-        self = [SFQuerySpec newExactQuerySpec:targetSoupName withPath:path withMatchKey:matchKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
+        self = [SFQuerySpec newExactQuerySpec:targetSoupName withSelectPaths:selectPaths withPath:path withMatchKey:matchKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
+    } else if ([rawQueryType isEqualToString:kQuerySpecTypeMatch]) {
+        self = [SFQuerySpec newMatchQuerySpec:targetSoupName withSelectPaths:selectPaths withPath:path withMatchKey:matchKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
     } else if ([rawQueryType isEqualToString:kQuerySpecTypeSmart]) {
         self = [SFQuerySpec newSmartQuerySpec:smartSql withPageSize:pageSize];
-    } else if ([rawQueryType isEqualToString:kQuerySpecTypeMatch]) {
-        self = [SFQuerySpec newMatchQuerySpec:targetSoupName withPath:path withMatchKey:matchKey withOrderPath:orderPath withOrder:order withPageSize:pageSize];
     } else {
         [self log:SFLogLevelDebug format:@"Invalid queryType: '%@'", rawQueryType];
         self = nil;
@@ -246,7 +271,15 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
 }
 
 - (NSString*)computeSelectClause {
-    return [@[@"SELECT ", [self computeFieldReference:@"_soup"], @" "] componentsJoinedByString:@""];
+    NSMutableArray* fieldReferences = [NSMutableArray new];
+    for (NSString* selectPath in (self.selectPaths ? self.selectPaths : @[@"_soup"])) {
+        [fieldReferences addObject:[self computeFieldReference:selectPath]];
+    }
+
+    return [@[@"SELECT ",
+              [fieldReferences componentsJoinedByString:@", "],
+              @" "]
+            componentsJoinedByString:@""];
 }
 
 - (NSString*)computeFromClause {

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -542,7 +542,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
         FMResultSet* frs = [db executeQuery:explainSql withArgumentsInArray:arguments];
         while ([frs next]) {
             NSMutableDictionary* explainRow = [NSMutableDictionary new];
-            for (NSUInteger i=0; i<frs.columnCount; i++) {
+            for (int i=0; i<frs.columnCount; i++) {
                 explainRow[[frs columnNameForIndex:i]] = [frs stringForColumnIndex:i];
             }
             [explainRows addObject:explainRow];
@@ -1012,7 +1012,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
         [createIndexStmts addObject:[NSString stringWithFormat:createIndexFormat, soupTableName, col, soupTableName, col]];
     }
     
-    for (NSUInteger i = 0; i < [indexSpecs count]; i++) {
+    for (int i = 0; i < [indexSpecs count]; i++) {
         SFSoupIndex *indexSpec = (SFSoupIndex*) indexSpecs[i];
         
         // for creating the soup table itself in the store db
@@ -1596,7 +1596,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
 {
     NSString *soupTableName = [self tableNameForSoup:soupName withDb:db];
     NSString* querySql = [self convertSmartSql: querySpec.idsSmartSql withDb:db];
-    NSString* limitSql = [NSString stringWithFormat:@"SELECT * FROM (%@) LIMIT %u", querySql, querySpec.pageSize];
+    NSString* limitSql = [NSString stringWithFormat:@"SELECT * FROM (%@) LIMIT %lu", querySql, (unsigned long)querySpec.pageSize];
     NSString *deleteSql = [NSString stringWithFormat:@"DELETE FROM %@ WHERE %@ in (%@)", soupTableName, ID_COL, limitSql];
     NSArray* args = [querySpec bindsForQuerySpec];
     [self executeUpdateThrows:deleteSql withArgumentsInArray:args withDb:db];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -1281,7 +1281,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
     FMResultSet *frs = [self executeQueryThrows:limitSql withArgumentsInArray:args withDb:db];
     while ([frs next]) {
         // Smart queries
-        if (querySpec.queryType == kSFSoupQueryTypeSmart) {
+        if (querySpec.queryType == kSFSoupQueryTypeSmart || querySpec.selectPaths != nil) {
             NSArray *data = [self getDataFromRow:frs];
             if (data) {
                 [result addObject:data];

--- a/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
@@ -45,6 +45,12 @@
     XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.smartSql, @"Wrong smart sql for all query spec");
 }
 
+- (void) testAllQuerySmartSqlWithSelectPaths
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newAllQuerySpec:@"employees" withSelectPaths:@[@"firstName", @"lastName"] withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderDescending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT {employees:firstName}, {employees:lastName} FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.smartSql, @"Wrong ids smart sql for all query spec with select paths");
+}
+
 - (void) testAllQueryCountSmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newAllQuerySpec:@"employees" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderDescending withPageSize:1];
@@ -61,6 +67,12 @@
 {
     SFQuerySpec* querySpec = [SFQuerySpec newRangeQuerySpec:@"employees" withPath:@"lastName" withBeginKey:@"Bond" withEndKey:@"Smith" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
     XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for range query spec");
+}
+
+- (void) testRangeQuerySmartSqlWithSelectPaths
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newRangeQuerySpec:@"employees" withSelectPaths:@[@"firstName"] withPath:@"lastName" withBeginKey:@"Bond" withEndKey:@"Smith" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT {employees:firstName} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for range query spec with select paths");
 }
 
 - (void) testRangeQueryCountSmartSql
@@ -81,6 +93,12 @@
     XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for exact query spec");
 }
 
+- (void) testExactQuerySmartSqlWithSelectPaths
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newExactQuerySpec:@"employees" withSelectPaths:@[@"firstName", @"lastName"] withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT {employees:firstName}, {employees:lastName} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for exact query spec with select paths");
+}
+
 - (void) testExactQueryCountSmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newExactQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
@@ -99,6 +117,12 @@
     XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec");
 }
 
+- (void) testMatchQuerySmartSqlWithSelectPaths
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withSelectPaths:@[@"firstName", @"lastName", @"title"] withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec with select paths");
+}
+
 - (void) testMatchQueryCountSmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
@@ -111,12 +135,16 @@
     XCTAssertEqualObjects(@"SELECT id FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for match query spec");
 }
 
-
-
 - (void) testLikeQuerySmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newLikeQuerySpec:@"employees" withPath:@"lastName" withLikeKey:@"Bon%" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
     XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for like query spec");
+}
+
+- (void) testLikeQuerySmartSqlWithSelectPaths
+{
+    SFQuerySpec* querySpec = [SFQuerySpec newLikeQuerySpec:@"employees" withSelectPaths:@[@"title"] withPath:@"lastName" withLikeKey:@"Bon%" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT {employees:title} FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for like query spec");
 }
 
 - (void) testLikeQueryCountSmartSql

--- a/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
@@ -114,25 +114,25 @@
 - (void) testMatchQuerySmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec");
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec");
 }
 
 - (void) testMatchQuerySmartSqlWithSelectPaths
 {
     SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withSelectPaths:@[@"firstName", @"lastName", @"title"] withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec with select paths");
+    XCTAssertEqualObjects(@"SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec with select paths");
 }
 
 - (void) testMatchQueryCountSmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT count(*) FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ", querySpec.countSmartSql, @"Wrong count smart sql for match query spec");
+    XCTAssertEqualObjects(@"SELECT count(*) FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ", querySpec.countSmartSql, @"Wrong count smart sql for match query spec");
 }
 
 - (void) testMatchQueryIdsSmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT id FROM {employees}, {employees}_fts WHERE {employees}_fts.docid = {employees:_soupEntryId} AND {employees}_fts.{employees:lastName} MATCH 'Bond' ORDER BY {employees}.{employees:firstName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for match query spec");
+    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees}.{employees:firstName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for match query spec");
 }
 
 - (void) testLikeQuerySmartSql

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreFullTextSearchTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreFullTextSearchTests.m
@@ -399,12 +399,22 @@
 
 - (void) trySearch:(NSArray*)expectedIds path:(NSString*)path matchKey:(NSString*)matchKey orderPath:(NSString*)orderPath
 {
+    // Returning soup elements
     SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:kEmployeesSoup withPath:path withMatchKey:matchKey withOrderPath:orderPath withOrder:kSFSoupQuerySortOrderAscending withPageSize:25];
     NSArray* results = [self.store queryWithQuerySpec:querySpec pageIndex:0 error:nil];
     XCTAssertEqual(expectedIds.count, results.count, @"Wrong number of results");
     for (int i=0; i<results.count; i++) {
-        XCTAssertEqual(((NSNumber*)expectedIds[i]).longValue, ((NSNumber*)results[i][SOUP_ENTRY_ID]).longValue, @"Wrong results");
+        XCTAssertEqual(((NSNumber*)expectedIds[i]).longValue, ((NSNumber*)results[i][SOUP_ENTRY_ID]).longValue, @"Wrong results for match query returning soup elements");
     }
+    
+    // Returning just id
+    querySpec = [SFQuerySpec newMatchQuerySpec:kEmployeesSoup withSelectPaths:@[SOUP_ENTRY_ID] withPath:path withMatchKey:matchKey withOrderPath:orderPath withOrder:kSFSoupQuerySortOrderAscending withPageSize:25];
+    results = [self.store queryWithQuerySpec:querySpec pageIndex:0 error:nil];
+    XCTAssertEqual(expectedIds.count, results.count, @"Wrong number of results");
+    for (int i=0; i<results.count; i++) {
+        XCTAssertEqual(((NSNumber*)expectedIds[i]).longValue, ((NSNumber*)results[i][0]).longValue, @"Wrong results for match query with selectPaths");
+    }
+    
 }
 
 

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreLoadTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreLoadTests.m
@@ -136,7 +136,7 @@ numberCharactersPerField:(NSUInteger)numberCharactersPerField
 {
     NSMutableArray* indexSpecs = [NSMutableArray new];
     for (NSUInteger indexNumber=0; indexNumber<numberIndexes; indexNumber++) {
-        indexSpecs[indexNumber] = @{kSoupIndexPath:[NSString stringWithFormat:@"k_%u", indexNumber], kSoupIndexType:indexType};
+        indexSpecs[indexNumber] = @{kSoupIndexPath:[NSString stringWithFormat:@"k_%tu", indexNumber], kSoupIndexType:indexType};
     }
     NSError* error = nil;
     [self.store registerSoup:TEST_SOUP withIndexSpecs:[SFSoupIndex asArraySoupIndexes:indexSpecs] error:&error];
@@ -154,8 +154,8 @@ numberCharactersPerField:(NSUInteger)numberCharactersPerField
         for (NSUInteger entryNumber=0; entryNumber<numberEntriesPerBatch; entryNumber++) {
             NSMutableDictionary* entry = [NSMutableDictionary new];
             for (NSUInteger fieldNumber=0; fieldNumber<numberFieldsPerEntry; fieldNumber++) {
-                NSString* value = [self pad:[NSString stringWithFormat:@"v_%u_%u_%u_", batchNumber, entryNumber, fieldNumber] numberCharacters:numberCharactersPerField];
-                entry[[NSString stringWithFormat:@"k_%u", fieldNumber]] = value;
+                NSString* value = [self pad:[NSString stringWithFormat:@"v_%lu_%lu_%lu_", (unsigned long)batchNumber, (unsigned long)entryNumber, (unsigned long)fieldNumber] numberCharacters:numberCharactersPerField];
+                entry[[NSString stringWithFormat:@"k_%lu", (unsigned long)fieldNumber]] = value;
             }
             [entries addObject:entry];
         }

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
@@ -150,7 +150,7 @@
 - (void) checkExplainQueryPlan:(NSString*) soupName index:(NSUInteger)index covering:(BOOL) covering dbOperation:(NSString*)dbOperation store:(SFSmartStore*)store
 {
     NSString* soupTableName = [self getSoupTableName:soupName store:store];
-    NSString* indexName = [NSString stringWithFormat:@"%@_%u_idx", soupTableName, index];
+    NSString* indexName = [NSString stringWithFormat:@"%@_%lu_idx", soupTableName, (unsigned long)index];
     NSString* expectedDetailPrefix = [NSString stringWithFormat:@"%@ TABLE %@ USING %@INDEX %@", dbOperation, soupTableName, (covering ? @"COVERING " : @""), indexName];
     NSString* actualDetail = ((NSArray*)store.lastExplainQueryPlan[EXPLAIN_ROWS])[0][@"detail"];
     XCTAssertTrue([actualDetail hasPrefix:expectedDetailPrefix], "Wrong explain plan actual: %@", actualDetail);

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -216,7 +216,7 @@
     for (SFSmartStore *store in @[ self.store, self.globalStore ]) {
         for (NSUInteger i = 0; i < numRegisterAndDropIterations; i++) {
             // Before
-            XCTAssertFalse([store soupExists:kTestSoupName], @"In iteration %u: Soup %@ should not exist before registration.", (i + 1), kTestSoupName);
+            XCTAssertFalse([store soupExists:kTestSoupName], @"In iteration %lu: Soup %@ should not exist before registration.", (i + 1), kTestSoupName);
             
             // Register
             NSError* error = nil;
@@ -224,7 +224,7 @@
                  withIndexSpecs:[SFSoupIndex asArraySoupIndexes:@[@{@"path": @"key",@"type": indexType}, @{@"path": @"value",@"type": @"string"}]]
                           error:&error];
             BOOL testSoupExists = [store soupExists:kTestSoupName];
-            XCTAssertTrue(testSoupExists, @"In iteration %u: Soup %@ should exist after registration.", (i + 1), kTestSoupName);
+            XCTAssertTrue(testSoupExists, @"In iteration %lu: Soup %@ should exist after registration.", (i + 1), kTestSoupName);
             XCTAssertNil(error, @"There should be no errors.");
             NSString* soupTableName = [self getSoupTableName:kTestSoupName store:store];
             
@@ -259,7 +259,7 @@
             // Remove
             [store removeSoup:kTestSoupName];
             testSoupExists = [store soupExists:kTestSoupName];
-            XCTAssertFalse(testSoupExists, @"In iteration %u: Soup %@ should no longer exist after dropping.", (i + 1), kTestSoupName);
+            XCTAssertFalse(testSoupExists, @"In iteration %lu: Soup %@ should no longer exist after dropping.", (i + 1), kTestSoupName);
         }
     }
 }

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -328,6 +328,15 @@
                                         covering:NO
                              expectedDbOperation:@"SCAN"
                                            store:store];
+
+        // Query all with select paths
+        [self runQueryCheckResultsAndExplainPlan:[SFQuerySpec newAllQuerySpec:kTestSoupName withSelectPaths:@[@"key"] withOrderPath:@"key" withOrder:kSFSoupQuerySortOrderAscending withPageSize:10]
+                                            page:0
+                                 expectedResults:@[@[@"ka1"], @[@"ka2"], @[@"ka3"]]
+                                        covering:![indexType isEqualToString:kSoupIndexTypeJSON1] //interestingly the explain plan doesn't use a covering index with a functional index
+                             expectedDbOperation:@"SCAN"
+                                           store:store];
+
     }
 }
 
@@ -385,6 +394,15 @@
                                             page:0
                                  expectedResults:@[soupEltsCreated[2], soupEltsCreated[1]]
                                         covering:NO
+                             expectedDbOperation:@"SEARCH"
+                                           store:store];
+        
+
+        // Range query with select paths
+        [self runQueryCheckResultsAndExplainPlan:[SFQuerySpec newRangeQuerySpec:kTestSoupName withSelectPaths:@[@"key"] withPath:@"key" withBeginKey:@"ka2" withEndKey:@"ka3" withOrderPath:@"key" withOrder:kSFSoupQuerySortOrderDescending withPageSize:10]
+                                            page:0
+                                 expectedResults:@[@[@"ka3"], @[@"ka2"]]
+                                        covering:![indexType isEqualToString:kSoupIndexTypeJSON1] // interestingly the explain plan doesn't use a covering index with a functional index
                              expectedDbOperation:@"SEARCH"
                                            store:store];
         
@@ -486,6 +504,15 @@
                                         covering:NO
                              expectedDbOperation:@"SCAN"
                                            store:store];
+
+        // Like query (contains) with select paths
+        [self runQueryCheckResultsAndExplainPlan:[SFQuerySpec newLikeQuerySpec:kTestSoupName withSelectPaths:@[@"key"] withPath:@"key" withLikeKey:@"%bc%" withOrderPath:@"key" withOrder:kSFSoupQuerySortOrderDescending withPageSize:10]
+                                            page:0
+                                 expectedResults:@[@[@"bbcd"], @[@"abcd"], @[@"abcc"]]
+                                        covering:![indexType isEqualToString:kSoupIndexTypeJSON1] // interestingly the explain plan doesn't use a covering index with a functional index
+                             expectedDbOperation:@"SCAN"
+                                           store:store];
+    
     }
 }
 

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -1273,7 +1273,7 @@ static NSException *authException = nil;
         NSInteger expectedProgress = (actualNumberChanges - 1) * 100 / numberChanges;
         [self checkStatus:[queue getNextSyncUpdate] expectedType:SFSyncStateSyncTypeUp expectedId:syncId expectedTarget:target expectedOptions:options expectedStatus:completionStatus expectedProgress:expectedProgress expectedTotalSize:numberChanges];
     } else {
-        XCTFail(@"completionStatus value '%d' not currently supported.", completionStatus);
+        XCTFail(@"completionStatus value '%ld' not currently supported.", (long)completionStatus);
     }
 }
 


### PR DESCRIPTION
If you specify [path1, path2] you get back [soupElt[path1], soupElt[path2]] for each matching row instead of the soupElt's.

This pull request has the native code changes and tests.
Hybrid and react native support will come in a separate pull request.