### PR TITLE
Nullability in prep for swift 3 change in implicit optionals

### DIFF
--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+Blocks.h
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+Blocks.h
@@ -27,14 +27,16 @@
 #import <Foundation/Foundation.h>
 #import "SFRestAPI.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SFRestAPI (Blocks) <SFRestDelegate>
 
 // Block types
-typedef void (^SFRestFailBlock) (NSError *e);
-typedef void (^SFRestDictionaryResponseBlock) (NSDictionary *dict);
-typedef void (^SFRestArrayResponseBlock) (NSArray *arr);
-typedef void (^SFRestDataResponseBlock) (NSData* data);
-typedef void (^SFRestResponseBlock) (id response);
+typedef void (^SFRestFailBlock) (NSError * _Nullable e);
+typedef void (^SFRestDictionaryResponseBlock) (NSDictionary * _Nullable dict);
+typedef void (^SFRestArrayResponseBlock) (NSArray * _Nullable arr);
+typedef void (^SFRestDataResponseBlock) (NSData* _Nullable data);
+typedef void (^SFRestResponseBlock) (id _Nullable response);
 /** Creates an error object with the given description.
  @param description Description
  */
@@ -126,7 +128,7 @@ typedef void (^SFRestResponseBlock) (id response);
  */
 - (SFRestRequest *) performRetrieveWithObjectType:(NSString *)objectType 
                                          objectId:(NSString *)objectId 
-                                        fieldList:(NSArray *)fieldList 
+                                        fieldList:(NSArray<NSString*> *)fieldList
                                         failBlock:(SFRestFailBlock)failBlock 
                                     completeBlock:(SFRestDictionaryResponseBlock)completeBlock;
 
@@ -141,7 +143,7 @@ typedef void (^SFRestResponseBlock) (id response);
  */
 - (SFRestRequest *) performUpdateWithObjectType:(NSString *)objectType 
                                        objectId:(NSString *)objectId 
-                                         fields:(NSDictionary *)fields 
+                                         fields:(NSDictionary<NSString*, id> *)fields
                                       failBlock:(SFRestFailBlock)failBlock 
                                   completeBlock:(SFRestDictionaryResponseBlock)completeBlock;
 
@@ -158,7 +160,7 @@ typedef void (^SFRestResponseBlock) (id response);
 - (SFRestRequest *) performUpsertWithObjectType:(NSString *)objectType 
                                 externalIdField:(NSString *)externalIdField 
                                      externalId:(NSString *)externalId 
-                                         fields:(NSDictionary *)fields 
+                                         fields:(NSDictionary<NSString*, id> *)fields
                                       failBlock:(SFRestFailBlock)failBlock 
                                   completeBlock:(SFRestDictionaryResponseBlock)completeBlock;
 
@@ -184,7 +186,7 @@ typedef void (^SFRestResponseBlock) (id response);
  * @return the newly sent SFRestRequest
  */
 - (SFRestRequest *) performCreateWithObjectType:(NSString *)objectType 
-                                         fields:(NSDictionary *)fields 
+                                         fields:(NSDictionary<NSString*, id> *)fields
                                       failBlock:(SFRestFailBlock)failBlock 
                                   completeBlock:(SFRestDictionaryResponseBlock)completeBlock;
 
@@ -258,8 +260,10 @@ typedef void (^SFRestResponseBlock) (id response);
 
 - (SFRestRequest *) performRequestWithMethod:(SFRestMethod)method
                                         path:(NSString*)path
-                                 queryParams:(NSDictionary*)queryParams
+                                 queryParams:(NSDictionary<NSString*, id>*)queryParams
                                    failBlock:(SFRestFailBlock)failBlock
                                completeBlock:(SFRestDictionaryResponseBlock)completeBlock;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+Files.h
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+Files.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param page if nil fetches the first page, otherwise fetches the specified page.
  * @return A new SFRestRequest that can be used to fetch this data
  */
-- (SFRestRequest *) requestForOwnedFilesList:(NSString *)userId page:(NSUInteger)page;
+- (SFRestRequest *) requestForOwnedFilesList:(nullable NSString *)userId page:(NSUInteger)page;
 
 /**
  * Build a Request that can fetch a page from the list of files from groups
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param page if nil fetches the first page, otherwise fetches the specified page.
  * @return A new SFRestRequest that can be used to fetch this data
  */
