### PR TITLE
Fixing potential deadlock

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -32,6 +32,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 FOUNDATION_EXTERN NSString * const SFUserAccountManagerDidChangeCurrentUserNotification;
 
+/** Notification sent when something user init has finished
+ */
+FOUNDATION_EXTERN NSString * const SFUserAccountManagerDidFinishUserInitNotification;
+
 /** The key containing the type of change for the SFUserAccountManagerDidChangeCurrentUserNotification
  The value is a NSNumber that can be casted to the option SFUserAccountChange
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -117,9 +117,8 @@ static NSString * const kSFAppFeatureMultiUser   = @"MU";
     static SFUserAccountManager *userAccountManager = nil;
     dispatch_once(&pred, ^{
 		userAccountManager = [[self alloc] init];
-        [[NSNotificationCenter defaultCenter] postNotificationName:SFUserAccountManagerDidFinishUserInitNotification
-                                                            object:self];
 	});
+    [NSNotificationCenter postNotificationOnceWithName:SFUserAccountManagerDidFinishUserInitNotification object:nil userInfo:nil];
     return userAccountManager;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -42,6 +42,7 @@
 
 // Notifications
 NSString * const SFUserAccountManagerDidChangeCurrentUserNotification   = @"SFUserAccountManagerDidChangeCurrentUserNotification";
+NSString * const SFUserAccountManagerDidFinishUserInitNotification   = @"SFUserAccountManagerDidFinishUserInitNotification";
 
 NSString * const SFUserAccountManagerUserChangeKey      = @"change";
 
@@ -116,6 +117,8 @@ static NSString * const kSFAppFeatureMultiUser   = @"MU";
     static SFUserAccountManager *userAccountManager = nil;
     dispatch_once(&pred, ^{
 		userAccountManager = [[self alloc] init];
+        [[NSNotificationCenter defaultCenter] postNotificationName:SFUserAccountManagerDidFinishUserInitNotification
+                                                            object:self];
 	});
     return userAccountManager;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.m
@@ -57,7 +57,7 @@ static NSString * const kSFDisableExternalPaste = @"DISABLE_EXTERNAL_PASTE";
 
 @synthesize rawPreferences = _rawPreferences;
 
-+ (instancetype) sharedPreferences {
++ (instancetype)sharedPreferences {
     static dispatch_once_t pred;
     static SFManagedPreferences *preferences = nil;
     dispatch_once(&pred, ^{
@@ -66,7 +66,7 @@ static NSString * const kSFDisableExternalPaste = @"DISABLE_EXTERNAL_PASTE";
     return preferences;
 }
 
-- (id) init {
+- (id)init {
     self = [super init];
     if (self) {
         self.syncQueue = [[NSOperationQueue alloc] init];
@@ -94,23 +94,23 @@ static NSString * const kSFDisableExternalPaste = @"DISABLE_EXTERNAL_PASTE";
     return self;
 }
 
-- (void) dealloc {
+- (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (BOOL) hasManagedPreferences {
+- (BOOL)hasManagedPreferences {
     return ([self.rawPreferences allKeys].count > 0);
 }
 
-- (BOOL) requireCertificateAuthentication {
+- (BOOL)requireCertificateAuthentication {
     return [self.rawPreferences[kManagedKeyRequireCertAuth] boolValue];
 }
 
-- (BOOL) onlyShowAuthorizedHosts {
+- (BOOL)onlyShowAuthorizedHosts {
     return [self.rawPreferences[kManagedKeyOnlyShowAuthorizedHosts] boolValue];
 }
 
-- (NSArray *) loginHosts {
+- (NSArray *)loginHosts {
     id objLoginHosts = self.rawPreferences[kManagedKeyLoginHosts];
     if ([objLoginHosts isKindOfClass:[NSString class]]) {
         objLoginHosts = @[ objLoginHosts ];
@@ -118,7 +118,7 @@ static NSString * const kSFDisableExternalPaste = @"DISABLE_EXTERNAL_PASTE";
     return objLoginHosts;
 }
 
-- (NSArray *) loginHostLabels {
+- (NSArray *)loginHostLabels {
     id objLoginHostLabels = self.rawPreferences[kManagedKeyLoginHostLabels];
     if ([objLoginHostLabels isKindOfClass:[NSString class]]) {
         objLoginHostLabels = @[ objLoginHostLabels ];
@@ -126,15 +126,15 @@ static NSString * const kSFDisableExternalPaste = @"DISABLE_EXTERNAL_PASTE";
     return objLoginHostLabels;
 }
 
-- (NSString *) connectedAppId {
+- (NSString *)connectedAppId {
     return self.rawPreferences[kManagedKeyConnectedAppId];
 }
 
-- (NSString *) connectedAppCallbackUri {
+- (NSString *)connectedAppCallbackUri {
     return self.rawPreferences[kManagedKeyConnectedAppCallbackUri];
 }
 
-- (BOOL) shouldDisableExternalPasteDefinedByConnectedApp {
+- (BOOL)shouldDisableExternalPasteDefinedByConnectedApp {
     NSDictionary *customAttributes = [SFUserAccountManager sharedInstance].currentUser.idData.customAttributes;
     if (customAttributes) {
         NSString *disableExternalPaste = customAttributes[kSFDisableExternalPaste];
@@ -145,11 +145,11 @@ static NSString * const kSFDisableExternalPaste = @"DISABLE_EXTERNAL_PASTE";
     return NO;
 }
 
-- (BOOL) clearClipboardOnBackground {
+- (BOOL)clearClipboardOnBackground {
     return [self.rawPreferences[kManagedKeyClearClipboardOnBackground] boolValue] || [self shouldDisableExternalPasteDefinedByConnectedApp];
 }
 
-- (void) storeAnalyticsEvent {
+- (void)storeAnalyticsEvent {
     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
     if (self.rawPreferences) {
         attributes[@"mdmIsActive"] = [NSNumber numberWithBool:YES];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.m
@@ -88,7 +88,7 @@ static NSString * const kSFDisableExternalPaste = @"DISABLE_EXTERNAL_PASTE";
         NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
         [notificationCenter addObserver:self
                                selector:@selector(storeAnalyticsEvent)
-                                   name:SFUserAccountManagerDidChangeCurrentUserNotification
+                                   name:SFUserAccountManagerDidFinishUserInitNotification
                                  object:nil];
     }
     return self;


### PR DESCRIPTION
Long story short, this could lead to a potential deadlock if an anonymous user is being initialized. It happens in `Wave` in playground mode. The proper fix appears to be calling this after the `init` call completes to prevent the deadlock.