### PR TITLE
Changing login host should not trigger user change

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostDelegate.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostDelegate.h
@@ -28,6 +28,7 @@
 */
 
 @class SFSDKLoginHostListViewController;
+@class SFSDKLoginHost;
 
 /**
  * Use the SFSDKLoginHostDelegate to be notified of the actions taken by the user on the login host list view controller.
@@ -61,6 +62,14 @@
  * @param hostListViewController The instance sending this message.
  */
 - (void)hostListViewControllerDidCancelLoginHost:(SFSDKLoginHostListViewController *)hostListViewController;
+
+/**
+ * Notifies the delegate that the login host has been changed in some capacity (user-selected, host entry edited,
+ * custom login host added, previous current login host deleted, etc.).
+ * @param hostListViewController The instance sending this message.
+ * @param newLoginHost The updated login host.
+ */
+- (void)hostListViewController:(SFSDKLoginHostListViewController *)hostListViewController didChangeLoginHost:(SFSDKLoginHost *)newLoginHost;
 
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -30,7 +30,7 @@
 #import "SFSDKNewLoginHostViewController.h"
 #import "SFSDKLoginHostStorage.h"
 #import "SFSDKLoginHost.h"
-#import "SFAuthenticationManager.h"
+#import "SFAuthenticationManager+Internal.h"
 #import "SFSDKResourceUtils.h"
 #import "SFLoginViewController.h"
 
@@ -52,8 +52,8 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
     // Change the login host and login again. Don't do any logout as we don't
     // want to remove anything at this point.
     m.loginHost = loginHost.host;
-    [[SFAuthenticationManager sharedManager] cancelAuthentication];
-    [[SFUserAccountManager sharedInstance] switchToNewUser];}
+    [[SFAuthenticationManager sharedManager] restartAuthentication];
+}
 
 /**
  * Scroll the table to make sure the host at the specified index is visible.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -30,9 +30,10 @@
 #import "SFSDKNewLoginHostViewController.h"
 #import "SFSDKLoginHostStorage.h"
 #import "SFSDKLoginHost.h"
-#import "SFAuthenticationManager+Internal.h"
+#import "SFAuthenticationManager.h"
 #import "SFSDKResourceUtils.h"
 #import "SFLoginViewController.h"
+#import "SFManagedPreferences.h"
 
 static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCellIdentifier";
 
@@ -47,12 +48,9 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
  */
 - (void)applyLoginHostAtIndex:(NSUInteger)index {
     SFSDKLoginHost *loginHost = [[SFSDKLoginHostStorage sharedInstance] loginHostAtIndex:index];
-    SFAuthenticationManager *authMgr = [SFAuthenticationManager sharedManager];
-    
-    // Change the login host and login again. Don't do any logout as we don't
-    // want to remove anything at this point.
-    authMgr.loginHost = loginHost.host;
-    [authMgr restartAuthentication];
+    if ([self.delegate respondsToSelector:@selector(hostListViewController:didChangeLoginHost:)]) {
+        [self.delegate hostListViewController:self didChangeLoginHost:loginHost];
+    }
 }
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -47,12 +47,12 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
  */
 - (void)applyLoginHostAtIndex:(NSUInteger)index {
     SFSDKLoginHost *loginHost = [[SFSDKLoginHostStorage sharedInstance] loginHostAtIndex:index];
-    SFAuthenticationManager *m = [SFAuthenticationManager sharedManager];
+    SFAuthenticationManager *authMgr = [SFAuthenticationManager sharedManager];
     
     // Change the login host and login again. Don't do any logout as we don't
     // want to remove anything at this point.
-    m.loginHost = loginHost.host;
-    [[SFAuthenticationManager sharedManager] restartAuthentication];
+    authMgr.loginHost = loginHost.host;
+    [authMgr restartAuthentication];
 }
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.h
@@ -26,7 +26,24 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "SalesforceSDKCore.h"
+@class SFLoginViewController;
+@class SFSDKLoginHost;
+
+/**
+ * Delegate protocol for the owner of SFLoginViewController.
+ */
+@protocol SFLoginViewControllerDelegate <NSObject>
+
+@optional
+
+/**
+ * Notifies the delegate that the selected login host has been changed.
+ * @param loginViewController The instance sending this message.
+ * @param newLoginHost The updated login host.
+ */
+- (void)loginViewController:(nonnull SFLoginViewController *)loginViewController didChangeLoginHost:(nonnull SFSDKLoginHost *)newLoginHost;
+
+@end
 
 
 /** The Salesforce login screen view.
@@ -36,6 +53,11 @@
 /** Returns a shared singleton of `SFLoginViewController` class.
  */
 +(_Nonnull instancetype)sharedInstance;