-- (SFRestRequest *) requestForFilesInUsersGroups:(NSString *)userId page:(NSUInteger)page;
+- (SFRestRequest *) requestForFilesInUsersGroups:(nullable NSString *)userId page:(NSUInteger)page;
 
 /**
  * Build a Request that can fetch a page from the list of files that have
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param page if nil fetches the first page, otherwise fetches the specified page.
  * @return A new SFRestRequest that can be used to fetch this data
  */
-- (SFRestRequest *) requestForFilesSharedWithUser:(NSString *)userId page:(NSUInteger)page;
+- (SFRestRequest *) requestForFilesSharedWithUser:(nullable NSString *)userId page:(NSUInteger)page;
 
 /**
  * Build a Request that can fetch the file details of a particular version
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param version if nil fetches the most recent version, otherwise fetches this specific version.
  * @return A new SFRestRequest that can be used to fetch this data
  */
-- (SFRestRequest *) requestForFileDetails:(NSString *)sfdcId forVersion:(NSString *)version;
+- (SFRestRequest *) requestForFileDetails:(NSString *)sfdcId forVersion:(nullable NSString *)version;
 
 /**
  * Build a request that can fetch the latest file details of one or more
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param sfdcIds The list of file Ids to fetch.
  * @return A new SFRestRequest that can be used to fetch this data
  */
-- (SFRestRequest *) requestForBatchFileDetails:(NSArray *)sfdcIds;
+- (SFRestRequest *) requestForBatchFileDetails:(NSArray<NSString*> *)sfdcIds;
 
 /**
  * Build a Request that can fetch the a preview/rendition of a particular
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param page which page to fetch, pages start at 0.
  * @return A new SFRestRequest that can be used to fetch this data
  */
-- (SFRestRequest *) requestForFileRendition:(NSString *)sfdcId version:(NSString *)version renditionType:(NSString *)renditionType page:(NSUInteger)page;
+- (SFRestRequest *) requestForFileRendition:(NSString *)sfdcId version:(nullable NSString *)version renditionType:(NSString *)renditionType page:(NSUInteger)page;
 
 /**
  * Builds a request that can fetch the actual binary file contents of this
@@ -100,7 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param version The version of the file
  * @return A new SFRestRequest that can be used to fetch this data
  */
-- (SFRestRequest *) requestForFileContents:(NSString *) sfdcId version:(NSString*) version;
+- (SFRestRequest *) requestForFileContents:(NSString *) sfdcId version:(nullable NSString*) version;
 
 /**
  * Build a request that can fetch a page from the list of entities that this

--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+Files.h
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI+Files.h
@@ -24,7 +24,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <Foundation/Foundation.h>
 #import "SFRestAPI.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface SFRestAPI (Files) <SFRestDelegate>
 
@@ -141,3 +144,5 @@
 - (SFRestRequest *) requestForUploadFile:(NSData *)data name:(NSString *)name description:(NSString *)description mimeType:(NSString *)mimeType;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI.h
+++ b/libs/SalesforceRestAPI/SalesforceRestAPI/Classes/SFRestAPI.h
@@ -25,6 +25,8 @@
 #import <Foundation/Foundation.h>
 #import "SFRestRequest.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*
  * Domain used for errors reported by the rest API (non HTTP errors)
  * (for example, passing an invalid SOQL string when doing a query)
@@ -190,7 +192,7 @@ extern NSString * const kSFMobileSDKNativeDesignator;
  * This overwrites the delegate property of the request.
  * Returns the SFNetworkOperation through which the network call is actually carried out
  */
-- (SFRestAPISalesforceAction *)send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate;
+- (SFRestAPISalesforceAction *)send:(SFRestRequest *)request delegate:(nullable id<SFRestDelegate>)delegate;
 
 ///---------------------------------------------------------------------------------------
 /// @name SFRestRequest factory methods
@@ -246,7 +248,7 @@ extern NSString * const kSFMobileSDKNativeDesignator;
  */
 - (SFRestRequest *)requestForRetrieveWithObjectType:(NSString *)objectType
                                            objectId:(NSString *)objectId 
