### PR TITLE
Fixing broken refresh flow for hybrid remote apps

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -563,7 +563,7 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
                      // Error is not invalid credentials, or developer otherwise wants to handle it.
                      [self loadErrorPageWithCode:error.code description:error.localizedDescription context:kErrorContextAuthExpiredSessionRefresh];
                  }
-             }];
+             } credentials:[SFUserAccountManager sharedInstance].currentUser.credentials];
             shouldAllowRequest = NO;
         } else {
             [self defaultWKNavigationHandling:webView decidePolicyForNavigationAction:navigationAction decisionHandler:decisionHandler];
@@ -650,7 +650,7 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
                     // Error is not invalid credentials, or developer otherwise wants to handle it.
                     [self loadErrorPageWithCode:error.code description:error.localizedDescription context:kErrorContextAuthExpiredSessionRefresh];
                 }
-            }];
+            } credentials:[SFUserAccountManager sharedInstance].currentUser.credentials];
             return NO;
         }
         NSURL* url = [request URL];


### PR DESCRIPTION
With the account management refactoring effort, we didn't update the hybrid view controller's refresh flow to pass in `credentials`. If `credentials` aren't passed in, `SFOauthCoordinator` creates a new `credentials` object and performs authentication, which brings up the `WebView` for new login flow instead of the refresh flow.