### PR TITLE
add bridge method for showing smartstore inspector

### DIFF
--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
@@ -265,6 +265,21 @@ RCT_EXPORT_METHOD(getSoupSpec:(NSDictionary *)argsDict callback:(RCTResponseSend
     }
 }
 
+RCT_EXPORT_METHOD(showInspector:(NSDictionary *)argsDict callback:(RCTResponseSenderBlock)callback)
+{
+    NSString *globalStoreStr = [argsDict nonNullObjectForKey:kIsGlobalStoreArg];
+    BOOL isGlobalStore = [globalStoreStr boolValue];
+    [self log:SFLogLevelDebug format:@"showInspector with isGlobalStore: %@", isGlobalStore ? @"true" : @"false"];
+    SFSmartStoreInspectorViewController *inspector;
+    if(isGlobalStore){
+        inspector = [self globalInspector];
+    } else {
+        inspector = [self inspector];
+    }
+    [inspector present:[UIApplication sharedApplication].keyWindow.rootViewController];
+    callback(@[[NSNull null], @"OK"]);
+}
+
 #pragma mark - Helper methods
 
 - (void)storeCursor:(SFStoreCursor*)cursor


### PR DESCRIPTION
Hello SDK team. Met Ivan and a few others on the team over some beers at DF this year. This pull request is to add a react native bridge method to pop open the smart store inspector. I've found it useful for debugging my RN app.