### PR TITLE
Fixed a crash with SFLogger and non-variadic arguments

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLogger.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLogger.m
@@ -230,24 +230,11 @@ SFLogLevel SFLoggerContextLogLevels[SF_LOG_MAX_IDENTIFIER_COUNT];
 }
 
 - (void)log:(SFLogLevel)level msg:(NSString *)msg {
-    [self log:level identifier:[self.class loggingIdentifier] msg:msg];
+    [self log:level identifier:[self.class loggingIdentifier] format:msg, nil];
 }
 
 - (void)log:(SFLogLevel)level identifier:(NSString*)logIdentifier msg:(NSString *)msg {
-    SFLogger *logger = [SFLogger sharedLogger];
-    NSString *identifierString = [self.class loggingIdentifier];
-    SFLogIdentifier *identifier = [logger logIdentifierForIdentifier:identifierString];
-    
-    [logger logAsync:YES
-               level:identifier.logLevel
-                flag:SFLogFlagForLogLevel(level)
-             context:identifier.context
-                file:nil
-            function:nil
-                line:0
-                 tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
-              format:msg
-                args:nil];
+    [self log:level identifier:logIdentifier format:msg, nil];
 }
 
 - (void)log:(SFLogLevel)level format:(NSString *)format, ... {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFLoggerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFLoggerTests.m
@@ -107,6 +107,23 @@
     return self;
 }
 
+- (instancetype)initWithAsync:(BOOL)asynchronous
+                        level:(DDLogLevel)level
+                         flag:(DDLogFlag)flag
+                      context:(NSInteger)context
+                         file:(const char *)file
+                     function:(const char *)function
+                         line:(NSUInteger)line
+                          tag:(id)tag
+                      message:(NSString *)message
+{
+    self = [self initWithAsync:asynchronous level:level flag:flag context:context file:file function:function line:line tag:tag format:message args:nil];
+    if (self) {
+        _message = message;
+    }
+    return self;
+}
+
 - (NSString*)description {
     NSString *flagName = nil;
     switch (_flag) {
@@ -529,18 +546,35 @@
                                                  function:nil
                                                      line:0
                                                       tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
-                                                   format:@"This is a error message"
-                                                  message:nil];
+                                                  message:@"This is a error message"];
     [self log:SFLogLevelError msg:@"This is a error message"];
     XCTAssertEqual(recorder.results.count, 1U);
     XCTAssertEqualObjects(recorder.results.lastObject, expectedMsg);
     [recorder.results removeAllObjects];
     
+    expectedMsg = [[LogItem alloc] initWithAsync:YES
+                                                    level:DDLogLevelError
+                                                     flag:DDLogFlagError
+                                                  context:3
+                                                     file:nil
+                                                 function:nil
+                                                     line:0
+                                                      tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                                  message:@"This is a error message"];
     [self log:SFLogLevelError identifier:kSFLogLevelInfoString msg:@"This is a error message"];
     XCTAssertEqual(recorder.results.count, 1U);
     XCTAssertEqualObjects(recorder.results.lastObject, expectedMsg);
     [recorder.results removeAllObjects];
     
+    expectedMsg = [[LogItem alloc] initWithAsync:YES
+                                           level:DDLogLevelVerbose
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:nil
+                                        function:nil
+                                            line:0
+                                             tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                         message:@"This is a error message"];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self log:SFLogLevelError context:0 msg:@"This is a error message"];
@@ -557,7 +591,6 @@
                                               function:nil
                                                   line:0
                                                    tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
-                                                format:@"This is a error message"
                                                message:@"This is a error message"];
     
     [self log:SFLogLevelError format:@"This is a error message"];
@@ -664,7 +697,7 @@ static NSInteger kMyLogContext;
     XCTAssertEqual(testLogger.messages.count, 3U);
     XCTAssertEqualObjects([self trimmedLogWithString:testLogger.messages[0]], @"ERROR com.salesforce <LogStorageRecorder>: Log message");
     XCTAssertEqualObjects([self trimmedLogWithString:testLogger.messages[1]], @"ERROR com.salesforce.test <LogStorageRecorder>: Log message");
-    XCTAssertEqualObjects([self trimmedLogWithString:testLogger.messages[2]], @"ERROR com.salesforce <SFLoggerTests.m:659 -[SFLoggerTests testLogFormatter]>: Log message");
+    XCTAssertEqualObjects([self trimmedLogWithString:testLogger.messages[2]], @"ERROR com.salesforce <SFLoggerTests.m:692 -[SFLoggerTests testLogFormatter]>: Log message");
 
 }
 
