### PR TITLE
Ensure select private headers are exposed under its own explicit module

### DIFF
--- a/libs/SalesforceSDKCore/Configuration/SalesforceSDKCore-Common-Dynamic.xcconfig
+++ b/libs/SalesforceSDKCore/Configuration/SalesforceSDKCore-Common-Dynamic.xcconfig
@@ -10,3 +10,6 @@
 
 INSTALL_PATH = /
 SKIP_INSTALL = YES
+
+MODULEMAP_FILE = $(SRCROOT)/SalesforceSDKCore/SalesforceSDKCore.modulemap
+MODULEMAP_PRIVATE_FILE = $(SRCROOT)/SalesforceSDKCore/SalesforceSDKCore.private.modulemap

--- a/libs/SalesforceSDKCore/Configuration/SalesforceSDKCore-Common.xcconfig
+++ b/libs/SalesforceSDKCore/Configuration/SalesforceSDKCore-Common.xcconfig
@@ -15,6 +15,3 @@ LIBRARY_SEARCH_PATHS = $(inherited)
 
 // Make sure to use only API that are safe for application extensions
 APPLICATION_EXTENSION_API_ONLY = YES
-
-MODULEMAP_FILE = $(SRCROOT)/SalesforceSDKCore/SalesforceSDKCore.modulemap
-MODULEMAP_PRIVATE_FILE = $(SRCROOT)/SalesforceSDKCore/SalesforceSDKCore.private.modulemap

--- a/libs/SalesforceSDKCore/Configuration/SalesforceSDKCore-Common.xcconfig
+++ b/libs/SalesforceSDKCore/Configuration/SalesforceSDKCore-Common.xcconfig
@@ -15,3 +15,6 @@ LIBRARY_SEARCH_PATHS = $(inherited)
 
 // Make sure to use only API that are safe for application extensions
 APPLICATION_EXTENSION_API_ONLY = YES
+
+MODULEMAP_FILE = $(SRCROOT)/SalesforceSDKCore/SalesforceSDKCore.modulemap
+MODULEMAP_PRIVATE_FILE = $(SRCROOT)/SalesforceSDKCore/SalesforceSDKCore.private.modulemap

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -367,7 +367,7 @@
 		CE8EA2B91D7F67FA00AAC74C /* CSFInternalDefines.m in Sources */ = {isa = PBXBuildFile; fileRef = CE8EA2701D7F67FA00AAC74C /* CSFInternalDefines.m */; };
 		CE8EA2BA1D7F67FA00AAC74C /* CSFISO8601DateFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA2711D7F67FA00AAC74C /* CSFISO8601DateFormatter.h */; };
 		CE8EA2BB1D7F67FA00AAC74C /* CSFISO8601DateFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = CE8EA2721D7F67FA00AAC74C /* CSFISO8601DateFormatter.m */; };
-		CE8EA2BC1D7F67FA00AAC74C /* CSFPrivateDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA2731D7F67FA00AAC74C /* CSFPrivateDefines.h */; };
+		CE8EA2BC1D7F67FA00AAC74C /* CSFPrivateDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA2731D7F67FA00AAC74C /* CSFPrivateDefines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CE8EA2BD1D7F67FA00AAC74C /* CSFPrivateDefines.m in Sources */ = {isa = PBXBuildFile; fileRef = CE8EA2741D7F67FA00AAC74C /* CSFPrivateDefines.m */; };
 		CE8EA2BE1D7F67FA00AAC74C /* CSFDateValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA2761D7F67FA00AAC74C /* CSFDateValueTransformer.h */; };
 		CE8EA2BF1D7F67FA00AAC74C /* CSFDateValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = CE8EA2771D7F67FA00AAC74C /* CSFDateValueTransformer.m */; };
