### PR TITLE
The "+" bar button on "Choose Connection" view is colored wrong.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -134,7 +134,7 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
     SFManagedPreferences *managedPreferences = [SFManagedPreferences sharedPreferences];
     if (!(managedPreferences.hasManagedPreferences && managedPreferences.onlyShowAuthorizedHosts)) {
         self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd target:self action:@selector(showAddLoginHost:)];
-        [self.navigationItem.rightBarButtonItem setTintColor:[UIColor whiteColor]];
+        [self.navigationItem.rightBarButtonItem setTintColor:[SFLoginViewController sharedInstance].navBarTextColor]];
     }
     self.title = [SFSDKResourceUtils localizedString:@"LOGIN_CHOOSE_SERVER"];
     self.navigationItem.backBarButtonItem = [[UIBarButtonItem alloc]


### PR DESCRIPTION
The tintColor for the "+" right bar button item on the "Choose Connection" view is always themed as White.
Thus it is barely visible when the Nav Bar color is a light color (like Yellow for instance).

This fix set the tint color to the "navBarTextColor" public property on SFLoginViewController, which is what the titleView text is colored and the <- (back arrow) is colored.

![002708aa-1947-11e7-851d-668553c0c82f](https://cloud.githubusercontent.com/assets/9701042/24719561/075b782e-19ef-11e7-99ea-5fada410de91.png)
