### PR TITLE
fix resyncghosts callback timing

### DIFF
--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSmartSyncReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSmartSyncReactBridge.m
@@ -85,8 +85,9 @@ RCT_EXPORT_METHOD(cleanResyncGhosts:(NSDictionary *)args callback:(RCTResponseSe
 {
     NSNumber* syncId = (NSNumber*) [args nonNullObjectForKey:kSyncIdArg];
     [self log:SFLogLevelDebug format:@"cleanResyncGhosts with sync id: %@", syncId];
-    [[self getSyncManagerInst:args] cleanResyncGhosts:syncId completionStatusBlock:nil];
-    callback(@[[NSNull null]]);
+    [[self getSyncManagerInst:isGlobal] cleanResyncGhosts:syncId completionStatusBlock:^void(SFSyncStateStatus syncStatus){
+        callback(@[[NSNull null], [SFSyncState syncStatusToString:syncStatus]]);
+    }];
 }
 
 RCT_EXPORT_METHOD(syncUp:(NSDictionary *)args callback:(RCTResponseSenderBlock)callback)

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSmartSyncReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSmartSyncReactBridge.m
@@ -85,7 +85,7 @@ RCT_EXPORT_METHOD(cleanResyncGhosts:(NSDictionary *)args callback:(RCTResponseSe
 {
     NSNumber* syncId = (NSNumber*) [args nonNullObjectForKey:kSyncIdArg];
     [self log:SFLogLevelDebug format:@"cleanResyncGhosts with sync id: %@", syncId];
-    [[self getSyncManagerInst:isGlobal] cleanResyncGhosts:syncId completionStatusBlock:^void(SFSyncStateStatus syncStatus){
+    [[self getSyncManagerInst:args] cleanResyncGhosts:syncId completionStatusBlock:^void(SFSyncStateStatus syncStatus){
         callback(@[[NSNull null], [SFSyncState syncStatusToString:syncStatus]]);
     }];
 }


### PR DESCRIPTION
The callback in the exported method clearResyncGhosts fires before the ghosts are done being cleared. We should expect this to happen after ghosts are cleared. That way if the callback method operates on the smartstore, it will not see any stale or ghost data.