### PR TITLE
Replacing network calls with our network stack

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAILTNPublisher.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAILTNPublisher.h
@@ -28,8 +28,7 @@
  */
 
 #import "SFSDKAnalyticsPublisher.h"
-#import "SFRestAPI.h"
 
-@interface SFSDKAILTNPublisher : NSObject <SFSDKAnalyticsPublisher, SFRestDelegate>
+@interface SFSDKAILTNPublisher : NSObject <SFSDKAnalyticsPublisher>
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAILTNPublisher.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAILTNPublisher.h
@@ -28,7 +28,8 @@
  */
 
 #import "SFSDKAnalyticsPublisher.h"
+#import "SFRestAPI.h"
 
-@interface SFSDKAILTNPublisher : NSObject <SFSDKAnalyticsPublisher>
+@interface SFSDKAILTNPublisher : NSObject <SFSDKAnalyticsPublisher, SFRestDelegate>
 
 @end


### PR DESCRIPTION
Tested end-to-end. This works.

To be done:

- Add a way to return completion status to the caller, so that it can determine whether to delete events or not (consequence of replacing a synchronous network call with our async stack).