### PR TITLE
Fix for bug related to migrating User Account files.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
@@ -31,6 +31,7 @@
 
 static NSString * const kDefaultOrgName = @"org";
 static NSString * const kDefaultCommunityName = @"internal";
+static NSString * const kSharedLibraryLocation = @"Library";
 
 @implementation SFDirectoryManager
 
@@ -76,7 +77,7 @@ static NSString * const kDefaultCommunityName = @"internal";
         directory = [sharedURL path];
         directory = [directory stringByAppendingPathComponent:[SFSDKDatasharingHelper sharedInstance].appGroupName];
         if(type == NSLibraryDirectory)
-            directory = [directory stringByAppendingPathComponent:@"Library"];
+            directory = [directory stringByAppendingPathComponent:kSharedLibraryLocation];
     } else {
         NSArray *directories = NSSearchPathForDirectoriesInDomains(type, NSUserDomainMask, YES);
         if (directories.count > 0) {
@@ -218,7 +219,7 @@ static NSString * const kDefaultCommunityName = @"internal";
         NSString *sharedDirectory = [sharedURL path];
         NSString *sharedLibDirectory = nil;
         sharedDirectory = [sharedDirectory stringByAppendingPathComponent:[SFSDKDatasharingHelper sharedInstance].appGroupName];
-        sharedLibDirectory = [sharedDirectory stringByAppendingPathComponent:@"Library"];
+        sharedLibDirectory = [sharedDirectory stringByAppendingPathComponent:kSharedLibraryLocation];
         
         if (isGroupAccessEnabled && !filesShared) {
             //move files from Docs to the Shared & App Libs to Shared,Shared Library location

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
@@ -32,6 +32,7 @@
 static NSString * const kDefaultOrgName = @"org";
 static NSString * const kDefaultCommunityName = @"internal";
 static NSString * const kSharedLibraryLocation = @"Library";
+static NSString * const kFilesSharedKey = @"filesShared";
 
 @implementation SFDirectoryManager
 
@@ -195,7 +196,7 @@ static NSString * const kSharedLibraryLocation = @"Library";
     //Migrate Files
     NSUserDefaults *sharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:[SFSDKDatasharingHelper sharedInstance].appGroupName];
     BOOL isGroupAccessEnabled = [SFSDKDatasharingHelper sharedInstance].appGroupEnabled;
-    BOOL filesShared = [sharedDefaults boolForKey:@"filesShared"];
+    BOOL filesShared = [sharedDefaults boolForKey:kFilesSharedKey];
     
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSString *docDirectory,*libDirectory;
@@ -225,12 +226,12 @@ static NSString * const kSharedLibraryLocation = @"Library";
             //move files from Docs to the Shared & App Libs to Shared,Shared Library location
             [self moveContentsOfDirectory:libDirectory toDirectory:sharedLibDirectory];
             [self moveContentsOfDirectory:docDirectory toDirectory:sharedDirectory];
-            [sharedDefaults setBool:YES forKey:@"filesShared"];
+            [sharedDefaults setBool:YES forKey:kFilesSharedKey];
         } else if (!isGroupAccessEnabled && filesShared) {
             //move files back from Sahred Location to  Library and the Docs
             [self moveContentsOfDirectory:sharedLibDirectory toDirectory:libDirectory];
             [self moveContentsOfDirectory:sharedDirectory toDirectory:docDirectory];
-            [sharedDefaults setBool:NO forKey:@"filesShared"];
+            [sharedDefaults setBool:NO forKey:kFilesSharedKey];
         }
     }
     


### PR DESCRIPTION
When App groups are enabled all files from app docs location and libs location are moved to the app group container. When disabled these are moved back.