### PR TITLE
Cookie handling for WKWebView

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -470,16 +470,28 @@ extern  NSString * const kOAuthRedirectUriKey;
 + (BOOL)errorIsInvalidAuthCredentials:(NSError *)error;
 
 /**
- Remove any cookies with the given names from the given domains.
- @param cookieNames The names of the cookies to remove.
+ Remove all cookies for the given domains. Fire and Forget.
  @param domainNames The names of the domains where the cookies are set.
  */
-+ (void)removeCookies:(NSArray<NSString*> *)cookieNames fromDomains:(NSArray<NSString*> *)domainNames;
++ (void)removeCookiesFromDomains:(NSArray<NSString*> *)domainNames;
+
+/**
+ Remove all cookies for the given domains. Call completion block when done.
+ @param domainNames The names of the domains where the cookies are set.
+ @param completionBlock Block invoked when cookies are removed
+ */
++ (void)removeCookiesFromDomains:(NSArray<NSString*> *)domainNames withCompletion:(nullable void(^)())completionBlock;
+
+/**
+ Remove all cookies from the cookie store. Fire and forget.
+ */
++ (void)removeAllCookies;
 
 /**
  Remove all cookies from the cookie store.
+ @param completionBlock Block invoked when cookies are removed
  */
-+ (void)removeAllCookies;
++ (void)removeAllCookiesWithCompletion:(nullable void(^)())completionBlock;
 
 /**
  Adds the access (session) token cookie to the web view, for authentication.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -470,22 +470,11 @@ extern  NSString * const kOAuthRedirectUriKey;
 + (BOOL)errorIsInvalidAuthCredentials:(NSError *)error;
 
 /**
- Remove all cookies for the given domains. Fire and Forget.
- @param domainNames The names of the domains where the cookies are set.
- */
-+ (void)removeCookiesFromDomains:(NSArray<NSString*> *)domainNames;
-
-/**
  Remove all cookies for the given domains. Call completion block when done.
  @param domainNames The names of the domains where the cookies are set.
  @param completionBlock Block invoked when cookies are removed
  */
 + (void)removeCookiesFromDomains:(NSArray<NSString*> *)domainNames withCompletion:(nullable void(^)())completionBlock;
