### PR TITLE
Fix CSFOutput to match encode to initwithcoder

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Network/Model/CSFOutput.m
@@ -72,12 +72,13 @@ static NSString * const kCSFInputCustomArrayAttributes = @"__CSFOutput_Array_Sto
 
         Ivar ivar = class_getInstanceVariable(ivarInfo[@"class"], [ivarName UTF8String]);
         Class ivarClass = CSFClassFromEncoding(ivarInfo[@"encoding"]);
+        NSString * encoding = ivarInfo[@"encoding"];
         if (ivarClass) {
             id value = object_getIvar(self, ivar);
             [encoder encodeObject:value forKey:propertyName];
-        } else if (ivarInfo[@"encoding"]) {
+        } else if (encoding && ![encoding hasPrefix:@"@"]) {
             const void * ivarPtr = (__bridge void*)(self) + ivar_getOffset(ivar);
-            [encoder encodeValueOfObjCType:[ivarInfo[@"encoding"] UTF8String] at:ivarPtr];
+            [encoder encodeValueOfObjCType:[encoding UTF8String] at:ivarPtr];
         }
     }];
 }
@@ -104,7 +105,7 @@ static NSString * const kCSFInputCustomArrayAttributes = @"__CSFOutput_Array_Sto
                 object_setIvar(self, ivar, result);
             } else if (encoding && ![encoding hasPrefix:@"@"]) {
                 const void * ivarPtr = (__bridge void*)(self) + ivar_getOffset(ivar);
-                [decoder decodeValueOfObjCType:[ivarInfo[@"encoding"] UTF8String] at:(void *)ivarPtr];
+                [decoder decodeValueOfObjCType:[encoding UTF8String] at:(void *)ivarPtr];
             }
         }];
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Utilities/CSFInternalDefines.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Utilities/CSFInternalDefines.m
@@ -76,8 +76,12 @@ CSFParameterStyle CSFRequiredParameterStyleForHTTPMethod(NSString *method) {
 Class CSFClassFromEncoding(NSString *encoding) {
     Class result = nil;
     if ([encoding hasPrefix:@"@"]) {
-        NSString *className = [[encoding substringFromIndex:2] stringByReplacingOccurrencesOfString:@"\"" withString:@""];
-        result = NSClassFromString(className);
+        if (encoding.length > 2) {
+            NSString *className = [[encoding substringFromIndex:2] stringByReplacingOccurrencesOfString:@"\"" withString:@""];
+            result = NSClassFromString(className);
+        } else {
+            result = [NSObject class];
+        }
     }
     return result;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Utilities/CSFInternalDefines.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Network/Utilities/CSFInternalDefines.m
@@ -76,12 +76,8 @@ CSFParameterStyle CSFRequiredParameterStyleForHTTPMethod(NSString *method) {
 Class CSFClassFromEncoding(NSString *encoding) {
     Class result = nil;
     if ([encoding hasPrefix:@"@"]) {
-        if (encoding.length > 2) {
-            NSString *className = [[encoding substringFromIndex:2] stringByReplacingOccurrencesOfString:@"\"" withString:@""];
-            result = NSClassFromString(className);
-        } else {
-            result = [NSObject class];
-        }
+        NSString *className = [[encoding substringFromIndex:2] stringByReplacingOccurrencesOfString:@"\"" withString:@""];
+        result = NSClassFromString(className);
     }
     return result;
 }


### PR DESCRIPTION
  - My previous change to CSFOutput failed to match the encode routine with the initWithCoder resulting in an incorrectly encoded object.
  - Reverted previous change to CSFClassFromEncoding as it had no impact on the problem at hand.  