### PR TITLE
More granular management of login state

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -429,11 +429,11 @@ static Class InstanceClass = nil;
         return;
     }
 
-    if (user.isUserLoggingOut) {
-        [self log:SFLogLevelInfo msg:@"logoutUser: user is already in the process of logout."];
+    if (user.loginState != SFUserAccountLoginStateLoggedIn) {
+        [self log:SFLogLevelInfo format:@"%@ User login state is not logged in (%d). No action taken.", NSStringFromSelector(_cmd), user.loginState];
         return;
     }
-    user.userLoggingOut = YES;
+    user.loginState = SFUserAccountLoginStateLoggingOut;
     [self log:SFLogLevelInfo format:@"Logging out user '%@'.", user.userName];
     NSDictionary *userInfo = @{ @"account": user };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserWillLogoutNotification
@@ -477,7 +477,7 @@ static Class InstanceClass = nil;
             }
         }];
     }
-    user.userLoggingOut = NO;
+    user.loginState = SFUserAccountLoginStateNotLoggedIn;
 }
 
 - (void)cancelAuthentication
@@ -742,6 +742,7 @@ static Class InstanceClass = nil;
     // current user as the proper credentials.
     SFUserAccount *user = [[SFUserAccountManager sharedInstance] applyCredentials:self.coordinator.credentials
                                                                        withIdData:self.idCoordinator.idData];
+    user.loginState = SFUserAccountLoginStateLoggedIn;
  
     // Notify the session is ready
     [self willChangeValueForKey:@"haveValidSession"];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -429,13 +429,12 @@ static Class InstanceClass = nil;
         return;
     }
 
-    @synchronized (user) {
-        if (user.loginState != SFUserAccountLoginStateLoggedIn) {
-            [self log:SFLogLevelInfo format:@"%@ User login state is not logged in (%d). No action taken.", NSStringFromSelector(_cmd), user.loginState];
-            return;
-        }
-        user.loginState = SFUserAccountLoginStateLoggingOut;
+    BOOL loggingOutTransitionSucceeded = [user transitionToLoginState:SFUserAccountLoginStateLoggingOut];
+    if (!loggingOutTransitionSucceeded) {
+        // SFUserAccount already logs the transition failure.
+        return;
     }
+    
     [self log:SFLogLevelInfo format:@"Logging out user '%@'.", user.userName];
     NSDictionary *userInfo = @{ @"account": user };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserWillLogoutNotification
@@ -479,7 +478,9 @@ static Class InstanceClass = nil;
             }
         }];
     }
-    user.loginState = SFUserAccountLoginStateNotLoggedIn;
+    // NB: There's no real action that can be taken if this login state transition fails.  At any rate,
+    // it's an unlikely scenario.
+    [user transitionToLoginState:SFUserAccountLoginStateNotLoggedIn];
 }
 
 - (void)cancelAuthentication
@@ -744,20 +745,25 @@ static Class InstanceClass = nil;
     // current user as the proper credentials.
     SFUserAccount *user = [[SFUserAccountManager sharedInstance] applyCredentials:self.coordinator.credentials
                                                                        withIdData:self.idCoordinator.idData];
-    user.loginState = SFUserAccountLoginStateLoggedIn;
- 
-    // Notify the session is ready
-    [self willChangeValueForKey:@"haveValidSession"];
-    [self didChangeValueForKey:@"haveValidSession"];
-    NSDictionary *userInfo = nil;
-    if (user) {
-        userInfo = @{ @"account" : user };
+    BOOL loginStateTransitionSucceeded = [user transitionToLoginState:SFUserAccountLoginStateLoggedIn];
+    if (!loginStateTransitionSucceeded) {
+        // We're in an unlikely, but nevertheless bad, state.  Fail this authentication.
+        [self log:SFLogLevelError format:@"%@: Unable to transition user to a logged in state.  Login failed.", NSStringFromSelector(_cmd)];
+        [self execFailureBlocks];
+    } else {
+        // Notify the session is ready
+        [self willChangeValueForKey:@"haveValidSession"];
+        [self didChangeValueForKey:@"haveValidSession"];
+        NSDictionary *userInfo = nil;
+        if (user) {
+            userInfo = @{ @"account" : user };
+        }
+        [self initAnalyticsManager];
+        [[NSNotificationCenter defaultCenter] postNotificationName:kSFAuthenticationManagerFinishedNotification
+                                                            object:self
+                                                          userInfo:userInfo];
+        [self execCompletionBlocksWithUser:user];
     }
-    [self initAnalyticsManager];
-    [[NSNotificationCenter defaultCenter] postNotificationName:kSFAuthenticationManagerFinishedNotification
-                                                        object:self
-                                                      userInfo:userInfo];
-    [self execCompletionBlocksWithUser:user];
 }
 
 - (void)initAnalyticsManager

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -429,11 +429,13 @@ static Class InstanceClass = nil;
         return;
     }
 
