### PR TITLE
Ensure logging macros don't leak `self`

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLogger.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLogger.m
@@ -149,35 +149,6 @@ SFLogLevel SFLoggerContextLogLevels[SF_LOG_MAX_IDENTIFIER_COUNT];
 
 /////////////////
 
-@implementation SFLogTag
-
-- (instancetype)initWithClass:(Class)originClass selector:(SEL)selector {
-    self = [self init];
-    if (self) {
-        _originClass = originClass;
-        _selector = selector;
-    }
-    return self;
-}
-
-- (BOOL)isEqual:(SFLogTag*)object {
-    BOOL result = YES;
-    if (self == object) {
-        result = YES;
-    } else if (![object isMemberOfClass:self.class]) {
-        result = NO;
-    } else if (_originClass != object->_originClass) {
-        result = NO;
-    } else if (_selector != object->_selector) {
-        result = NO;
-    }
-    return result;
-}
-
-@end
-
-/////////////////
-
 @implementation SFLogIdentifier
 
 + (NSSet*)keyPathsForValuesAffectingLogFlag {
@@ -251,7 +222,7 @@ SFLogLevel SFLoggerContextLogLevels[SF_LOG_MAX_IDENTIFIER_COUNT];
                 file:nil
             function:nil
                 line:0
-                 tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                 tag:self.class
               format:format
                 args:args];
     va_end(args);
@@ -274,7 +245,7 @@ SFLogLevel SFLoggerContextLogLevels[SF_LOG_MAX_IDENTIFIER_COUNT];
                 file:nil
             function:nil
                 line:0
-                 tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                 tag:self.class
               format:format
                 args:args];
     va_end(args);
@@ -293,7 +264,7 @@ SFLogLevel SFLoggerContextLogLevels[SF_LOG_MAX_IDENTIFIER_COUNT];
                 file:nil
             function:nil
                 line:0
-                 tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                 tag:self.class
               format:format
                 args:args];
     va_end(args);
@@ -525,7 +496,7 @@ static BOOL assertionRecorded = NO;
               file:nil
           function:nil
               line:0
-               tag:[[SFLogTag alloc] initWithClass:cls selector:nil]
+               tag:cls
             format:msg];
 }
 
@@ -539,7 +510,7 @@ static BOOL assertionRecorded = NO;
               file:nil
           function:nil
               line:0
-               tag:[[SFLogTag alloc] initWithClass:cls selector:nil]
+               tag:cls
             format:msg];
 }
 
@@ -668,7 +639,7 @@ static BOOL assertionRecorded = NO;
                            file:[file cStringUsingEncoding:NSUTF8StringEncoding]
                        function:[NSStringFromSelector(method) cStringUsingEncoding:NSUTF8StringEncoding]
                            line:line
-                            tag:[[SFLogTag alloc] initWithClass:[obj class] selector:method]
+                            tag:[obj class]
                          format:message
                            args:args];
     va_end(args);
@@ -695,7 +666,7 @@ static BOOL assertionRecorded = NO;
                            file:[file cStringUsingEncoding:NSUTF8StringEncoding]
                        function:[NSStringFromSelector(method) cStringUsingEncoding:NSUTF8StringEncoding]
                            line:line
-                            tag:[[SFLogTag alloc] initWithClass:[obj class] selector:method]
+                            tag:[obj class]
                          format:stackTraces
                            args:nil];
     
