### PR TITLE
Fix a crasher with NSTimer

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -948,8 +948,9 @@ static NSString * const kSFAppFeatureSafariBrowserForLogin   = @"BW";
 - (void)stopRefreshFlowConnectionTimer
 {
     if (![NSThread isMainThread]) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self stopRefreshFlowConnectionTimer];
+        __weak typeof(self) weakSelf = self;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [weakSelf stopRefreshFlowConnectionTimer];
         });
         return;
     }


### PR DESCRIPTION
-  We call stopRefreshFlowConnectionTimer in dealloc
-  An async dispatch is almost guaranteed to crash in such a situation
-  Switched to a sync call, and a weak reference (the weak reference is to avoid a retain during dealloc)