### PR TITLE
Full-text indexes now using FTS5 

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFAlterSoupLongOperation.m
+++ b/libs/SmartStore/SmartStore/Classes/SFAlterSoupLongOperation.m
@@ -251,7 +251,7 @@
         // Fts
         if ([SFSoupIndex hasFts:self.indexSpecs]) {
             NSMutableArray* oldColumnsFts = [NSMutableArray arrayWithObjects:ID_COL, nil];
-            NSMutableArray* newColumnsFts = [NSMutableArray arrayWithObjects:DOCID_COL, nil];
+            NSMutableArray* newColumnsFts = [NSMutableArray arrayWithObjects:ROWID_COL, nil];
 
             // Adding indexed path columns that we are keeping
             for (NSString* keptPath in keptPaths) {

--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
@@ -293,9 +293,7 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
     
     NSString* field;
     
-    if (self.queryType == kSFSoupQueryTypeMatch && self.path == nil) {
-        field = [self computeSoupFtsReference];
-    } else {
+    if (self.path) {
         field = [self computeFieldReference:self.path];
     }
     
@@ -321,13 +319,13 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
                       [self computeFieldReference:SOUP_ENTRY_ID],
                       @" IN ",
                       @"(SELECT ",
-                      DOCID_COL,
+                      ROWID_COL,
                       @" FROM ",
                       [self computeSoupFtsReference],
                       @" WHERE ",
-                      field,
+                      [self computeSoupFtsReference],
                       @" MATCH '",
-                      self.matchKey, // match clause -- statement arg binding doesn't seem to work so inlining matchKey
+                      [SFQuerySpec qualifyMatchKey:self.matchKey field:field], // match clause -- statement arg binding doesn't seem to work so inlining matchKey
                       @"') "
                       ]
                     componentsJoinedByString:@""];
@@ -336,6 +334,20 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
     }
 
     return @""; // we should never get here