@@ -747,15 +718,7 @@ static BOOL assertionRecorded = NO;
     va_list args;
     
     if (format) {
-        va_start(args, format);
-        if (tag && ![tag isKindOfClass:[SFLogTag class]]) {
-            if ([tag conformsToProtocol:@protocol(NSObject)]) {
-                tag = [[SFLogTag alloc] initWithClass:[(NSObject*)tag class] selector:nil];
-            } else {
-                tag = [[SFLogTag alloc] initWithClass:tag selector:nil];
-            }
-        }
-        
+        va_start(args, format);        
         [self.sharedLogger logAsync:asynchronous
                               level:level
                                flag:flag

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLoggerMacros.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLoggerMacros.h
@@ -118,11 +118,11 @@ static BOOL const kSFASLLoggerEnabledDefault = NO;
 #define SFLogDebug(frmt, ...)      SFLogDebugToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
 #define SFLogVerbose(frmt, ...)  SFLogVerboseToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
 
-#define SFLogCError(frmt, ...)      SFLogError(frmt, ##__VA_ARGS__)
-#define SFLogCWarn(frmt, ...)        SFLogWarn(frmt, ##__VA_ARGS__)
-#define SFLogCInfo(frmt, ...)        SFLogInfo(frmt, ##__VA_ARGS__)
-#define SFLogCDebug(frmt, ...)      SFLogDebug(frmt, ##__VA_ARGS__)
-#define SFLogCVerbose(frmt, ...)  SFLogVerbose(frmt, ##__VA_ARGS__)
+#define SFLogCError(frmt, ...)    _Pragma ("GCC warning \"'SFLogCError' macro is deprecated, use SFLogError\"")     SFLogError(frmt, ##__VA_ARGS__)
+#define SFLogCWarn(frmt, ...)     _Pragma ("GCC warning \"'SFLogCWarn' macro is deprecated, use SFLogWarn\"")       SFLogWarn(frmt, ##__VA_ARGS__)
+#define SFLogCInfo(frmt, ...)     _Pragma ("GCC warning \"'SFLogCInfo' macro is deprecated, use SFLogInfo\"")       SFLogInfo(frmt, ##__VA_ARGS__)
+#define SFLogCDebug(frmt, ...)    _Pragma ("GCC warning \"'SFLogCDebug' macro is deprecated, use SFLogDebug\"")     SFLogDebug(frmt, ##__VA_ARGS__)
+#define SFLogCVerbose(frmt, ...)  _Pragma ("GCC warning \"'SFLogCVerbose' macro is deprecated, use SFLogVerbose\"") SFLogVerbose(frmt, ##__VA_ARGS__)
 
 
 #endif /* SFLoggerMacros_h */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLoggerMacros.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLoggerMacros.h
@@ -106,23 +106,23 @@ static BOOL const kSFASLLoggerEnabledDefault = NO;
 #define SFLogDebugToContext(context, tag, frmt, ...)   SF_LOG_MAYBE(YES, SFLogFlagDebug,   context, tag, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 #define SFLogVerboseToContext(context, tag, frmt, ...) SF_LOG_MAYBE(YES, SFLogFlagVerbose, context, tag, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 
-#define SFLogErrorToIdentifier(identifier, frmt, ...)     SFLogErrorToContext([SFLogger contextForIdentifier:identifier], self, frmt, ##__VA_ARGS__)
-#define SFLogWarnToIdentifier(identifier, frmt, ...)       SFLogWarnToContext([SFLogger contextForIdentifier:identifier], self, frmt, ##__VA_ARGS__)
-#define SFLogInfoToIdentifier(identifier, frmt, ...)       SFLogInfoToContext([SFLogger contextForIdentifier:identifier], self, frmt, ##__VA_ARGS__)
-#define SFLogDebugToIdentifier(identifier, frmt, ...)     SFLogDebugToContext([SFLogger contextForIdentifier:identifier], self, frmt, ##__VA_ARGS__)
-#define SFLogVerboseToIdentifier(identifier, frmt, ...) SFLogVerboseToContext([SFLogger contextForIdentifier:identifier], self, frmt, ##__VA_ARGS__)
+#define SFLogErrorToIdentifier(identifier, frmt, ...)     SFLogErrorToContext([SFLogger contextForIdentifier:identifier], nil, frmt, ##__VA_ARGS__)
+#define SFLogWarnToIdentifier(identifier, frmt, ...)       SFLogWarnToContext([SFLogger contextForIdentifier:identifier], nil, frmt, ##__VA_ARGS__)
+#define SFLogInfoToIdentifier(identifier, frmt, ...)       SFLogInfoToContext([SFLogger contextForIdentifier:identifier], nil, frmt, ##__VA_ARGS__)
+#define SFLogDebugToIdentifier(identifier, frmt, ...)     SFLogDebugToContext([SFLogger contextForIdentifier:identifier], nil, frmt, ##__VA_ARGS__)
+#define SFLogVerboseToIdentifier(identifier, frmt, ...) SFLogVerboseToContext([SFLogger contextForIdentifier:identifier], nil, frmt, ##__VA_ARGS__)
 
-#define SFLogError(frmt, ...)      SFLogErrorToContext(SFLoggerDefaultContext, self, frmt, ##__VA_ARGS__)
-#define SFLogWarn(frmt, ...)        SFLogWarnToContext(SFLoggerDefaultContext, self, frmt, ##__VA_ARGS__)
-#define SFLogInfo(frmt, ...)        SFLogInfoToContext(SFLoggerDefaultContext, self, frmt, ##__VA_ARGS__)
-#define SFLogDebug(frmt, ...)      SFLogDebugToContext(SFLoggerDefaultContext, self, frmt, ##__VA_ARGS__)
-#define SFLogVerbose(frmt, ...)  SFLogVerboseToContext(SFLoggerDefaultContext, self, frmt, ##__VA_ARGS__)
+#define SFLogError(frmt, ...)      SFLogErrorToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
+#define SFLogWarn(frmt, ...)        SFLogWarnToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
+#define SFLogInfo(frmt, ...)        SFLogInfoToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
+#define SFLogDebug(frmt, ...)      SFLogDebugToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
+#define SFLogVerbose(frmt, ...)  SFLogVerboseToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
 
-#define SFLogCError(frmt, ...)      SFLogErrorToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
-#define SFLogCWarn(frmt, ...)        SFLogWarnToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
-#define SFLogCInfo(frmt, ...)        SFLogInfoToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
-#define SFLogCDebug(frmt, ...)      SFLogDebugToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
-#define SFLogCVerbose(frmt, ...)  SFLogVerboseToContext(SFLoggerDefaultContext, nil, frmt, ##__VA_ARGS__)
+#define SFLogCError(frmt, ...)      SFLogError(frmt, ##__VA_ARGS__)
+#define SFLogCWarn(frmt, ...)        SFLogWarn(frmt, ##__VA_ARGS__)
+#define SFLogCInfo(frmt, ...)        SFLogInfo(frmt, ##__VA_ARGS__)
+#define SFLogCDebug(frmt, ...)      SFLogDebug(frmt, ##__VA_ARGS__)
+#define SFLogCVerbose(frmt, ...)  SFLogVerbose(frmt, ##__VA_ARGS__)
 
 
 #endif /* SFLoggerMacros_h */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLogger_Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/Logging/SFLogger_Internal.h
@@ -45,17 +45,6 @@ extern NSString * SFLogNameForLogLevel(SFLogLevel level);
 
 /////////////////
 
-@interface SFLogTag : NSObject
-
-@property (nonatomic, readonly) SEL selector;
-@property (nonatomic, strong, readonly) Class originClass;
-
-- (instancetype)initWithClass:(Class)originClass selector:(SEL)selector;
-
-@end
-
-/////////////////
-
 @interface SFLogger () {
 @public
     atomic_int_least32_t _contextCounter;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFLoggerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFLoggerTests.m
@@ -365,7 +365,7 @@
                                          file:nil
                                      function:nil
                                          line:0
-                                          tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                          tag:self.class
                                        format:@"Warning message"
                                       message:@"Warning message"];
     [SFLogger log:self.class level:SFLogLevelWarning msg:@"Warning message"];
@@ -379,7 +379,7 @@
                                          file:nil
                                      function:nil
                                          line:0
-                                          tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                          tag:self.class
                                        format:@"Warning message with an argument"
                                       message:@"Warning message with an argument"];
     [SFLogger log:self.class level:SFLogLevelError format:@"Warning message with %@", @"an argument"];
@@ -406,7 +406,7 @@
                                          file:nil
                                      function:nil
                                          line:0
-                                          tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                          tag:self.class
                                        format:@"Message to Woof"
                                       message:@"Message to Woof"];
     XCTAssertEqualObjects([recorder.results lastObject], expected);
