### PR TITLE
Refactoring, simplifying some of the JWT code, flow

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(NSUInteger, SFOAuthTokenEndpointFlow) {
 
 - (void)beginUserAgentFlow;
 - (void)beginTokenEndpointFlow:(SFOAuthTokenEndpointFlow)flowType;
+- (void)beginJwtTokenExchangeFlow;
 - (void)handleTokenEndpointResponse:(NSMutableData *)data;
 - (void)beginNativeBrowserFlow;
 - (void)retrieveOrgAuthConfiguration:(void (^)(SFOAuthOrgAuthConfiguration*, NSError*))retrievedAuthConfigBlock;
@@ -80,6 +81,7 @@ typedef NS_ENUM(NSUInteger, SFOAuthTokenEndpointFlow) {
 
 + (NSDictionary *)parseQueryString:(NSString *)query;
 + (NSError *)errorWithType:(NSString *)type description:(NSString *)description;
++ (NSError *)errorWithType:(NSString *)type description:(NSString *)description underlyingError:(NSError *)underlyingError;
 + (NSDate *)timestampStringToDate:(NSString *)timestamp;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -209,7 +209,7 @@ static NSString * const kOAuthUserAgentUserDefaultsKey          = @"UserAgent";
         // clear any access token we may have and begin refresh flow
         [self notifyDelegateOfBeginAuthentication];
         [self.oauthCoordinatorFlow beginTokenEndpointFlow:SFOAuthTokenEndpointFlowRefresh];
-    } else if (self.credentials.jwt.length > 0) {
+    } else if (self.credentials.jwt) {
         // JWT token existence means we're doing JWT token exchange.
         self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeJwtTokenExchange];
         [self notifyDelegateOfBeginAuthentication];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -208,6 +208,11 @@ static NSString * const kOAuthUserAgentUserDefaultsKey          = @"UserAgent";
         // clear any access token we may have and begin refresh flow
         [self notifyDelegateOfBeginAuthentication];
         [self.oauthCoordinatorFlow beginTokenEndpointFlow:SFOAuthTokenEndpointFlowRefresh];
+    } else if (self.credentials.jwt.length > 0) {
+        // JWT token existence means we're doing JWT token exchange.
+        self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeJwtTokenExchange];
+        [self notifyDelegateOfBeginAuthentication];
+        [self.oauthCoordinatorFlow beginJwtTokenExchangeFlow];
     } else {
         __weak SFOAuthCoordinator *weakSelf = self;
         switch (self.advancedAuthConfiguration) {
@@ -533,72 +538,60 @@ static NSString * const kOAuthUserAgentUserDefaultsKey          = @"UserAgent";
         [self.delegate oauthCoordinator:self willBeginAuthenticationWithView:self.view];
     }
     
-    // optional query params: 
-    //     state - opaque state value to be passed back
-    //     immediate - determines whether the user should be prompted for login and approval (default false)
-    
-    NSAssert(nil != self.credentials.domain, @"credentials.domain is required");
-    NSAssert(nil != self.credentials.clientId, @"credentials.clientId is required");
-    NSAssert(nil != self.credentials.redirectUri, @"credentials.redirectUri is required");
-
-    NSMutableString *approvalUrl = [[NSMutableString alloc] initWithFormat:@"%@://%@%@?%@=%@&%@=%@&%@=%@",
-                                    self.credentials.protocol, self.credentials.domain, kSFOAuthEndPointAuthorize,
-                                    kSFOAuthClientId, self.credentials.clientId,
-                                    kSFOAuthRedirectUri, self.credentials.redirectUri,
-                                    kSFOAuthDisplay, kSFOAuthDisplayTouch];
-
-    // If an activation code is available (IP bypass flow), then use the "activated client" response type.
-    if (self.credentials.activationCode) {
-        [approvalUrl appendFormat:@"&%@=%@", kSFOAuthResponseType, kSFOAuthResponseTypeActivatedClientCode];
-    } else {
-        [approvalUrl appendFormat:@"&%@=%@", kSFOAuthResponseType, kSFOAuthResponseTypeToken];        
-    }
-        
-    NSString *scopeString = [self scopeQueryParamString];
-    if (scopeString != nil) {
-        [approvalUrl appendString:scopeString];
-    }
-    
-    // JWT Flow
-    if (self.credentials.jwt) {
-        [self swapJWTWithcompletionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-            if (!error) {
-                bool swapOK = NO;
-                NSError *jsonError = nil;
-                id json = nil;
-                
-                json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
-                if (nil == jsonError && [json isKindOfClass:[NSDictionary class]]) {
-                    NSDictionary *dict = (NSDictionary *)json;
-                    [self updateCredentials:dict];
-                    if (self.credentials.accessToken && self.credentials.apiUrl) {
-                        NSString *baseUrlString = [self.credentials.apiUrl absoluteString];
-                        NSString *escapedString = [approvalUrl stringByURLEncoding];
-                        NSString* approvalUrl = [NSString stringWithFormat:@"%@/secur/frontdoor.jsp?sid=%@&retURL=%@", baseUrlString, self.credentials.accessToken, escapedString];
-                        [self doLoadURL:approvalUrl withCookie:YES];
-                        swapOK = YES;
-                        self.credentials.jwt = nil;
-                    }
-                }
-                if (!swapOK) {
-                    NSError *error = [[self class] errorWithType:kSFOAuthErrorTypeJWTLaunchFailed description:@"The breeze link failed to launch."];
-                    [self notifyDelegateOfFailure:error authInfo:self.authInfo];
-                    self.credentials.jwt = nil;
-                }
-            }
-            else {
-                [self log:SFLogLevelError msg:[NSString stringWithFormat:@"Fail to swap JWT for access token: %@", [error localizedDescription]]];
-                [self notifyDelegateOfFailure:error authInfo:self.authInfo];
-            }
-        }];
-    }
-    else {
-        [self doLoadURL:approvalUrl withCookie:NO];
-    }
+    NSString *approvalUrlString = [self generateApprovalUrlString];
+    [self doLoadURL:approvalUrlString withCookie:NO];
 }
 
