### PR TITLE
Sync up failure bug fix

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -510,12 +510,16 @@ static NSMutableDictionary *syncMgrList = nil;
     NSMutableDictionary* record = [[self.store retrieveEntries:@[idStr] fromSoup:soupName][0] mutableCopy];
     
     // Do we need to do a create, update or delete
+    BOOL locallyCreated = [record[kSyncManagerLocallyCreated] boolValue];
+    BOOL locallyUpdated = [record[kSyncManagerLocallyUpdated] boolValue];
+    BOOL locallyDeleted = [record[kSyncManagerLocallyDeleted] boolValue];
+    
     SFSyncUpTargetAction action = SFSyncUpTargetActionNone;
-    if ([record[kSyncManagerLocallyDeleted] boolValue])
+    if (locallyDeleted)
         action = SFSyncUpTargetActionDelete;
-    else if ([record[kSyncManagerLocallyCreated] boolValue])
+    else if (locallyCreated)
         action = SFSyncUpTargetActionCreate;
-    else if ([record[kSyncManagerLocallyUpdated] boolValue])
+    else if (locallyUpdated)
         action = SFSyncUpTargetActionUpdate;
     
     if (action == SFSyncUpTargetActionNone) {
@@ -530,18 +534,15 @@ static NSMutableDictionary *syncMgrList = nil;
      * passed in tells us to leave the record alone under these
      * circumstances, we will do nothing and return here.
      */
-    if (mergeMode == SFSyncStateMergeModeLeaveIfChanged &&
-        (action == SFSyncUpTargetActionUpdate || action == SFSyncUpTargetActionDelete)) {
+    if (mergeMode == SFSyncStateMergeModeLeaveIfChanged && !locallyCreated) {
         // Need to check the modification date on the server, against the local date.
         __weak SFSmartSyncSyncManager *weakSelf = self;
         SFSyncUpRecordModificationResultBlock modificationBlock = ^(NSDate *localDate, NSDate *serverDate, NSError *error) {
             __strong SFSmartSyncSyncManager *strongSelf = weakSelf;
-            if (error) {
-                if (failBlock != NULL) {
-                    failBlock(error);
-                }
-            } else if ([localDate compare:serverDate] != NSOrderedAscending) {
-                // Local date is newer than or the same as the server date.
+            if (localDate == nil // We didn't capture the last modified date so we can't really enforce merge mode
+                || serverDate == nil // We were unable to get the last modified date from the server
+                || [localDate compare:serverDate] != NSOrderedAscending) // local date is newer than server
+            {
                 [strongSelf resumeSyncUpOneEntry:sync
                                        recordIds:recordIds
                                            index:i

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
@@ -113,7 +113,7 @@ static NSString * const kSFSyncUpTargetTypeCustom = @"custom";
     NSString *objectType = [SFJsonUtils projectIntoJson:record path:kObjectTypeField];
     NSString *objectId = record[self.idFieldName];
     NSDate *localLastModifiedDate = [SFSmartSyncObjectUtils getDateFromIsoDateString:record[self.modificationDateFieldName]];
-    __block NSDate *serverLastModifiedDate = [NSDate dateWithTimeIntervalSince1970:0.0];
+    __block NSDate *serverLastModifiedDate = nil;
     
     SFSmartSyncSoqlBuilder *soqlBuilder = [SFSmartSyncSoqlBuilder withFields:self.modificationDateFieldName];
     [soqlBuilder from:objectType];
@@ -123,7 +123,7 @@ static NSString * const kSFSyncUpTargetTypeCustom = @"custom";
     SFRestFailBlock failBlock = ^(NSError *error) {
         [self log:SFLogLevelError format:@"REST request failed with error: %@", error];
         if (modificationResultBlock != NULL) {
-            modificationResultBlock(nil, nil, error);
+            modificationResultBlock(localLastModifiedDate, nil, error);
         }
     };
     
@@ -133,10 +133,7 @@ static NSString * const kSFSyncUpTargetTypeCustom = @"custom";
             if (nil != record) {
                 NSString *serverLastModifiedStr = record[self.modificationDateFieldName];
                 if (nil != serverLastModifiedStr) {
-                    NSDate *testServerModifiedDate = [SFSmartSyncObjectUtils getDateFromIsoDateString:serverLastModifiedStr];
-                    if (testServerModifiedDate != nil) {
-                        serverLastModifiedDate = testServerModifiedDate;
-                    }
+                    serverLastModifiedDate = [SFSmartSyncObjectUtils getDateFromIsoDateString:serverLastModifiedStr];
                 }
             }
         }


### PR DESCRIPTION
iOS equivalent of: https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/1159

- we shouldn't go to the server for locally created records
- but if the app code unchecks the locally_created flag (e.g. after doing an local update or delete), the smart sync code should not fail the sync up
- added tests