@@ -439,7 +439,7 @@
                                                     file:__FILE__
                                                 function:"-[SFLoggerTests testMacroLogging]"
                                                     line:baseLine + 2
-                                                     tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                                     tag:nil
                                                   format:@"This is a verbose message"
                                                  message:@"This is a verbose message"]);
     XCTAssertEqualObjects(recorder.results[1],
@@ -450,7 +450,7 @@
                                                     file:__FILE__
                                                 function:"-[SFLoggerTests testMacroLogging]"
                                                     line:baseLine + 4
-                                                     tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                                     tag:nil
                                                   format:@"This is a debug message: %d"
                                                  message:@"This is a debug message: 1"]);
     XCTAssertEqualObjects(recorder.results[2],
@@ -461,7 +461,7 @@
                                                     file:__FILE__
                                                 function:"-[SFLoggerTests testMacroLogging]"
                                                     line:baseLine + 6
-                                                     tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                                     tag:nil
                                                   format:@"This is a info message"
                                                  message:@"This is a info message"]);
     XCTAssertEqualObjects(recorder.results[3],
@@ -472,7 +472,7 @@
                                                     file:__FILE__
                                                 function:"-[SFLoggerTests testMacroLogging]"
                                                     line:baseLine + 8
-                                                     tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                                     tag:nil
                                                   format:@"This is a warning %@"
                                                  message:@"This is a warning message"]);
     XCTAssertEqualObjects(recorder.results[4],
@@ -483,7 +483,7 @@
                                                     file:__FILE__
                                                 function:"-[SFLoggerTests testMacroLogging]"
                                                     line:baseLine + 10
-                                                     tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                                     tag:nil
                                                   format:@"This is a error message"
                                                  message:@"This is a error message"]);
 }
