### PR TITLE
CSFOutput Crashes if subclass has a non-encodable ivar

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.m
@@ -92,6 +92,7 @@ static NSString * const kCSFInputCustomArrayAttributes = @"__CSFOutput_Array_Sto
             
             Ivar ivar = class_getInstanceVariable(ivarInfo[@"class"], [ivarName UTF8String]);
             Class ivarClass = CSFClassFromEncoding(ivarInfo[@"encoding"]);
+            NSString * encoding = ivarInfo[@"encoding"];
             if (ivarClass) {
                 id result = [decoder decodeObjectOfClass:ivarClass forKey:propertyName];
                 if ([result isKindOfClass:[CSFOutput class]]) {
@@ -99,7 +100,7 @@ static NSString * const kCSFInputCustomArrayAttributes = @"__CSFOutput_Array_Sto
                     resultOutput.parentObject = self;
                 }
                 object_setIvar(self, ivar, result);
-            } else if (ivarInfo[@"encoding"]) {
+            } else if (encoding && ![encoding hasPrefix:@"@"]) {
                 const void * ivarPtr = (__bridge void*)(self) + ivar_getOffset(ivar);
                 [decoder decodeValueOfObjCType:[ivarInfo[@"encoding"] UTF8String] at:(void *)ivarPtr];
             }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.m
@@ -70,11 +70,10 @@ static NSString * const kCSFInputCustomArrayAttributes = @"__CSFOutput_Array_Sto
 
         Ivar ivar = class_getInstanceVariable(ivarInfo[@"class"], [ivarName UTF8String]);
         Class ivarClass = CSFClassFromEncoding(ivarInfo[@"encoding"]);
-        NSString * encoding = ivarInfo[@"encoding"];
         if (ivarClass) {
             id value = object_getIvar(self, ivar);
             [encoder encodeObject:value forKey:propertyName];
-        } else if (encoding) {
+        } else if (ivarInfo[@"encoding"]) {
             const void * ivarPtr = (__bridge void*)(self) + ivar_getOffset(ivar);
             [encoder encodeValueOfObjCType:[ivarInfo[@"encoding"] UTF8String] at:ivarPtr];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.m
@@ -74,7 +74,7 @@ static NSString * const kCSFInputCustomArrayAttributes = @"__CSFOutput_Array_Sto
         if (ivarClass) {
             id value = object_getIvar(self, ivar);
             [encoder encodeObject:value forKey:propertyName];
-        } else if (encoding && ![encoding hasPrefix:@"@"]) {
+        } else if (encoding) {
             const void * ivarPtr = (__bridge void*)(self) + ivar_getOffset(ivar);
             [encoder encodeValueOfObjCType:[ivarInfo[@"encoding"] UTF8String] at:ivarPtr];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.m
@@ -70,10 +70,11 @@ static NSString * const kCSFInputCustomArrayAttributes = @"__CSFOutput_Array_Sto
 
         Ivar ivar = class_getInstanceVariable(ivarInfo[@"class"], [ivarName UTF8String]);
         Class ivarClass = CSFClassFromEncoding(ivarInfo[@"encoding"]);
+        NSString * encoding = ivarInfo[@"encoding"];
         if (ivarClass) {
             id value = object_getIvar(self, ivar);
             [encoder encodeObject:value forKey:propertyName];
-        } else if (ivarInfo[@"encoding"]) {
+        } else if (encoding && ![encoding hasPrefix:@"@"]) {
             const void * ivarPtr = (__bridge void*)(self) + ivar_getOffset(ivar);
             [encoder encodeValueOfObjCType:[ivarInfo[@"encoding"] UTF8String] at:ivarPtr];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Utilities/CSFInternalDefines.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Utilities/CSFInternalDefines.m
@@ -76,8 +76,12 @@ CSFParameterStyle CSFRequiredParameterStyleForHTTPMethod(NSString *method) {
 Class CSFClassFromEncoding(NSString *encoding) {
     Class result = nil;
     if ([encoding hasPrefix:@"@"]) {
-        NSString *className = [[encoding substringFromIndex:2] stringByReplacingOccurrencesOfString:@"\"" withString:@""];
-        result = NSClassFromString(className);
+        if (encoding.length > 2) {
+            NSString *className = [[encoding substringFromIndex:2] stringByReplacingOccurrencesOfString:@"\"" withString:@""];
+            result = NSClassFromString(className);
+        } else {
+            result = [NSObject class];
+        }
     }
     return result;
 }


### PR DESCRIPTION
-  We needed to add some concurrency control to a subclass
-  I implemented a Multiple Reader/Single Writer pattern in order to achieve this goal
-  Unfortunately, the current implementation of CSFOutput assumes every ivar is serializable via NSCopying

I believe this patch will handle the situation where the encoding specifier is '@' signifying an Objective-C object, yet we could not obtain a class for it. This is the situation for OS_dispatch_queue.