### PR TITLE
Removing Community Id handling in SFUserAccountManager

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
@@ -35,9 +35,6 @@
  */
 @property (nonatomic, strong, nonnull) NSMutableDictionary *userAccountMap;
 
-@property (nonatomic, strong, nullable) NSString *lastChangedOrgId;
-@property (nonatomic, strong, nullable) NSString *lastChangedUserId;
-@property (nonatomic, strong, nullable) NSString *lastChangedCommunityId;
 @property (nonatomic, strong, nullable) id<SFUserAccountPersister> accountPersister;
 /**
  Executes the given block for each configured delegate.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -145,16 +145,6 @@ FOUNDATION_EXTERN NSString * const kSFLoginHostChangedNotificationUpdatedHostKey
  */
 @property (readonly, nonatomic, nullable) SFUserAccountIdentity *currentUserIdentity;
 
-/**  Convenience property to retrieve the current user's communityId.
- This property is an alias for `currentUser.communityId`
- */
-@property (nonatomic, nullable) NSString *currentCommunityId;
-
-/** A convenience property to store the previous community
- id as it may change during early OAuth flow and we want to retain it
- */
-@property (nonatomic, strong, nullable) NSString *previousCommunityId;
-
 /** Shared singleton
  */
 + (instancetype)sharedInstance;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -452,7 +452,6 @@ static NSString * const kSFAppFeatureMultiUser   = @"MU";
                 currentAccount.communities = @[communityData];
             }
         }
-        [self setCurrentCommunityId:currentAccount.communityId];
     }
 
     [self saveAccountForUser:currentAccount error:nil];
@@ -613,19 +612,8 @@ static NSString * const kSFAppFeatureMultiUser   = @"MU";
     }];
 }
 
-#pragma mark -
-#pragma mark User Change Notifications
-- (BOOL)hasCommunityChanged {
-    // If the last changed communityID exists and is inequal or
-    // if there was no previous communityID and now there is
-    if ((self.lastChangedCommunityId && ![self.lastChangedCommunityId isEqualToString:self.currentUser.communityId])
-        || (!self.lastChangedCommunityId && self.currentUser.communityId)) {
-        return YES;
-    } else {
-        return NO;
-    }
-}
 
+#pragma mark - User Change Notifications
 - (void)userChanged:(SFUserAccount *)user change:(SFUserAccountDataChange)change {
     [self notifyUserDataChange:SFUserAccountManagerDidChangeUserDataNotification withUser:user andChange:change];
 }


### PR DESCRIPTION
@khawkins @sgoldberg-sfdc  @bhariharan Please review. The preferred way to handle current/ last used  community for a user is through the SFUserAccount. 