### PR TITLE
Fix for sync up regression in hybrid app

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncDownTarget.m
@@ -43,7 +43,7 @@ NSString * const kSFSyncTargetQueryTypeCustom = @"custom";
 #pragma mark - From/to dictionary
 
 + (SFSyncDownTarget*) newFromDict:(NSDictionary*)dict {
-    // We should have an implementation class unless sync down was created with SDK before 5.1 and is not custom
+    // We should have an implementation class or a target type
     NSString* implClassName = dict[kSFSyncTargetiOSImplKey];
     if (implClassName.length > 0) {
         Class customSyncDownClass = NSClassFromString(implClassName);

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncUpTarget.m
@@ -58,7 +58,7 @@ static NSString * const kSFSyncUpTargetTypeCustom = @"custom";
 #pragma mark - Serialization and factory methods
 
 + (instancetype)newFromDict:(NSDictionary*)dict {
-    // We should have an implementation class unless sync up was created with SDK before 5.1 and is not custom
+    // We should have an implementation class or a target type
     NSString* implClassName = dict[kSFSyncTargetiOSImplKey];
     if (implClassName.length > 0) {
         Class customSyncUpClass = NSClassFromString(implClassName);
@@ -71,7 +71,9 @@ static NSString * const kSFSyncUpTargetTypeCustom = @"custom";
     }
     // No implementation class - using target type
     else {
-        switch ([self targetTypeFromString:dict[kSFSyncTargetTypeKey]]) {
+        // No target type - assume kSFSyncUpTargetTypeRestStandard (hybrid apps don't specify it a sync up target type by default)
+        NSString *targetTypeString = (dict[kSFSyncTargetTypeKey] == nil ? kSFSyncUpTargetTypeRestStandard : dict[kSFSyncTargetTypeKey]);
+        switch ([self targetTypeFromString:targetTypeString]) {
             case SFSyncUpTargetTypeRestStandard:
                 return [[SFSyncUpTarget alloc] initWithDict:dict];
                 


### PR DESCRIPTION
Hybrid apps don’t specify query type or implementation class by default. In the past, default sync up target was assumed in those cases. The recent refactor changed that and broke hybrid sync up.