### PR TITLE
Warnings - Inconsistent prototype/implementation

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.h
@@ -44,7 +44,7 @@
  @param context Dictionary of relevant information about the request and the action that performed it.
  @return Initialized model object.
  */
-- (instancetype)initWithJSON:(NSDictionary*)json context:(NSDictionary*)context NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithJSON:(id)json context:(NSDictionary*)context NS_DESIGNATED_INITIALIZER;
 
 /** Returns a boolean value that indicates whether a given model object is equal to the receiver.
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Protocols/CSFActionModel.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Protocols/CSFActionModel.h
@@ -41,6 +41,6 @@
  @param context Dictionary of relevant information about the request and the action that performed it.
  @return Initialized model object.
  */
-- (id)initWithJSON:(NSDictionary*)json context:(NSDictionary*)context;
+- (id)initWithJSON:(id)json context:(NSDictionary*)context;
 
 @end


### PR DESCRIPTION
-  The implementation of some of the initWithJSON methods accept either NSArray or NSDictionary
-  The header reflected only NSDictionary leading to compile warnings