### PR TITLE
Shared WKProcessPool instance on SalesforceSDKManager

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -339,7 +339,9 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
         self.errorPageUIWebView.delegate = self;
         [self.view addSubview:self.errorPageUIWebView];
     } else {
-        self.errorPageWKWebView = [[WKWebView alloc] initWithFrame:self.view.frame];
+        WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+        config.processPool = [SalesforceSDKManager sharedManager].processPool;
+        self.errorPageWKWebView = [[WKWebView alloc] initWithFrame:self.view.frame configuration:config];
         self.errorPageWKWebView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
         self.errorPageWKWebView.navigationDelegate = self;
         [self.view addSubview:self.errorPageWKWebView];
@@ -824,7 +826,9 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
             self.vfPingPageHiddenUIWebView.delegate = self;
             [self.vfPingPageHiddenUIWebView loadRequest:pingRequest];
         } else {
-            self.vfPingPageHiddenWKWebView = [[WKWebView alloc] initWithFrame:CGRectZero];
+            WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+            config.processPool = [SalesforceSDKManager sharedManager].processPool;
+            self.vfPingPageHiddenWKWebView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:config];
             self.vfPingPageHiddenWKWebView.navigationDelegate = self;
             [self.vfPingPageHiddenWKWebView loadRequest:pingRequest];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -232,6 +232,13 @@ typedef void (^SFSnapshotViewControllerDismissalBlock)(UIViewController* snapsho
 @property (nonatomic, copy) SFSDKUserAgentCreationBlock userAgentString;
 
 /**
+ + Gets or sets an instance of WKProcessPool that will be used during instantiation of any WKWebView instances
+ + @discussion
+ + Use the default instance or provide an instance to share state between WKWebView instances
+ + */
+@property (nonatomic, strong) WKProcessPool *processPool;
+
+/**
  Launches the SDK.  This will verify an existing passcode the first time it runs, and attempt to
  authenticate if the current user is not already authenticated.  @see postLaunchAction, launchErrorAction,
  postLogoutAction, and switchUserAction for callbacks that can be set for handling post launch

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -160,6 +160,7 @@ static NSString* ailtnAppName = nil;
         self.useSnapshotView = YES;
         self.authenticateAtLaunch = YES;
         self.userAgentString = [self defaultUserAgentString];
+        self.processPool = [[WKProcessPool alloc] init];
     }
     return self;
 }
@@ -213,6 +214,13 @@ static NSString* ailtnAppName = nil;
 - (void)setPreferredPasscodeProvider:(NSString *)preferredPasscodeProvider
 {
     [SFPasscodeManager sharedManager].preferredPasscodeProvider = preferredPasscodeProvider;
+}
+
+- (void)setProcessPool:(WKProcessPool *)processPool
+{
+    if (_processPool == processPool) return;
+
+    _processPool = processPool ?: [[WKProcessPool alloc] init];
 }
 
 - (BOOL)launch

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -39,6 +39,7 @@
 #import "SFSDKLoginHost.h"
 #import "SFSDKEventBuilderHelper.h"
 #import "SFSDKAppFeatureMarkers.h"
+#import "SalesforceSDKManager.h"
 
 // Public constants
 
@@ -343,7 +344,9 @@ static NSString * const kSFAppFeatureSafariBrowserForLogin   = @"BW";
 
 - (WKWebView *)view {
     if (_view == nil) {
-        _view = [[WKWebView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+        WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+        config.processPool = [SalesforceSDKManager sharedManager].processPool;
+        _view = [[WKWebView alloc] initWithFrame:[[UIScreen mainScreen] bounds] configuration:config];
         _view.navigationDelegate = self;
         _view.UIDelegate = self;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
@@ -368,6 +368,31 @@ static NSString* const kTestAppName = @"OverridenAppName";
     XCTAssertEqual(customSnapshot, snapshotOnDismissal, @"Custom snapshot view controller was not used on dismissal!");
 }
 
+#pragma mark - Process Pool Tests
+
+- (void)testDefaultProcessPoolIsNotNil
+{
+    SalesforceSDKManager *manager = [SalesforceSDKManager sharedManager];
+    XCTAssertNotNil(manager.processPool);
+}
+
+- (void)testProcessPoolCannotBeNil
+{
+    SalesforceSDKManager *manager = [SalesforceSDKManager sharedManager];
+    XCTAssertNotNil(manager.processPool);
+    manager.processPool = nil;
+    XCTAssertNotNil(manager.processPool);
+}
+
+- (void)testProcessPoolIsAssignable
+{
+    SalesforceSDKManager *manager = [SalesforceSDKManager sharedManager];
+    WKProcessPool *newPool = [[WKProcessPool alloc] init];
+    manager.processPool = newPool;
+    XCTAssertEqualObjects(newPool, manager.processPool);
+}
+
+
 #pragma mark - Private helpers
 
 - (void)createStandardPostLaunchBlock


### PR DESCRIPTION
@bhariharan @khawkins 

This exposes an instance of WKProcessPool on SalesforceSDKManager which can either be used or set by SDK consumers to share WKWebView state with between WKWebView instances. The shared instance is then used whenever the SDK instantiates a WKWebView.