### PR TITLE
Deprecated method updates

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLogger.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLogger.m
@@ -29,7 +29,6 @@
 #import "SFLogger_Internal.h"
 #import "SFPathUtil.h"
 #import "NSString+SFAdditions.h"
-#import <libkern/OSAtomic.h>
 #import <execinfo.h> // backtrace_symbols
 #import "SFCocoaLumberJackCustomFormatter.h"
 
@@ -435,7 +434,7 @@ static BOOL assertionRecorded = NO;
         
         result = [[SFLogIdentifier alloc] initWithIdentifier:identifier];
         result.logger = self;
-        result.context = OSAtomicIncrement32(&_contextCounter) - 1;
+        result.context = atomic_fetch_add_explicit(&_contextCounter, 1, memory_order_relaxed);
         _logIdentifiers[identifier] = result;
         _logIdentifiersByContext[result.context] = result;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLogger_Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLogger_Internal.h
@@ -23,7 +23,7 @@
  */
 
 #import <CocoaLumberjack/CocoaLumberjack.h>
-
+#import <stdatomic.h>
 #import "SFLogStorage.h"
 
 extern NSString * SFLogNameForFlag(SFLogFlag flag);
@@ -58,7 +58,7 @@ extern NSString * SFLogNameForLogLevel(SFLogLevel level);
 
 @interface SFLogger () {
 @public
-    int32_t _contextCounter;
+    atomic_int_least32_t _contextCounter;
     NSMutableDictionary<NSString*,SFLogIdentifier*> *_logIdentifiers;
     NSMutableArray<SFLogIdentifier*> *_logIdentifiersByContext;
     NSObject<SFLogStorage> *_ddLog;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -718,7 +718,7 @@ static NSString * const kOAuthUserAgentUserDefaultsKey          = @"UserAgent";
 {
     NSMutableSet *scopes = (self.scopes.count > 0 ? [NSMutableSet setWithSet:self.scopes] : [NSMutableSet set]);
     [scopes addObject:kSFOAuthRefreshToken];
-    NSString *scopeStr = [[[scopes allObjects] componentsJoinedByString:@" "] stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSString *scopeStr = [[[scopes allObjects] componentsJoinedByString:@" "] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
     return [NSString stringWithFormat:@"&%@=%@", kSFOAuthScope, scopeStr];
 }
 
@@ -940,11 +940,9 @@ static NSString * const kOAuthUserAgentUserDefaultsKey          = @"UserAgent";
         NSString *value = keyValue[1];
         if (decodeParams) {
             key = [[key
-                    stringByReplacingOccurrencesOfString:@"+" withString:@" "]
-                   stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                    stringByReplacingOccurrencesOfString:@"+" withString:@" "] stringByRemovingPercentEncoding];
             value = [[value
-                      stringByReplacingOccurrencesOfString:@"+" withString:@" "]
-                     stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+                      stringByReplacingOccurrencesOfString:@"+" withString:@" "] stringByRemovingPercentEncoding];
         }
         dict[key] = value;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPushNotificationManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPushNotificationManagerTests.m
@@ -64,7 +64,7 @@ static NSString* const kSFDeviceSalesforceId = @"deviceSalesforceId";
 }
 
 - (void)testUnregisterSalesforceNotifications_NoUserCredentials {
-    self.user.credentials = nil;
+    self.user.credentials = (SFOAuthCredentials* _Nonnull)nil;
     BOOL result = [self.manager unregisterSalesforceNotifications:self.user];
     XCTAssertFalse(result);
 }


### PR DESCRIPTION
* All deprecation fixes work on iOS 7 and newer
* stdatomic requires Xcode 7 (which is fine)