### PR TITLE
minor mixups for swift

### DIFF
--- a/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFAction.h
+++ b/libs/SalesforceNetwork/SalesforceNetwork/SalesforceNetwork/Classes/Network/Action/CSFAction.h
@@ -31,6 +31,7 @@
 @class CSFNetwork;
 @class CSFAction;
 
+NS_ASSUME_NONNULL_BEGIN
 /**
  This is a class that represents an chatter action that the action executer executes
  */
@@ -137,7 +138,7 @@
 @property (nonatomic, readonly) NSUInteger retryCount;
 @property (nonatomic) NSUInteger maxRetryCount;
 
-@property (nonatomic, strong) NSMutableData *responseData;
+@property (nullable, nonatomic, strong) NSMutableData *responseData;
 
 /**
  @brief Indicates if this request should be run on a NSURLSession capable of performing background uploads or downloads.
@@ -258,7 +259,7 @@
  
  @return `YES` if the network request should be overridden, otherwise `NO`.
  */
-- (BOOL)overrideRequest:(NSURLRequest*)request withResponseData:(NSData**)data andHTTPResponse:(NSHTTPURLResponse**)response;
+- (BOOL)overrideRequest:(NSURLRequest*)request withResponseData:(NSData* _Nullable * _Nonnull)data andHTTPResponse:(NSHTTPURLResponse* _Nullable * _Nonnull)response;
 
 /**
  @brief Overridable method that permits subclasses to opt-out of contributing its progress to the parent CSFNetwork instance.
@@ -299,3 +300,5 @@ CSF_EXTERN CSFActionTiming kCSFActionTimingPostProcessingKey;
 - (NSTimeInterval)intervalForTimingKey:(CSFActionTiming)key;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeProviderManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeProviderManager.h
@@ -35,12 +35,12 @@ typedef NSString * SFPasscodeProviderId NS_EXTENSIBLE_STRING_ENUM;
 /**
  * String representing the provider name for the SHA-256 passcode provider.
  */
-FOUNDATION_EXTERN SFPasscodeProviderId kSFPasscodeProviderSHA256;
+FOUNDATION_EXTERN SFPasscodeProviderId const kSFPasscodeProviderSHA256;
 
 /**
  * String representing the provider name for the PBKDF2 passcode provider.
  */
-FOUNDATION_EXTERN SFPasscodeProviderId kSFPasscodeProviderPBKDF2;
+FOUNDATION_EXTERN SFPasscodeProviderId const kSFPasscodeProviderPBKDF2;
 
 /**
  * Protocol that a passcode provider class must implement.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeProviderManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeProviderManager.m
@@ -28,8 +28,8 @@
 #import "SFPBKDF2PasscodeProvider.h"
 
 // Public constants
-SFPasscodeProviderId kSFPasscodeProviderSHA256 = @"sha256";
-SFPasscodeProviderId kSFPasscodeProviderPBKDF2 = @"pbkdf2";
+SFPasscodeProviderId const kSFPasscodeProviderSHA256 = @"sha256";
+SFPasscodeProviderId const kSFPasscodeProviderPBKDF2 = @"pbkdf2";
 
 // Private constants
 static NSString * const kSFCurrentPasscodeProviderUserDefaultsKey = @"com.salesforce.mobilesdk.currentPasscodeProvider";


### PR DESCRIPTION
Looked into making the swift enum strings more closely tied... but the naming is weird due to the `k` prefix, because changing that would mean breaking compatibility I am deferring for now.