### PR TITLE
Removed Anonymous Client Secret & Fixed Crashes/Race Condition between handling errors and dismissal of Snapshot

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -39,5 +39,8 @@
 
 - (void)passcodeValidatedToAuthValidation;
 - (void)authValidatedToPostAuth:(SFSDKLaunchAction)launchAction;
+- (void)presentSnapshot;
+- (BOOL)isSnapshotPresented;
+- (void)dismissSnapshot;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -85,7 +85,6 @@ static NSString * const kSFOAuthApprovalCode                    = @"code";
 static NSString * const kSFOAuthGrantTypeAuthorizationCode      = @"authorization_code";
 static NSString * const kSFOAuthResponseTypeActivatedClientCode = @"activated_client_code";
 static NSString * const kSFOAuthResponseClientSecret            = @"client_secret";
-static NSString * const kSFOAuthClientSecretAnonymous           = @"anonymous";
 
 // OAuth Error Descriptions
 // see https://na1.salesforce.com/help/doc/en/remoteaccess_oauth_refresh_token_flow.htm
@@ -683,7 +682,6 @@ static NSString * const kSFAppFeatureSafariBrowserForLogin   = @"BW";
         if (self.authInfo.authType == SFOAuthTypeAdvancedBrowser) {
             [params appendFormat:@"&%@=%@", kSFOAuthCodeVerifierParamName, self.codeVerifier];
             [logString appendFormat:@"&%@=REDACTED", kSFOAuthCodeVerifierParamName];
-            [params appendFormat:@"&%@=%@", kSFOAuthResponseClientSecret, kSFOAuthClientSecretAnonymous];
         }
         
         // Discard the approval code.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -923,6 +923,7 @@ static Class InstanceClass = nil;
     if (self.statusAlert) {
         self.statusAlert = nil;
     }
+    [[SalesforceSDKManager sharedManager] dismissSnapshot];
     [self log:SFLogLevelError format:@"Error during authentication: %@", error];
     [self showAlertWithTitle:[SFSDKResourceUtils localizedString:kAlertErrorTitleKey]
                      message:[NSString stringWithFormat:[SFSDKResourceUtils localizedString:kAlertConnectionErrorFormatStringKey], [error localizedDescription]]
@@ -1061,7 +1062,6 @@ static Class InstanceClass = nil;
     self.genericAuthErrorHandler = [[SFAuthErrorHandler alloc]
                                                  initWithName:kSFGenericFailureAuthErrorHandler
                                                  evalBlock:^BOOL(NSError *error, SFOAuthInfo *authInfo) {
-                                                     [[SalesforceSDKManager sharedManager] dismissSnapshot];
                                                      [weakSelf clearAccountState:NO];
                                                      [weakSelf showRetryAlertForAuthError:error alertTag:kOAuthGenericAlertViewTag];
                                                      return YES;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFRootViewManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFRootViewManager.m
@@ -115,7 +115,8 @@
         
         if (currentViewController != nil) {
             if (currentViewController != viewController
-                && viewController.presentedViewController != currentViewController) {
+                && viewController.presentedViewController != currentViewController
+                && !(viewController.isViewLoaded && viewController.view.window && [viewController.view.window isKeyWindow])) {
                 [strongSelf log:SFLogLevelDebug format:@"pushViewController: Presenting view controller (%@).", viewController];
                 
                 [strongSelf enumerateDelegates:^(id<SFRootViewManagerDelegate> delegate) {


### PR DESCRIPTION
Removed Anonymous Client Secret & Fixed Crashes/Race Condition between handling errors and dismissal of Snapshot. Crashes were related to changes being done to the UI state on background threads. The alert would get dismissed when normally run. Could not reproduce  run in a debugger. The fix for the timing issue is a short term fix. The long term solution remains to be addressed. 