@@ -697,8 +730,8 @@ static NSInteger kMyLogContext;
     
     NSArray<NSString*> *messages = [logContents componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
     XCTAssertEqual(messages.count, 3U);
-    XCTAssertEqualObjects([self trimmedLogWithString:messages[0]], @"WARNING com.salesforce <SFLoggerTests.m:688 -[SFLoggerTests testExtraLoggers]>: Log warning");
-    XCTAssertEqualObjects([self trimmedLogWithString:messages[1]], @"VERBOSE com.salesforce <SFLoggerTests.m:689 -[SFLoggerTests testExtraLoggers]>: Log verbose");
+    XCTAssertEqualObjects([self trimmedLogWithString:messages[0]], @"WARNING com.salesforce <SFLoggerTests.m:721 -[SFLoggerTests testExtraLoggers]>: Log warning");
+    XCTAssertEqualObjects([self trimmedLogWithString:messages[1]], @"VERBOSE com.salesforce <SFLoggerTests.m:722 -[SFLoggerTests testExtraLoggers]>: Log verbose");
 
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFLoggerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFLoggerTests.m
@@ -28,6 +28,16 @@
 #import "SFLogger_Internal.h"
 #import "SFCocoaLumberJackCustomFormatter.h"
 
+@interface SFLogger (Testing)
+- (int) maxContextForIdentifiers;
+@end
+
+@implementation SFLogger (Testing)
+- (int) maxContextForIdentifiers {
+    return _contextCounter;
+}
+@end
+
 @interface LogItem : NSObject
 
 @property (nonatomic, assign, readonly) BOOL async;
@@ -552,10 +562,11 @@
     XCTAssertEqualObjects(recorder.results.lastObject, expectedMsg);
     [recorder.results removeAllObjects];
     
+    int nextMaxContext = [[SFLogger sharedLogger] maxContextForIdentifiers];
     expectedMsg = [[LogItem alloc] initWithAsync:YES
                                                     level:DDLogLevelError
                                                      flag:DDLogFlagError
-                                                  context:3
+                                                  context:nextMaxContext
                                                      file:nil
                                                  function:nil
                                                      line:0
@@ -697,7 +708,7 @@ static NSInteger kMyLogContext;
     XCTAssertEqual(testLogger.messages.count, 3U);
     XCTAssertEqualObjects([self trimmedLogWithString:testLogger.messages[0]], @"ERROR com.salesforce <LogStorageRecorder>: Log message");
     XCTAssertEqualObjects([self trimmedLogWithString:testLogger.messages[1]], @"ERROR com.salesforce.test <LogStorageRecorder>: Log message");
-    XCTAssertEqualObjects([self trimmedLogWithString:testLogger.messages[2]], @"ERROR com.salesforce <SFLoggerTests.m:692 -[SFLoggerTests testLogFormatter]>: Log message");
+    XCTAssertEqualObjects([self trimmedLogWithString:testLogger.messages[2]], @"ERROR com.salesforce <SFLoggerTests.m:703 -[SFLoggerTests testLogFormatter]>: Log message");
 
 }
 
@@ -730,8 +741,8 @@ static NSInteger kMyLogContext;
     
     NSArray<NSString*> *messages = [logContents componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
     XCTAssertEqual(messages.count, 3U);
-    XCTAssertEqualObjects([self trimmedLogWithString:messages[0]], @"WARNING com.salesforce <SFLoggerTests.m:721 -[SFLoggerTests testExtraLoggers]>: Log warning");
-    XCTAssertEqualObjects([self trimmedLogWithString:messages[1]], @"VERBOSE com.salesforce <SFLoggerTests.m:722 -[SFLoggerTests testExtraLoggers]>: Log verbose");
+    XCTAssertEqualObjects([self trimmedLogWithString:messages[0]], @"WARNING com.salesforce <SFLoggerTests.m:732 -[SFLoggerTests testExtraLoggers]>: Log warning");
+    XCTAssertEqualObjects([self trimmedLogWithString:messages[1]], @"VERBOSE com.salesforce <SFLoggerTests.m:733 -[SFLoggerTests testExtraLoggers]>: Log verbose");
 
 }
 


### PR DESCRIPTION
- If the msg (later format string) contained characters typically associated with format specifiers '%' , etc this could crash
- A format string as described above, with nil passed in place of the va_list crashes
- Instead delegate to ... variant and pass nil for arguments. This will properly initialize a va_list with nothing in it and avoid the crash

These are also not Swift friendly. Consider in future PR (with update to newer version of CocoaLumberjack