### PR TITLE
Fixing bug with unknown response type

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -267,6 +267,9 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
             NSError *parsingError;
             NSDictionary *jsonDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:&parsingError];
             if (parsingError) {
+                if (data == nil || [data isEqualToData:[[NSData alloc] init]]) {
+                    data = nil;
+                }
                 [delegate request:request didLoadResponse:data];
             } else {
                 [delegate request:request didLoadResponse:jsonDict];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -267,7 +267,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
             NSError *parsingError;
             NSDictionary *jsonDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:&parsingError];
             if (parsingError) {
-                if (data == nil || [data isEqualToData:[[NSData alloc] init]]) {
+                if (data.length == 0) {
                     data = nil;
                 }
                 [delegate request:request didLoadResponse:data];


### PR DESCRIPTION
Sometimes we get a response that just contains `<>`.