-    if (user.loginState != SFUserAccountLoginStateLoggedIn) {
-        [self log:SFLogLevelInfo format:@"%@ User login state is not logged in (%d). No action taken.", NSStringFromSelector(_cmd), user.loginState];
-        return;
+    @synchronized (user) {
+        if (user.loginState != SFUserAccountLoginStateLoggedIn) {
+            [self log:SFLogLevelInfo format:@"%@ User login state is not logged in (%d). No action taken.", NSStringFromSelector(_cmd), user.loginState];
+            return;
+        }
+        user.loginState = SFUserAccountLoginStateLoggingOut;
     }
-    user.loginState = SFUserAccountLoginStateLoggingOut;
     [self log:SFLogLevelInfo format:@"Logging out user '%@'.", user.userName];
     NSDictionary *userInfo = @{ @"account": user };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserWillLogoutNotification

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount+Internal.h
@@ -30,4 +30,15 @@
 @property (nonatomic, readwrite, getter = isUserDeleted) BOOL userDeleted;
 @property (nonatomic, readwrite, assign) SFUserAccountLoginState loginState;
 
+/*!
+ * @method transitionToLoginState:
+ * @abstract Attempts to transition from the current login state to the new login state.
+ * @discussion Only certain state transitions are allowed.  For example, you cannot transition
+ * from `SFUserAccountLoginStateNotLoggedIn` to `SFUserAccountLoginStateNotLoggingOut`, but
+ * you can transition from `SFUserAccountLoginStateNotLoggedIn` to `SFUserAccountLoginStateLoggedIn`.
+ * @param newLoginState The new login state to set.
+ * @return YES if the login state change was successful, NO otherwise.
+ */
+- (BOOL)transitionToLoginState:(SFUserAccountLoginState)newLoginState;
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount+Internal.h
@@ -28,6 +28,6 @@
 @interface SFUserAccount ()
 
 @property (nonatomic, readwrite, getter = isUserDeleted) BOOL userDeleted;
-@property (nonatomic, readwrite, getter = isUserLoggingOut) BOOL userLoggingOut;
+@property (nonatomic, readwrite, assign) SFUserAccountLoginState loginState;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
@@ -33,6 +33,26 @@ NS_ASSUME_NONNULL_BEGIN
 @class SFIdentityData;
 @class SFOAuthCredentials;
 
+/**
+ Enumeration of the potential login states of the user account.
+ */
+typedef NS_ENUM(NSUInteger, SFUserAccountLoginState) {
+    /**
+     User account is not logged in.
+     */
+    SFUserAccountLoginStateNotLoggedIn = 0,
+    
+    /**
+     User account is logged in.
+     */
+    SFUserAccountLoginStateLoggedIn,
+    
+    /**
+     User account is in the process of logging out.
+     */
+    SFUserAccountLoginStateLoggingOut,
+};
+
 /** Class that represents an `account`. An `account` represents
  a user together with the current community it is logged in.
  */
@@ -106,9 +126,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, getter = isUserDeleted) BOOL userDeleted;
 
 
-/** Indicates if this user is being logged out.  Returns `YES` if this user is being logged out.
+/** Indicates this user's current login state.
  */
