### PR TITLE
Guarding logout to only get processed once

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -26,7 +26,7 @@
 #import "SFApplication.h"
 #import "SFAuthenticationManager+Internal.h"
 #import "SalesforceSDKManager+Internal.h"
-#import "SFUserAccount.h"
+#import "SFUserAccount+Internal.h"
 #import "SFUserAccountManager.h"
 #import "SFUserAccountIdentity.h"
 #import "SFUserAccountManagerUpgrade.h"
@@ -449,6 +449,12 @@ static Class InstanceClass = nil;
         [self log:SFLogLevelDebug msg:@"logoutUser: user is anonymous.  No action taken."];
         return;
     }
+    
+    if (user.isUserLoggingOut) {
+        [self log:SFLogLevelInfo msg:@"logoutUser: user is already in the process of logout."];
+        return;
+    }
+    user.userLoggingOut = YES;
     [self log:SFLogLevelInfo format:@"Logging out user '%@'.", user.userName];
     NSDictionary *userInfo = @{ @"account": user };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserWillLogoutNotification
@@ -469,33 +475,32 @@ static Class InstanceClass = nil;
         [[SFPushNotificationManager sharedInstance] unregisterSalesforceNotifications:user];
         [userAccountManager deleteAccountForUser:user error:nil];
         [self revokeRefreshToken:user];
-        return;
-    }
-    
-    // Otherwise, the current user is being logged out.  Supply the user account to the
-    // "Will Logout" notification before the credentials are revoked.  This will ensure
-    // that databases and other resources keyed off of the userID can be destroyed/cleaned up.
-    if ([SFPushNotificationManager sharedInstance].deviceSalesforceId) {
-        [[SFPushNotificationManager sharedInstance] unregisterSalesforceNotifications];
-    }
-    
-    [self cancelAuthentication];
-    [self clearAccountState:YES];
-    
-    [self willChangeValueForKey:@"haveValidSession"];
-    [userAccountManager deleteAccountForUser:user error:nil];
-    [userAccountManager saveAccounts:nil];
-    [self revokeRefreshToken:user];
-    userAccountManager.currentUser = nil;
-    [self didChangeValueForKey:@"haveValidSession"];
-    
-    NSNotification *logoutNotification = [NSNotification notificationWithName:kSFUserLogoutNotification object:self];
-    [[NSNotificationCenter defaultCenter] postNotification:logoutNotification];
-    [self enumerateDelegates:^(id<SFAuthenticationManagerDelegate> delegate) {
-        if ([delegate respondsToSelector:@selector(authManagerDidLogout:)]) {
-            [delegate authManagerDidLogout:weakSelf];
+    } else{
+        // Otherwise, the current user is being logged out.  Supply the user account to the
+        // "Will Logout" notification before the credentials are revoked.  This will ensure
+        // that databases and other resources keyed off of the userID can be destroyed/cleaned up.
+        if ([SFPushNotificationManager sharedInstance].deviceSalesforceId) {
+            [[SFPushNotificationManager sharedInstance] unregisterSalesforceNotifications];
         }
-    }];
+        [self cancelAuthentication];
+        [self clearAccountState:YES];
+        
+        [self willChangeValueForKey:@"haveValidSession"];
+        [userAccountManager deleteAccountForUser:user error:nil];
+        [userAccountManager saveAccounts:nil];
+        [self revokeRefreshToken:user];
+        userAccountManager.currentUser = nil;
+        [self didChangeValueForKey:@"haveValidSession"];
+        
+        NSNotification *logoutNotification = [NSNotification notificationWithName:kSFUserLogoutNotification object:self];
+        [[NSNotificationCenter defaultCenter] postNotification:logoutNotification];
+        [self enumerateDelegates:^(id<SFAuthenticationManagerDelegate> delegate) {
+            if ([delegate respondsToSelector:@selector(authManagerDidLogout:)]) {
+                [delegate authManagerDidLogout:weakSelf];
+            }
+        }];
+    }
+    user.userLoggingOut = NO;
 }
 
 - (void)cancelAuthentication

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount+Internal.h
@@ -31,5 +31,6 @@ static NSString * const SFUserAccountManagerTemporaryUserAccountOrgId = @"TEMP_O
 @interface SFUserAccount ()
 
 @property (nonatomic, readwrite, getter = isUserDeleted) BOOL userDeleted;
+@property (nonatomic, readwrite, getter = isUserLoggingOut) BOOL userLoggingOut;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
@@ -109,6 +109,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly, getter = isUserDeleted) BOOL userDeleted;
 
+/** Indicates if this user is being logged out.  Returns `YES` if this user is being logged out.
+ */
+@property (nonatomic, readonly, getter = isUserLoggingOut) BOOL userLoggingOut;
+
 /** Returns YES if the user is a temporary user.
  Note: a temporary user is created when a new user
  is requested, for example during the login into


### PR DESCRIPTION
If multiple threads enter `logoutUser:` with the same user, this should ensure that the logout logic is only processed once.

@trooper2013 @bhariharan I formed this up so that, when merged with the user account management PR, you should just be able to accept your version of the files.  I think it's totally compatible with the changes there, but let me know if you see any disparities.  Attn: @sgoldberg-sfdc 