### PR TITLE
Fix baseURL updates after an org split

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFSalesforceAction.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Action/CSFSalesforceAction.m
@@ -43,6 +43,13 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
     return errorDict[@"message"] ?: (errorDict[@"msg"] ?: errorDict[@"errorMsg"]);
 }
 
+@interface CSFSalesforceAction()
+
+@property (nonatomic, copy) NSURL *cachedAPIURL;
+
+@end
+
+
 @implementation CSFSalesforceAction
 
 - (instancetype)initWithResponseBlock:(CSFActionResponseBlock)responseBlock {
@@ -79,6 +86,7 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
         if (_enqueuedNetwork) {
             if ([self shouldUpdateBaseUrl]) {
                 self.baseURL = self.enqueuedNetwork.account.credentials.apiUrl;
+                self.cachedAPIURL = self.enqueuedNetwork.account.credentials.apiUrl;
             }
             [_enqueuedNetwork addObserver:self forKeyPath:kNetworkAccessTokenPath
                                  options:(NSKeyValueObservingOptionInitial |
@@ -266,6 +274,7 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
                     // If an action is API based action, make sure the base URL it matches current credential's api URL
                     // For actions that uses absolute URL like https://c.gus.visual.force.com/resource/1460146879000/HatImage, we should avoid the logic of changing base URL, otherwise raw content served server by absolute URL will not work
                     self.baseURL = self.enqueuedNetwork.account.credentials.apiUrl;
+                    self.cachedAPIURL = self.enqueuedNetwork.account.credentials.apiUrl;
                 }
             } else {
                 self.credentialsReady = NO;
@@ -280,7 +289,7 @@ static NSString inline * CSFSalesforceErrorMessage(NSDictionary *errorDict) {
 - (BOOL)shouldUpdateBaseUrl {
     // only set base URL to apiURL if baseURL is not already specified as absolute URL with it's own host
     // this check is necessary as there are salesforce URL that is content server based and not API based
-    return (!self.baseURL.scheme && !self.baseURL.host);
+    return (!self.baseURL.scheme && !self.baseURL.host) || (self.baseURL == self.cachedAPIURL);
 }
 
 - (BOOL)isEqualToAction:(CSFAction *)action {


### PR DESCRIPTION
- After an org split we were continuing to send requests to the old org
- This will cache the previous API URL
- After an update to credentials, i the baseURL and the cachedAPIURL were the same we know it was not a content URL and can update

This is the initial PR. I will review the unit tests to see if we can add one for this.