### PR TITLE
Replacing Direct Usage of NSURLSession with SFNetwork

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -40,6 +40,7 @@
 #import "SFSDKEventBuilderHelper.h"
 #import "SFSDKAppFeatureMarkers.h"
 #import "SalesforceSDKManager.h"
+#import "SFNetwork.h"
 
 // Public constants
 
@@ -935,20 +936,20 @@ static NSString * const kSFAppFeatureSafariBrowserForLogin   = @"BW";
 
 - (NSURLSession*)session {
     if (_session == nil) {
-        _session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
+        SFNetwork *network = [[SFNetwork alloc] init];
+        _session = network.activeSession;
     }
     return _session;
 }
 
 #pragma mark - WKNavigationDelegate (User-Agent Token Flow)
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler {
-
     NSURL *url = navigationAction.request.URL;
     NSString *requestUrl = [url absoluteString];
     if ([self isRedirectURL:requestUrl]) {
         [self handleUserAgentResponse:url];
         decisionHandler(WKNavigationActionPolicyCancel);
-    }else {
+    } else {
         decisionHandler(WKNavigationActionPolicyAllow);
     }
 }
@@ -958,13 +959,10 @@ static NSString * const kSFAppFeatureSafariBrowserForLogin   = @"BW";
 }
 
 - (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation {
-
-    NSURL *url = [webView URL];  //.request.URL;
-
+    NSURL *url = [webView URL];
     if (self.credentials.logLevel < kSFOAuthLogLevelWarning) {
         [self log:SFLogLevelDebug format:@"%@ host=%@ : path=%@", NSStringFromSelector(_cmd), url.host, url.path];
     }
-
     if ([self.delegate respondsToSelector:@selector(oauthCoordinator:didStartLoad:)]) {
         [self.delegate oauthCoordinator:self didStartLoad:webView];
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -159,9 +159,11 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         // Sets HTTP method on the request.
         [self.request setHTTPMethod:[SFRestRequest httpMethodFromSFRestMethod:self.method]];
 
-        // Sets OAuth Bearer token header on the request.
-        NSString *bearer = [NSString stringWithFormat:@"Bearer %@", user.credentials.accessToken];
-        [self.request setValue:bearer forHTTPHeaderField:@"Authorization"];
+        // Sets OAuth Bearer token header on the request (if not already present).
+        if (self.request.allHTTPHeaderFields && self.request.allHTTPHeaderFields.allKeys && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"Authorization"]) {
+            NSString *bearer = [NSString stringWithFormat:@"Bearer %@", user.credentials.accessToken];
+            [self.request setValue:bearer forHTTPHeaderField:@"Authorization"];
+        }
 
         // Adds custom headers to the request if any are set.
         if (self.customHeaders) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -43,6 +43,7 @@
 #import "SFOAuthInfo.h"
 #import "SFLoginViewController.h"
 #import "SFOAuthCoordinator+Internal.h"
+#import "SFNetwork.h"
 
 static SFAuthenticationManager *sharedInstance = nil;
 
@@ -845,8 +846,8 @@ static Class InstanceClass = nil;
         NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
         [request setHTTPMethod:@"GET"];
         [request setHTTPShouldHandleCookies:NO];
-        NSURLSession* session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
-        [[session dataTaskWithRequest:request] resume];
+        SFNetwork *network = [[SFNetwork alloc] init];
+        [network sendRequest:request dataResponseBlock:nil];
     }
     [user.credentials revoke];
 }


### PR DESCRIPTION
This pull request replaces areas where we use `NSURLSession` directly with `SFNetwork`, such as auth flow and push notification registration/un-registration.