### PR TITLE
Salesforce React pod spec changes - to make it work with frameworks

### DIFF
--- a/SalesforceReact.podspec
+++ b/SalesforceReact.podspec
@@ -19,7 +19,12 @@ Pod::Spec.new do |s|
 
   s.subspec 'SalesforceReact' do |salesforcereact|
 
+      salesforcereact.dependency 'React'
       salesforcereact.dependency 'SmartSync'
+      salesforcereact.dependency 'SalesforceRestAPI'
+      salesforcereact.dependency 'SmartStore'
+      salesforcereact.dependency 'SalesforceSDKCore'
+
       salesforcereact.source_files = 'libs/SalesforceReact/SalesforceReact/Classes/**/*.{h,m}'
       salesforcereact.public_header_files = 'libs/SalesforceReact/SalesforceReact/Classes/SFNetReactBridge.h', 'libs/SalesforceReact/SalesforceReact/Classes/SFOauthReactBridge.h', 'libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.h', 'libs/SalesforceReact/SalesforceReact/Classes/SFSmartSyncReactBridge.h', 'libs/SalesforceReact/SalesforceReact/SalesforceReact.h'
       salesforcereact.prefix_header_contents = '#import <SalesforceSDKCore/SFLogger.h>'


### PR DESCRIPTION
Before that change app generated with forceios would not compile if use_frameworks! was used.
With that change, it works with and without use_frameworks!.

This fixes: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/1525