### PR TITLE
Fixing bug that caused testCleanResyncGhostsForMRUTarget unit test failure

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -480,7 +480,7 @@ static NSMutableDictionary *syncMgrList = nil;
 
             // Deletes extra IDs from SmartStore.
             if (localIds.count > 0) {
-                NSString* smartSql = [NSString stringWithFormat:@"SELECT {%@:_soupEntryId}, {%@:%@} FROM {%@} WHERE {%@:%@} IN ('%@')", soupName, soupName, idFieldName, soupName, soupName, idFieldName, [localIds componentsJoinedByString:@", "]];
+                NSString* smartSql = [NSString stringWithFormat:@"SELECT {%@:%@} FROM {%@} WHERE {%@:%@} IN ('%@')", soupName, SOUP_ENTRY_ID, soupName, soupName, idFieldName, [localIds componentsJoinedByString:@", "]];
                 querySpec = [SFQuerySpec newSmartQuerySpec:smartSql withPageSize:localIds.count];
                 [weakSelf.store removeEntriesByQuery:querySpec fromSoup:soupName];
             }

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -480,7 +480,7 @@ static NSMutableDictionary *syncMgrList = nil;
 
             // Deletes extra IDs from SmartStore.
             if (localIds.count > 0) {
-                NSString* smartSql = [NSString stringWithFormat:@"SELECT {%@:%@} FROM {%@} WHERE {%@:%@} IN ('%@')", soupName, idFieldName, soupName, soupName, idFieldName, [localIds componentsJoinedByString:@", "]];
+                NSString* smartSql = [NSString stringWithFormat:@"SELECT {%@:_soupEntryId}, {%@:%@} FROM {%@} WHERE {%@:%@} IN ('%@')", soupName, soupName, idFieldName, soupName, soupName, idFieldName, [localIds componentsJoinedByString:@", "]];
                 querySpec = [SFQuerySpec newSmartQuerySpec:smartSql withPageSize:localIds.count];
                 [weakSelf.store removeEntriesByQuery:querySpec fromSoup:soupName];
             }


### PR DESCRIPTION
When passing a smart sql query spec to remove by query, it must be selecting on _soupEntryId 

NB: it's documented in the .h here: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/blob/unstable/libs/SmartStore/SmartStore/Classes/SFSmartStore.h#L348