### PR TITLE
Instrument inherited selectors

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.h
@@ -91,6 +91,10 @@ typedef BOOL (^SFInstrumentationSelectorFilter)(SEL selector, BOOL isInstanceSel
  */
 -(void)instrumentForTiming:(SFInstrumentationSelectorFilter)selectorFilter afterBlock:(SFMethodInterceptorInvocationAfterCallback)after;
 
+- (void)instrumentForTiming:(SFInstrumentationSelectorFilter)selectorFilter
+          inheritanceLevels:(NSUInteger)numInheritanceLevels
+                 afterBlock:(SFMethodInterceptorInvocationAfterCallback)after;
+
 /** Instrument some selectors of a the target class for performance timing
  @param selectorConfigs An array of selector configs defining the selector and whether
  or not it's an instance method.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.h
@@ -27,18 +27,6 @@
 
 typedef BOOL (^SFInstrumentationSelectorFilter)(SEL selector, BOOL isInstanceSelector);
 
-/** A configuration object to specify a selector and whether or not
- it's an instance method.
- */
-@interface SFSDKInstrumentationSelectorConfig : NSObject
-
-@property (nonatomic, assign, readonly) SEL selector;
-@property (nonatomic, assign, readonly) BOOL isInstanceSelector;
-
-+ (instancetype)configWithSelector:(SEL)selector isInstanceSelector:(BOOL)isInstanceSelector;
-
-@end
-
 
 /** This class exposes API that allow to intercept
  method call and introspect the object being intercepted.
@@ -55,6 +43,9 @@ typedef BOOL (^SFInstrumentationSelectorFilter)(SEL selector, BOOL isInstanceSel
  */
 + (instancetype)instrumentationForClass:(Class)clazz;
 
+/** Returns an instrumentation instance for the class with the specified name.
+ @param className The name of the class to be instrumented.
+ */
 + (instancetype)instrumentationForClassWithName:(NSString *)className;
 
 /** Use this method to intercept the instance method specified by `selector`
@@ -87,23 +78,26 @@ typedef BOOL (^SFInstrumentationSelectorFilter)(SEL selector, BOOL isInstanceSel
  */
 - (void)interceptClassMethod:(SEL)selector replaceWithInvocationBlock:(SFMethodInterceptorInvocationCallback)replace;
 
-/** Instrument some selectors of a the target class for performance timing
+/** Instrument some selectors of a the target class for performance timing.
  @param selectorFilter A block invoked when to select selectors from the class to instrument
  @param after An optional block invoked after any selector is executed
+ @discussion This method will only instrument selectors defined on or explicitly overridden
+ in the class.  To instrument inherited selectors, use the
+ instrumentForTiming:inheritanceLevels:afterBlock: overload.  Calling this method is
+ the same as calling instrumentForTiming:inheritanceLevels:afterBlock: with an
+ inheritance levels value of zero.
  */
 -(void)instrumentForTiming:(SFInstrumentationSelectorFilter)selectorFilter afterBlock:(SFMethodInterceptorInvocationAfterCallback)after;
 
+/** Instrument some selectors of the target class and its parent class(es)
+ for performance timing.
+ @param selectorFilter A block invoked when to select selectors from the class to instrument
+ @param numInheritanceLevels The number of inherited classes whose selectors will be made available.
+ @param after An optional block invoked after any selector is executed
+ */
 - (void)instrumentForTiming:(SFInstrumentationSelectorFilter)selectorFilter
           inheritanceLevels:(NSUInteger)numInheritanceLevels
                  afterBlock:(SFMethodInterceptorInvocationAfterCallback)after;
-
-/** Instrument some selectors of a the target class for performance timing
- @param selectorConfigs An array of selector configs defining the selector and whether
- or not it's an instance method.
- @param after An optional block invoked after any selector is executed
- */
-- (void)instrumentSelectorsForTiming:(NSArray<SFSDKInstrumentationSelectorConfig *> *)selectorConfigs
-                          afterBlock:(SFMethodInterceptorInvocationAfterCallback)after;
 
 /** Loads the array of instructions execute them. The instructions usually
  comes from a JSON file.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.h
@@ -27,6 +27,18 @@
 
 typedef BOOL (^SFInstrumentationSelectorFilter)(SEL selector, BOOL isInstanceSelector);
 
+/** A configuration object to specify a selector and whether or not
+ it's an instance method.
+ */
+@interface SFSDKInstrumentationSelectorConfig : NSObject
+
+@property (nonatomic, assign, readonly) SEL selector;
+@property (nonatomic, assign, readonly) BOOL isInstanceSelector;
+
++ (instancetype)configWithSelector:(SEL)selector isInstanceSelector:(BOOL)isInstanceSelector;
+
+@end
+
 
 /** This class exposes API that allow to intercept
  method call and introspect the object being intercepted.
@@ -78,6 +90,14 @@ typedef BOOL (^SFInstrumentationSelectorFilter)(SEL selector, BOOL isInstanceSel
  @param after An optional block invoked after any selector is executed
  */
 -(void)instrumentForTiming:(SFInstrumentationSelectorFilter)selectorFilter afterBlock:(SFMethodInterceptorInvocationAfterCallback)after;
+
+/** Instrument some selectors of a the target class for performance timing
+ @param selectorConfigs An array of selector configs defining the selector and whether
+ or not it's an instance method.
+ @param after An optional block invoked after any selector is executed
+ */
+- (void)instrumentSelectorsForTiming:(NSArray<SFSDKInstrumentationSelectorConfig *> *)selectorConfigs
+                          afterBlock:(SFMethodInterceptorInvocationAfterCallback)after;
 
 /** Loads the array of instructions execute them. The instructions usually
  comes from a JSON file.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.h
@@ -55,6 +55,8 @@ typedef BOOL (^SFInstrumentationSelectorFilter)(SEL selector, BOOL isInstanceSel
  */
 + (instancetype)instrumentationForClass:(Class)clazz;
 
++ (instancetype)instrumentationForClassWithName:(NSString *)className;
+
 /** Use this method to intercept the instance method specified by `selector`
  @param selector The selector to intercept
  @param before An optional block invoked before the selector is executed

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.m
@@ -67,6 +67,13 @@
     return perf;
 }
 
++ (instancetype)instrumentationForClassWithName:(NSString *)className {
+    NSAssert(className.length > 0, @"Class name cannot be empty.");
+    Class classToInstrument = NSClassFromString(className);
+    NSAssert(classToInstrument != nil, @"Class '%@' does not exist.", className);
+    return [self instrumentationForClass:classToInstrument];
+}
+
 - (instancetype)init {
     self = [super init];
     if (self) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.m
@@ -42,23 +42,6 @@
 
 @end
 
-@implementation SFSDKInstrumentationSelectorConfig
-
-+ (instancetype)configWithSelector:(SEL)selector isInstanceSelector:(BOOL)isInstanceSelector {
-    return [[self alloc] initWithSelector:selector isInstanceSelector:isInstanceSelector];
-}
-
-- (instancetype)initWithSelector:(SEL)selector isInstanceSelector:(BOOL)isInstanceSelector {
-    self = [super init];
-    if (self) {
-        _selector = selector;
-        _isInstanceSelector = isInstanceSelector;
-    }
-    return self;
-}
-
-@end
-
 @implementation SFInstrumentation
 
 + (instancetype)instrumentationForClass:(Class)clazz {
@@ -178,21 +161,6 @@ replaceWithInvocationBlock:(SFMethodInterceptorInvocationCallback)replace
         
         currentInheritanceLevel++;
         currentClass = [currentClass superclass];
-    }
-}
-
-- (void)instrumentSelectorsForTiming:(NSArray<SFSDKInstrumentationSelectorConfig *> *)selectorConfigs
-                          afterBlock:(SFMethodInterceptorInvocationAfterCallback)after {
-    if (after == nil) {
-        after = [self defaultPostTimingBlock];
-    }
-    
-    for (SFSDKInstrumentationSelectorConfig *selectorConfig in selectorConfigs) {
-        if (selectorConfig.isInstanceSelector) {
-            [self interceptInstanceMethod:selectorConfig.selector beforeBlock:nil afterBlock:after];
-        } else {
-            [self interceptClassMethod:selectorConfig.selector beforeBlock:nil afterBlock:after];
-        }
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFInstrumentation.m
@@ -131,28 +131,46 @@ replaceWithInvocationBlock:(SFMethodInterceptorInvocationCallback)replace
 }
 
 - (void)instrumentForTiming:(SFInstrumentationSelectorFilter)selectorFilter afterBlock:(SFMethodInterceptorInvocationAfterCallback)after {
+    [self instrumentForTiming:selectorFilter inheritanceLevels:0 afterBlock:after];
+}
+
+- (void)instrumentForTiming:(SFInstrumentationSelectorFilter)selectorFilter
+          inheritanceLevels:(NSUInteger)numInheritanceLevels
+                 afterBlock:(SFMethodInterceptorInvocationAfterCallback)after {
     if (after == nil) {
         after = [self defaultPostTimingBlock];
     }
     
-    // Instance methods
-    unsigned int mc = 0;
-    Method *instanceMethodList = class_copyMethodList(self.clazz, &mc);
-    for(int i=0;i<mc;i++) {
-        SEL selector = method_getName(instanceMethodList[i]);
-        if (selectorFilter(selector, YES)) {
-            [self interceptInstanceMethod:selector beforeBlock:nil afterBlock:after];
+    NSMutableDictionary<NSString *, NSNumber *> *configuredSelectorsDict = [NSMutableDictionary dictionary];
+    NSUInteger currentInheritanceLevel = 0;
+    Class currentClass = self.clazz;
+    while (currentInheritanceLevel <= numInheritanceLevels && currentClass != nil) {
+        // Instance methods
+        unsigned int mc = 0;
+        Method *instanceMethodList = class_copyMethodList(currentClass, &mc);
+        for(NSUInteger i = 0; i < mc; i++) {
+            SEL selector = method_getName(instanceMethodList[i]);
+            NSString *selectorName = [NSString stringWithFormat:@"%@_%@", NSStringFromSelector(selector), @"inst"];
+            if (configuredSelectorsDict[selectorName] == nil && selectorFilter(selector, YES)) {
+                configuredSelectorsDict[selectorName] = @YES;
+                [self interceptInstanceMethod:selector beforeBlock:nil afterBlock:after];
+            }
         }
-    }
-    
-    // Class methods
-    mc = 0;
-    Method *classMethodList = class_copyMethodList(object_getClass(self.clazz), &mc);
-    for(int i=0;i<mc;i++) {
-        SEL selector = method_getName(classMethodList[i]);
-        if (selectorFilter(selector, NO)) {
-            [self interceptClassMethod:selector beforeBlock:nil afterBlock:after];
+        
+        // Class methods
+        mc = 0;
+        Method *classMethodList = class_copyMethodList(object_getClass(currentClass), &mc);
+        for(NSUInteger i = 0; i < mc; i++) {
+            SEL selector = method_getName(classMethodList[i]);
+            NSString *selectorName = [NSString stringWithFormat:@"%@_%@", NSStringFromSelector(selector), @"class"];
+            if (configuredSelectorsDict[selectorName] == nil && selectorFilter(selector, NO)) {
+                configuredSelectorsDict[selectorName] = @YES;
+                [self interceptClassMethod:selector beforeBlock:nil afterBlock:after];
+            }
         }
+        
+        currentInheritanceLevel++;
+        currentClass = [currentClass superclass];
     }
 }
 


### PR DESCRIPTION
The current functionality will only allow you to choose from selectors explicitly defined on the class you're instrumenting.  In the case of inherited classes—particularly decorators—this can be pretty limiting.

`instrumentForTiming:inheritanceLevels:afterBlock:` allows you to specify the number of inheritance levels you want to go down, to be presented with selectors to instrument.