### PR TITLE
Add international roaming as a cause of network failure

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -615,6 +615,7 @@ static Class InstanceClass = nil;
             case NSURLErrorCannotConnectToHost:
             case NSURLErrorNetworkConnectionLost:
             case NSURLErrorNotConnectedToInternet:
+            case NSURLErrorInternationalRoamingOff:
                 isNetworkFailure = YES;
                 break;
             default:


### PR DESCRIPTION
This was requested in issue: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/1552

Roaming is not considered as a cause of network failure.