### PR TITLE
Bug fixes:

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -716,7 +716,13 @@ static NSMutableDictionary *syncMgrList = nil;
             [target updateOnServer:objectType objectId:objectId fields:fields completionBlock:completeBlockUpdate failBlock:failBlockUpdate];
             break;
         case SFSyncUpTargetActionDelete:
-            [target deleteOnServer:objectType objectId:objectId completionBlock:completeBlockDelete failBlock:failBlockDelete];
+            // if locally created it can't exist on the server - we don't need to actually do the deleteOnServer call
+            if ([record[kSyncManagerLocallyCreated] boolValue]) {
+                completeBlockDelete(record);
+            }
+            else {
+                [target deleteOnServer:objectType objectId:objectId completionBlock:completeBlockDelete failBlock:failBlockDelete];
+            }
             break;
         default:
             // Action is unsupported here.  Move on.

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/ContactListViewController.m
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/ContactListViewController.m
@@ -301,12 +301,15 @@ static NSUInteger const kColorCodesList[] = { 0x1abc9c,  0x2ecc71,  0x3498db,  0
 
     if ([self.dataMgr dataHasLocalChanges:contact]) {
         UIImage *localImage;
-        if ([self.dataMgr dataLocallyCreated:contact])
-            localImage = sLocalAddImage;
-        else if ([self.dataMgr dataLocallyUpdated:contact])
-            localImage = sLocalUpdateImage;
-        else
+        // If deleted and created or updated, we should show deleted
+        if ([self.dataMgr dataLocallyDeleted:contact])
             localImage = sLocalDeleteImage;
+        // If created and updated, we should show created
+        else if ([self.dataMgr dataLocallyCreated:contact])
+            localImage = sLocalAddImage;
+        // If updated (but not deleted or created), we should show updated
+        else
+            localImage = sLocalUpdateImage;
 
         //
         // Uber view

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorerCommon/SObjectDataManager.m
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorerCommon/SObjectDataManager.m
@@ -172,13 +172,13 @@ static char* const kSearchFilterQueueName = "com.salesforce.smartSyncExplorer.se
 - (void)updateLocalData:(SObjectData *)updatedData {
     [updatedData updateSoupForFieldName:kSyncManagerLocal fieldValue:@YES];
     [updatedData updateSoupForFieldName:kSyncManagerLocallyUpdated fieldValue:@YES];
-    [self.store upsertEntries:@[ updatedData.soupDict ] toSoup:[[updatedData class] dataSpec].soupName withExternalIdPath:kSObjectIdField error:nil];
+    [self.store upsertEntries:@[ updatedData.soupDict ] toSoup:[[updatedData class] dataSpec].soupName];
 }
 
 - (void)deleteLocalData:(SObjectData *)dataToDelete {
     [dataToDelete updateSoupForFieldName:kSyncManagerLocal fieldValue:@YES];
     [dataToDelete updateSoupForFieldName:kSyncManagerLocallyDeleted fieldValue:@YES];
-    [self.store upsertEntries:@[ dataToDelete.soupDict ] toSoup:[[dataToDelete class] dataSpec].soupName withExternalIdPath:kSObjectIdField error:nil];
+    [self.store upsertEntries:@[ dataToDelete.soupDict ] toSoup:[[dataToDelete class] dataSpec].soupName];
 }
 
 - (void)undeleteLocalData:(SObjectData *)dataToUnDelete {


### PR DESCRIPTION
- smart sync explorer should show new image for locally created and updated record / deleted image for locally created or updated then deleted record
- sync up locally created then deleted records should not go to server
- smartsyncexplorer was not doing correct update/delete for locally created records