### PR TITLE
Adding the ability to plug in NSURLSessionConfiguration to be used

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Queue/CSFNetwork.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Queue/CSFNetwork.h
@@ -124,6 +124,14 @@
 - (NSArray*)actionsWithContext:(id)context;
 
 /**
+ * Sets a session configuration to be used for network requests in the Network SDK.
+ *
+ * @param sessionConfig Session configuration to be used.
+ * @param isBackgroundSession YES - if it is a background session configuration, NO - otherwise.
+ */
+- (void)setSessionConfiguration:(NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession;
+
+/**
  Cross-site Request Forgery (CSRF) token provided in each server response and required for all Push API
  requests that change state (i.e. POST).
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Queue/CSFNetwork.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Queue/CSFNetwork.m
@@ -186,6 +186,14 @@ static NSMutableDictionary *SharedInstances = nil;
     [[SFAuthenticationManager sharedManager] removeDelegate:self];
 }
 
+- (void)setSessionConfiguration:(NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession {
+    if (isBackgroundSession) {
+        self.backgroundSession = [NSURLSession sessionWithConfiguration:sessionConfig];
+    } else {
+        self.ephemeralSession = [NSURLSession sessionWithConfiguration:sessionConfig delegate:self delegateQueue:nil];
+    }
+}
+
 - (void)setAccount:(SFUserAccount *)account {
     if (_account != account) {
         _account = account;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.h
@@ -51,4 +51,12 @@ typedef void (^SFDataResponseBlock) (NSData * _Nullable data, NSURLResponse * _N
  */
 - (nonnull NSURLSession *)activeSession;
 
+/**
+ * Sets a session configuration to be used for network requests in the Mobile SDK.
+ *
+ * @param sessionConfig Session configuration to be used.
+ * @param isBackgroundSession YES - if it is a background session configuration, NO - otherwise.
+ */
+- (void)setSessionConfiguration:(nonnull NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession;
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
@@ -63,4 +63,12 @@
     return (self.useBackground ? self.backgroundSession : self.ephemeralSession);
 }
 
+- (void)setSessionConfiguration:(NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession {
+    if (isBackgroundSession) {
+        self.backgroundSession = [NSURLSession sessionWithConfiguration:sessionConfig];
+    } else {
+        self.ephemeralSession = [NSURLSession sessionWithConfiguration:sessionConfig delegate:self delegateQueue:nil];
+    }
+}
+
 @end


### PR DESCRIPTION
This adds the ability to plug in an `NSURLSessionConfiguration` instance to be used for `Mobile SDK` requests by the app, such as one obtained from `TwinPrime`.