-@property (nonatomic, readonly, getter = isUserLoggingOut) BOOL userLoggingOut;
+@property (nonatomic, readonly, assign) SFUserAccountLoginState loginState;
 
 /** Initialize with SFOAuthCredentials credentials
  @param credentials The credentials to link with the SFUserAccount.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
@@ -281,6 +281,31 @@ static NSString * const kGlobalScopingKey = @"-global-";
     return object;
 }
 
+- (BOOL)transitionToLoginState:(SFUserAccountLoginState)newLoginState {
+    __block BOOL transitionSucceeded;
+    dispatch_sync(_syncQueue, ^{
+        switch (newLoginState) {
+            case SFUserAccountLoginStateLoggedIn:
+                transitionSucceeded = (self.loginState == SFUserAccountLoginStateNotLoggedIn || self.loginState == SFUserAccountLoginStateLoggedIn);
+                break;
+            case SFUserAccountLoginStateNotLoggedIn:
+                transitionSucceeded = (self.loginState == SFUserAccountLoginStateNotLoggedIn || self.loginState == SFUserAccountLoginStateLoggingOut);
+                break;
+            case SFUserAccountLoginStateLoggingOut:
+                transitionSucceeded = (self.loginState == SFUserAccountLoginStateLoggedIn);
+                break;
+            default:
+                transitionSucceeded = NO;
+        }
+        if (transitionSucceeded) {
+            self.loginState = newLoginState;
+        } else {
+            [self log:SFLogLevelWarning format:@"%@ Invalid login state transition from '%@' to '%@'. No action taken.", NSStringFromSelector(_cmd), [[self class] loginStateDescriptionFromLoginState:self.loginState], [[self class] loginStateDescriptionFromLoginState:newLoginState]];
+        }
+    });
+    return transitionSucceeded;
+}
+
 - (BOOL)isSessionValid {
 
     // A session is considered "valid" when the user
@@ -302,6 +327,19 @@ static NSString * const kGlobalScopingKey = @"-global-";
     NSString * s = [NSString stringWithFormat:@"<SFUserAccount username=%@ fullName=%@ accessScopes=%@ credentials=%@, community=%@>",
                     theUserName, theFullName, self.accessScopes, self.credentials, self.communityId];
     return s;
+}
+
++ (NSString *)loginStateDescriptionFromLoginState:(SFUserAccountLoginState)loginState {
+    switch (loginState) {
+        case SFUserAccountLoginStateLoggedIn:
+            return @"SFUserAccountLoginStateLoggedIn";
+        case SFUserAccountLoginStateLoggingOut:
+            return @"SFUserAccountLoginStateLoggingOut";
+        case SFUserAccountLoginStateNotLoggedIn:
+            return @"SFUserAccountLoginStateNotLoggedIn";
+        default:
+            return [NSString stringWithFormat:@"Unknown login state (code: %lu)", (unsigned long)loginState];
+    }
 }
 
 NSString *SFKeyForUserAndScope(SFUserAccount *user, SFUserAccountScope scope) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
@@ -84,7 +84,8 @@ static NSString * const kGlobalScopingKey = @"-global-";
     self = [super init];
     if (self) {
         _observingCredentials = NO;
-        self.credentials = credentials;
+        _credentials = credentials;
+        _loginState = (credentials.refreshToken.length > 0 ? SFUserAccountLoginStateLoggedIn : SFUserAccountLoginStateNotLoggedIn);
         _syncQueue = dispatch_queue_create(kSyncQueue, NULL);
     }
     return self;
@@ -131,6 +132,7 @@ static NSString * const kGlobalScopingKey = @"-global-";
         _communities      = [decoder decodeObjectOfClass:[NSArray class] forKey:kUser_COMMUNITIES];
         _customData       = [[decoder decodeObjectOfClass:[NSDictionary class] forKey:kUser_CUSTOM_DATA] mutableCopy];
         _accessRestrictions = [decoder decodeIntegerForKey:kUser_ACCESS_RESTRICTIONS];
+        _loginState = (_credentials.refreshToken.length > 0 ? SFUserAccountLoginStateLoggedIn : SFUserAccountLoginStateNotLoggedIn);
         _syncQueue = dispatch_queue_create(kSyncQueue, NULL);
 	}
 	return self;


### PR DESCRIPTION
The current implementation provides a pretty small "exclusive" window for not allowing multiple logouts.  Realistically, logout of a user shouldn't be allowed until that account has made it back into a logged in state.

Cc: @sgoldberg-sfdc 