### PR TITLE
Fix regression caused by #1560

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator.m
@@ -140,15 +140,6 @@ static NSString * const kSFIdentityDataPropertyKey            = @"com.salesforce
     self.session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
     [[self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
          __strong __typeof(self) strongSelf = weakSelf;
-        SFOAuthCredentials *currentCredentials = [SFUserAccountManager sharedInstance].currentUser.credentials;
-        if (![request.URL isEqual:currentCredentials.identityUrl]) {
-            // user account has changed, ignore the ID update
-            [strongSelf log:SFLogLevelDebug format:@"SFIdentityCoordinator Ignore ID data due to account change, old identity URL %@, new identity URL %@",
-             request.URL.absoluteString,
-             currentCredentials.identityUrl.absoluteString];
-            return;
-        }
-        
         if (error) {
             [strongSelf log:SFLogLevelDebug format:@"SFIdentityCoordinator session failed with error: %@", error];
             [strongSelf notifyDelegateOfFailure:error];


### PR DESCRIPTION
The bug here is the identity coordinator is comparing a value stored on a singleton instance.  This only works on the assumption that the identity coordinator will always be used with a user account that's the `currentUser` value.  If your SFUserAccount instance isn't assigned as the currentUser, it becomes impossible to load identity data for it.

Instead, this logic should be handled by the SFIdentityCoordinatorDelegate instance receiving updates about this class, and perform the necessary guard checks at that time.

I've discussed this with @qingqingliu and she agrees.