### PR TITLE
Deprecated loginWithCompletion:failure:credentials, adding refreshCredentials

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -529,7 +529,7 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
     BOOL shouldAllowRequest = YES;
     if ([webView isEqual:self.vfPingPageHiddenWKWebView]) { // Hidden ping page load.
         [self log:SFLogLevelDebug msg:@"Setting up VF web state after plugin-based refresh."];
-    }else if ([webView isEqual:self.errorPageWKWebView]) { // Local error page load.
+    } else if ([webView isEqual:self.errorPageWKWebView]) { // Local error page load.
         [self log:SFLogLevelDebug format:@"Local error page ('%@') is loading.", navigationAction.request.URL.absoluteString];
     } else if ([webView isEqual:self.webView]) { // Cordova web view load.
         /*
@@ -539,31 +539,31 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
         NSString *refreshUrl = [self isLoginRedirectUrl:navigationAction.request.URL];
         if (refreshUrl != nil) {
             [self log:SFLogLevelWarning msg:@"Caught login redirect from session timeout. Reauthenticating."];
-
+            
             /*
              * Reconfigure user agent. Basically this ensures that Cordova whitelisting won't apply to the
              * WKWebView that hosts the login screen (important for SSO outside of Salesforce domains).
              */
             [SFSDKWebUtils configureUserAgent:[self sfHybridViewUserAgentString]];
-            [[SFAuthenticationManager sharedManager]
-             loginWithCompletion:^(SFOAuthInfo *authInfo,SFUserAccount *userAccount) {
-                 [SFUserAccountManager sharedInstance].currentUser = userAccount;
-                 // Reset the user agent back to Cordova.
-                 [self authenticationCompletion:refreshUrl authInfo:authInfo];
-             } failure:^(SFOAuthInfo *authInfo, NSError *error) {
-                 if ([self logoutOnInvalidCredentials:error]) {
-                     [self log:SFLogLevelError msg:@"Could not refresh expired session. Logging out."];
-                     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
-                     attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
-                     attributes[@"errorDescription"] = error.localizedDescription;
-                     [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:nil className:NSStringFromClass([self class]) attributes:attributes];
-                     [[SFAuthenticationManager sharedManager] logout];
-                 } else {
-                     
-                     // Error is not invalid credentials, or developer otherwise wants to handle it.
-                     [self loadErrorPageWithCode:error.code description:error.localizedDescription context:kErrorContextAuthExpiredSessionRefresh];
-                 }
-             } credentials:[SFUserAccountManager sharedInstance].currentUser.credentials];
+            [[SFAuthenticationManager sharedManager] refreshCredentials:[SFUserAccountManager sharedInstance].currentUser.credentials
+                                                             completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
+                                                                 [SFUserAccountManager sharedInstance].currentUser = userAccount;
+                                                                 // Reset the user agent back to Cordova.
+                                                                 [self authenticationCompletion:refreshUrl authInfo:authInfo];
+                                                             } failure:^(SFOAuthInfo *authInfo, NSError *error) {
+                                                                 if ([self logoutOnInvalidCredentials:error]) {
+                                                                     [self log:SFLogLevelError msg:@"Could not refresh expired session. Logging out."];
+                                                                     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
+                                                                     attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
+                                                                     attributes[@"errorDescription"] = error.localizedDescription;
+                                                                     [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:nil className:NSStringFromClass([self class]) attributes:attributes];
+                                                                     [[SFAuthenticationManager sharedManager] logout];
+                                                                 } else {
+                                                                     
+                                                                     // Error is not invalid credentials, or developer otherwise wants to handle it.
+                                                                     [self loadErrorPageWithCode:error.code description:error.localizedDescription context:kErrorContextAuthExpiredSessionRefresh];
+                                                                 }
+                                                             }];
             shouldAllowRequest = NO;
         } else {
             [self defaultWKNavigationHandling:webView decidePolicyForNavigationAction:navigationAction decisionHandler:decisionHandler];
@@ -627,30 +627,31 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
         NSString *refreshUrl = [self isLoginRedirectUrl:webView.request.URL];
         if (refreshUrl != nil) {
             [self log:SFLogLevelWarning msg:@"Caught login redirect from session timeout. Reauthenticating."];
-
+            
             /*
              * Reconfigure user agent. Basically this ensures that Cordova whitelisting won't apply to the
              * UIWebView that hosts the login screen (important for SSO outside of Salesforce domains).
              */
             [SFSDKWebUtils configureUserAgent:[self sfHybridViewUserAgentString]];
-            [[SFAuthenticationManager sharedManager] loginWithCompletion:^(SFOAuthInfo *authInfo,SFUserAccount *userAccount) {
-                [SFUserAccountManager sharedInstance].currentUser = userAccount;
-                // Reset the user agent back to Cordova.
-                [self authenticationCompletion:refreshUrl authInfo:authInfo];
-            } failure:^(SFOAuthInfo *authInfo, NSError *error) {
-                if ([self logoutOnInvalidCredentials:error]) {
-                    [self log:SFLogLevelError msg:@"Could not refresh expired session. Logging out."];
-                    NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
-                    attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
-                    attributes[@"errorDescription"] = error.localizedDescription;
-                    [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:nil className:NSStringFromClass([self class]) attributes:attributes];
-                    [[SFAuthenticationManager sharedManager] logout];
-                } else {
-
-                    // Error is not invalid credentials, or developer otherwise wants to handle it.
-                    [self loadErrorPageWithCode:error.code description:error.localizedDescription context:kErrorContextAuthExpiredSessionRefresh];
-                }
-            } credentials:[SFUserAccountManager sharedInstance].currentUser.credentials];
+            [[SFAuthenticationManager sharedManager] refreshCredentials:[SFUserAccountManager sharedInstance].currentUser.credentials
+                                                             completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
+                                                                 [SFUserAccountManager sharedInstance].currentUser = userAccount;
+                                                                 // Reset the user agent back to Cordova.
+                                                                 [self authenticationCompletion:refreshUrl authInfo:authInfo];
+                                                             } failure:^(SFOAuthInfo *authInfo, NSError *error) {
+                                                                 if ([self logoutOnInvalidCredentials:error]) {
+                                                                     [self log:SFLogLevelError msg:@"Could not refresh expired session. Logging out."];
+                                                                     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
+                                                                     attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
+                                                                     attributes[@"errorDescription"] = error.localizedDescription;
+                                                                     [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:nil className:NSStringFromClass([self class]) attributes:attributes];
+                                                                     [[SFAuthenticationManager sharedManager] logout];
+                                                                 } else {
+                                                                     
+                                                                     // Error is not invalid credentials, or developer otherwise wants to handle it.
+                                                                     [self loadErrorPageWithCode:error.code description:error.localizedDescription context:kErrorContextAuthExpiredSessionRefresh];
+                                                                 }
+                                                             }];
             return NO;
         }
         NSURL* url = [request URL];

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -545,25 +545,26 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
              * WKWebView that hosts the login screen (important for SSO outside of Salesforce domains).
              */
             [SFSDKWebUtils configureUserAgent:[self sfHybridViewUserAgentString]];
