### PR TITLE
Prevent empty label when adding a new Connection URL

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKNewLoginHostViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKNewLoginHostViewController.m
@@ -75,7 +75,8 @@ static NSString * const SFSDKNewLoginHostCellIdentifier = @"SFSDKNewLoginHostCel
  * Invoked when the user taps on the done button to add the login host to the list of hosts.
  */
 - (void)addNewServer:(id)sender {
-    [self.loginHostListViewController addLoginHost:[SFSDKLoginHost hostWithName:self.name.text host:[self.server.text stringByTrimmingCharactersInSet:
+    [self.loginHostListViewController addLoginHost:[SFSDKLoginHost hostWithName:[self.name.text stringByTrimmingCharactersInSet:
+                                                                                 [NSCharacterSet whitespaceCharacterSet]] host:[self.server.text stringByTrimmingCharactersInSet:
                                                                                                      [NSCharacterSet whitespaceCharacterSet]] deletable:YES]];
 }
 


### PR DESCRIPTION
Currently, if you enter a single space (or multiple spaces) for the label, the row will show up in the pick list, but appear to have no text entry (since it's showing a single space).
This code will trim the label, so that if a single space (or multiple spaces) is entered, the hostWithName method actually just uses the host instead of a single space label entry for the name.

## The issue:
![emptylabelissue](https://cloud.githubusercontent.com/assets/9701042/26224030/7db279fc-3bd5-11e7-8ef6-cf1c560170db.gif)


## How this fixes it:
![emptylabelfix](https://cloud.githubusercontent.com/assets/9701042/26223859/d9622fc8-3bd4-11e7-8283-1e71b746f1b0.gif)
