### PR TITLE
Alert View positioning issue

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -27,7 +27,6 @@
 @interface SalesforceSDKManager () <SalesforceSDKManagerFlow, SFUserAccountManagerDelegate>
 {
     BOOL _isLaunching;
-    UIViewController* _defaultSnapshotViewController;
     UIViewController* _snapshotViewController;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -522,14 +522,10 @@ static Class InstanceClass = nil;
     // Custom snapshot view controller provided
     if (customSnapshotViewController) {
         _snapshotViewController = customSnapshotViewController;
-        _defaultSnapshotViewController = nil; //no need to keep the default in memory
     }
     // No custom snapshot view controller provided
     else {
-        if (!_defaultSnapshotViewController) {
-            _defaultSnapshotViewController = [[SnapshotViewController alloc] initWithNibName:nil bundle:nil];
-        }
-        _snapshotViewController = _defaultSnapshotViewController;
+        _snapshotViewController =  [[SnapshotViewController alloc] initWithNibName:nil bundle:nil];
     }
     
     // Presentation

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFRootViewManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFRootViewManager.m
@@ -113,8 +113,8 @@
         UIViewController *currentViewController = strongSelf.mainWindow.rootViewController;
         while (currentViewController.presentedViewController != nil && !currentViewController.presentedViewController.isBeingDismissed) {
             if([currentViewController.presentedViewController isKindOfClass:[UIAlertController class]]) {
-                [currentViewController.presentedViewController dismissViewControllerAnimated:NO completion:nil];
                 strongSelf->_modalViewController = (UIAlertController *)currentViewController.presentedViewController;
+                [currentViewController.presentedViewController dismissViewControllerAnimated:NO completion:nil];
                 break;
             }
             currentViewController = currentViewController.presentedViewController;
@@ -178,7 +178,6 @@
                           [prevController presentViewController:strongSelf->_modalViewController animated:NO completion:^{
                             strongSelf->_modalViewController = nil;
                            }];
-                          return;
                       }
                       [strongSelf enumerateDelegates:^(id<SFRootViewManagerDelegate> delegate) {
                           if ([delegate respondsToSelector:@selector(rootViewManager:didPopViewControler:)]) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFRootViewManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFRootViewManager.m
@@ -174,16 +174,18 @@
             } else {
                 [strongSelf log:SFLogLevelDebug format:@"popViewController: View controller (%@) is now being dismissed from presentation.", viewController];
                 [[currentViewController presentingViewController] dismissViewControllerAnimated:NO completion:^{
-                    [strongSelf enumerateDelegates:^(id<SFRootViewManagerDelegate> delegate) {
-                        if ([delegate respondsToSelector:@selector(rootViewManager:didPopViewControler:)]) {
-                            [delegate rootViewManager:strongSelf didPopViewControler:viewController];
-                        }
-                    }];
-                    if(strongSelf->_modalViewController) {
-                        [prevController presentViewController:strongSelf->_modalViewController animated:NO completion:^{
+                      if(strongSelf->_modalViewController) {
+                          [prevController presentViewController:strongSelf->_modalViewController animated:NO completion:^{
                             strongSelf->_modalViewController = nil;
-                        }];
-                    }
+                           }];
+                          return;
+                      }
+                      [strongSelf enumerateDelegates:^(id<SFRootViewManagerDelegate> delegate) {
+                          if ([delegate respondsToSelector:@selector(rootViewManager:didPopViewControler:)]) {
+                              [delegate rootViewManager:strongSelf didPopViewControler:viewController];
+                          }
+                      }];
+
                 }];
                 
             }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFRootViewManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFRootViewManager.m
@@ -32,7 +32,9 @@
 
 @end
 
-@implementation SFRootViewManager
+@implementation SFRootViewManager {
+    UIAlertController *_modalViewController;
+}
 
 @synthesize mainWindow = _mainWindow;
 
@@ -110,13 +112,18 @@
         __strong typeof(weakSelf) strongSelf = weakSelf;
         UIViewController *currentViewController = strongSelf.mainWindow.rootViewController;
         while (currentViewController.presentedViewController != nil && !currentViewController.presentedViewController.isBeingDismissed) {
+            if([currentViewController.presentedViewController isKindOfClass:[UIAlertController class]]) {
+                [currentViewController.presentedViewController dismissViewControllerAnimated:NO completion:nil];
+                strongSelf->_modalViewController = (UIAlertController *)currentViewController.presentedViewController;
+                break;
+            }
             currentViewController = currentViewController.presentedViewController;
         }
         
         if (currentViewController != nil) {
             if (currentViewController != viewController
                 && viewController.presentedViewController != currentViewController
-                && !(viewController.isViewLoaded && viewController.view.window && [viewController.view.window isKeyWindow])) {
+                ) {
                 [strongSelf log:SFLogLevelDebug format:@"pushViewController: Presenting view controller (%@).", viewController];
                 
                 [strongSelf enumerateDelegates:^(id<SFRootViewManagerDelegate> delegate) {
@@ -124,6 +131,10 @@
                         [delegate rootViewManager:strongSelf willPushViewControler:viewController];
                     }
                 }];
+                
+                if([currentViewController isKindOfClass:[UINavigationController class]]) {
+                    currentViewController =[((UINavigationController *) currentViewController) visibleViewController];
+                }
                 
                 [currentViewController presentViewController:viewController animated:NO completion:NULL];
             } else {
@@ -151,7 +162,10 @@
             strongSelf.mainWindow.rootViewController = nil;
             [self restorePreviousKeyWindow];
         } else {
+            UIViewController *prevController = currentViewController;
             while ((currentViewController != nil) && (currentViewController != viewController)) {
+                if([currentViewController presentedViewController]!=nil)
+                    prevController = currentViewController;
                 currentViewController = [currentViewController presentedViewController];
             }
             
@@ -165,9 +179,16 @@
                             [delegate rootViewManager:strongSelf didPopViewControler:viewController];
                         }
                     }];
+                    if(strongSelf->_modalViewController) {
+                        [prevController presentViewController:strongSelf->_modalViewController animated:NO completion:^{
+                            strongSelf->_modalViewController = nil;
+                        }];
+                    }
                 }];
+                
             }
         }
+        
     };
     
     dispatch_async(dispatch_get_main_queue(), popControllerBlock);


### PR DESCRIPTION
More evil problems surface related to SFRootViewManager and Alerts. It is reported that when the alert is presented and app is sent to background and later resumed it is noticed that the alert is positioned off the screen. Unfortunately this has to do with the views being managed by the SFRootViewManager. I've temporarily patched the problem i.e we check if the presented view is a UIAlertController before presenting a snapshot. If so we dismiss it and continue to push the SnapshotView and then when the app is foregrounded we present the same alert after the SnapshotView is popped.