### PR TITLE
Setting session config should be a class method

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.h
@@ -57,6 +57,6 @@ typedef void (^SFDataResponseBlock) (NSData * _Nullable data, NSURLResponse * _N
  * @param sessionConfig Session configuration to be used.
  * @param isBackgroundSession YES - if it is a background session configuration, NO - otherwise.
  */
-- (void)setSessionConfiguration:(nonnull NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession;
++ (void)setSessionConfiguration:(nonnull NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
@@ -38,11 +38,22 @@
 
 @implementation SFNetwork
 
+static NSURLSessionConfiguration *kSFEphemeralSessionConfig;
+static NSURLSessionConfiguration *kSFBackgroundSessionConfig;
+
 - (instancetype)init {
     self = [super init];
     if (self) {
-        self.ephemeralSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration] delegate:self delegateQueue:nil];
-        self.backgroundSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:@"com.salesforce.network"]
+        NSURLSessionConfiguration *ephemeralSessionConfig = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+        if (kSFEphemeralSessionConfig) {
+            ephemeralSessionConfig = kSFEphemeralSessionConfig;
+        }
+        self.ephemeralSession = [NSURLSession sessionWithConfiguration:ephemeralSessionConfig delegate:self delegateQueue:nil];
+        NSURLSessionConfiguration *backgroundSessionConfig = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:@"com.salesforce.network"];
+        if (kSFBackgroundSessionConfig) {
+            backgroundSessionConfig = kSFBackgroundSessionConfig;
+        }
+        self.backgroundSession = [NSURLSession sessionWithConfiguration:backgroundSessionConfig
             delegate:self delegateQueue:nil];
         self.useBackground = NO;
     }
@@ -63,11 +74,11 @@
     return (self.useBackground ? self.backgroundSession : self.ephemeralSession);
 }
 
-- (void)setSessionConfiguration:(NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession {
++ (void)setSessionConfiguration:(NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession {
     if (isBackgroundSession) {
-        self.backgroundSession = [NSURLSession sessionWithConfiguration:sessionConfig];
+        kSFBackgroundSessionConfig = sessionConfig;
     } else {
-        self.ephemeralSession = [NSURLSession sessionWithConfiguration:sessionConfig delegate:self delegateQueue:nil];
+        kSFEphemeralSessionConfig = sessionConfig;
     }
 }
 


### PR DESCRIPTION
Session configuration should be set once and used every time `SFNetwork` is instantiated, since `SFNetwork` has a new instance for every request.