### PR TITLE
Fix anomalous invalid selector exceptions on iOS 10

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.m
@@ -61,7 +61,7 @@
 }
 
 - (nullable instancetype)initWithFileAtPath:(NSString *)path {
-    self = [super initWithFileAtPath:path];
+    self = [super initWithURL:[NSURL fileURLWithPath:path]];
     if (self){
         _inStream = [[NSInputStream alloc] initWithFileAtPath:path];
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.m
@@ -63,7 +63,7 @@
 }
 
 - (nullable instancetype)initToFileAtPath:(NSString *)path append:(BOOL)shouldAppend {
-    self = [super initToFileAtPath:path append:shouldAppend];
+    self = [super initWithURL:[NSURL fileURLWithPath:path] append:shouldAppend];
     if (self){
         _outStream = [[NSOutputStream alloc] initToFileAtPath:path append:shouldAppend];
     }


### PR DESCRIPTION
by using the designated initializers