+- (void)beginJwtTokenExchangeFlow {
+    NSAssert(self.credentials.jwt.length > 0, @"JWT token should be present at this point.");
+    
+    [self swapJWTWithCompletionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        if (error != nil) {
+            [self log:SFLogLevelError format:@"Fail to swap JWT for access token: %@", error.localizedDescription];
+            [self notifyDelegateOfFailure:error authInfo:self.authInfo];
+            return;
+        }
+        
+        self.credentials.jwt = nil;
+        NSError *jsonError = nil;
+        id json = nil;
+        
+        json = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
+        if (jsonError != nil) {
+            NSError *error = [[self class] errorWithType:kSFOAuthErrorTypeJWTLaunchFailed
+                                                 description:@"Error parsing JWT token exchange response."
+                                             underlyingError:jsonError];
+                [self notifyDelegateOfFailure:error authInfo:self.authInfo];
+            return;
+        }
+        
+        if (![json isKindOfClass:[NSDictionary class]]) {
+            NSString *errorDesc = [NSString stringWithFormat:@"Expected NSDictionary for JWT token response, received %@ instance.", NSStringFromClass([json class])];
+                NSError *error = [[self class] errorWithType:kSFOAuthErrorTypeJWTLaunchFailed
+                                                 description:errorDesc];
+            [self notifyDelegateOfFailure:error authInfo:self.authInfo];
+            return;
+        }
+        
+        NSDictionary *dict = (NSDictionary *)json;
+        if (nil != dict[kSFOAuthError]) {
+            NSError *error = [[self class] errorWithType:dict[kSFOAuthError] description:dict[kSFOAuthErrorDescription]];
+            [self notifyDelegateOfFailure:error authInfo:self.authInfo];
+            return;
+        }
+        
+        [self updateCredentials:dict];
+        if (self.credentials.accessToken && self.credentials.apiUrl) {
+            NSString *baseUrlString = [self.credentials.apiUrl absoluteString];
+            NSString *approvalUrlString = [self generateApprovalUrlString];
+            NSString *escapedApprovalUrlString = [approvalUrlString stringByURLEncoding];
+            NSString *frontDoorUrl = [NSString stringWithFormat:@"%@/secur/frontdoor.jsp?sid=%@&retURL=%@", baseUrlString, self.credentials.accessToken, escapedApprovalUrlString];
+            [self doLoadURL:frontDoorUrl withCookie:YES];
+        }
+    }];
+}
 