-                                          fieldList:(NSString *)fieldList;
+                                          fieldList:(nullable NSString *)fieldList;
 
 /**
  * Returns an `SFRestRequest` which creates a new record of the given type.
@@ -257,7 +259,7 @@ extern NSString * const kSFMobileSDKNativeDesignator;
  * @see http://www.salesforce.com/us/developer/docs/api_rest/Content/resources_sobject_retrieve.htm
  */
 - (SFRestRequest *)requestForCreateWithObjectType:(NSString *)objectType 
-                                           fields:(NSDictionary *)fields;
+                                           fields:(nullable NSDictionary<NSString*, id> *)fields;
 
 /**
  * Returns an `SFRestRequest` which creates or updates record of the given type, based on the 
@@ -273,7 +275,7 @@ extern NSString * const kSFMobileSDKNativeDesignator;
 - (SFRestRequest *)requestForUpsertWithObjectType:(NSString *)objectType
                                   externalIdField:(NSString *)externalIdField
                                        externalId:(NSString *)externalId
-                                           fields:(NSDictionary *)fields;
+                                           fields:(NSDictionary<NSString*, id> *)fields;
 
 /**
  * Returns an `SFRestRequest` which updates field values on a record of the given type.
@@ -286,7 +288,7 @@ extern NSString * const kSFMobileSDKNativeDesignator;
  */
 - (SFRestRequest *)requestForUpdateWithObjectType:(NSString *)objectType 
                                          objectId:(NSString *)objectId
