### PR TITLE
On some machine, forceios prints out hex

### DIFF
--- a/node/forceios.js
+++ b/node/forceios.js
@@ -182,8 +182,8 @@ function createNativeApp(config) {
             process.exit(3);
         }
     });
-    createAppProcess.stdout.on('data', function(data) { console.log(data); });
-    createAppProcess.stderr.on('data', function(data) { console.log(data); });
+    createAppProcess.stdout.on('data', function(data) { console.log(data.toString('utf8')); });
+    createAppProcess.stderr.on('data', function(data) { console.log(data.toString('utf8')); });
 }
 
 function buildArgsFromArgMap(config) {


### PR DESCRIPTION
Solution found here: http://stackoverflow.com/questions/7337564/why-does-console-logbuffer-give-me-a-hexadecimal-list