### PR TITLE
add back metadata tests

### DIFF
--- a/libs/SmartSync/SmartSyncTests/MetadataManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/MetadataManagerTests.m
@@ -90,7 +90,7 @@ static NSString* const kCaseOneName = @"00001001";
     [super tearDown];
 }
 
-- (void)FIXMEtestGlobalMRUObjectsFromServer
+- (void)testGlobalMRUObjectsFromServer
 {
     XCTestExpectation *objectMarkedAsViewed = [self expectationWithDescription:@"objectMarkedAsViewed"];
     [self.metadataManager markObjectAsViewed:kCaseOneId objectType:@"Case" networkFieldName:nil completionBlock:^() {
@@ -275,7 +275,7 @@ static NSString* const kCaseOneName = @"00001001";
     XCTAssertEqualObjects(cachedObjects, nil, @"MRU list should be nil");
 }
 
-- (void)FIXMEtestCleanCache
+- (void)testCleanCache
 {
     XCTestExpectation *objectsLoaded = [self expectationWithDescription:@"objectsLoaded"];
     [self.metadataManager loadMRUObjects:nil limit:1 cachePolicy:SFDataCachePolicyReloadAndReturnCacheOnFailure refreshCacheIfOlderThan:kRefreshInterval networkFieldName:nil inRetry:NO


### PR DESCRIPTION
@kchitalia @helenren @bhariharan @wmathurin Those tests are passing now after I use a new test account particularly for ios unit tests to reduce noise.