### PR TITLE
Update network error handling

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFAction.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFAction.h
@@ -247,6 +247,16 @@ NS_ASSUME_NONNULL_BEGIN
  @return The data to populate outputContent with, otherwise `nil` if nothing is appropriate.
  */
 - (id)contentFromData:(NSData*)data fromResponse:(NSHTTPURLResponse*)response error:(NSError**)error;
+
+/**
+ Subclassable method that will pre-process the HTTP response for errors, prior to handing off to
+ contentFromData:fromResponse:error: .
+ 
+ @param data NSData instance containing the HTTP response body.
+ @param response The HTTP response to process.
+ 
+ @return An NSError describing the error response, or `nil` if no errors were found in the response.
+ */
 - (NSError *)errorFromData:(NSData *)data response:(NSHTTPURLResponse *)response;
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFAction.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFAction.h
@@ -247,6 +247,7 @@ NS_ASSUME_NONNULL_BEGIN
  @return The data to populate outputContent with, otherwise `nil` if nothing is appropriate.
  */
 - (id)contentFromData:(NSData*)data fromResponse:(NSHTTPURLResponse*)response error:(NSError**)error;
+- (NSError *)errorFromData:(NSData *)data response:(NSHTTPURLResponse *)response;
 
 /**
  Method that can override the HTTP request process, and can allow a subclass to forcibly inject explicit response data without performing a network request.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFAction.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFAction.m
@@ -777,8 +777,11 @@ CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
     self.timingValues[@"responseTime"] = [NSDate date];
     self.httpResponse = response;
     
-    NSError *error = nil;
-    self.outputContent = [self contentFromData:self.responseData fromResponse:response error:&error];
+    NSError *error = [self errorFromData:self.responseData response:response];
+    if (error == nil) {
+        // No pre-determined error.  Process content.
+        self.outputContent = [self contentFromData:self.responseData fromResponse:response error:&error];
+    }
     self.responseData = nil;
     
     // Check to see if this action should be saved somewhere

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFAction.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFAction.m
@@ -768,6 +768,11 @@ CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
     return content;
 }
 
+- (NSError *)errorFromData:(NSData *)data response:(NSHTTPURLResponse *)response {
+    // Default behavior is to not evaluate the response for errors.
+    return nil;
+}
+
 - (void)completeOperationWithResponse:(NSHTTPURLResponse *)response {
     self.timingValues[@"responseTime"] = [NSDate date];
     self.httpResponse = response;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFSalesforceAction.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFSalesforceAction.m
@@ -118,128 +118,39 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
 - (id)contentFromData:(NSData*)data fromResponse:(NSHTTPURLResponse*)response error:(NSError**)error {
     NSError *responseError = nil;
     id content = [super contentFromData:data fromResponse:response error:&responseError];
-
-    if (!responseError) {
-        NSObject *msgObj = nil;
-        NSString *errorCode = nil;
-        if (content) {
-            if ([content isKindOfClass:[NSArray class]] && [(NSArray*)content count] > 0) {
-                NSArray *jsonArray = (NSArray*)content;
-                NSDictionary *errorDict = jsonArray[0];
-                if ([errorDict isKindOfClass:[NSDictionary class]] && errorDict[@"errorCode"]) {
-                    msgObj = CSFSalesforceErrorMessage(errorDict);
-                    errorCode = errorDict[@"errorCode"];
-                }
-            } else if (response.statusCode >= 400 && [content isKindOfClass:[NSDictionary class]]) {
-                NSDictionary *errorDict = (NSDictionary*)content;
-                msgObj = CSFSalesforceErrorMessage(errorDict);
-                errorCode = errorDict[@"errorCode"];
-            }
-        }
-        CSFNetwork *network = self.enqueuedNetwork;
-        if (response.statusCode >= 400) {
-            
-            // Note: request session refresh only when the error indicates the session expired (see W-2005000)
-            BOOL requestSessionRefresh = NO;
-            switch (response.statusCode) {
-                case 400:
-                    // bad request (invalid URI / invalid params)
-                    // The request could not be understood, usually because of an invalid ID, such as a userId, feedItemId,
-                    // or groupId being incorrect.
-                    break;
-                    
-                case 401:
-                    // unauthorized (not logged in / session expired)
-                    // The session ID or OAuth token used has expired or is invalid.
-                    // The response body contains the message and errorCode.
-                    if ([errorCode isEqualToString:@"INVALID_SESSION_ID"]) {
-                        requestSessionRefresh = YES;
-                    }
-                    break;
-                    
-                case 403:
-                    // forbidden (user isn't allowed to do the operation). The request has been refused.
-                    // i.e. 'operation couldn't be completed'
-                    
-                    // With Connect, the server returns this error code when the device is no longer authorized on core.
-                    if ([errorCode isEqualToString:@"CLIENT_NOT_ACCESSIBLE_FOR_USER"]) {
-                        [network receivedDevicedUnauthorizedError:self];
-                        //allow error to propagate on to the original caller as well-- allows for facade completions etc
-                    }
-                    break;
-                    
-                case 404:
-                    // resource was not found or deleted
-                    break;
-                    
-                case 408:
-                    // request timeout
-                    // request took too long and was aborted - max time per request is a setting, when last check, 120s
-                    break;
-                    
-                case 503:
-                    // unavailable - too many requests in an hour
-                    // max concurrent requests hit - max concurrent requests is a setting, when last confirmed it was 50 per JVM)
-                    break;
-                    
-                case 500:
-                    // all other errors: "An error has occurred within Force.com"
-                    // fall-through
-                    
-                default:
-                    // When the user is revoked, the response object is nil (so error code is 0)
-                    // but the errorObj contains the invalid session message that we need to handle.
-                    if ([errorCode isEqualToString:@"INVALID_SESSION_ID"]) {
-                        requestSessionRefresh = YES;
-                    }
-                    break;
-            }
-            
-            NSString *errorDescription = [msgObj description] ?: [NSString stringWithFormat:@"HTTP %ld for %@ %@", (long)response.statusCode, self.method, self.verb];
-            NSMutableDictionary *userInfoDict = [NSMutableDictionary dictionaryWithDictionary:@{ NSLocalizedDescriptionKey:errorDescription,
-                                                                                                 CSFNetworkErrorActionKey: self,
-                                                                                                 CSFNetworkErrorAuthenticationFailureKey: @(requestSessionRefresh) }
-                                                 ];
-            if (errorCode.length > 0) {
-                userInfoDict[NSLocalizedFailureReasonErrorKey] = errorCode;
-            }
-            responseError = [NSError errorWithDomain:CSFNetworkErrorDomain
-                                                code:response.statusCode
-                                            userInfo:userInfoDict];
-        }
-        
-        // TODO: We need to figure out how to handle the security token some other way, so it doesn't collide with other action types.
-        if (!responseError && [content isKindOfClass:[NSDictionary class]]) {
-            NSDictionary *jsonContent = (NSDictionary*)content;
-            NSString *securityToken = jsonContent[CSFActionSecurityTokenKey]; // retrieve the CSRF security token
-            if (securityToken) {
-                network.securityToken = securityToken;
-            }
+    if (responseError != nil) {
+        if (error) *error = responseError;
+        return content;
+    }
+    
+    // TODO: We need to figure out how to handle the security token some other way, so it doesn't collide with other action types.
+    CSFNetwork *network = self.enqueuedNetwork;
+    if ([content isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *jsonContent = (NSDictionary*)content;
+        NSString *securityToken = jsonContent[CSFActionSecurityTokenKey]; // retrieve the CSRF security token
+        if (securityToken) {
+            network.securityToken = securityToken;
         }
     }
     
-    if (error) {
-        *error = responseError;
-    }
-
     return content;
 }
 
 - (NSError *)errorFromData:(NSData *)data response:(NSHTTPURLResponse *)response {
-    NSError *error = [super errorFromData:data response:response];
-    if (error != nil) {
-        return error;
+    // If there are upstream error(s), just return those.
+    NSError *superError = [super errorFromData:data response:response];
+    if (superError != nil) {
+        return superError;
     }
     
     if (response.statusCode < 400) {
         // Nothing that we care about, from an error standpoint.
-        return  nil;
+        return nil;
     }
     
     NSString *errorMessage = nil;
     NSString *errorCode = nil;
-    CSFNetwork *network = self.enqueuedNetwork;
-        
+    
     // Note: request session refresh only when the error indicates the session expired.
     BOOL requestSessionRefresh = NO;
     switch (response.statusCode) {
@@ -253,7 +164,7 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
             // unauthorized (not logged in / session expired)
             // The session ID or OAuth token used has expired or is invalid.
             // The response body contains the message and errorCode.
-            [self contentData:data hasErrorMessage:&errorMessage errorCode:&errorCode];
+            [self contentData:data extractErrorMessage:&errorMessage errorCode:&errorCode];
             if ([errorCode isEqualToString:@"INVALID_SESSION_ID"]) {
                 requestSessionRefresh = YES;
             }
@@ -285,7 +196,7 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
         default:
             // When the user is revoked, the response object is nil (so error code is 0)
             // but the errorObj contains the invalid session message that we need to handle.
-            [self contentData:data hasErrorMessage:&errorMessage errorCode:&errorCode];
+            [self contentData:data extractErrorMessage:&errorMessage errorCode:&errorCode];
             if ([errorCode isEqualToString:@"INVALID_SESSION_ID"]) {
                 requestSessionRefresh = YES;
             }
@@ -293,37 +204,28 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
     }
     
     NSString *errorDescription = errorMessage ?: [NSString stringWithFormat:@"HTTP %ld for %@ %@", (long)response.statusCode, self.method, self.verb];
-    NSMutableDictionary *userInfoDict = [NSMutableDictionary dictionaryWithDictionary:@{ NSLocalizedDescriptionKey:errorDescription,
-                                                                                         CSFNetworkErrorActionKey: self,
-                                                                                         CSFNetworkErrorAuthenticationFailureKey: @(requestSessionRefresh) }
-                                         ];
-        if (errorCode.length > 0) {
-            userInfoDict[NSLocalizedFailureReasonErrorKey] = errorCode;
-        }
-        NSError *responseError = [NSError errorWithDomain:CSFNetworkErrorDomain
-                                            code:response.statusCode
-                                        userInfo:userInfoDict];
+    NSDictionary *baseErrorDict = @{ NSLocalizedDescriptionKey:errorDescription,
+                                     CSFNetworkErrorActionKey: self,
+                                     CSFNetworkErrorAuthenticationFailureKey: @(requestSessionRefresh) };
+    NSMutableDictionary *userInfoDict = [NSMutableDictionary dictionaryWithDictionary:baseErrorDict];
+    if (errorCode.length > 0) {
+        userInfoDict[NSLocalizedFailureReasonErrorKey] = errorCode;
     }
-    
-    // TODO: We need to figure out how to handle the security token some other way, so it doesn't collide with other action types.
-    if (!responseError && [content isKindOfClass:[NSDictionary class]]) {
-        NSDictionary *jsonContent = (NSDictionary*)content;
-        NSString *securityToken = jsonContent[CSFActionSecurityTokenKey]; // retrieve the CSRF security token
-        if (securityToken) {
-            network.securityToken = securityToken;
-        }
-    }
+    NSError *responseError = [NSError errorWithDomain:CSFNetworkErrorDomain
+                                                 code:response.statusCode
+                                             userInfo:userInfoDict];
+    return responseError;
 }
 
-- (void)contentData:(NSData *)data hasErrorMessage:(NSString **)errorMessage errorCode:(NSString **)errorCode {
+- (void)contentData:(NSData *)data extractErrorMessage:(NSString **)errorMessage errorCode:(NSString **)errorCode {
     NSString *retErrorMessage = nil;
     NSString *retErrorCode = nil;
     
     NSError *jsonParseError = nil;
     id content = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&jsonParseError];
     if (jsonParseError == nil && content != nil) {
-        if ([content isKindOfClass:[NSArray class]] && ((NSArray*)content).count > 0) {
-            NSArray *jsonArray = (NSArray*)content;
+        if ([content isKindOfClass:[NSArray class]] && ((NSArray *)content).count > 0) {
+            NSArray *jsonArray = (NSArray *)content;
             NSDictionary *errorDict = jsonArray[0];
             if ([errorDict isKindOfClass:[NSDictionary class]] && errorDict[@"errorCode"]) {
                 retErrorMessage = CSFSalesforceErrorMessage(errorDict);

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFSalesforceAction.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFSalesforceAction.m
@@ -150,6 +150,7 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
     
     NSString *errorMessage = nil;
     NSString *errorCode = nil;
+    [self contentData:data extractErrorMessage:&errorMessage errorCode:&errorCode];
     
     // Note: request session refresh only when the error indicates the session expired.
     BOOL requestSessionRefresh = NO;
@@ -164,7 +165,6 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
             // unauthorized (not logged in / session expired)
             // The session ID or OAuth token used has expired or is invalid.
             // The response body contains the message and errorCode.
-            [self contentData:data extractErrorMessage:&errorMessage errorCode:&errorCode];
             if ([errorCode isEqualToString:@"INVALID_SESSION_ID"]) {
                 requestSessionRefresh = YES;
             }
@@ -196,7 +196,6 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
         default:
             // When the user is revoked, the response object is nil (so error code is 0)
             // but the errorObj contains the invalid session message that we need to handle.
-            [self contentData:data extractErrorMessage:&errorMessage errorCode:&errorCode];
             if ([errorCode isEqualToString:@"INVALID_SESSION_ID"]) {
                 requestSessionRefresh = YES;
             }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFSalesforceAction.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFSalesforceAction.m
@@ -137,15 +137,12 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
 }
 
 - (NSError *)errorFromData:(NSData *)data response:(NSHTTPURLResponse *)response {
-    // If there are upstream error(s), just return those.
+    // Check for upstream errors.
     NSError *superError = [super errorFromData:data response:response];
-    if (superError != nil) {
-        return superError;
-    }
     
     if (response.statusCode < 400) {
         // Nothing that we care about, from an error standpoint.
-        return nil;
+        return superError;
     }
     
     NSString *errorMessage = nil;
@@ -209,6 +206,9 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
     NSMutableDictionary *userInfoDict = [NSMutableDictionary dictionaryWithDictionary:baseErrorDict];
     if (errorCode.length > 0) {
         userInfoDict[NSLocalizedFailureReasonErrorKey] = errorCode;
+    }
+    if (superError != nil) {
+        userInfoDict[NSUnderlyingErrorKey] = superError;
     }
     NSError *responseError = [NSError errorWithDomain:CSFNetworkErrorDomain
                                                  code:response.statusCode

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Queue/CSFNetwork+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Queue/CSFNetwork+Internal.h
@@ -72,12 +72,6 @@
 
 - (CSFAction*)duplicateActionInFlight:(CSFAction*)action;
 
-/*!
- Provides a means for low-level code to tell us that this device has been de-authorized.
- This can happen if the device is unchecked from Chatter settings in the org setup.
- */
-- (void)receivedDevicedUnauthorizedError:(CSFAction*)action;
-
 - (CSFAction*)actionForSessionTask:(NSURLSessionTask*)task;
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Queue/CSFNetwork.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Queue/CSFNetwork.m
@@ -483,15 +483,6 @@ static NSMutableDictionary *SharedInstances = nil;
     [action sessionTask:task willPerformHTTPRedirection:response newRequest:request completionHandler:completionHandler];
 }
 
-#pragma mark - Device Authorization support
-
-// TODO: This should probably be relocated to the CSFSalesforceAction logic, and cleaned up
-//       so that it fires a notification of some sort so we can decouple the alert view work.
-//       This way we don't ahve to reference UIKit from the network stack, and the consumer
-//       is capable of handling the unauthorized response.
-- (void)receivedDevicedUnauthorizedError:(CSFAction *)action {
-}
-
 #pragma mark - SFAuthenticationManagerDelegate
 
 - (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user {


### PR DESCRIPTION
Instituting a new workflow to preprocess errors in network responses, before further processing of their content.  Allows functionality like `SFRestAPISalesforceAction.parseResponse` to interoperate with auth token refresh functionality upstream.