### PR TITLE
Don't remove security view on app foreground event.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -369,14 +369,7 @@ static Class InstanceClass = nil;
             [delegate sdkManagerWillEnterForeground];
         }
     }];
-    
-    @try {
-        [self dismissSnapshot];
-    }
-    @catch (NSException *exception) {
-        [self log:SFLogLevelWarning format:@"Exception thrown while removing security snapshot view: '%@'. Will continue to resume app.", [exception reason]];
-    }
-    
+        
     if (_isLaunching) {
         [self log:SFLogLevelDebug format:@"SDK is still launching.  No foreground action taken."];
     } else {


### PR DESCRIPTION
This hook to dismiss the security view is faulty in scenarios where the app enters foreground but never becomes active (e.g. launch the app, then double tap the home button before the app actually completes the launch: the app will have entered foreground but never became active).

Dismissing the security view when the app enters foreground is not safe. It needs to wait until it the app actually becomes active.

@bhariharan @khawkins 