### PR TITLE
Fix retain cycle when an error occurs

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFAction.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFAction.m
@@ -36,7 +36,7 @@
 NSString * const CSFActionSecurityTokenKey = @"securityToken"; // CSRF security token key
 
 NSString * const CSFDefaultLocale = @"en-us";
-NSString * const CSFNetworkErrorActionKey = @"action";
+NSString * const CSFNetworkErrorActionDescriptionKey = @"action";
 NSString * const CSFNetworkErrorAuthenticationFailureKey = @"isAuthenticationFailure";
 
 NSTimeInterval const CSFActionDefaultTimeOut = 3 * 60; // 3 minutes
@@ -78,7 +78,7 @@ CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
             *error = [NSError errorWithDomain:CSFNetworkErrorDomain
                                          code:CSFNetworkURLCredentialsError
                                      userInfo:@{ NSLocalizedDescriptionKey: @"Network action must have a base URL defined",
-                                             CSFNetworkErrorActionKey: self }];
+                                             CSFNetworkErrorActionDescriptionKey: [self description] }];
         }
         return nil;
     }
@@ -92,7 +92,7 @@ CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
             *error = [NSError errorWithDomain:CSFNetworkErrorDomain
                                          code:CSFNetworkURLCredentialsError
                                      userInfo:@{ NSLocalizedDescriptionKey: @"Network action must have a valid path",
-                                             CSFNetworkErrorActionKey: self }];
+                                             CSFNetworkErrorActionDescriptionKey: [self description] }];
         }
         return nil;
     }
@@ -137,7 +137,7 @@ CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
                 if (potentialErrorCode && potentialErrorMessage) {
                     NSDictionary *errorDictionary = @{ NSLocalizedDescriptionKey: potentialErrorMessage,
                                                        NSLocalizedFailureReasonErrorKey: potentialErrorCode,
-                                                       CSFNetworkErrorActionKey: action };
+                                                       CSFNetworkErrorActionDescriptionKey: [action description] };
                     error = [NSError errorWithDomain:CSFNetworkErrorDomain
                                                 code:CSFNetworkAPIError
                                             userInfo:errorDictionary];
@@ -460,7 +460,7 @@ CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
             [self completeOperationWithError:[NSError errorWithDomain:CSFNetworkErrorDomain
                                                                  code:CSFNetworkHTTPResponseError
                                                              userInfo:@{ NSLocalizedDescriptionKey: @"HTTP request returned an error",
-                                                                         CSFNetworkErrorActionKey: self,
+                                                                         CSFNetworkErrorActionDescriptionKey: [self description],
                                                                          NSUnderlyingErrorKey: error }]];
         }
     } else if (![task.response isKindOfClass:[NSHTTPURLResponse class]]) {
@@ -468,7 +468,7 @@ CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
         [self completeOperationWithError:[NSError errorWithDomain:CSFNetworkErrorDomain
                                                              code:CSFNetworkURLResponseInvalidError
                                                          userInfo:@{ NSLocalizedDescriptionKey: @"Unexpected URL response type returned.",
-                                                                     CSFNetworkErrorActionKey: self }]];
+                                                                     CSFNetworkErrorActionDescriptionKey: [self description] }]];
     } else {
         NetworkVerbose(@"Successfully completed request");
         [self completeOperationWithResponse:(NSHTTPURLResponse *)task.response];
@@ -518,7 +518,7 @@ CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
         [self completeOperationWithError:[NSError errorWithDomain:CSFNetworkErrorDomain
                                                              code:CSFNetworkCancelledError
                                                          userInfo:@{ NSLocalizedDescriptionKey: @"Operation was cancelled",
-                                                                     CSFNetworkErrorActionKey: self }]];
+                                                                     CSFNetworkErrorActionDescriptionKey: [self description] }]];
         return;
     }
     [self willChangeValueForKey:@"isExecuting"];
