### PR TITLE
Having the os restriction here means that we need to use a different …

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
 	"licenses" : [
 	    { "type": "Salesforce.com Mobile SDK License", "url": "https://github.com/forcedotcom/SalesforceMobileSDK-iOS/blob/master/LICENSE.md" }
 	],
-	"os" : [ "darwin" ],
 	"repository": {
 		"type" : "git",
 		"url" : "https://github.com/forcedotcom/SalesforceMobileSDK-iOS.git"


### PR DESCRIPTION
…package.json for iOS react native template and Android react native template

So the only place where we will have the os = darwin constraint is in the package.json for forceios