### PR TITLE
More targeted import

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.h
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.h
@@ -27,7 +27,8 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <CocoaLumberjack/CocoaLumberjack.h>
+#define DD_LEGACY_MACROS 0
+#import <CocoaLumberjack/DDLog.h>
 #import "SFSDKFileLogger.h"
 
 @interface SFSDKLogger : NSObject


### PR DESCRIPTION
Importing a specific header file instead of importing the umbrella header. This probably makes no major difference in the native space but works much better for our `Cordova` plugin since we're still using static libs there and have to manually add the headers in the plugin spec.