@@ -581,7 +581,7 @@ CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
     [self completeOperationWithError:[NSError errorWithDomain:CSFNetworkErrorDomain
                                                          code:CSFNetworkCancelledError
                                                      userInfo:@{ NSLocalizedDescriptionKey: @"Operation was cancelled",
-                                                                 CSFNetworkErrorActionKey: self }]];
+                                                                 CSFNetworkErrorActionDescriptionKey: [self description] }]];
 }
 
 - (BOOL)isAsynchronous {
@@ -760,7 +760,7 @@ CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
                                          code:CSFNetworkJSONInvalidError
                                      userInfo:@{ NSLocalizedDescriptionKey: @"Processing response content failed",
                                                  NSUnderlyingErrorKey: jsonParseError,
-                                                 CSFNetworkErrorActionKey: self }];
+                                                 CSFNetworkErrorActionDescriptionKey: [self description] }];
         }
     }
     return content;
@@ -771,7 +771,7 @@ CSFActionTiming kCSFActionTimingPostProcessingKey = @"postProcessing";
     if (response.statusCode >= 400) {
         NSString *errorDescription = [NSString stringWithFormat:@"HTTP %ld for %@ %@", (long)response.statusCode, self.method, self.verb];
         NSDictionary *userInfoDict = @{ NSLocalizedDescriptionKey:errorDescription,
-                                        CSFNetworkErrorActionKey: self };
+                                        CSFNetworkErrorActionDescriptionKey: [self description] };
         error = [NSError errorWithDomain:CSFNetworkErrorDomain
                                     code:response.statusCode
                                 userInfo:userInfoDict];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFSalesforceAction.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFSalesforceAction.m
@@ -201,7 +201,7 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
     
     NSString *errorDescription = errorMessage ?: [NSString stringWithFormat:@"HTTP %ld for %@ %@", (long)response.statusCode, self.method, self.verb];
     NSDictionary *baseErrorDict = @{ NSLocalizedDescriptionKey:errorDescription,
-                                     CSFNetworkErrorActionKey: self,
+                                     CSFNetworkErrorActionDescriptionKey: [self description],
                                      CSFNetworkErrorAuthenticationFailureKey: @(requestSessionRefresh) };
     NSMutableDictionary *userInfoDict = [NSMutableDictionary dictionaryWithDictionary:baseErrorDict];
     if (errorCode.length > 0) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Utilities/CSFDefines.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Utilities/CSFDefines.h
@@ -96,7 +96,7 @@ typedef NS_ENUM(NSInteger, CSFChatterCommunityMode)  {
 };
 
 CSF_EXTERN NSString * const CSFNetworkErrorDomain;
-CSF_EXTERN NSString * const CSFNetworkErrorActionKey;
+CSF_EXTERN NSString * const CSFNetworkErrorActionDescriptionKey;
 CSF_EXTERN NSString * const CSFNetworkErrorAuthenticationFailureKey;
 
 /** Enumerator listing the error codes used by CSFNetwork

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPISalesforceAction.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPISalesforceAction.m
@@ -48,7 +48,7 @@
             *error = [NSError errorWithDomain:CSFNetworkErrorDomain
                                                 code:response.statusCode
                                             userInfo:@{ NSLocalizedDescriptionKey:[NSString stringWithFormat:@"HTTP %ld for %@ %@", (long)response.statusCode, self.method, self.verb],
-                                                        CSFNetworkErrorActionKey: self }];
+                                                        CSFNetworkErrorActionDescriptionKey: [self description] }];
         }
     }
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/MockNetworkTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/MockNetworkTests.m
@@ -62,7 +62,7 @@
         error = [NSError errorWithDomain:CSFNetworkErrorDomain
                                     code:CSFNetworkInternalError
                                 userInfo:@{ NSLocalizedDescriptionKey: @"Semaphore wait timed out",
-                                            CSFNetworkErrorActionKey: self }];
+                                            CSFNetworkErrorActionDescriptionKey: [self description] }];
     }
     [super completeOperationWithError:error];
 }


### PR DESCRIPTION
The error userInfo description can capture `self` which creates a retain cycle.  I've removed the original key, and changed the key to instead use a description of itself, and changed the developer-facing constant to signify this change.