### PR TITLE
Analytics transform should return generic object

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Transform/SFSDKAILTNTransform.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Transform/SFSDKAILTNTransform.m
@@ -56,7 +56,7 @@ static NSString* const kSFPerfEventType = @"defs";
 
 @implementation SFSDKAILTNTransform
 
-+ (NSDictionary *) transform:(SFSDKInstrumentationEvent *) event {
++ (id) transform:(SFSDKInstrumentationEvent *) event {
     if (!event) {
         return nil;
     }

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Transform/SFSDKTransform.h
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Transform/SFSDKTransform.h
@@ -36,8 +36,8 @@
  * Transforms an event into the required format.
  *
  * @param event Event to be transformed.
- * @return JSON representation after transformation.
+ * @return Transformed representation of the event, or nil if event is to be skipped from publishing.
  */
-+ (nullable NSDictionary *) transform:(nonnull SFSDKInstrumentationEvent *) event;
++ (nullable id) transform:(nonnull SFSDKInstrumentationEvent *) event;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -286,16 +286,16 @@ static NSMutableDictionary *analyticsManagerList = nil;
 
 - (void) applyTransformAndPublish:(Class<SFSDKTransform>) curTransform events:(NSArray<SFSDKInstrumentationEvent *> *) events publishCompleteBlock:(PublishCompleteBlock) publishCompleteBlock {
     if (curTransform) {
-        NSMutableArray<NSDictionary *> *eventsJSONArray = [[NSMutableArray alloc] init];
+        NSMutableArray *eventsArray = [[NSMutableArray alloc] init];
         for (SFSDKInstrumentationEvent *event in events) {
-            NSDictionary *eventJSON = [curTransform transform:event];
-            if (eventJSON) {
-                [eventsJSONArray addObject:eventJSON];
+            id transformedEvent = [curTransform transform:event];
+            if (transformedEvent != nil) {
+                [eventsArray addObject:transformedEvent];
             }
         }
         Class<SFSDKAnalyticsPublisher> networkPublisher = self.remotes[curTransform];
         if (networkPublisher) {
-            [networkPublisher publish:eventsJSONArray publishCompleteBlock:publishCompleteBlock];
+            [networkPublisher publish:eventsArray publishCompleteBlock:publishCompleteBlock];
         }
     }
 }


### PR DESCRIPTION
Since transforms and publishers share their own contract, transformations should be able to occur into any format desired by the implementer.