### PR TITLE
Since FTS query are done through a subquery instead of a join

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
@@ -343,7 +343,7 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
         return @"";
     }
     
-    return [@[@"ORDER BY ", [self computeSoupReference], @".", [self computeFieldReference:self.orderPath], @" ", [self sqlSortOrder], @" "] componentsJoinedByString:@""];
+    return [@[@"ORDER BY ", [self computeFieldReference:self.orderPath], @" ", [self sqlSortOrder], @" "] componentsJoinedByString:@""];
 }
 
 - (NSString*)computeFieldReference:(NSString*) field {

--- a/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
@@ -42,13 +42,13 @@
 - (void) testAllQuerySmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newAllQuerySpec:@"employees" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderDescending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.smartSql, @"Wrong smart sql for all query spec");
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} ORDER BY {employees:lastName} DESC ", querySpec.smartSql, @"Wrong smart sql for all query spec");
 }
 
 - (void) testAllQuerySmartSqlWithSelectPaths
 {
     SFQuerySpec* querySpec = [SFQuerySpec newAllQuerySpec:@"employees" withSelectPaths:@[@"firstName", @"lastName"] withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderDescending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:firstName}, {employees:lastName} FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.smartSql, @"Wrong ids smart sql for all query spec with select paths");
+    XCTAssertEqualObjects(@"SELECT {employees:firstName}, {employees:lastName} FROM {employees} ORDER BY {employees:lastName} DESC ", querySpec.smartSql, @"Wrong ids smart sql for all query spec with select paths");
 }
 
 - (void) testAllQueryCountSmartSql
@@ -60,19 +60,19 @@
 - (void) testAllQueryIdsSmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newAllQuerySpec:@"employees" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderDescending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT id FROM {employees} ORDER BY {employees}.{employees:lastName} DESC ", querySpec.idsSmartSql, @"Wrong ids smart sql for all query spec");
+    XCTAssertEqualObjects(@"SELECT id FROM {employees} ORDER BY {employees:lastName} DESC ", querySpec.idsSmartSql, @"Wrong ids smart sql for all query spec");
 }
 
 - (void) testRangeQuerySmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newRangeQuerySpec:@"employees" withPath:@"lastName" withBeginKey:@"Bond" withEndKey:@"Smith" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for range query spec");
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for range query spec");
 }
 
 - (void) testRangeQuerySmartSqlWithSelectPaths
 {
     SFQuerySpec* querySpec = [SFQuerySpec newRangeQuerySpec:@"employees" withSelectPaths:@[@"firstName"] withPath:@"lastName" withBeginKey:@"Bond" withEndKey:@"Smith" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:firstName} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for range query spec with select paths");
+    XCTAssertEqualObjects(@"SELECT {employees:firstName} FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for range query spec with select paths");
 }
 
 - (void) testRangeQueryCountSmartSql
@@ -84,19 +84,19 @@
 - (void) testRangeQueryIdsSmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newRangeQuerySpec:@"employees" withPath:@"lastName" withBeginKey:@"Bond" withEndKey:@"Smith" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for range query spec");
+    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:lastName} >= ? AND {employees:lastName} <= ? ORDER BY {employees:lastName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for range query spec");
 }
 
 - (void) testExactQuerySmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newExactQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for exact query spec");
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for exact query spec");
 }
 
 - (void) testExactQuerySmartSqlWithSelectPaths
 {
     SFQuerySpec* querySpec = [SFQuerySpec newExactQuerySpec:@"employees" withSelectPaths:@[@"firstName", @"lastName"] withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:firstName}, {employees:lastName} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for exact query spec with select paths");
+    XCTAssertEqualObjects(@"SELECT {employees:firstName}, {employees:lastName} FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for exact query spec with select paths");
 }
 
 - (void) testExactQueryCountSmartSql
@@ -108,19 +108,19 @@
 - (void) testExactQueryIdsSmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newExactQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for exact query spec");
+    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:lastName} = ? ORDER BY {employees:lastName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for exact query spec");
 }
 
 - (void) testMatchQuerySmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec");
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec");
 }
 
 - (void) testMatchQuerySmartSqlWithSelectPaths
 {
     SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withSelectPaths:@[@"firstName", @"lastName", @"title"] withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees}.{employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec with select paths");
+    XCTAssertEqualObjects(@"SELECT {employees:firstName}, {employees:lastName}, {employees:title} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec with select paths");
 }
 
 - (void) testMatchQueryCountSmartSql
@@ -132,19 +132,19 @@
 - (void) testMatchQueryIdsSmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"Bond" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees}.{employees:firstName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for match query spec");
+    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT docid FROM {employees}_fts WHERE {employees:lastName} MATCH 'Bond') ORDER BY {employees:firstName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for match query spec");
 }
 
 - (void) testLikeQuerySmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newLikeQuerySpec:@"employees" withPath:@"lastName" withLikeKey:@"Bon%" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for like query spec");
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for like query spec");
 }
 
 - (void) testLikeQuerySmartSqlWithSelectPaths
 {
     SFQuerySpec* querySpec = [SFQuerySpec newLikeQuerySpec:@"employees" withSelectPaths:@[@"title"] withPath:@"lastName" withLikeKey:@"Bon%" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT {employees:title} FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for like query spec");
+    XCTAssertEqualObjects(@"SELECT {employees:title} FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees:lastName} ASC ", querySpec.smartSql, @"Wrong smart sql for like query spec");
 }
 
 - (void) testLikeQueryCountSmartSql
@@ -156,7 +156,7 @@
 - (void) testLikeQueryIdsSmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newLikeQuerySpec:@"employees" withPath:@"lastName" withLikeKey:@"Bon%" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
-    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees}.{employees:lastName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for like query spec");
+    XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:lastName} LIKE ? ORDER BY {employees:lastName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for like query spec");
 }
 
 - (void) testSmartQueryCountSmartSql


### PR DESCRIPTION
we no longer need to qualify the order by column

NB: should have gone with this change: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/commit/95486afffcdc236de4161aa473dad70bc9df2180