-            [[SFAuthenticationManager sharedManager] refreshCredentials:[SFUserAccountManager sharedInstance].currentUser.credentials
-                                                             completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
-                                                                 [SFUserAccountManager sharedInstance].currentUser = userAccount;
-                                                                 // Reset the user agent back to Cordova.
-                                                                 [self authenticationCompletion:refreshUrl authInfo:authInfo];
-                                                             } failure:^(SFOAuthInfo *authInfo, NSError *error) {
-                                                                 if ([self logoutOnInvalidCredentials:error]) {
-                                                                     [self log:SFLogLevelError msg:@"Could not refresh expired session. Logging out."];
-                                                                     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
-                                                                     attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
-                                                                     attributes[@"errorDescription"] = error.localizedDescription;
-                                                                     [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:nil className:NSStringFromClass([self class]) attributes:attributes];
-                                                                     [[SFAuthenticationManager sharedManager] logout];
-                                                                 } else {
-                                                                     
-                                                                     // Error is not invalid credentials, or developer otherwise wants to handle it.
-                                                                     [self loadErrorPageWithCode:error.code description:error.localizedDescription context:kErrorContextAuthExpiredSessionRefresh];
-                                                                 }
-                                                             }];
+            [[SFAuthenticationManager sharedManager]
+             refreshCredentials:[SFUserAccountManager sharedInstance].currentUser.credentials
+             completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
+                 [SFUserAccountManager sharedInstance].currentUser = userAccount;
+                 // Reset the user agent back to Cordova.
+                 [self authenticationCompletion:refreshUrl authInfo:authInfo];
+             } failure:^(SFOAuthInfo *authInfo, NSError *error) {
+                 if ([self logoutOnInvalidCredentials:error]) {
+                     [self log:SFLogLevelError msg:@"Could not refresh expired session. Logging out."];
+                     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
+                     attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
+                     attributes[@"errorDescription"] = error.localizedDescription;
+                     [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:nil className:NSStringFromClass([self class]) attributes:attributes];
+                     [[SFAuthenticationManager sharedManager] logout];
+                 } else {
+                     
+                     // Error is not invalid credentials, or developer otherwise wants to handle it.
+                     [self loadErrorPageWithCode:error.code description:error.localizedDescription context:kErrorContextAuthExpiredSessionRefresh];
+                 }
+             }];
             shouldAllowRequest = NO;
         } else {
             [self defaultWKNavigationHandling:webView decidePolicyForNavigationAction:navigationAction decisionHandler:decisionHandler];
@@ -633,25 +634,26 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
              * UIWebView that hosts the login screen (important for SSO outside of Salesforce domains).
              */
             [SFSDKWebUtils configureUserAgent:[self sfHybridViewUserAgentString]];
-            [[SFAuthenticationManager sharedManager] refreshCredentials:[SFUserAccountManager sharedInstance].currentUser.credentials
-                                                             completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
-                                                                 [SFUserAccountManager sharedInstance].currentUser = userAccount;
-                                                                 // Reset the user agent back to Cordova.
-                                                                 [self authenticationCompletion:refreshUrl authInfo:authInfo];
-                                                             } failure:^(SFOAuthInfo *authInfo, NSError *error) {
-                                                                 if ([self logoutOnInvalidCredentials:error]) {
-                                                                     [self log:SFLogLevelError msg:@"Could not refresh expired session. Logging out."];
-                                                                     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
-                                                                     attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
-                                                                     attributes[@"errorDescription"] = error.localizedDescription;
-                                                                     [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:nil className:NSStringFromClass([self class]) attributes:attributes];
-                                                                     [[SFAuthenticationManager sharedManager] logout];
-                                                                 } else {
-                                                                     
-                                                                     // Error is not invalid credentials, or developer otherwise wants to handle it.
-                                                                     [self loadErrorPageWithCode:error.code description:error.localizedDescription context:kErrorContextAuthExpiredSessionRefresh];
-                                                                 }
-                                                             }];
+            [[SFAuthenticationManager sharedManager]
+             refreshCredentials:[SFUserAccountManager sharedInstance].currentUser.credentials
+             completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
+                 [SFUserAccountManager sharedInstance].currentUser = userAccount;
+                 // Reset the user agent back to Cordova.
+                 [self authenticationCompletion:refreshUrl authInfo:authInfo];
+             } failure:^(SFOAuthInfo *authInfo, NSError *error) {
+                 if ([self logoutOnInvalidCredentials:error]) {
+                     [self log:SFLogLevelError msg:@"Could not refresh expired session. Logging out."];
+                     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
+                     attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
+                     attributes[@"errorDescription"] = error.localizedDescription;
+                     [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:nil className:NSStringFromClass([self class]) attributes:attributes];
+                     [[SFAuthenticationManager sharedManager] logout];
+                 } else {
+                     
+                     // Error is not invalid credentials, or developer otherwise wants to handle it.
+                     [self loadErrorPageWithCode:error.code description:error.localizedDescription context:kErrorContextAuthExpiredSessionRefresh];
+                 }
+             }];
             return NO;
         }
         NSURL* url = [request URL];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager+Internal.h