-
-/**
- Remove all cookies from the cookie store. Fire and forget.
- */
-+ (void)removeAllCookies;
 
 /**
  Remove all cookies from the cookie store.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -632,13 +632,10 @@ static Class InstanceClass = nil;
 
 + (void)resetSessionCookie
 {
-    [self removeCookiesFromDomains:@[@".salesforce.com", @".force.com", @".cloudforce.com"]];
-    [self addSidCookieForInstance];
-}
-
-+ (void)removeCookiesFromDomains:(NSArray *)domainNames
-{
-    [self removeCookiesFromDomains:domainNames withCompletion:nil];
+    __weak typeof(self) weakSelf = self;
+    [self removeCookiesFromDomains:@[@".salesforce.com", @".force.com", @".cloudforce.com"] withCompletion:^{
+        [weakSelf addSidCookieForInstance];
+    }];
 }
 
 + (void)removeCookiesFromDomains:(NSArray *)domainNames withCompletion:(nullable void(^)())completionBlock {
@@ -646,13 +643,12 @@ static Class InstanceClass = nil;
     WKWebsiteDataStore *dateStore = [WKWebsiteDataStore defaultDataStore];
     NSSet *websiteDataTypes = [NSSet setWithArray:@[ WKWebsiteDataTypeCookies]];
     [dateStore fetchDataRecordsOfTypes:websiteDataTypes
-                     completionHandler:^(NSArray<WKWebsiteDataRecord *> * __nonnull records) {
+                     completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
                          
                          NSMutableArray<WKWebsiteDataRecord *> *deletedRecords = [NSMutableArray new];
-                         
                          for ( WKWebsiteDataRecord * record in records) {
                              for(NSString *domainName in domainNames) {
-                                 if ([record.displayName hasSuffix:domainName] || [record.displayName hasSuffix:[domainName substringFromIndex:1]]) {
+                                 if ([record.displayName containsString:domainName]) {
                                      [deletedRecords addObject:record];
                                  }
                              }
@@ -666,11 +662,6 @@ static Class InstanceClass = nil;
                                                                    }];
                      }];
 
-}
-
-+ (void)removeAllCookies
-{
-    [self removeAllCookiesWithCompletion:nil];
 }
 
 + (void)removeAllCookiesWithCompletion:(void(^)())completionBlock

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -454,6 +454,11 @@ static Class InstanceClass = nil;
         [[SFPushNotificationManager sharedInstance] unregisterSalesforceNotifications:user];
         [userAccountManager deleteAccountForUser:user error:nil];
         [self revokeRefreshToken:user];
+        
+        // NB: There's no real action that can be taken if this login state transition fails.  At any rate,
+        // it's an unlikely scenario.
+        [user transitionToLoginState:SFUserAccountLoginStateNotLoggedIn];
+
     }else {
         // Otherwise, the current user is being logged out.  Supply the user account to the
         // "Will Logout" notification before the credentials are revoked.  This will ensure
@@ -462,25 +467,28 @@ static Class InstanceClass = nil;
             [[SFPushNotificationManager sharedInstance] unregisterSalesforceNotifications];
         }
         [self cancelAuthentication];
-        [self clearAccountState:YES];
-
-        [self willChangeValueForKey:@"haveValidSession"];
-        [userAccountManager deleteAccountForUser:user error:nil];
-        [self revokeRefreshToken:user];
-        userAccountManager.currentUser = nil;
-        [self didChangeValueForKey:@"haveValidSession"];
-
-        NSNotification *logoutNotification = [NSNotification notificationWithName:kSFUserLogoutNotification object:self];
-        [[NSNotificationCenter defaultCenter] postNotification:logoutNotification];
-        [self enumerateDelegates:^(id<SFAuthenticationManagerDelegate> delegate) {
-            if ([delegate respondsToSelector:@selector(authManagerDidLogout:)]) {
-                [delegate authManagerDidLogout:weakSelf];
-            }
+        __weak typeof (self) weakSelf = self;
+        [self clearAccountState:YES withCompletion:^{
+            __weak typeof (weakSelf) strongSelf = weakSelf;
+            [strongSelf willChangeValueForKey:@"haveValidSession"];
+            [userAccountManager deleteAccountForUser:user error:nil];
+            [strongSelf revokeRefreshToken:user];
+            userAccountManager.currentUser = nil;
+            [strongSelf didChangeValueForKey:@"haveValidSession"];
+            
+            NSNotification *logoutNotification = [NSNotification notificationWithName:kSFUserLogoutNotification object:strongSelf];
+            [[NSNotificationCenter defaultCenter] postNotification:logoutNotification];
+            [strongSelf enumerateDelegates:^(id<SFAuthenticationManagerDelegate> delegate) {
+                if ([delegate respondsToSelector:@selector(authManagerDidLogout:)]) {
+                    [delegate authManagerDidLogout:strongSelf];
+                }
+            }];
+            // NB: There's no real action that can be taken if this login state transition fails.  At any rate,
+            // it's an unlikely scenario.
+            [user transitionToLoginState:SFUserAccountLoginStateNotLoggedIn];
         }];
+
     }
-    // NB: There's no real action that can be taken if this login state transition fails.  At any rate,
-    // it's an unlikely scenario.
-    [user transitionToLoginState:SFUserAccountLoginStateNotLoggedIn];
 }
 
 - (void)cancelAuthentication
@@ -624,39 +632,58 @@ static Class InstanceClass = nil;
 
 + (void)resetSessionCookie
 {
-    [self removeCookies:@[@"sid"]
-            fromDomains:@[@".salesforce.com", @".force.com", @".cloudforce.com"]];
+    [self removeCookiesFromDomains:@[@".salesforce.com", @".force.com", @".cloudforce.com"]];
     [self addSidCookieForInstance];
 }
 
-+ (void)removeCookies:(NSArray *)cookieNames fromDomains:(NSArray *)domainNames
++ (void)removeCookiesFromDomains:(NSArray *)domainNames
 {
-    NSAssert(cookieNames != nil && [cookieNames count] > 0, @"No cookie names given to delete.");
+    [self removeCookiesFromDomains:domainNames withCompletion:nil];
+}
+
++ (void)removeCookiesFromDomains:(NSArray *)domainNames withCompletion:(nullable void(^)())completionBlock {
     NSAssert(domainNames != nil && [domainNames count] > 0, @"No domain names given for deleting cookies.");
-    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    NSArray *fullCookieList = [NSArray arrayWithArray:[cookieStorage cookies]];
-    for (NSHTTPCookie *cookie in fullCookieList) {
-        for (NSString *cookieToRemoveName in cookieNames) {
-            if ([[cookie.name lowercaseString] isEqualToString:[cookieToRemoveName lowercaseString]]) {
-                for (NSString *domainToRemoveName in domainNames) {
-                    if ([[cookie.domain lowercaseString] hasSuffix:[domainToRemoveName lowercaseString]]) {
-                        [cookieStorage deleteCookie:cookie];
-                    }
-                }
-            }
-        }
-    }
+    WKWebsiteDataStore *dateStore = [WKWebsiteDataStore defaultDataStore];
+    NSSet *websiteDataTypes = [NSSet setWithArray:@[ WKWebsiteDataTypeCookies]];
+    [dateStore fetchDataRecordsOfTypes:websiteDataTypes
+                     completionHandler:^(NSArray<WKWebsiteDataRecord *> * __nonnull records) {
+                         
+                         NSMutableArray<WKWebsiteDataRecord *> *deletedRecords = [NSMutableArray new];
+                         
+                         for ( WKWebsiteDataRecord * record in records) {
+                             for(NSString *domainName in domainNames) {
+                                 if ([record.displayName hasSuffix:domainName] || [record.displayName hasSuffix:[domainName substringFromIndex:1]]) {
+                                     [deletedRecords addObject:record];
+                                 }
+                             }
+                         }
+                         if (deletedRecords.count > 0)
+                            [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes
+                                                                      forDataRecords:deletedRecords
+                                                                   completionHandler:^{
+                                                                       if (completionBlock)
+                                                                           completionBlock();
+                                                                   }];
+                     }];
+
 }
 
 + (void)removeAllCookies
 {
-    NSHTTPCookieStorage *cookieStorage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
-    NSArray *fullCookieList = [NSArray arrayWithArray:[cookieStorage cookies]];
-    for (NSHTTPCookie *cookie in fullCookieList) {
-        if (![[cookie.name lowercaseString] isEqualToString:kUserNameCookieKey]) {
-            [cookieStorage deleteCookie:cookie];
-        }
-    }
+    [self removeAllCookiesWithCompletion:nil];
+}
+
++ (void)removeAllCookiesWithCompletion:(void(^)())completionBlock
+{
+    NSSet *websiteDataTypes = [NSSet setWithArray:@[WKWebsiteDataTypeCookies]];
+    NSDate *dateFrom = [NSDate dateWithTimeIntervalSince1970:0];
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:websiteDataTypes
+                                               modifiedSince:dateFrom
+                                           completionHandler:^{
+                                                if (completionBlock) {
+                                                    completionBlock();
+                                                }
+    }];
 }
 
 + (void)addSidCookieForInstance
@@ -912,6 +939,16 @@ static Class InstanceClass = nil;
  *        with the account.
  */
 - (void)clearAccountState:(BOOL)clearAccountData {
+    [self clearAccountState:clearAccountData withCompletion:nil];
+}
+
+/**
+ * Clears the account state of the given account (i.e. clears credentials, coordinator
+ * instances, etc.
+ * @param clearAccountData Whether to optionally revoke credentials and persisted data associated
+ *        with the account.
+ */
+- (void)clearAccountState:(BOOL)clearAccountData withCompletion:(void(^)())completion {
     if (![NSThread isMainThread]) {
         dispatch_sync(dispatch_get_main_queue(), ^{
             [self clearAccountState:clearAccountData];
@@ -927,11 +964,20 @@ static Class InstanceClass = nil;
         [self.coordinator.view removeFromSuperview];
     }
     
-    [SFAuthenticationManager removeAllCookies];
-    [self.coordinator stopAuthentication];
-
-    self.idCoordinator.idData = nil;
-    self.coordinator.credentials = nil;
+    __weak typeof(self) weakSelf = self;
+    [SFAuthenticationManager removeAllCookiesWithCompletion:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [strongSelf.coordinator stopAuthentication];
+            strongSelf.idCoordinator.idData = nil;
+            strongSelf.coordinator.credentials = nil;
+            if (completion) {
+                completion();
+            }
+        });
+        
+    }];
+    
 }
 
 - (void)cleanupStatusAlert


### PR DESCRIPTION
Switched to using WKWebsiteDataStore for handling cookies. WKWebview has gaping holes in functionality related to cookie handling, hence the SFAuthenticationManager  was reworked to handle cookie deletion successfully. Problems have been noticed by consumers of SDK in use with their custom SSO pages, where Logout completed but the cookie deletion was either incomplete or out of sync with the WKWebView.