### PR TITLE
Fixing bug with app version and build number

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SDKInfo/SFSDKInfoPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SDKInfo/SFSDKInfoPlugin.m
@@ -93,20 +93,17 @@ NSString * const kForcePluginPrefix = @"com.salesforce.";
 - (void)getInfo:(CDVInvokedUrlCommand *)command
 {
     NSString* callbackId = command.callbackId;
-    /* NSString* jsVersionStr = */[self getVersion:@"getInfo" withArguments:command.arguments];
-    
+    [self getVersion:@"getInfo" withArguments:command.arguments];
     NSString *appName = [[NSBundle mainBundle] infoDictionary][(NSString*)kCFBundleNameKey];
-    NSString *appVersion = [[NSBundle mainBundle] infoDictionary][(NSString*)kCFBundleVersionKey];
-    
-    
+    NSString *prodAppVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+    NSString *buildNumber = [[NSBundle mainBundle] infoDictionary][(NSString*)kCFBundleVersionKey];
+    NSString *appVersion = [NSString stringWithFormat:@"%@ (%@)", prodAppVersion, buildNumber];
     NSDictionary *bootConfig = ((SFHybridViewController *)self.viewController).hybridViewConfig.configDict;
-    
     NSDictionary *sdkInfo = @{kSDKVersionKey: SALESFORCE_SDK_VERSION,
                               kAppNameKey: appName,
                               kAppVersionKey: appVersion,
                               kForcePluginsAvailableKey: self.forcePlugins,
                               kBootConfigKey: bootConfig};
-    
     [self writeSuccessDictToJsRealm:sdkInfo callbackId:callbackId];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -653,7 +653,9 @@ static Class InstanceClass = nil;
     return ^NSString *(NSString *qualifier) {
         UIDevice *curDevice = [UIDevice currentDevice];
         NSString *appName = [[NSBundle mainBundle] infoDictionary][(NSString*)kCFBundleNameKey];
-        NSString *appVersion = [[NSBundle mainBundle] infoDictionary][(NSString*)kCFBundleVersionKey];
+        NSString *prodAppVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+        NSString *buildNumber = [[NSBundle mainBundle] infoDictionary][(NSString*)kCFBundleVersionKey];
+        NSString *appVersion = [NSString stringWithFormat:@"%@ (%@)", prodAppVersion, buildNumber];
 
         // App type.
         NSString* appTypeStr;


### PR DESCRIPTION
Looks like we were using the wrong field in our user agent, and hence getting build number instead of app version. This PR fetches both now.

From Apple's documentation [here](https://developer.apple.com/library/ios/technotes/tn2420/_index.html) - `Note that the Version Number is saved with the key CFBundleShortVersionString and the Build Number is associated with the key CFBundleVersion. You will find the Version Number (CFBundleShortVersionString) and Build Number (CFBundleVersion) described in many different places in the documentation and referred to using these key values`.