### PR TITLE
Various native SmartSyncExplorer fixes:

### DIFF
--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/ContactDetailViewController.m
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/ContactDetailViewController.m
@@ -255,6 +255,12 @@
     [self.navigationController popViewControllerAnimated:YES];
 }
 
+- (void)undeleteContact {
+    [self.dataMgr undeleteLocalData:self.contact];
+    self.contactUpdated = YES;
+    [self.navigationController popViewControllerAnimated:YES];
+}
+
 - (UITextField *)contactTextField:(NSString *)propertyValue {
     UITextField *textField = [[UITextField alloc] initWithFrame:CGRectZero];
     textField.text = propertyValue;
@@ -262,13 +268,14 @@
 }
 
 - (UIButton *)deleteButtonView {
+    BOOL deleted = ([[self.contact fieldValueForFieldName:kSyncManagerLocallyDeleted] boolValue]);
     UIButton *deleteButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [deleteButton setTitle:@"Delete Contact" forState:UIControlStateNormal];
+    [deleteButton setTitle:(deleted ? @"Undelete Contact" : @"Delete Contact") forState:UIControlStateNormal];
     [deleteButton setTitleColor:[UIColor redColor] forState:UIControlStateNormal];
     deleteButton.titleLabel.font = [UIFont systemFontOfSize:18.0];
     deleteButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
     deleteButton.contentEdgeInsets = UIEdgeInsetsMake(0, 15, 0, 0);
-    [deleteButton addTarget:self action:@selector(deleteContactConfirm) forControlEvents:UIControlEventTouchUpInside];
+    [deleteButton addTarget:self action:(deleted ? @selector(undeleteContact) : @selector(deleteContactConfirm)) forControlEvents:UIControlEventTouchUpInside];
     return deleteButton;
 }
 

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/Data/SObjectDataManager.h
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/Data/SObjectDataManager.h
@@ -27,23 +27,24 @@
 #import "SObjectDataSpec.h"
 #import "SObjectData.h"
 
+
 @interface SObjectDataManager : NSObject
 
 @property (nonatomic, readonly) SFSmartStore *store;
 @property (nonatomic, strong) NSArray *dataRows;
 
-- (id)initWithViewController:(UITableViewController *)parentVc
-                    dataSpec:(SObjectDataSpec *)dataSpec;
+- (id)initWithDataSpec:(SObjectDataSpec *)dataSpec;
 
-- (void)refreshLocalData;
+- (void)refreshLocalData:(void (^)(void))completionBlock;
 - (void)createLocalData:(SObjectData *)newData;
 - (void)updateLocalData:(SObjectData *)updatedData;
 - (void)deleteLocalData:(SObjectData *)dataToDelete;
+- (void)undeleteLocalData:(SObjectData *)dataToDelete;
 - (BOOL)dataHasLocalChanges:(SObjectData *)data;
 - (BOOL)dataLocallyCreated:(SObjectData *)data;
 - (BOOL)dataLocallyUpdated:(SObjectData *)data;
 - (BOOL)dataLocallyDeleted:(SObjectData *)data;
-- (void)refreshRemoteData;
+- (void)refreshRemoteData:(void (^)(void))completionBlock;
 - (void)updateRemoteData:(SFSyncSyncManagerUpdateBlock)completionBlock;
 - (void)filterOnSearchTerm:(NSString *)searchTerm completion:(void (^)(void))completionBlock;
 - (void)resetDataRows;


### PR DESCRIPTION
- in the detail screen, delete button becomes undelete when items is already marked as deleted
- after sync, search filter already typed is re-applied (before the filter would still be shown but all records would be listed)
- after fail sync, list is still refreshed because failure means not all records could be synched up, it doesn't mean that none could be synched up