### PR TITLE
Passcode view not showing in advanced auth flow.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -39,6 +39,7 @@
 #import "SFApplication.h"
 #import "NSUserDefaults+SFAdditions.h"
 #import "SFSDKEventBuilderHelper.h"
+#import "SalesforceSDKManager+Internal.h"
 
 // Private constants
 
@@ -105,6 +106,7 @@ static BOOL _showPasscode = YES;
         }];
         
         [SFSecurityLockout setPresentPasscodeViewControllerBlock:^(UIViewController *pvc) {
+            [[SalesforceSDKManager sharedManager] dismissSnapshot];
             [[SFRootViewManager sharedManager] pushViewController:pvc];
         }];
         


### PR DESCRIPTION
Trivial fix which is similar to the rendering of alerts. We dismiss the snapshotview before rendering the passcode view.