### PR TITLE
Enable using NS_STRING_ENUM

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFAction.h
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFAction.h
@@ -271,10 +271,12 @@
 
 @end
 
-CSF_EXTERN NSString * const kCSFActionTimingTotalTimeKey;
-CSF_EXTERN NSString * const kCSFActionTimingNetworkTimeKey;
-CSF_EXTERN NSString * const kCSFActionTimingStartDelayKey;
-CSF_EXTERN NSString * const kCSFActionTimingPostProcessingKey;
+typedef NSString*const CSFActionTiming NS_STRING_ENUM;
+
+CSF_EXTERN CSFActionTiming kCSFActionTimingTotalTimeKey;
+CSF_EXTERN CSFActionTiming kCSFActionTimingNetworkTimeKey;
+CSF_EXTERN CSFActionTiming kCSFActionTimingStartDelayKey;
+CSF_EXTERN CSFActionTiming kCSFActionTimingPostProcessingKey;
 
 @interface CSFAction (Timing)
 
@@ -294,6 +296,6 @@ CSF_EXTERN NSString * const kCSFActionTimingPostProcessingKey;
  
  @return The time interval for the requested key, or `0` if the key is invalid or if the request hasn't gathered enough information to supply that value yet.
  */
-- (NSTimeInterval)intervalForTimingKey:(NSString*)key;
+- (NSTimeInterval)intervalForTimingKey:(CSFActionKey)key;
 
 @end

--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFAction.m
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFAction.m
@@ -41,10 +41,10 @@ NSString * const CSFNetworkErrorAuthenticationFailureKey = @"isAuthenticationFai
 
 NSTimeInterval const CSFActionDefaultTimeOut = 3 * 60; // 3 minutes
 
-NSString * const kCSFActionTimingTotalTimeKey = @"total";
-NSString * const kCSFActionTimingNetworkTimeKey = @"network";
-NSString * const kCSFActionTimingStartDelayKey = @"startDelay";
-NSString * const kCSFActionTimingPostProcessingKey = @"postProcessing";
+CSFActionTiming kCSFActionTimingTotalTimeKey = @"total";
+CSFActionTiming kCSFActionTimingNetworkTimeKey = @"network";
+CSFActionTiming kCSFActionTimingStartDelayKey = @"startDelay";
+CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
 
 @interface CSFAction () {
     BOOL _ready;
@@ -876,7 +876,7 @@ NSString * const kCSFActionTimingPostProcessingKey = @"postProcessing";
 
 @implementation CSFAction (Timing)
 
-- (NSTimeInterval)intervalForTimingKey:(NSString *)key {
+- (NSTimeInterval)intervalForTimingKey:(CSFActionTiming)key {
     NSTimeInterval result = 0;
     
     NSDate *firstDate = nil, *secondDate = nil;

--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Utilities/CSFDefines.h
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Utilities/CSFDefines.h
@@ -32,6 +32,10 @@
 #endif
 #endif
 
+#ifndef NS_STRING_ENUM
+#define NS_STRING_ENUM
+#endif
+
 @class CSFAction;
 
 CSF_EXTERN NSString * const kCSFConnectVersion;


### PR DESCRIPTION
to make CSFActionKey a strongly typed `enum` in Swift 3, if we have an open ended value we should use `NS_EXTENSIBLE_STRING_ENUM` which wraps the values in a struct not an `enum`

* Define compatibility macro in headers