+
+/**
+ * The delegate representing the owner of this object.
+ */
+@property (nonatomic, weak, nullable) id<SFLoginViewControllerDelegate> delegate;
 
 /**
  * Outlet to the OAuth web view.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -32,9 +32,12 @@
 #import "SFSDKLoginHostListViewController.h"
 #import "SFSDKLoginHostDelegate.h"
 #import "UIColor+SFColors.h"
+#import "SFSDKResourceUtils.h"
+#import "SFUserAccountManager.h"
+#import "SFAuthenticationManager.h"
 
 
-@interface SFLoginViewController () <SFSDKLoginHostDelegate, SFUserAccountManagerDelegate, SFAuthenticationManagerDelegate>
+@interface SFLoginViewController () <SFSDKLoginHostDelegate, SFUserAccountManagerDelegate>
 
 @property (nonatomic, strong) UINavigationBar *navBar;
 
@@ -236,6 +239,12 @@
     [self hideHostListView:YES];
 }
 
+- (void)hostListViewController:(SFSDKLoginHostListViewController *)hostListViewController didChangeLoginHost:(SFSDKLoginHost *)newLoginHost {
+    if ([self.delegate respondsToSelector:@selector(loginViewController:didChangeLoginHost:)]) {
+        [self.delegate loginViewController:self didChangeLoginHost:newLoginHost];
+    }
+}
+
 #pragma mark - Login Host
 
 - (void)showHostListView {
@@ -248,7 +257,7 @@
     [self dismissViewControllerAnimated:animated completion:nil];
 }
 
-#pragma mark - SF Authentication Manager
+#pragma mark - SFUserAccountManagerDelegate
 
 - (void)userAccountManager:(SFUserAccountManager *)userAccountManager
         willSwitchFromUser:(SFUserAccount *)fromUser

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager+Internal.h
@@ -39,5 +39,13 @@
  */
 - (void)clearAccountState:(BOOL)clearAccountData;
 
+/**
+ Restarts an authentication process that's already in progress.  Useful if underyling configuration
+ changes in the process, such as a login host change.
+ @discussion
+ If authentication is not already in progress, this method will exit without action.
+ */
+- (void)restartAuthentication;
+
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager+Internal.h
@@ -39,13 +39,5 @@
  */
 - (void)clearAccountState:(BOOL)clearAccountData;
 
-/**
- Restarts an authentication process that's already in progress.  Useful if underyling configuration
- changes in the process, such as a login host change.
- @discussion
- If authentication is not already in progress, this method will exit without action.
- */
-- (void)restartAuthentication;
-
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -44,6 +44,14 @@
 #import "SFLoginViewController.h"
 #import "SFOAuthCoordinator+Internal.h"
 #import "SFNetwork.h"
+#import "SFSDKLoginHostDelegate.h"
+#import "NSUserDefaults+SFAdditions.h"
+#import "SFSDKWebViewStateManager.h"
+#import "SFSDKSalesforceAnalyticsManager.h"
+#import "SFSDKLoginHostListViewController.h"
+#import "SFSDKEventBuilderHelper.h"
+#import "SFSDKLoginHostStorage.h"
+#import "SFSDKLoginHost.h"
 
 static SFAuthenticationManager *sharedInstance = nil;
 
