### PR TITLE
Simplifying boilerplate needed in custom sync up or sync down targets

### DIFF
--- a/hybrid/SampleApps/NoteSync/NoteSync/SFContentSoqlSyncDownTarget.m
+++ b/hybrid/SampleApps/NoteSync/NoteSync/SFContentSoqlSyncDownTarget.m
@@ -225,39 +225,15 @@ typedef void (^SFSoapSoqlResponseParseComplete) ();
 
 @implementation SFContentSoqlSyncDownTarget
 
-- (instancetype)initWithDict:(NSDictionary *)dict {
-    self = [super initWithDict:dict];
-    if (self) {
-        self.queryType = SFSyncDownTargetQueryTypeCustom;
-    }
-    return self;
-}
-
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        self.queryType = SFSyncDownTargetQueryTypeCustom;
-    }
-    return self;
-}
 
 #pragma mark - Factory methods
 
 + (SFContentSoqlSyncDownTarget*) newSyncTarget:(NSString*)query {
     SFContentSoqlSyncDownTarget* syncTarget = [[SFContentSoqlSyncDownTarget alloc] init];
-    syncTarget.queryType = SFSyncDownTargetQueryTypeCustom;
     syncTarget.query = query;
     return syncTarget;
 }
 
-
-#pragma mark - To dictionary
-
-- (NSMutableDictionary*) asDict {
-    NSMutableDictionary *dict = [super asDict];
-    dict[kSFSyncTargetiOSImplKey] = NSStringFromClass([self class]);
-    return dict;
-}
 
 # pragma mark - Data fetching
 

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncTarget.m
@@ -52,6 +52,7 @@
 
 - (NSMutableDictionary *)asDict {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+    dict[kSFSyncTargetiOSImplKey] = NSStringFromClass([self class]);
     dict[kSFSyncTargetIdFieldNameKey] = self.idFieldName;
     dict[kSFSyncTargetModificationDateFieldNameKey] = self.modificationDateFieldName;
     return dict;

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -75,28 +75,6 @@
     return syncTarget;
 }
 
-- (instancetype)initWithDict:(NSDictionary *)dict {
-    self = [super initWithDict:dict];
-    if (self) {
-        self.queryType = SFSyncDownTargetQueryTypeCustom;
-    }
-    return self;
-}
-
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        self.queryType = SFSyncDownTargetQueryTypeCustom;
-    }
-    return self;
-}
-
-- (NSMutableDictionary*) asDict {
-    NSMutableDictionary *dict = [super asDict];
-    dict[kSFSyncTargetiOSImplKey] = NSStringFromClass([self class]);
-    return dict;
-}
-
 - (void) startFetch:(SFSmartSyncSyncManager*)syncManager
        maxTimeStamp:(long long)maxTimeStamp
          errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
@@ -355,8 +333,7 @@ static NSException *authException = nil;
 - (void)testSyncUpTargetSerialization {
     
     // Default sync up target should be the base class.
-    NSDictionary *defaultDict = @{ };
-    SFSyncUpTarget *defaulttarget = [SFSyncUpTarget newFromDict:defaultDict];
+    SFSyncUpTarget *defaulttarget = [[SFSyncUpTarget alloc] init];
     XCTAssertEqual([defaulttarget class], [SFSyncUpTarget class], @"Default class should be SFSyncUpTarget");
     XCTAssertEqual(defaulttarget.targetType, SFSyncUpTargetTypeRestStandard, @"Sync sync up target type is incorrect.");
     
@@ -367,13 +344,11 @@ static NSException *authException = nil;
     XCTAssertEqual(resttarget.targetType, SFSyncUpTargetTypeRestStandard, @"Sync sync up target type is incorrect.");
     
     // Custom sync up target
-    TestSyncUpTarget *customTarget = [[TestSyncUpTarget alloc] initWithDict:@{ }];
+    TestSyncUpTarget *customTarget = [[TestSyncUpTarget alloc] init];
     NSDictionary *customDict = [customTarget asDict];
-    XCTAssertEqualObjects(customDict[kSFSyncTargetTypeKey], @"custom", @"Should be a custom sync up target.");
     XCTAssertEqualObjects(customDict[kSFSyncTargetiOSImplKey], NSStringFromClass([TestSyncUpTarget class]), @"Custom class is incorrect.");
     SFSyncUpTarget *customTargetFromDict = [SFSyncUpTarget newFromDict:customDict];
     XCTAssertEqual([customTargetFromDict class], [TestSyncUpTarget class], @"Custom class is incorrect.");
-    XCTAssertEqual(customTargetFromDict.targetType, SFSyncUpTargetTypeCustom, @"Target type should be custom.");
 }
 
 /**
@@ -1619,7 +1594,7 @@ static NSException *authException = nil;
 
 - (void)trySyncUp:(NSInteger)numberChanges
           options:(SFSyncOptions *) options {
-    SFSyncUpTarget *defaultTarget = [SFSyncUpTarget newFromDict:@{ }];
+    SFSyncUpTarget *defaultTarget = [[SFSyncUpTarget alloc] init];
     [self trySyncUp:numberChanges
       actualChanges:numberChanges
              target:defaultTarget

--- a/libs/SmartSync/SmartSyncTests/Targets/TestSyncUpTarget.m
+++ b/libs/SmartSync/SmartSyncTests/Targets/TestSyncUpTarget.m
@@ -74,7 +74,6 @@ static NSString * const kTestSyncUpSendSyncUpErrorKey = @"sendSyncUpErrorKey";
 - (void)commonInitWithRemoteModDateCompare:(TestSyncUpTargetModDateCompare)dateCompare
                         sendRemoteModError:(BOOL)sendRemoteModError
                            sendSyncUpError:(BOOL)sendSyncUpError {
-    self.targetType = SFSyncUpTargetTypeCustom;
     self.dateCompare = dateCompare;
     self.sendRemoteModError = sendRemoteModError;
     self.sendSyncUpError = sendSyncUpError;
@@ -82,7 +81,6 @@ static NSString * const kTestSyncUpSendSyncUpErrorKey = @"sendSyncUpErrorKey";
 
 - (NSMutableDictionary *)asDict {
     NSMutableDictionary *dict = [super asDict];
-    dict[kSFSyncTargetiOSImplKey] = NSStringFromClass([self class]);
     dict[kTestSyncUpDateCompareKey] = @(self.dateCompare);
     dict[kTestSyncUpSendRemoteModErrorKey] = @(self.sendRemoteModError);
     dict[kTestSyncUpSendSyncUpErrorKey] = @(self.sendSyncUpError);


### PR DESCRIPTION
Sync up/down targets will always serialize their implementation class - the target type will only be used if no implementation class is provided (which should only happen if the sync up/down target was created with pre 5.1 code).