### PR TITLE
Post notification when oauth session is refreshed

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/OAuth/CSFSalesforceOAuthRefresh.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/OAuth/CSFSalesforceOAuthRefresh.m
@@ -97,6 +97,12 @@
     self.network.account.credentials = coordinator.credentials;
     CSFOAuthTokenRefreshOutput *output = [[CSFOAuthTokenRefreshOutput alloc] initWithCoordinator:coordinator];
     [self finishWithOutput:output error:nil];
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:kSFAuthenticationManagerFinishedNotification
+                                                            object:nil
+                                                          userInfo:nil];
+    });
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFailWithError:(NSError *)error authInfo:(SFOAuthInfo *)info {


### PR DESCRIPTION
This is a temporary fix for notifying when oauth credentials have changed until there is a central place to observe changes to instanceUrl