-- (void)swapJWTWithcompletionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler  {
+- (void)swapJWTWithCompletionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler  {
     NSString *url = [[NSString alloc] initWithFormat:@"%@://%@%@", self.credentials.protocol,
                      self.credentials.domain,
                      kSFOAuthEndPointToken];
@@ -817,8 +810,33 @@ static NSString * const kOAuthUserAgentUserDefaultsKey          = @"UserAgent";
     }
 }
 
-- (NSString *)scopeQueryParamString
-{
+- (NSString *)generateApprovalUrlString {
+    NSAssert(nil != self.credentials.domain, @"credentials.domain is required");
+    NSAssert(nil != self.credentials.clientId, @"credentials.clientId is required");
+    NSAssert(nil != self.credentials.redirectUri, @"credentials.redirectUri is required");
+    
+    NSMutableString *approvalUrlString = [[NSMutableString alloc] initWithFormat:@"%@://%@%@?%@=%@&%@=%@&%@=%@",
+                                          self.credentials.protocol, self.credentials.domain, kSFOAuthEndPointAuthorize,
+                                          kSFOAuthClientId, self.credentials.clientId,
+                                          kSFOAuthRedirectUri, self.credentials.redirectUri,
+                                          kSFOAuthDisplay, kSFOAuthDisplayTouch];
+    
+    // If an activation code is available (IP bypass flow), then use the "activated client" response type.
+    if (self.credentials.activationCode) {
+        [approvalUrlString appendFormat:@"&%@=%@", kSFOAuthResponseType, kSFOAuthResponseTypeActivatedClientCode];
+    } else {
+        [approvalUrlString appendFormat:@"&%@=%@", kSFOAuthResponseType, kSFOAuthResponseTypeToken];
+    }
+    
+    NSString *scopeString = [self scopeQueryParamString];
+    if (scopeString != nil) {
+        [approvalUrlString appendString:scopeString];
+    }
+    
+    return approvalUrlString;
+}
+
+- (NSString *)scopeQueryParamString {
     NSMutableSet *scopes = (self.scopes.count > 0 ? [NSMutableSet setWithSet:self.scopes] : [NSMutableSet set]);
     [scopes addObject:kSFOAuthRefreshToken];
     NSString *scopeStr = [[[scopes allObjects] componentsJoinedByString:@" "] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
@@ -1058,6 +1076,10 @@ static NSString * const kOAuthUserAgentUserDefaultsKey          = @"UserAgent";
 }
 
 + (NSError *)errorWithType:(NSString *)type description:(NSString *)description {
+    return [self errorWithType:type description:description underlyingError:nil];
+}
+
++ (NSError *)errorWithType:(NSString *)type description:(NSString *)description underlyingError:(NSError *)underlyingError {
     NSAssert(type, @"error type can't be nil");
     
     NSInteger code = kSFOAuthErrorUnknown;
@@ -1095,9 +1117,12 @@ static NSString * const kOAuthUserAgentUserDefaultsKey          = @"UserAgent";
         code = kSFOAuthErrorJWTInvalidGrant;
     }
 
-    NSDictionary *dict = @{kSFOAuthError: type,
-                                                                    NSLocalizedDescriptionKey: description};
-    NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain code:code userInfo:dict];
+    NSMutableDictionary *userInfoDict = [NSMutableDictionary dictionaryWithDictionary:@{kSFOAuthError: type,
+                                                                                        NSLocalizedDescriptionKey: description}];
+    if (underlyingError != nil) {
+        userInfoDict[NSUnderlyingErrorKey] = underlyingError;
+    }
+    NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain code:code userInfo:userInfoDict];
     return error;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthInfo.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthInfo.h
@@ -31,7 +31,8 @@ typedef NS_ENUM(NSUInteger, SFOAuthType) {
     SFOAuthTypeUnknown = 0,
     SFOAuthTypeUserAgent,
     SFOAuthTypeRefresh,
-    SFOAuthTypeAdvancedBrowser
+    SFOAuthTypeAdvancedBrowser,
+    SFOAuthTypeJwtTokenExchange
 };
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthInfo.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthInfo.m
@@ -56,6 +56,9 @@
         case SFOAuthTypeAdvancedBrowser:
             desc = @"SFOAuthTypeAdvancedBrowser";
             break;
+        case SFOAuthTypeJwtTokenExchange:
+            desc = @"SFOAuthTypeJwtTokenExchange";
+            break;
         case SFOAuthTypeUnknown:
         default:
             desc = @"SFOAuthTypeUnknown";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -331,6 +331,10 @@ extern NSString * const kSFAuthenticationManagerFinishedNotification;
                     failure:(SFOAuthFlowFailureCallbackBlock)failureBlock
                     account:(nullable SFUserAccount *)account;
 
