### PR TITLE
Adding class name to instrumentation results

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFMethodInterceptor.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFMethodInterceptor.h
@@ -28,6 +28,10 @@
  */
 @interface SFSDKInstrumentationPostExecutionData : NSObject
 
+/** The name of the class associated with the selector.
+ */
+@property (nonatomic, copy) NSString *className;
+
 /** The name of the original selector executed.
  */
 @property (nonatomic, copy) NSString *selectorName;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFMethodInterceptor.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFMethodInterceptor.m
@@ -187,8 +187,10 @@ static NSString * const kSFSDKInstrumentationForwardBlockPrefix = @"__method_for
     NSDate *endTime = [NSDate date];
     if (self.targetAfterBlock) {
         SFSDKInstrumentationPostExecutionData *data = [[SFSDKInstrumentationPostExecutionData alloc] init];
+        Class targetClass = object_getClass(anInvocation.target);
+        data.className = NSStringFromClass(targetClass);
         data.selectorName = [NSStringFromSelector(anInvocation.selector) substringFromIndex:kSFSDKInstrumentationForwardMethodPrefix.length];
-        data.isInstanceMethod = !(class_isMetaClass(object_getClass(anInvocation.target)));
+        data.isInstanceMethod = !(class_isMetaClass(targetClass));
         data.executionStartDate = startTime;
         data.executionEndDate = endTime;
         data.executionTime = [endTime timeIntervalSinceDate:startTime];


### PR DESCRIPTION
Makes `SFSDKInstrumentationPostExecutionData` a lot more modular.  Otherwise, you end up pretty tied to its defining `SFMethodInterceptor` instance to get the whole picture of the instrumented method.