@@ -501,7 +501,7 @@
                                                   file:nil
                                               function:nil
                                                   line:0
-                                                   tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                                   tag:self.class
                                                 format:@"This is a error message"
                                                message:@"This is a error message"];
     
@@ -555,7 +555,7 @@
                                                      file:nil
                                                  function:nil
                                                      line:0
-                                                      tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                                      tag:self.class
                                                   message:@"This is a error message"];
     [self log:SFLogLevelError msg:@"This is a error message"];
     XCTAssertEqual(recorder.results.count, 1U);
@@ -570,7 +570,7 @@
                                                      file:nil
                                                  function:nil
                                                      line:0
-                                                      tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                                      tag:self.class
                                                   message:@"This is a error message"];
     [self log:SFLogLevelError identifier:kSFLogLevelInfoString msg:@"This is a error message"];
     XCTAssertEqual(recorder.results.count, 1U);
@@ -584,7 +584,7 @@
                                             file:nil
                                         function:nil
                                             line:0
-                                             tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                             tag:self.class
                                          message:@"This is a error message"];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -601,7 +601,7 @@
                                                   file:nil
                                               function:nil
                                                   line:0
-                                                   tag:[[SFLogTag alloc] initWithClass:self.class selector:nil]
+                                                   tag:self.class
                                                message:@"This is a error message"];
     
     [self log:SFLogLevelError format:@"This is a error message"];
@@ -625,11 +625,11 @@
 
 static NSString *identifier = @"com.salesforce.test";
 static NSInteger kMyLogContext;
-#define MyLogError(frmt, ...)      SFLogErrorToContext(kMyLogContext, self, frmt, ##__VA_ARGS__)
-#define MyLogWarn(frmt, ...)        SFLogWarnToContext(kMyLogContext, self, frmt, ##__VA_ARGS__)
-#define MyLogInfo(frmt, ...)        SFLogInfoToContext(kMyLogContext, self, frmt, ##__VA_ARGS__)
-#define MyLogDebug(frmt, ...)      SFLogDebugToContext(kMyLogContext, self, frmt, ##__VA_ARGS__)
-#define MyLogVerbose(frmt, ...)  SFLogVerboseToContext(kMyLogContext, self, frmt, ##__VA_ARGS__)
+#define MyLogError(frmt, ...)      SFLogErrorToContext(kMyLogContext, nil, frmt, ##__VA_ARGS__)
+#define MyLogWarn(frmt, ...)        SFLogWarnToContext(kMyLogContext, nil, frmt, ##__VA_ARGS__)
+#define MyLogInfo(frmt, ...)        SFLogInfoToContext(kMyLogContext, nil, frmt, ##__VA_ARGS__)
+#define MyLogDebug(frmt, ...)      SFLogDebugToContext(kMyLogContext, nil, frmt, ##__VA_ARGS__)
+#define MyLogVerbose(frmt, ...)  SFLogVerboseToContext(kMyLogContext, nil, frmt, ##__VA_ARGS__)
 
 - (void)testCustomLogMacros {
     SFLogger *logger = [SFLogger sharedLogger];


### PR DESCRIPTION
Since the macros reference `self`, if those logging macros are invoked from within a block copied to the heap, it's possible for a retain cycle to be created.  Instead, use the `__PRETTY_FUNCTION__` and `__FILE__` precompiler definitions.