@@ -155,7 +163,7 @@ NSString * const kOAuthRedirectUriKey = @"oauth_redirect_uri";
 
 #pragma mark - SFAuthenticationManager
 
-@interface SFAuthenticationManager () <SFSDKLoginHostDelegate>
+@interface SFAuthenticationManager () <SFSDKLoginHostDelegate, SFLoginViewControllerDelegate>
 {
 }
 
@@ -201,12 +209,6 @@ NSString * const kOAuthRedirectUriKey = @"oauth_redirect_uri";
  Dismisses the authentication retry alert box, if present.
  */
 - (void)cleanupStatusAlert;
-
-/**
- Method to present the authorizing view controller with the given auth webView.
- @param webView The auth webView to present.
- */
-- (void)presentAuthViewController:(WKWebView *)webView;
 
 /**
  Called after initial authentication has completed.
@@ -307,8 +309,10 @@ static Class InstanceClass = nil;
         self.authViewHandler = [[SFAuthenticationViewHandler alloc]
                                 initWithDisplayBlock:^(SFAuthenticationManager *authManager, WKWebView *authWebView) {
                                     __strong typeof(weakSelf) strongSelf = weakSelf;
-                                    if (strongSelf.authViewController == nil)
+                                    if (strongSelf.authViewController == nil) {
                                         strongSelf.authViewController = [SFLoginViewController sharedInstance];
+                                        strongSelf.authViewController.delegate = strongSelf;
+                                    }
                                     [strongSelf.authViewController setOauthView:authWebView];
                                     [[SFRootViewManager sharedManager] pushViewController:strongSelf.authViewController];
                                 } dismissBlock:^(SFAuthenticationManager *authViewManager) {
@@ -892,21 +896,6 @@ static Class InstanceClass = nil;
    [self.statusAlert dismissViewControllerAnimated:NO completion:nil];
 }
 
-- (void)presentAuthViewController:(WKWebView *)webView
-{
-    if (![NSThread isMainThread]) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self presentAuthViewController:webView];
-        });
-        return;
-    }
-    
-    if (self.authViewController == nil)
-        self.authViewController = [[SFLoginViewController alloc] initWithNibName:nil bundle:nil];
-    [self.authViewController setOauthView:webView];
-    [[SFRootViewManager sharedManager] pushViewController:self.authViewController];
-}
-
 - (void)dismissAuthViewControllerIfPresent
 {
     if (![NSThread isMainThread]) {
@@ -1196,6 +1185,13 @@ static Class InstanceClass = nil;
 
 - (void)hostListViewControllerDidSelectLoginHost:(SFSDKLoginHostListViewController *)hostListViewController {
     [hostListViewController dismissViewControllerAnimated:YES completion:nil];
+}
+
+#pragma mark - SFLoginViewControllerDelegate
+
+- (void)loginViewController:(SFLoginViewController *)loginViewController didChangeLoginHost:(SFSDKLoginHost *)newLoginHost {
+    self.loginHost = newLoginHost.host;
+    [self restartAuthentication];
 }
 
 #pragma mark - SFUserAccountManagerDelegate

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -846,6 +846,18 @@ static Class InstanceClass = nil;
     self.idCoordinator.delegate = self;
 }
 
+- (void)restartAuthentication {
+    @synchronized (self.authBlockList) {
+        if (!self.authenticating) {
+            [self log:SFLogLevelWarning format:@"%@: Authentication manager is not currently authenticating.  No action taken.", NSStringFromSelector(_cmd)];
+            return;
+        }
+        [self log:SFLogLevelInfo format:@"%@: Restarting in-progress authentication process.", NSStringFromSelector(_cmd)];
+        [self.coordinator stopAuthentication];
+        [self loginWithCredentials:[self createOAuthCredentials]];
+    }
+}
+
 /**
  * Clears the account state of the given account (i.e. clears credentials, coordinator
  * instances, etc.


### PR DESCRIPTION
Changing the current user should be a deliberate action on the part of the SDK consumer.  When switching login hosts from the login screen, all we really want to do is restart the authentication that was already in progress, with the new login host configuration.