@@ -454,7 +454,7 @@
 		CE8EA33E1D7F6AA600AAC74C /* CSFForceDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA26D1D7F67FA00AAC74C /* CSFForceDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE8EA33F1D7F6AAA00AAC74C /* CSFInternalDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA26F1D7F67FA00AAC74C /* CSFInternalDefines.h */; };
 		CE8EA3401D7F6AAE00AAC74C /* CSFISO8601DateFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA2711D7F67FA00AAC74C /* CSFISO8601DateFormatter.h */; };
-		CE8EA3411D7F6AB300AAC74C /* CSFPrivateDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA2731D7F67FA00AAC74C /* CSFPrivateDefines.h */; };
+		CE8EA3411D7F6AB300AAC74C /* CSFPrivateDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA2731D7F67FA00AAC74C /* CSFPrivateDefines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CE8EA3421D7F6AB900AAC74C /* CSFDateValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA2761D7F67FA00AAC74C /* CSFDateValueTransformer.h */; };
 		CE8EA3431D7F6ABD00AAC74C /* CSFJPEGImageValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA2781D7F67FA00AAC74C /* CSFJPEGImageValueTransformer.h */; };
 		CE8EA3441D7F6AC100AAC74C /* CSFPNGImageValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = CE8EA27A1D7F67FA00AAC74C /* CSFPNGImageValueTransformer.h */; };
@@ -1174,6 +1174,8 @@
 		6FB714931CEA613D007D858C /* SFLoggerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFLoggerTests.m; path = ../SalesforceSDKCoreTests/SFLoggerTests.m; sourceTree = "<group>"; };
 		6FB714A31CEA61BF007D858C /* SFLogStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFLogStorage.h; sourceTree = "<group>"; };
 		6FB714A61CEA6630007D858C /* SFLogger_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFLogger_Internal.h; sourceTree = "<group>"; };
+		6FDFF9931E2EA4E400B7D0B5 /* SalesforceSDKCore.private.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = SalesforceSDKCore.private.modulemap; path = SalesforceSDKCore/SalesforceSDKCore.private.modulemap; sourceTree = "<group>"; };
+		6FDFF9BC1E2EA72400B7D0B5 /* SalesforceSDKCore.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; name = SalesforceSDKCore.modulemap; path = SalesforceSDKCore/SalesforceSDKCore.modulemap; sourceTree = "<group>"; };
 		8220B74F16D804CA00EC3921 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		8220B75316D804CA00EC3921 /* SalesforceSDKCore-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SalesforceSDKCore-Prefix.pch"; sourceTree = "<group>"; };
 		8280EBB316E14E9F00768DE8 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
@@ -1832,6 +1834,8 @@
 		82C5E3EF1C1B62C400376C00 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				6FDFF9BC1E2EA72400B7D0B5 /* SalesforceSDKCore.modulemap */,
+				6FDFF9931E2EA4E400B7D0B5 /* SalesforceSDKCore.private.modulemap */,
 				E1C80D071C5AF029001B3A21 /* SalesforceSDKAssets.xcassets */,
 				82C5E3ED1C1B62AF00376C00 /* SalesforceSDKResources.bundle */,
 			);

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Utilities/CSFInternalDefines.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Utilities/CSFInternalDefines.h
@@ -22,6 +22,8 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <objc/runtime.h>
+
 #import "CSFDefines.h"
 #import "CSFPrivateDefines.h"
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/SalesforceSDKCore.modulemap
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/SalesforceSDKCore.modulemap
@@ -1,0 +1,6 @@
+framework module SalesforceSDKCore {
+  umbrella header "SalesforceSDKCore.h"
+
+  export *
+  module * { export * }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/SalesforceSDKCore.private.modulemap
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/SalesforceSDKCore.private.modulemap
@@ -1,0 +1,3 @@
+explicit framework module SalesforceSDKCore.Private {
+    header "CSFPrivateDefines.h"
+}


### PR DESCRIPTION
There are some shared capabilities that are exposed by portions of the network logic that are used across other products and frameworks. These functions and constants aren't intended to be used by your average MobileSDK consumer, but their declarations still need to be exposed for other teams to be able to use it.