@@ -29,11 +29,9 @@
 
 @interface SFAuthenticationManager ()
 
-- (void)login;
+- (void)loginWithCredentials:(SFOAuthCredentials *)credentials;
 
-- (void)loginWithCredentials:(SFOAuthCredentials *) credentials;
-
-- (void)setupWithCredentials:(SFOAuthCredentials*) credentials;
+- (void)setupWithCredentials:(SFOAuthCredentials *)credentials;
 
 /**
  Clears the account state associated with the current account.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -387,17 +387,31 @@ extern  NSString * const kOAuthRedirectUriKey;
                     failure:(nullable SFOAuthFlowFailureCallbackBlock)failureBlock;
 
 /**
- Kick off the login process for the specified credentials.
- @param completionBlock The block of code to execute when the authentication process successfully completes.
- @param failureBlock The block of code to execute when the authentication process has a fatal failure.
- @param credentials SFOAuthCredentials to be logged in.
+ Kick off the refresh process for the specified credentials.
+ Note: This method is deprecated.  Use refreshCredentials:completion:failure: to refresh existing credentials.
+ @param completionBlock The block of code to execute when the refresh process successfully completes.
+ @param failureBlock The block of code to execute when the refresh process has a fatal failure.
+ @param credentials SFOAuthCredentials to be refreshed.
  @return YES if this call kicks off the authentication process.  NO if an authentication process has already
  started, in which case subsequent requests are queued up to have their completion or failure blocks executed
  in succession.
  */
 - (BOOL)loginWithCompletion:(nullable SFOAuthFlowSuccessCallbackBlock)completionBlock
                     failure:(nullable SFOAuthFlowFailureCallbackBlock)failureBlock
