### PR TITLE
Cleaning up logging enabled functionality

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.h
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.h
@@ -38,7 +38,7 @@ typedef NSData * _Nullable (^ _Nullable DataDecryptorBlock)(NSData * _Nullable d
 @property (nonatomic, strong, readonly, nullable) DataEncryptorBlock dataEncryptorBlock;
 @property (nonatomic, strong, readonly, nullable) DataDecryptorBlock dataDecryptorBlock;
 @property (nonatomic, assign, readonly) NSInteger numStoredEvents;
-@property (nonatomic, assign, readwrite) BOOL isLoggingEnabled;
+@property (nonatomic, assign, readwrite, getter=isLoggingEnabled) BOOL loggingEnabled;
 @property (nonatomic, assign, readwrite) NSInteger maxEvents;
 
 /**

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
@@ -43,7 +43,7 @@
 - (instancetype) initWithStoreDirectory:(NSString *) storeDirectory dataEncryptorBlock:(DataEncryptorBlock) dataEncryptorBlock dataDecryptorBlock:(DataDecryptorBlock) dataDecryptorBlock {
     self = [super init];
     if (self) {
-        self.isLoggingEnabled = YES;
+        self.loggingEnabled = YES;
         self.maxEvents = 1000;
         self.storeDirectory = storeDirectory;
 
@@ -161,12 +161,6 @@
         if ([fileManager fileExistsAtPath:filePath]) {
             [fileManager removeItemAtPath:filePath error:nil];
         }
-    }
-}
-
-- (void) disableOrEnableLogging:(BOOL) enabled {
-    @synchronized (self) {
-        self.isLoggingEnabled = enabled;
     }
 }
 

--- a/libs/SalesforceAnalytics/SalesforceAnalyticsTests/EventStoreManagerTests.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalyticsTests/EventStoreManagerTests.m
@@ -175,7 +175,7 @@ static NSString * const kTestSessionId = @"TEST_SESSION_ID";
 - (void) testDisablingLogging {
     SFSDKInstrumentationEvent *event = [self createTestEvent];
     XCTAssertTrue(event != nil, @"Generated event stored should not be nil");
-    self.storeManager.isLoggingEnabled = NO;
+    self.storeManager.loggingEnabled = NO;
     [self.storeManager storeEvent:event];
     NSArray<SFSDKInstrumentationEvent *> *events = [self.storeManager fetchAllEvents];
     XCTAssertTrue(events != nil, @"List of events should not be nil");
@@ -188,12 +188,12 @@ static NSString * const kTestSessionId = @"TEST_SESSION_ID";
 - (void) testEnablingLogging {
     SFSDKInstrumentationEvent *event = [self createTestEvent];
     XCTAssertTrue(event != nil, @"Generated event stored should not be nil");
-    self.storeManager.isLoggingEnabled = NO;
+    self.storeManager.loggingEnabled = NO;
     [self.storeManager storeEvent:event];
     NSArray<SFSDKInstrumentationEvent *> *events = [self.storeManager fetchAllEvents];
     XCTAssertTrue(events != nil, @"List of events should not be nil");
     XCTAssertEqual(0, events.count, @"Number of events stored should be 0");
-    self.storeManager.isLoggingEnabled = YES;
+    self.storeManager.loggingEnabled = YES;
     [self.storeManager storeEvent:event];
     events = [self.storeManager fetchAllEvents];
     XCTAssertTrue(events != nil, @"List of events should not be nil");

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.h
@@ -37,7 +37,14 @@
 @property (nonatomic, readonly, strong, nonnull) SFSDKEventStoreManager *eventStoreManager;
 @property (nonatomic, readonly, strong, nonnull) SFSDKAnalyticsManager *analyticsManager;
 @property (nonatomic, readonly, strong, nonnull) SFUserAccount *userAccount;
-@property (nonatomic, readonly, assign) BOOL enabled;
+
+/**
+ * Disables or enables logging of events.
+ *
+ * @discussion If logging is disabled, no events will be stored. However, publishing
+ * of events is still possible.
+ */
+@property (nonatomic, readonly, assign, getter=isLoggingEnabled) BOOL loggingEnabled;
 
 /**
  * Returns an instance of this class associated with the specified user account.
@@ -91,23 +98,8 @@
 - (void) addRemotePublisher:(nonnull Class<SFSDKTransform>) transformer publisher:(nonnull Class<SFSDKAnalyticsPublisher>) publisher;
 
 /**
- * Disables or enables logging of events. If logging is disabled, no events
- * will be stored. However, publishing of events is still possible.
- *
- * @param enabled True - if logging should be enabled, False - otherwise.
- */
-- (void) disableOrEnableLogging:(BOOL) enabled;
-
-/**
  * Updates the preferences of this library.
  */
 - (void) updateLoggingPrefs;
-
-/**
- * Returns whether logging is enabled or disabled.
- *
- * @return True - if logging is enabled, False - otherwise.
- */
-- (BOOL) isLoggingEnabled;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -110,9 +110,6 @@ static NSMutableDictionary *analyticsManagerList = nil;
         self.eventStoreManager = self.analyticsManager.storeManager;
         self.remotes = [[NSMutableDictionary alloc] init];
         self.remotes[(id<NSCopying>) [SFSDKAILTNTransform class]] = [SFSDKAILTNPublisher class];
-
-        // Reads the existing analytics policy and sets it upon initialization.
-        [self readAnalyticsPolicy];
     }
     return self;
 }


### PR DESCRIPTION
@bhariharan For your consideration:

- Refactoring the enabled/disabled functionality to a more Objective-C-friendly design pattern.
- Making property getter/setters simply front-ends to the persisted values.