### PR TITLE
Allow SFRestRequests to have a defined baseURL

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -104,6 +104,13 @@ extern NSString * const kSFDefaultRestEndpoint;
 @property (nullable, nonatomic, strong, readwrite) NSURLSessionDataTask *sessionDataTask;
 
 /**
+ * The base URL of the request, to be prepended to the value of the `path` property.
+ * By default, this will be the API URL associated with the current user's account.
+ * One use would be when in a community setting and you want to send a request against the base API URL.
+ */
+@property (nullable, nonatomic, strong, readwrite) NSString *baseURL;
+
+/**
  * The path of the request.
  * For instance, "" (empty string), "v22.0/recent", "v22.0/query".
  * Note that the path doesn't have to start with a '/'. For instance, passing "v22.0/recent" is the same as passing "/v22.0/recent".
@@ -228,6 +235,15 @@ extern NSString * const kSFDefaultRestEndpoint;
  * @param queryParams the parameters of the request (could be nil)
  */
 + (instancetype)requestWithMethod:(SFRestMethod)method path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams;
+
+/**
+ * Creates an `SFRestRequest` object. See SFRestMethod.
+ * @param method the HTTP method
+ * @param baseURL the request URL
+ * @param path the request path
+ * @param queryParams the parameters of the request (could be nil)
+ */
++ (instancetype)requestWithMethod:(SFRestMethod)method baseURL:(NSString *)baseURL path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -31,10 +31,11 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
 
 @implementation SFRestRequest
 
-- (id)initWithMethod:(SFRestMethod)method path:(NSString *)path queryParams:(NSDictionary *)queryParams {
+- (id)initWithMethod:(SFRestMethod)method baseURL:(NSString *)baseURL path:(NSString *)path queryParams:(NSDictionary *)queryParams {
     self = [super init];
     if (self) {
         self.method = method;
+        self.baseURL = baseURL;
         self.path = path;
         self.queryParams = [queryParams mutableCopy];
         self.endpoint = kSFDefaultRestEndpoint;
@@ -46,7 +47,11 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
 }
 
 + (instancetype)requestWithMethod:(SFRestMethod)method path:(NSString *)path queryParams:(NSDictionary *)queryParams {
-    return [[self alloc] initWithMethod:method path:path queryParams:queryParams];
+    return [[self alloc] initWithMethod:method baseURL:nil path:path queryParams:queryParams];
+}
+
++ (instancetype)requestWithMethod:(SFRestMethod)method baseURL:(NSString *)baseURL path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams {
+    return [[self alloc] initWithMethod:method baseURL:baseURL path:path queryParams:queryParams];
 }
 
 - (NSString *)description {
@@ -113,7 +118,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
 - (NSURLRequest *)prepareRequestForSend {
     SFUserAccount *user = [SFUserAccountManager sharedInstance].currentUser;
     if (user) {
-        NSString *baseUrl = user.credentials.apiUrl.absoluteString;
+        NSString *baseUrl = self.baseURL ?: user.credentials.apiUrl.absoluteString;
 
         // Performs sanity checks on the path against the endpoint value.
         if (self.endpoint.length > 0 && [self.path hasPrefix:self.endpoint]) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -1709,4 +1709,15 @@ static NSException *authException = nil;
     }
 }
 
+#pragma mark - custom rest requests
+
+- (void)testCustomBaseURLRequest {
+    SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodGET baseURL:@"http://www.apple.com" path:@"/test/testing" queryParams:nil];
+    XCTAssertEqual(request.baseURL, @"http://www.apple.com", @"Base URL should match");
+    
+    NSURLRequest *finalRequest = [request prepareRequestForSend];
+    NSString *expectedURL = [NSString stringWithFormat:@"http://www.apple.com%@%@", kSFDefaultRestEndpoint, @"/test/testing"];
+    XCTAssertEqualObjects(finalRequest.URL.absoluteString, expectedURL, @"Final URL should utilize base URL that was passed in");
+}
+
 @end


### PR DESCRIPTION
This allows users of SFRestAPI to choose their baseURL per-request if needed.

I'm still testing this but wanted it up for review.