-                                           fields:(NSDictionary *)fields;
+                                           fields:(nullable NSDictionary<NSString*, id> *)fields;
 
 /**
  * Returns an `SFRestRequest` which deletes a record of the given type.
@@ -355,3 +357,5 @@ extern NSString * const kSFMobileSDKNativeDesignator;
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceRestAPI/SalesforceRestAPITests/SalesforceRestAPITests.m
+++ b/libs/SalesforceRestAPI/SalesforceRestAPITests/SalesforceRestAPITests.m
@@ -405,7 +405,7 @@ static NSException *authException = nil;
 
 // issue invalid SOQL and test for errors
 - (void)testSOQLError {
-    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForQuery:nil];
+    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForQuery:(NSString* _Nonnull)nil];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidFail , @"request was supposed to fail");
     XCTAssertEqualObjects(listener.lastError.domain, CSFNetworkErrorDomain, @"invalid domain");
@@ -818,7 +818,7 @@ static NSException *authException = nil;
     [self changeOauthTokens:invalidAccessToken refreshToken:nil];
     
     // request (invalid)
-    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForQuery:nil];
+    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForQuery:(NSString* _Nonnull)nil];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidFail, @"request was supposed to fail");
     
@@ -1326,10 +1326,10 @@ static NSException *authException = nil;
 
 - (void) testSOQL {
 
-    XCTAssertNil( [SFRestAPI SOQLQueryWithFields:nil sObject:nil whereClause:nil limit:0],
+    XCTAssertNil( [SFRestAPI SOQLQueryWithFields:(NSArray<NSString*>* _Nonnull)nil sObject:(NSString* _Nonnull) nil whereClause:nil limit:0],
                 @"Invalid query did not result in nil output.");
     
-    XCTAssertNil( [SFRestAPI SOQLQueryWithFields:@[@"Id"] sObject:nil whereClause:nil limit:0],
+    XCTAssertNil( [SFRestAPI SOQLQueryWithFields:@[@"Id"] sObject:(NSString* _Nonnull)nil whereClause:nil limit:0],
                 @"Invalid query did not result in nil output.");
     
     NSString *simpleQuery = @"select id from Lead where id<>null limit 10";
@@ -1357,7 +1357,7 @@ static NSException *authException = nil;
 
 - (void) testSOSL {
     
-    XCTAssertNil( [SFRestAPI SOSLSearchWithSearchTerm:nil objectScope:nil],
+    XCTAssertNil( [SFRestAPI SOSLSearchWithSearchTerm:(NSString* _Nonnull)nil objectScope:nil],
                  @"Invalid search did not result in nil output.");
     
     BOOL searchLimitEnforced = [[SFRestAPI SOSLSearchWithSearchTerm:@"Test Term" fieldScope:nil objectScope:nil limit:kMaxSOSLSearchLimit + 1] 

--- a/libs/SalesforceRestAPI/SalesforceRestAPITests/SalesforceRestAPITests.m
+++ b/libs/SalesforceRestAPI/SalesforceRestAPITests/SalesforceRestAPITests.m
@@ -1142,56 +1142,56 @@ static NSException *authException = nil;
     
     // Block functions that should always fail
     self.currentExpectation = [self expectationWithDescription:@"performDeleteWithObjectType-nil"];
-    [api performDeleteWithObjectType:nil objectId:nil
+    [api performDeleteWithObjectType:(NSString* _Nonnull) nil objectId:(NSString* _Nonnull)nil
                            failBlock:failWithExpectedFail
                        completeBlock:successWithUnexpectedSuccessBlock];
     [self waitForExpectation];
     
     self.currentExpectation = [self expectationWithDescription:@"performCreateWithObjectType-nil"];
-    [api performCreateWithObjectType:nil fields:nil
+    [api performCreateWithObjectType:(NSString* _Nonnull)nil fields:(NSDictionary<NSString*, id>* _Nonnull)nil
                            failBlock:failWithExpectedFail
                        completeBlock:successWithUnexpectedSuccessBlock];
     [self waitForExpectation];
     
     self.currentExpectation = [self expectationWithDescription:@"performMetadataWithObjectType-nil"];
-    [api performMetadataWithObjectType:nil
+    [api performMetadataWithObjectType:(NSString* _Nonnull)nil
                              failBlock:failWithExpectedFail
                          completeBlock:successWithUnexpectedSuccessBlock];
     [self waitForExpectation];
     
     self.currentExpectation = [self expectationWithDescription:@"performDescribeWithObjectType-nil"];
-    [api performDescribeWithObjectType:nil
+    [api performDescribeWithObjectType:(NSString* _Nonnull)nil
                              failBlock:failWithExpectedFail
                          completeBlock:successWithUnexpectedSuccessBlock];
     [self waitForExpectation];
     
     self.currentExpectation = [self expectationWithDescription:@"performRetrieveWithObjectType-nil"];
-    [api performRetrieveWithObjectType:nil objectId:nil fieldList:nil
+    [api performRetrieveWithObjectType:(NSString* _Nonnull)nil objectId:(NSString* _Nonnull)nil fieldList:(NSArray<NSString*>* _Nonnull)nil
                              failBlock:failWithExpectedFail
                          completeBlock:successWithUnexpectedSuccessBlock];
     [self waitForExpectation];
     
     self.currentExpectation = [self expectationWithDescription:@"performUpdateWithObjectType-nil"];
-    [api performUpdateWithObjectType:nil objectId:nil fields:nil
+    [api performUpdateWithObjectType:(NSString* _Nonnull)nil objectId:(NSString* _Nonnull)nil fields:(NSDictionary<NSString*, id>* _Nonnull)nil
                            failBlock:failWithExpectedFail
                        completeBlock:successWithUnexpectedSuccessBlock];
     [self waitForExpectation];
     
     self.currentExpectation = [self expectationWithDescription:@"performUpsertWithObjectType-nil"];
-    [api performUpsertWithObjectType:nil externalIdField:nil externalId:nil
-                              fields:nil
+    [api performUpsertWithObjectType:(NSString* _Nonnull)nil externalIdField:(NSString* _Nonnull)nil externalId:(NSString* _Nonnull)nil
+                              fields:(NSDictionary<NSString*, id>* _Nonnull)nil
                            failBlock:failWithExpectedFail
                        completeBlock:successWithUnexpectedSuccessBlock];
     [self waitForExpectation];
     
     self.currentExpectation = [self expectationWithDescription:@"performSOQLQuery-nil"];
-    [api performSOQLQuery:nil
+    [api performSOQLQuery:(NSString* _Nonnull)nil
                 failBlock:failWithExpectedFail
             completeBlock:successWithUnexpectedSuccessBlock];
     [self waitForExpectation];
     
     self.currentExpectation = [self expectationWithDescription:@"performSOQLQueryAll-nil"];
-    [api performSOQLQueryAll:nil
+    [api performSOQLQueryAll:(NSString* _Nonnull)nil
                    failBlock:failWithExpectedFail
                completeBlock:successWithUnexpectedSuccessBlock];
     [self waitForExpectation];


### PR DESCRIPTION
Swift 3 is significantly changing how implicit optionals are working, anything marked as implicitly optional will have significantly different semantics in Swift 3. All of these don't return nil so there is no reason for optional semantics at all.