+}
+
+/**
+ * fts5 doesn't allow WHERE column MATCH 'value' - only allows WHERE table MATCH 'column:value'
+ * This method changes the matchKey to add field: in the right places
+ */
++ (NSString*) qualifyMatchKey:(NSString*)matchKey field:(NSString*)field {
+    if (!field) {
+        return matchKey;
+    }
+    else {
+        // FIXME
+        return [NSString stringWithFormat:@"%@:%@", field, matchKey];
+     }
 }
 
 - (NSString*)computeOrderClause {

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore+Internal.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore+Internal.h
@@ -31,11 +31,18 @@
 @class FMDatabase;
 @class FMResultSet;
 
+typedef NS_ENUM(NSUInteger, SFSmartStoreFtsExtension) {
+    SFSmartStoreFTS4 = 4,
+    SFSmartStoreFTS5 = 5
+};
+
+
 @interface SFSmartStore () <SFAuthenticationManagerDelegate>
 
 @property (nonatomic, strong) FMDatabaseQueue *storeQueue;
 @property (nonatomic, strong) SFSmartStoreDatabaseManager *dbMgr;
 @property (nonatomic, assign) BOOL isGlobal;
+@property (nonatomic, assign) SFSmartStoreFtsExtension ftsExtension;
 
 /**
  Simply open the db file.

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -56,7 +56,7 @@ extern NSString *const SOUP_COL;
 /**
  The columns of a soup fts table
  */
-extern NSString *const DOCID_COL;
+extern NSString *const ROWID_COL;
 
 /**
  Soup index map table

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -83,7 +83,7 @@ NSString *const LAST_MODIFIED_COL = @"lastModified";
 NSString *const SOUP_COL = @"soup";
 
 // Columns of a soup fts table
-NSString *const DOCID_COL = @"docid";
+NSString *const ROWID_COL = @"rowid";
 
 // Table to keep track of status of long operations in flight
 NSString *const LONG_OPERATIONS_STATUS_TABLE = @"long_operations_status";
@@ -176,6 +176,9 @@ NSString *const EXPLAIN_ROWS = @"rows";
         _indexSpecsBySoup = [[NSMutableDictionary alloc] init];
         
         _smartSqlToSql = [[NSMutableDictionary alloc] init];
+        
+        // Using FTS5 by default
+        _ftsExtension = SFSmartStoreFTS5;
         
         if (![_dbMgr persistentStoreExists:name]) {
             if (![self firstTimeStoreDatabaseSetup]) {
@@ -1048,7 +1051,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
     
     // fts
     if (columnsForFts.count > 0) {
-        [createFtsStmt appendFormat:@"CREATE VIRTUAL TABLE %@_fts USING fts4(%@)", soupTableName, [columnsForFts componentsJoinedByString:@","]];
+        [createFtsStmt appendFormat:@"CREATE VIRTUAL TABLE %@_fts USING fts%u(%@)", soupTableName, self.ftsExtension, [columnsForFts componentsJoinedByString:@","]];
         [self log:SFLogLevelDebug format:@"createFtsStmt: %@",createFtsStmt];
     }
     
@@ -1403,7 +1406,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
     // fts
     if ([SFSoupIndex hasFts:indices]) {
         NSMutableDictionary *ftsValues = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                          newEntryId, DOCID_COL,
+                                          newEntryId, ROWID_COL,
                                           nil];
         [self projectIndexedPaths:entry values:ftsValues indices:indices typeFilter:kValueExtractedToFtsColumn];
         [self insertIntoTable:[NSString stringWithFormat:@"%@_fts", soupTableName] values:ftsValues withDb:db];
@@ -1440,7 +1443,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
     if ([SFSoupIndex hasFts:indices]) {
         NSMutableDictionary *ftsValues = [NSMutableDictionary new];
         [self projectIndexedPaths:entry values:ftsValues indices:indices typeFilter:kValueExtractedToFtsColumn];
-        [self updateTable:[NSString stringWithFormat:@"%@_fts", soupTableName] values:ftsValues entryId:entryId idCol:DOCID_COL withDb:db];
+        [self updateTable:[NSString stringWithFormat:@"%@_fts", soupTableName] values:ftsValues entryId:entryId idCol:ROWID_COL withDb:db];
     }
     
     return mutableEntry;
@@ -1574,7 +1577,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
         [self executeUpdateThrows:deleteSql withDb:db];
         // fts
         if ([self hasFts:soupName withDb:db]) {
-            NSString *deleteFtsSql = [NSString stringWithFormat:@"DELETE FROM %@_fts WHERE %@", soupTableName, [self idsInPredicate:soupEntryIds idCol:DOCID_COL]];
+            NSString *deleteFtsSql = [NSString stringWithFormat:@"DELETE FROM %@_fts WHERE %@", soupTableName, [self idsInPredicate:soupEntryIds idCol:ROWID_COL]];
             [self executeUpdateThrows:deleteFtsSql withDb:db];
         }
     }
@@ -1602,7 +1605,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
     [self executeUpdateThrows:deleteSql withArgumentsInArray:args withDb:db];
     // fts
     if ([self hasFts:soupName withDb:db]) {
-        NSString *deleteFtsSql = [NSString stringWithFormat:@"DELETE FROM %@_fts %@ in (%@)", soupTableName, DOCID_COL, querySql];
+        NSString *deleteFtsSql = [NSString stringWithFormat:@"DELETE FROM %@_fts %@ in (%@)", soupTableName, ROWID_COL, querySql];
         [self executeUpdateThrows:deleteFtsSql withDb:db];
     }
 }
@@ -1690,7 +1693,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
                 NSMutableDictionary *ftsValues = [NSMutableDictionary dictionary];
                 [self projectIndexedPaths:entry values:ftsValues indices:indices typeFilter:kValueExtractedToFtsColumn];
                 if ([ftsValues count] > 0) {
-                    [self updateTable:[NSString stringWithFormat:@"%@_fts", soupTableName] values:ftsValues entryId:entryId idCol:DOCID_COL withDb:db];
+                    [self updateTable:[NSString stringWithFormat:@"%@_fts", soupTableName] values:ftsValues entryId:entryId idCol:ROWID_COL withDb:db];
                 }
             }
         }

--- a/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
@@ -185,6 +185,8 @@
     XCTAssertEqualObjects([SFQuerySpec qualifyMatchKey:@"abc OR {soup:path2}:def" field:@"{soup:path1}"], @"{soup:path1}:abc OR {soup:path2}:def", "Wrong qualified match query");
     XCTAssertEqualObjects([SFQuerySpec qualifyMatchKey:@"(abc AND def) OR ghi" field:@"{soup:path}"], @"({soup:path}:abc AND {soup:path}:def) OR {soup:path}:ghi", "Wrong qualified match query");
     XCTAssertEqualObjects([SFQuerySpec qualifyMatchKey:@"(abc AND {soup:path2}:def) OR ghi" field:@"{soup:path1}"], @"({soup:path1}:abc AND {soup:path2}:def) OR {soup:path1}:ghi", "Wrong qualified match query");
+    XCTAssertEqualObjects([SFQuerySpec qualifyMatchKey:@"((abc AND {soup:path2}:def) AND NOT ghi) OR jkl" field:@"{soup:path1}"], @"(({soup:path1}:abc AND {soup:path2}:def) AND NOT {soup:path1}:ghi) OR {soup:path1}:jkl", "Wrong qualified match query");
+
 }
 
 @end

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreAlterTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreAlterTests.m
@@ -335,14 +335,14 @@
     if ([kCityCol isEqualToString:kSoupIndexTypeFullText] || [kCountryCol isEqualToString:kSoupIndexTypeFullText]) {
         // Check fts table columns
         expectedColumns = [NSMutableArray new];
-        [expectedColumns addObject:@"docid"];
+        [expectedColumns addObject:@"rowid"];
         if ([cityColType isEqualToString:kSoupIndexTypeFullText]) [expectedColumns addObject:kCityCol];
         if ([countryColType isEqualToString:kSoupIndexTypeFullText]) [expectedColumns addObject:kCountryCol];
         [self checkColumns:kTestSoupFtsTableName expectedColumns:expectedColumns store:self.store];
 
         // Check fts table rows
         [self.store.storeQueue inDatabase:^(FMDatabase *db) {
-            FMResultSet* frs = [self.store queryTable:kTestSoupFtsTableName forColumns:expectedColumns orderBy:@"docid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
+            FMResultSet* frs = [self.store queryTable:kTestSoupFtsTableName forColumns:expectedColumns orderBy:@"rowid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
             [self checkFtsRow:frs withExpectedEntry:expectedEntries[0] withSoupIndexes:actualIndexSpecs];
             [self checkFtsRow:frs withExpectedEntry:expectedEntries[1] withSoupIndexes:actualIndexSpecs];
             XCTAssertFalse([frs next], @"Only two rows should have been returned");

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreAlterTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreAlterTests.m
@@ -401,6 +401,45 @@
     [self checkDb:savedEntries cityColType:indexType countryColType:indexType];
 }
 
+/**
+ * Create soup with fts4 virtual table
+ * Call alterSoup passing in same index specs
+ * Make sure virtual table is recreated with fts5
+ * That way soup created before 4.2 (using fts4 virutal table) can be migrated to fts5 by calling alterSoup
+ */
+- (void) testAlterSoupwithFullTextIndexesFromFts4ToFts5
+{
+    NSArray* indexSpecs = [SFSoupIndex asArraySoupIndexes:@[@{@"path":kCity, @"type":kSoupIndexTypeFullText}, @{@"path": kCountry, @"type":kSoupIndexTypeFullText}]];
+    
+    // Using fts4 to simulate pre 4.2 sdk
+    self.store.ftsExtension = SFSmartStoreFTS4;
+    
+    XCTAssertFalse([self.store soupExists:kTestSoupName], "Test soup should not exists");
+    [self.store registerSoup:kTestSoupName withIndexSpecs:indexSpecs error:nil];
+    XCTAssertTrue([self.store soupExists:kTestSoupName], "Register soup call failed");
+    
+    NSArray* savedEntries = [self.store upsertEntries:@[@{kCity:@"San Francisco", kCountry:@"United States"}, @{kName:@"Paris", kCountry:@"France"}]
+                                               toSoup:kTestSoupName];
+    
+    // Check db
+    [self checkDb:savedEntries cityColType:kSoupIndexTypeFullText countryColType:kSoupIndexTypeFullText];
+    
+    // Check type of fts table
+    [self checkCreateTableStatment:kTestSoupFtsTableName expectedSqlStatementPrefix:[NSString stringWithFormat:@"CREATE VIRTUAL TABLE %@ USING fts4", kTestSoupFtsTableName] store:self.store];
+
+    // Using fts5
+    self.store.ftsExtension = SFSmartStoreFTS5;
+    
+    // Alter soup - passing same indexSpecs as before
+    [self.store alterSoup:kTestSoupName withIndexSpecs:indexSpecs reIndexData:YES];
+    
+    // Check db
+    [self checkDb:savedEntries cityColType:kSoupIndexTypeFullText countryColType:kSoupIndexTypeFullText];
+    
+    // Check type of fts table
+    [self checkCreateTableStatment:kTestSoupFtsTableName expectedSqlStatementPrefix:[NSString stringWithFormat:@"CREATE VIRTUAL TABLE %@ USING fts5", kTestSoupFtsTableName] store:self.store];
+}
+
 - (void) alterSoupHelper:(BOOL)reIndexData
 {
     NSArray* indexSpecs = [SFSoupIndex asArraySoupIndexes:@[@{@"path": kLastName, @"type": @"string"}, @{@"path": kAddressCity, @"type": @"string"}]];

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreFullTextSearchTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreFullTextSearchTests.m
@@ -128,7 +128,7 @@
     
     // Check fts table
     [self.store.storeQueue inDatabase:^(FMDatabase *db) {
-        FMResultSet* frs = [self.store queryTable:@"TABLE_1_fts" forColumns:@[DOCID_COL, @"TABLE_1_0", @"TABLE_1_1"] orderBy:@"docid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
+        FMResultSet* frs = [self.store queryTable:@"TABLE_1_fts" forColumns:@[ROWID_COL, @"TABLE_1_0", @"TABLE_1_1"] orderBy:@"rowid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
         [self checkFtsRow:frs withExpectedEntry:firstEmployee withSoupIndexes:actualIndexSpecs];
         [self checkFtsRow:frs withExpectedEntry:secondEmployee withSoupIndexes:actualIndexSpecs];
         XCTAssertFalse([frs next], @"Only two rows should have been returned");
@@ -162,7 +162,7 @@
     
     // Check fts table
     [self.store.storeQueue inDatabase:^(FMDatabase *db) {
-        FMResultSet* frs = [self.store queryTable:@"TABLE_1_fts" forColumns:@[DOCID_COL, @"TABLE_1_0", @"TABLE_1_1"] orderBy:@"docid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
+        FMResultSet* frs = [self.store queryTable:@"TABLE_1_fts" forColumns:@[ROWID_COL, @"TABLE_1_0", @"TABLE_1_1"] orderBy:@"rowid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
         [self checkFtsRow:frs withExpectedEntry:firstEmployee withSoupIndexes:actualIndexSpecs];
         [self checkFtsRow:frs withExpectedEntry:secondEmployeeUpdated withSoupIndexes:actualIndexSpecs];
         XCTAssertFalse([frs next], @"Only two rows should have been returned");
@@ -195,7 +195,7 @@
     
     // Check fts table
     [self.store.storeQueue inDatabase:^(FMDatabase *db) {
-        FMResultSet* frs = [self.store queryTable:@"TABLE_1_fts" forColumns:@[DOCID_COL, @"TABLE_1_0", @"TABLE_1_1"] orderBy:@"docid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
+        FMResultSet* frs = [self.store queryTable:@"TABLE_1_fts" forColumns:@[ROWID_COL, @"TABLE_1_0", @"TABLE_1_1"] orderBy:@"rowid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
         [self checkFtsRow:frs withExpectedEntry:secondEmployee withSoupIndexes:actualIndexSpecs];
         XCTAssertFalse([frs next], @"Only one should have been returned");
         [frs close];
@@ -213,7 +213,7 @@
     
     // Check fts table
     [self.store.storeQueue inDatabase:^(FMDatabase *db) {
-        FMResultSet* frs = [self.store queryTable:@"TABLE_1_fts" forColumns:@[DOCID_COL, @"TABLE_1_0", @"TABLE_1_1"] orderBy:@"docid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
+        FMResultSet* frs = [self.store queryTable:@"TABLE_1_fts" forColumns:@[ROWID_COL, @"TABLE_1_0", @"TABLE_1_1"] orderBy:@"rowid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
         XCTAssertFalse([frs next], @"No rows should have been returned");
         [frs close];
     }];
@@ -240,7 +240,7 @@
     
     // Check fts table
     [self.store.storeQueue inDatabase:^(FMDatabase *db) {
-        FMResultSet* frs = [self.store queryTable:@"TABLE_1_fts" forColumns:@[DOCID_COL, @"TABLE_1_0", @"TABLE_1_1"] orderBy:@"docid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
+        FMResultSet* frs = [self.store queryTable:@"TABLE_1_fts" forColumns:@[ROWID_COL, @"TABLE_1_0", @"TABLE_1_1"] orderBy:@"rowid ASC" limit:nil whereClause:nil whereArgs:nil withDb:db];
         XCTAssertFalse([frs next], @"No rows should have been returned");
         [frs close];
     }];

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreFullTextSearchTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreFullTextSearchTests.m
@@ -57,14 +57,6 @@
 {
     [super setUp];
     self.store = [SFSmartStore sharedGlobalStoreWithName:kTestStore];
-    NSArray* soupIndices = [SFSoupIndex asArraySoupIndexes:
-                            @[[self createFullTextIndexSpec:kFirstName],    // should be TABLE_1_0
-                              [self createFullTextIndexSpec:kLastName],     // should be TABLE_1_1
-                              [self createStringIndexSpec:kEmployeeId]]];   // should be TABLE_1_2
-    // Employees soup
-    [self.store registerSoup:kEmployeesSoup                             // should be TABLE_1
-              withIndexSpecs:soupIndices
-                       error:nil];
 }
 
 - (void) tearDown
@@ -75,18 +67,49 @@
     self.store = nil;
 }
 
+- (void) setupSoup:(SFSmartStoreFtsExtension) ftsExtension
+{
+    self.store.ftsExtension = ftsExtension;
+    NSArray* soupIndices = [SFSoupIndex asArraySoupIndexes:
+                            @[[self createFullTextIndexSpec:kFirstName],    // should be TABLE_1_0
+                              [self createFullTextIndexSpec:kLastName],     // should be TABLE_1_1
+                              [self createStringIndexSpec:kEmployeeId]]];   // should be TABLE_1_2
+    // Employees soup
+    [self.store registerSoup:kEmployeesSoup                             // should be TABLE_1
+              withIndexSpecs:soupIndices
+                       error:nil];
+}
+
 #pragma mark - Tests
 
 /**
- * Test register/drop soup that uses full-text search indices
+ * Test register/drop soup that uses full-text search indices - with fts4
  */
-- (void) testRegisterDropSoup
+- (void) testRegisterDropSoupFts4
 {
+    [self tryRegisterDropSoup:SFSmartStoreFTS4];
+}
+
+/**
+ * Test register/drop soup that uses full-text search indices - with fts5
+ */
+- (void) testRegisterDropSoupFts5
+{
+    [self tryRegisterDropSoup:SFSmartStoreFTS5];
+}
+
+- (void) tryRegisterDropSoup:(SFSmartStoreFtsExtension)ftsExtension
+{
+    [self setupSoup:ftsExtension];
+    
     NSString* soupTableName = [self getSoupTableName:kEmployeesSoup store:self.store];
     XCTAssertEqualObjects(@"TABLE_1", soupTableName, @"getSoupTableName should have returned TABLE_1");
     XCTAssertTrue([self hasTable:@"TABLE_1" store:self.store], @"Table for soup employees does exit");
     XCTAssertTrue([self hasTable:@"TABLE_1_fts" store:self.store], @"FTS Table for soup employees does exit");
     XCTAssertTrue([self.store soupExists:kEmployeesSoup], @"Register soup failed");
+    
+    NSString* expectedCreateSql = [NSString stringWithFormat:@"CREATE VIRTUAL TABLE TABLE_1_fts USING fts%u", ftsExtension];
+    [self checkCreateTableStatment:@"TABLE_1_fts" expectedSqlStatementPrefix:expectedCreateSql store:self.store];
 
     // Drop
     [self.store removeSoup:kEmployeesSoup];
@@ -99,10 +122,25 @@
 }
 
 /**
- * Test inserting rows
+ * Test inserting rows with fts4
  */
-- (void) testInsert
+- (void) testInsertWithFts4
 {
+    [self tryInsert:SFSmartStoreFTS4];
+}
+
+/**
+ * Test inserting rows with fts5
+ */
+- (void) testInsertWithFts5
+{
+    [self tryInsert:SFSmartStoreFTS5];
+}
+
+- (void) tryInsert:(SFSmartStoreFtsExtension)ftsExtension
+{
+    [self setupSoup:ftsExtension];
+
     // Insert a couple of rows
     NSDictionary* firstEmployee = [self createEmployeeWithFirstName:@"Christine" lastName:@"Haas" employeeId:@"00010"];
     NSDictionary* secondEmployee = [self createEmployeeWithFirstName:@"Michael" lastName:@"Thompson" employeeId:@"00020"];
@@ -137,10 +175,25 @@
 }
 
 /**
- * Test updating rows
+ * Test updating rows with fts4
  */
-- (void) testUpdate
+- (void) testUpdateWithFts4
 {
+    [self tryUpdate:SFSmartStoreFTS4];
+}
+
+/**
+ * Test updating rows with fts5
+ */
+- (void) testUpdateWithFts5
+{
+    [self tryUpdate:SFSmartStoreFTS5];
+}
+
+- (void) tryUpdate:(SFSmartStoreFtsExtension)ftsExtension
+{
+    [self setupSoup:SFSmartStoreFTS5];
+
     // Insert a couple of rows
     NSDictionary* firstEmployee = [self createEmployeeWithFirstName:@"Christine" lastName:@"Haas" employeeId:@"00010"];
     NSDictionary* secondEmployee = [self createEmployeeWithFirstName:@"Michael" lastName:@"Thompson" employeeId:@"00020"];
@@ -171,10 +224,25 @@
 }
 
 /**
- * Test deleting rows
+ * Test deleting rows with fts4
  */
-- (void) testDelete
+- (void) testDeleteWithFts4
 {
+    [self tryDelete:SFSmartStoreFTS4];
+}
+
+/**
+ * Test deleting rows with fts5
+ */
+- (void) testDeleteWithFts5
+{
+    [self tryDelete:SFSmartStoreFTS5];
+}
+
+- (void) tryDelete:(SFSmartStoreFtsExtension)ftsExtension
+{
+    [self setupSoup:ftsExtension];
+    
     // Insert a couple of rows
     NSDictionary* firstEmployee = [self createEmployeeWithFirstName:@"Christine" lastName:@"Haas" employeeId:@"00010"];
     NSDictionary* secondEmployee = [self createEmployeeWithFirstName:@"Michael" lastName:@"Thompson" employeeId:@"00020"];
@@ -220,10 +288,25 @@
 }
 
 /**
- * Test clearing soup
+ * Test clearing rows with fts4
  */
-- (void) testClear
+- (void) testClearWithFts4
 {
+    [self tryClear:SFSmartStoreFTS4];
+}
+
+/**
+ * Test clearing rows with fts5
+ */
+- (void) testClearWithFts5
+{
+    [self tryClear:SFSmartStoreFTS5];
+}
+
+- (void) tryClear:(SFSmartStoreFtsExtension)ftsExtension
+{
+    [self setupSoup:ftsExtension];
+
     // Insert a couple of rows
     [self createEmployeeWithFirstName:@"Christine" lastName:@"Haas" employeeId:@"00010"];
     [self createEmployeeWithFirstName:@"Michael" lastName:@"Thompson" employeeId:@"00020"];
@@ -247,11 +330,24 @@
 }
 
 /**
- * Test search on single field returning no results
+ * Test search on single field returning no results with fts4
  */
-- (void) testSearchSingleFielNoResults
+- (void) testSearchSingleFielNoResultsWithFts4
 {
-    [self loadData];
+    [self trySearchSingleFielNoResults:SFSmartStoreFTS4];
+}
+
+/**
+ * Test search on single field returning no results with fts5
+ */
+- (void) testSearchSingleFielNoResultsWithFts5
+{
+    [self trySearchSingleFielNoResults:SFSmartStoreFTS5];
+}
+
+- (void) trySearchSingleFielNoResults:(SFSmartStoreFtsExtension) ftsExtension
+{
+    [self loadData:ftsExtension];
     
     // One field - full word - no results
     [self trySearch:@[] path:kFirstName matchKey:@"Christina" orderPath:nil];
@@ -266,11 +362,24 @@
 }
 
 /**
- * Test search on single field returning a single result
+ * Test search on single field returning a single result with fts4
  */
-- (void) testSearchSingleFieldSingleResult
+- (void) testSearchSingleFieldSingleResultWithFts4
 {
-    [self loadData];
+    [self trySearchSingleFieldSingleResult:SFSmartStoreFTS4];
+}
+
+/**
+ * Test search on single field returning a single result with fts5
+ */
+- (void) testSearchSingleFieldSingleResultWithFts5
+{
+    [self trySearchSingleFieldSingleResult:SFSmartStoreFTS5];
+}
+
+- (void) trySearchSingleFieldSingleResult:(SFSmartStoreFtsExtension) ftsExtension
+{
+    [self loadData:ftsExtension];
     
     // One field - full word - one result
     [self trySearch:@[self.christineHaasId] path:kFirstName matchKey:@"Christine" orderPath:nil];
@@ -285,11 +394,24 @@
 }
 
 /**
- * Test search on single field returning multiple results - testing ordering
+ * Test search on single field returning multiple results - testing ordering with fts4
  */
-- (void) testSearchSingleFieldMultipleResults
+- (void) testSearchSingleFieldMultipleResultsWithFts4
 {
-    [self loadData];
+    [self trySearchSingleFieldMultipleResults:SFSmartStoreFTS4];
+}
+
+/**
+ * Test search on single field returning multiple results - testing ordering with fts5
+ */
+- (void) testSearchSingleFieldMultipleResultsWithFts5
+{
+    [self trySearchSingleFieldMultipleResults:SFSmartStoreFTS5];
+}
+
+- (void) trySearchSingleFieldMultipleResults:(SFSmartStoreFtsExtension) ftsExtension
+{
+    [self loadData:ftsExtension];
 
     // One field - full word - more than one results
     [self trySearch:@[self.christineHaasId, self.aliHaasId] path:kLastName matchKey:@"Haas" orderPath:kEmployeeId];
@@ -305,11 +427,24 @@
 }
 
 /**
- * Test search on all fields returning no results
+ * Test search on all fields returning no results with fts4
  */
-- (void) testSearchAllFieldsNoResults
+- (void) testSearchAllFieldsNoResultsWithFts4
 {
-    [self loadData];
+    [self trySearchAllFieldsNoResults:SFSmartStoreFTS4];
+}
+
+/**
+ * Test search on all fields returning no results with fts5
+ */
+- (void) testSearchAllFieldsNoResultsWithFts5
+{
+    [self trySearchAllFieldsNoResults:SFSmartStoreFTS5];
+}
+
+- (void) trySearchAllFieldsNoResults:(SFSmartStoreFtsExtension) ftsExtension
+{
+    [self loadData:ftsExtension];
 
     // All fields - full word - no results
     [self trySearch:@[] path:nil matchKey:@"Sternn" orderPath:nil];
@@ -325,11 +460,24 @@
 }
 
 /**
- * Test search on all fields returning a single result
+ * Test search on all fields returning a single result with fts4
  */
-- (void) testSearchAllFieldsSingleResult
+- (void) testSearchAllFieldsSingleResultWithFts4
 {
-    [self loadData];
+    [self trySearchAllFieldsSingleResult:SFSmartStoreFTS4];
+}
+
+/**
+ * Test search on all fields returning a single result with fts5
+ */
+- (void) testSearchAllFieldsSingleResultWithFts5
+{
+    [self trySearchAllFieldsSingleResult:SFSmartStoreFTS5];
+}
+
+- (void) trySearchAllFieldsSingleResult:(SFSmartStoreFtsExtension) ftsExtension
+{
+    [self loadData:ftsExtension];
 
     // All fields - full word - one result
     [self trySearch:@[self.irvingSternId] path:nil matchKey:@"Stern" orderPath:nil];
@@ -345,11 +493,24 @@
 }
 
 /**
- * Test search on all fields returning multiple results - testing ordering
+ * Test search on all fields returning multiple results - testing ordering with fts4
  */
-- (void) testSearchAllFieldMultipleResults
+- (void) testSearchAllFieldMultipleResultsWithFts4
 {
-    [self loadData];
+    [self trySearchAllFieldMultipleResults:SFSmartStoreFTS4];
+}
+
+/**
+ * Test search on all fields returning multiple results - testing ordering with fts5
+ */
+- (void) testSearchAllFieldMultipleResultsWithFts5
+{
+    [self trySearchAllFieldMultipleResults:SFSmartStoreFTS5];
+}
+
+- (void) trySearchAllFieldMultipleResults:(SFSmartStoreFtsExtension) ftsExtension
+{
+    [self loadData:ftsExtension];
 
     // All fields - full word - more than one results
     [self trySearch:@[self.evaPulaskiId, self.eileenEvaId] path:nil matchKey:@"Eva" orderPath:kEmployeeId];
@@ -367,11 +528,24 @@
 }
 
 /**
- * Test search with queries that have field:value predicates
+ * Test search with queries that have field:value predicates with fts4
  */
-- (void) testSearchWithFieldColonQueries
+- (void) testSearchWithFieldColonQueriesWithFts4
 {
-    [self loadData];
+    [self trySearchWithFieldColonQueries:SFSmartStoreFTS4];
+}
+
+/**
+ * Test search with queries that have field:value predicates with fts5
+ */
+- (void) testSearchWithFieldColonQueriesWithFts5
+{
+    [self trySearchWithFieldColonQueries:SFSmartStoreFTS5];
+}
+
+- (void) trySearchWithFieldColonQueries:(SFSmartStoreFtsExtension) ftsExtension
+{
+    [self loadData:ftsExtension];
 
     // All fields - full word - no results
     [self trySearch:@[] path:nil matchKey:@"{employees:firstName}:Haas" orderPath:nil];
@@ -418,8 +592,10 @@
 }
 
 
-- (void) loadData
+- (void) loadData:(SFSmartStoreFtsExtension) ftsExtension
 {
+    [self setupSoup:ftsExtension];
+    
     self.christineHaasId = [self createEmployeeWithFirstName:@"Christine" lastName:@"Haas" employeeId:@"00010"][SOUP_ENTRY_ID];
     self.michaelThompsonId = [self createEmployeeWithFirstName:@"Michael" lastName:@"Thompson" employeeId:@"00020"][SOUP_ENTRY_ID];
     self.aliHaasId = [self createEmployeeWithFirstName:@"Ali" lastName:@"Haas" employeeId:@"00030"][SOUP_ENTRY_ID];

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.h
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.h
@@ -46,6 +46,7 @@
 - (void) checkExplainQueryPlan:(NSString*) soupName index:(NSUInteger)index covering:(BOOL) covering dbOperation:(NSString*)dbOperation store:(SFSmartStore*)store;
 - (void) checkColumns:(NSString*)tableName expectedColumns:(NSArray*)expectedColumns store:(SFSmartStore*)store;
 - (void) checkDatabaseIndexes:(NSString*)tableName expectedSqlStatements:(NSArray*)expectedSqlStatements store:(SFSmartStore*)store;
+- (void) checkCreateTableStatment:(NSString*)tableName expectedSqlStatementPrefix:(NSString*)expectedSqlStatementPrefix store:(SFSmartStore*)store;
 - (void) checkSoupIndex:(SFSoupIndex*)indexSpec expectedPath:(NSString*)expectedPath expectedType:(NSString*)expectedType expectedColumnName:(NSString*)expectedColumnName ;
 
 - (void) checkSoupRow:(FMResultSet*) frs withExpectedEntry:(NSDictionary*)expectedEntry withSoupIndexes:(NSArray*)arraySoupIndexes;

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
@@ -222,8 +222,8 @@
 {
     XCTAssertTrue([frs next], @"Expected rows to be returned");
     
-    // Check docid
-    XCTAssertEqualObjects(@([frs longForColumn:DOCID_COL]), expectedEntry[SOUP_ENTRY_ID], @"Wrong id");
+    // Check rowid
+    XCTAssertEqualObjects(@([frs longForColumn:ROWID_COL]), expectedEntry[SOUP_ENTRY_ID], @"Wrong id");
 
     // Check indexed columns
     for (SFSoupIndex* soupIndex in arraySoupIndexes)

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
@@ -183,8 +183,19 @@
     }];
     NSString* message = [NSString stringWithFormat:@"Wrong indexes actual:%@", [actualSqlStatements componentsJoinedByString:@","]];
     [self assertSameJSONArrayWithExpected:expectedSqlStatements actual:actualSqlStatements message:message];
-    
 }
+
+- (void) checkCreateTableStatment:(NSString*)tableName expectedSqlStatementPrefix:(NSString*)expectedSqlStatementPrefix store:(SFSmartStore*)store {
+    __block NSString* actualSqlStatement;
+    [store.storeQueue inDatabase:^(FMDatabase* db) {
+        FMResultSet *frs = [db executeQuery:@"SELECT sql FROM sqlite_master WHERE type='table' AND tbl_name=?", tableName];
+        [frs next];
+        actualSqlStatement = [frs stringForColumnIndex:0];
+        [frs close];
+    }];
+    XCTAssert([actualSqlStatement containsString:expectedSqlStatementPrefix], @"Wrong statement actual:%@", actualSqlStatement);
+}
+
 
 - (void) checkSoupIndex:(SFSoupIndex*)indexSpec expectedPath:(NSString*)expectedPath expectedType:(NSString*)expectedType expectedColumnName:(NSString*)expectedColumnName {
     XCTAssertEqualObjects(expectedPath, indexSpec.path, @"Wrong path");

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -116,6 +116,14 @@
 }
 
 /**
+ * Test fts extension
+ */
+- (void) testFtsExtension
+{
+    XCTAssertEqual(self.store.ftsExtension, 5, @"Expected FTS5");
+}
+
+/**
  * Testing method with paths to top level string/integer/array/map as well as edge cases (nil object/nil or empty path)
  */
 - (void) testProjectTopLevel


### PR DESCRIPTION
NB: In the future we should provide a way for developers to use advanced FTS features like selecting the tokenizer (https://www.sqlite.org/fts5.html#section_4_3) or sorting using bm25 (https://www.sqlite.org/fts5.html#section_5_1_1).

Added a way to select FTS4 or FTS5 -- not meant for app but used by tests to make sure no behavior changed.

For a soup created before 4.2, one simply needs to do an alterSoup passing in the original index specs, and the FTS virtual table will be recreated using FTS5 (there is a test for that).