### PR TITLE
Implemented missing WKNavigationDelegate method in SFWKWebViewDelegate

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFWKWebViewEngine/SFWKWebViewDelegate.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFWKWebViewEngine/SFWKWebViewDelegate.m
@@ -184,6 +184,14 @@ static NSString* stripFragment(NSString *url) {
     }
 }
 
+- (void) webView:(WKWebView *) webView decidePolicyForNavigationResponse:(WKNavigationResponse *) navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy)) decisionHandler {
+    if ([_delegate respondsToSelector:@selector(webView:decidePolicyForNavigationResponse:decisionHandler:)]) {
+        [_delegate webView:webView decidePolicyForNavigationResponse:navigationResponse decisionHandler:decisionHandler];
+    } else {
+        decisionHandler(WKNavigationResponsePolicyAllow);
+    }
+}
+
 - (void) webView:(WKWebView *) webView didCommitNavigation:(WKNavigation *) navigation {
     [self webView:webView didStartProvisionalNavigation:navigation];
 }


### PR DESCRIPTION
**SFHybridViewController** conforms to the protocol **WKNavigationDelegate**, but it's not really the delegate of its cordova WKWebView, rather, the **SFWKWebViewDelegate** is the actual delegate. It passes all **WKNavigationDelegate** calls to its owner/delegate: **SFHybridViewController**. 

The issue here is **SFWKWebViewDelegate** doesn't implement `-webView:decidePolicyForNavigationResponse:decisionHandler:` consequentially **SFHybridViewController** never receives it. This is particularly bad for subclasses of **SFHybridViewController**, that have no way to receive such callback.

@khawkins @bhariharan