### PR TITLE
Fix NSTimer Race Condition

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
@@ -56,7 +56,6 @@ typedef NS_ENUM(NSUInteger, SFOAuthTokenEndpointFlow) {
 @property (nonatomic, assign) BOOL initialRequestLoaded;
 @property (nonatomic, copy) NSString *approvalCode;
 @property (nonatomic, strong) NSTimer *refreshFlowConnectionTimer;
-@property (nonatomic, strong) NSThread *refreshTimerThread;
 @property (nonatomic, strong) WKWebView *view;
 @property (nonatomic, strong) NSString *codeVerifier;
 @property (nonatomic, strong) SFOAuthInfo *authInfo;
@@ -66,8 +65,6 @@ typedef NS_ENUM(NSUInteger, SFOAuthTokenEndpointFlow) {
 - (void)startRefreshFlowConnectionTimer;
 - (void)stopRefreshFlowConnectionTimer;
 - (void)refreshFlowConnectionTimerFired:(NSTimer *)rfcTimer;
-- (void)invalidateRefreshTimer;
-- (void)cleanupRefreshTimer;
 - (void)handleUserAgentResponse:(NSURL *)requestUrl;
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -135,7 +135,6 @@ static NSString * const kSFAppFeatureSafariBrowserForLogin   = @"BW";
 @synthesize approvalCode                = _approvalCode;
 @synthesize scopes                      = _scopes;
 @synthesize refreshFlowConnectionTimer  = _refreshFlowConnectionTimer;
-@synthesize refreshTimerThread          = _refreshTimerThread;
 @synthesize advancedAuthConfiguration   = _advancedAuthConfiguration;
 @synthesize advancedAuthState           = _advancedAuthState;
 @synthesize codeVerifier                = _codeVerifier;
@@ -932,31 +931,35 @@ static NSString * const kSFAppFeatureSafariBrowserForLogin   = @"BW";
 
 - (void)startRefreshFlowConnectionTimer
 {
-    self.refreshTimerThread = [NSThread currentThread];
+    if (![NSThread isMainThread]) {
+        __weak typeof(self) weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf startRefreshFlowConnectionTimer];
+        });
+        return;
+    }
+
     self.refreshFlowConnectionTimer = [NSTimer scheduledTimerWithTimeInterval:self.timeout
-                                                                       target:self
-                                                                     selector:@selector(refreshFlowConnectionTimerFired:)
-                                                                     userInfo:nil
-                                                                      repeats:NO];
+                                                                           target:self
+                                                                         selector:@selector(refreshFlowConnectionTimerFired:)
+                                                                         userInfo:nil
+                                                                          repeats:NO];
 }
 
 - (void)stopRefreshFlowConnectionTimer
 {
-    if (self.refreshFlowConnectionTimer != nil && self.refreshTimerThread != nil) {
-        [self performSelector:@selector(invalidateRefreshTimer) onThread:self.refreshTimerThread withObject:nil waitUntilDone:YES];
-        [self cleanupRefreshTimer];
+    if (![NSThread isMainThread]) {
+        __weak typeof(self) weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf stopRefreshFlowConnectionTimer];
+        });
+        return;
     }
-}
 
-- (void)invalidateRefreshTimer
-{
-    [self.refreshFlowConnectionTimer invalidate];
-}
-
-- (void)cleanupRefreshTimer
-{
-    self.refreshFlowConnectionTimer = nil;
-    self.refreshTimerThread = nil;
+    if (self.refreshFlowConnectionTimer != nil) {
+        [self.refreshFlowConnectionTimer invalidate];
+        self.refreshFlowConnectionTimer = nil;
+    }
 }
 
 - (void)refreshFlowConnectionTimerFired:(NSTimer *)rfcTimer
@@ -964,7 +967,7 @@ static NSString * const kSFAppFeatureSafariBrowserForLogin   = @"BW";
     // If this timer fired, the timeout period for the refresh flow has expired, without the
     // refresh flow completing.
     
-    [self cleanupRefreshTimer];
+    self.refreshFlowConnectionTimer = nil;
     [self log:SFLogLevelDebug format:@"Refresh attempt timed out after %f seconds.", self.timeout];
     [self stopAuthentication];
     NSError *error = [[self class] errorWithType:kSFOAuthErrorTypeTimeout

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -932,9 +932,8 @@ static NSString * const kSFAppFeatureSafariBrowserForLogin   = @"BW";
 - (void)startRefreshFlowConnectionTimer
 {
     if (![NSThread isMainThread]) {
-        __weak typeof(self) weakSelf = self;
         dispatch_async(dispatch_get_main_queue(), ^{
-            [weakSelf startRefreshFlowConnectionTimer];
+            [self startRefreshFlowConnectionTimer];
         });
         return;
     }
@@ -949,9 +948,8 @@ static NSString * const kSFAppFeatureSafariBrowserForLogin   = @"BW";
 - (void)stopRefreshFlowConnectionTimer
 {
     if (![NSThread isMainThread]) {
-        __weak typeof(self) weakSelf = self;
         dispatch_async(dispatch_get_main_queue(), ^{
-            [weakSelf stopRefreshFlowConnectionTimer];
+            [self stopRefreshFlowConnectionTimer];
         });
         return;
     }


### PR DESCRIPTION
- Original code was developed to ensure thread is stopped on same thread it is created on
- This can also be accomplished by ensuring it is always run on the main thread (which in practice it most often was)
- If the timer had been created on a background thread this could result in a race condition between the performselector call and the thread terminating.