### PR TITLE
SFRestRequest - Property Mutability

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -115,13 +115,13 @@ extern NSString * const kSFDefaultRestEndpoint;
  * The query parameters of the request (could be nil).
  * Note that URL encoding of the parameters will automatically happen when the request is sent.
  */
-@property (nullable, nonatomic, strong, readwrite) NSDictionary<NSString*, id> *queryParams;
+@property (nullable, nonatomic, strong, readwrite) NSMutableDictionary<NSString*, id> *queryParams;
 
 /**
  * Dictionary of any custom HTTP headers you wish to add to your request.  You can also use
  * `setHeaderValue:forHeaderName:` to add headers to this property.
  */
-@property (nullable, nonatomic, strong, readwrite) NSDictionary<NSString*, NSString*> *customHeaders;
+@property (nullable, nonatomic, strong, readwrite) NSMutableDictionary<NSString*, NSString*> *customHeaders;
 
 /**
  * The delegate for this request. Notified of request status.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -36,7 +36,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
     if (self) {
         self.method = method;
         self.path = path;
-        self.queryParams = queryParams;
+        self.queryParams = [queryParams mutableCopy];
         self.endpoint = kSFDefaultRestEndpoint;
         self.requiresAuthentication = YES;
         self.request = [[NSMutableURLRequest alloc] init];
@@ -197,7 +197,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
     if (!self.customHeaders) {
         self.customHeaders = [[NSMutableDictionary alloc] init];
     }
-    [self.customHeaders setValue:value forKey:name];
+    [self.customHeaders setObject:value forKey:name];
 }
 
 #pragma mark - Upload


### PR DESCRIPTION
-  Properties designed for mutation should be mutable
-  Rather than change the init method signature, making a mutable copy of the dictionary supplied for potential mutation later