-                    credentials:(nullable SFOAuthCredentials *)credentials;
+                    credentials:(nullable SFOAuthCredentials *)credentials SFSDK_DEPRECATED(5.2, "Use refreshCredentials:completion:failure: to refresh existing credentials.");
+
+/**
+ Kick off the refresh process for the specified credentials.
+ @param credentials SFOAuthCredentials to be refreshed.
+ @param completionBlock The block of code to execute when the refresh process successfully completes.
+ @param failureBlock The block of code to execute when the refresh process has a fatal failure.
+ @return YES if this call kicks off the authentication process.  NO if an authentication process has already
+ started, in which case subsequent requests are queued up to have their completion or failure blocks executed
+ in succession.
+ */
+- (BOOL)refreshCredentials:(nonnull SFOAuthCredentials *)credentials
+                completion:(nullable SFOAuthFlowSuccessCallbackBlock)completionBlock
+                   failure:(nullable SFOAuthFlowFailureCallbackBlock)failureBlock;
 
 /**
  Login using the given JWT token to exchange with the service for credentials.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -398,7 +398,7 @@ extern  NSString * const kOAuthRedirectUriKey;
  */
 - (BOOL)loginWithCompletion:(nullable SFOAuthFlowSuccessCallbackBlock)completionBlock
                     failure:(nullable SFOAuthFlowFailureCallbackBlock)failureBlock
-                    credentials:(nullable SFOAuthCredentials *)credentials SFSDK_DEPRECATED(5.2, "Use refreshCredentials:completion:failure: to refresh existing credentials.");
+                credentials:(nullable SFOAuthCredentials *)credentials SFSDK_DEPRECATED(5.2, "Use refreshCredentials:completion:failure: to refresh existing credentials. This method will go away in 6.0.");
 
 /**
  Kick off the refresh process for the specified credentials.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
@@ -97,20 +97,20 @@ static SFOAuthCredentials *credentials = nil;
     NSAssert(credentials!=nil, @"You must call populateAuthCredentialsFromConfigFileForClass before synchronousAuthRefresh");
     __block SFSDKTestRequestListener *authListener = [[SFSDKTestRequestListener alloc] init];
     __block SFUserAccount *user = nil;
-    [[SFAuthenticationManager sharedManager] loginWithCompletion:^(SFOAuthInfo *authInfo,SFUserAccount *userAccount) {
-        authListener.returnStatus = kTestRequestStatusDidLoad;
-        user = userAccount;
-    } failure:^(SFOAuthInfo *authInfo, NSError *error) {
-        authListener.lastError = error;
-        authListener.returnStatus = kTestRequestStatusDidFail;
-    } credentials:credentials
-    ];
+    [[SFAuthenticationManager sharedManager] refreshCredentials:credentials
+                                                     completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
+                                                         authListener.returnStatus = kTestRequestStatusDidLoad;
+                                                         user = userAccount;
+                                                     } failure:^(SFOAuthInfo *authInfo, NSError *error) {
+                                                         authListener.lastError = error;
+                                                         authListener.returnStatus = kTestRequestStatusDidFail;
+                                                     }];
     [authListener waitForCompletion];
     [[SFUserAccountManager sharedInstance] setCurrentUser:user];
-
+    
     NSAssert([authListener.returnStatus isEqualToString:kTestRequestStatusDidLoad], @"After auth attempt, expected status '%@', got '%@'",
-              kTestRequestStatusDidLoad,
-              authListener.returnStatus);
+             kTestRequestStatusDidLoad,
+             authListener.returnStatus);
 }
 
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
@@ -97,14 +97,15 @@ static SFOAuthCredentials *credentials = nil;
     NSAssert(credentials!=nil, @"You must call populateAuthCredentialsFromConfigFileForClass before synchronousAuthRefresh");
     __block SFSDKTestRequestListener *authListener = [[SFSDKTestRequestListener alloc] init];
     __block SFUserAccount *user = nil;
-    [[SFAuthenticationManager sharedManager] refreshCredentials:credentials
-                                                     completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
-                                                         authListener.returnStatus = kTestRequestStatusDidLoad;
-                                                         user = userAccount;
-                                                     } failure:^(SFOAuthInfo *authInfo, NSError *error) {
-                                                         authListener.lastError = error;
-                                                         authListener.returnStatus = kTestRequestStatusDidFail;
-                                                     }];
+    [[SFAuthenticationManager sharedManager]
+     refreshCredentials:credentials
+     completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
+         authListener.returnStatus = kTestRequestStatusDidLoad;
+         user = userAccount;
+     } failure:^(SFOAuthInfo *authInfo, NSError *error) {
+         authListener.lastError = error;
+         authListener.returnStatus = kTestRequestStatusDidFail;
+     }];
     [authListener waitForCompletion];
     [[SFUserAccountManager sharedInstance] setCurrentUser:user];
     


### PR DESCRIPTION
Now that authentication through `SFAuthenticationManager` is based strictly on credentials, it makes more sense to explicitly call out authentication with existing credentials as an auth refresh.

- Deprecated `loginWithCompletion:failure:credentials:`
- Added `refreshCredentials:completion:failure:`
- Move some of the internals around, removed unneeded internal methods, etc.