### PR TITLE
Fix for swizzling from a community org

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -647,6 +647,7 @@ static NSString * const kSFAppFeatureMultiUser   = @"MU";
     
     if (account) {
         curUserIdentity = account.accountIdentity;
+        self.previousCommunityId = nil;
     }
     
     if (curUserIdentity){


### PR DESCRIPTION
- If swizzling from a community org we do not want to use the old communityid
- A new communityId if needed should be provided with the swizzle params.