+- (BOOL)loginWithJwtToken:(NSString *)jwtToken
+               completion:(SFOAuthFlowSuccessCallbackBlock)completionBlock
+                  failure:(SFOAuthFlowFailureCallbackBlock)failureBlock;
+
 /**
  Forces a logout from the current account, redirecting the user to the login process.
  This throws out the OAuth refresh token.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -331,6 +331,15 @@ extern NSString * const kSFAuthenticationManagerFinishedNotification;
                     failure:(SFOAuthFlowFailureCallbackBlock)failureBlock
                     account:(nullable SFUserAccount *)account;
 
+/**
+ Login using the given JWT token to exchange with the service for credentials.
+ @param jwtToken The JWT token (received out of band) to exchange for credentials.
+ @param completionBlock The block of code to execute when the authentication process successfully completes.
+ @param failureBlock The block of code to execute when the authentication process has a fatal failure.
+ @return YES if this call kicks off the authentication process.  NO if an authentication process has already
+ started, in which case subsequent requests are queued up to have their completion or failure blocks executed
+ in succession.
+ */
 - (BOOL)loginWithJwtToken:(NSString *)jwtToken
                completion:(SFOAuthFlowSuccessCallbackBlock)completionBlock
                   failure:(SFOAuthFlowFailureCallbackBlock)failureBlock;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -388,6 +388,21 @@ static Class InstanceClass = nil;
     }
 }
 
+- (BOOL)loginWithJwtToken:(NSString *)jwtToken
+               completion:(SFOAuthFlowSuccessCallbackBlock)completionBlock
+                  failure:(SFOAuthFlowFailureCallbackBlock)failureBlock
+{
+    
+    NSAssert(jwtToken.length > 0, @"JWT token value required.");
+    
+    SFUserAccount *jwtUserAccount = [[SFUserAccountManager sharedInstance] createUserAccount];
+    jwtUserAccount.credentials.jwt = jwtToken;
+    return [self loginWithCompletion:completionBlock
+                             failure:failureBlock
+                             account:jwtUserAccount];
+}
+
+
 - (void)loggedIn:(BOOL)fromOffline
 {
     if (!fromOffline) {
@@ -973,11 +988,6 @@ static Class InstanceClass = nil;
                                            evalBlock:^BOOL(NSError *error, SFOAuthInfo *authInfo) {
                                                if ([[weakSelf class] errorIsInvalidAuthCredentials:error]) {
                                                    [weakSelf log:SFLogLevelWarning format:@"OAuth refresh failed due to invalid grant.  Error code: %ld", (long)error.code];
-                                                   [weakSelf execFailureBlocks];
-                                                   return YES;
-                                               }
-                                               if (error.code == kSFOAuthErrorJWTInvalidGrant) {
-                                                   [weakSelf log:SFLogLevelWarning format:@"JWT swap failed due to invalid grant.  Error code: %ld", (long)error.code];
                                                    [weakSelf execFailureBlocks];
                                                    return YES;
                                                }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlow.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlow.h
@@ -34,6 +34,7 @@
 @property (nonatomic, assign) BOOL beginUserAgentFlowCalled;
 @property (nonatomic, assign) BOOL beginTokenEndpointFlowCalled;
 @property (nonatomic, assign) BOOL beginNativeBrowserFlowCalled;
+@property (nonatomic, assign) BOOL beginJwtTokenExchangeFlowCalled;
 @property (nonatomic, assign) SFOAuthTokenEndpointFlow tokenEndpointFlowType;
 @property (nonatomic, assign) BOOL handleTokenEndpointResponseCalled;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlow.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlow.m
@@ -131,6 +131,11 @@
     });
 }
 
+- (void)beginJwtTokenExchangeFlow {
+    [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    self.beginJwtTokenExchangeFlowCalled = YES;
+}
+
 - (void)beginNativeBrowserFlow {
     [self log:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     self.beginNativeBrowserFlowCalled = YES;


### PR DESCRIPTION
At a high level:

- Adding a new method the `SFAuthenticationManager` to login with a JWT token exchange, which encapsulates more of the details of configuring such a flow from the consumer.
- Reorganized the code in `SFOAuthCoordinator` to better fit the design patterns there.

More comments below.