### PR TITLE
Managing postAppForeground for in-progress passcode

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -1,5 +1,5 @@
 #import "SalesforceSDKManager.h"
-
+#import "SFSecurityLockout+Internal.h"
 #import "SFUserAccountManager.h"
 #import "SFUserAccount.h"
 #import "SFSDKAppConfig.h"
@@ -24,7 +24,7 @@
 
 @end
 
-@interface SalesforceSDKManager () <SalesforceSDKManagerFlow, SFUserAccountManagerDelegate>
+@interface SalesforceSDKManager () <SalesforceSDKManagerFlow, SFUserAccountManagerDelegate, SFSecurityLockoutDelegate>
 {
     BOOL _isLaunching;
     UIViewController* _snapshotViewController;
@@ -35,6 +35,8 @@
 @property (nonatomic, assign) BOOL hasVerifiedPasscodeAtStartup;
 @property (nonatomic, assign) SFSDKLaunchAction launchActions;
 @property (nonatomic, strong, nonnull) NSHashTable<id<SalesforceSDKManagerDelegate>> *delegates;
+@property (nonatomic, assign, getter=isPasscodeDisplayed) BOOL passcodeDisplayed;
+@property (nonatomic, assign, getter=isInManagerForegroundProcess) BOOL inManagerForegroundProcess;
 
 - (void)passcodeValidatedToAuthValidation;
 - (void)authValidatedToPostAuth:(SFSDKLaunchAction)launchAction;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -24,7 +24,6 @@
 
 #import "SalesforceSDKManager+Internal.h"
 #import "SFAuthenticationManager+Internal.h"
-#import "SFSecurityLockout+Internal.h"
 #import "SFRootViewManager.h"
 #import "SFSDKWebUtils.h"
 #import "SFManagedPreferences.h"
@@ -142,6 +141,7 @@ static NSString* ailtnAppName = nil;
         self.delegates = [NSHashTable weakObjectsHashTable];
         [[SFUserAccountManager sharedInstance] addDelegate:self];
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        [SFSecurityLockout addDelegate:self];
         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleAppForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleAppBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleAppTerminate:) name:UIApplicationWillTerminateNotification object:nil];
@@ -377,10 +377,17 @@ static NSString* ailtnAppName = nil;
 
 - (void)sendPostLogout
 {
-    _isLaunching = NO;
+    [self logoutCleanup];
     if (self.postLogoutAction) {
         self.postLogoutAction();
     }
+}
+
+- (void)logoutCleanup
+{
+    _isLaunching = NO;
+    self.inManagerForegroundProcess = NO;
+    self.passcodeDisplayed = NO;
 }
 
 - (void)sendPostLaunch
@@ -399,10 +406,13 @@ static NSString* ailtnAppName = nil;
     }
 }
 
-- (void)sendPostAppForeground
+- (void)sendPostAppForegroundIfRequired
 {
-    if (self.postAppForegroundAction) {
-        self.postAppForegroundAction();
+    if (self.isInManagerForegroundProcess) {
+        self.inManagerForegroundProcess = NO;
+        if (self.postAppForegroundAction) {
+            self.postAppForegroundAction();
+        }
     }
 }
 
@@ -415,26 +425,31 @@ static NSString* ailtnAppName = nil;
             [delegate sdkManagerWillEnterForeground];
         }
     }];
-        
+    
     if (_isLaunching) {
         [SFSDKCoreLogger d:[self class] format:@"SDK is still launching.  No foreground action taken."];
     } else {
-        
-        // Check to display pin code screen.
-        
-        [SFSecurityLockout setLockScreenFailureCallbackBlock:^{
-            // Note: Failed passcode verification automatically logs out users, which the logout
-            // delegate handler will catch and pass on.  We just log the error and reset launch
-            // state here.
-            [SFSDKCoreLogger e:[self class] format:@"Passcode validation failed.  Logging the user out."];
-        }];
-        
-        [SFSecurityLockout setLockScreenSuccessCallbackBlock:^(SFSecurityLockoutAction lockoutAction) {
-            [SFSDKCoreLogger i:[self class] format:@"Passcode validation succeeded, or was not required, on app foreground.  Triggering postAppForeground handler."];
-            [self sendPostAppForeground];
-        }];
-        
-        [SFSecurityLockout validateTimer];
+        self.inManagerForegroundProcess = YES;
+        if (self.isPasscodeDisplayed) {
+            // Passcode was already displayed prior to app foreground.  Leverage delegates to manage
+            // post-foreground process.
+            [SFSDKCoreLogger i:[self class] format:@"%@ Passcode screen already displayed. Post-app foreground will continue after passcode challenge completes.", NSStringFromSelector(_cmd)];
+        } else {
+            // Check to display pin code screen.
+            [SFSecurityLockout setLockScreenFailureCallbackBlock:^{
+                // Note: Failed passcode verification automatically logs out users, which the logout
+                // delegate handler will catch and pass on.  We just log the error and reset launch
+                // state here.
+                [SFSDKCoreLogger e:[self class] format:@"Passcode validation failed.  Logging the user out."];
+            }];
+            
+            [SFSecurityLockout setLockScreenSuccessCallbackBlock:^(SFSecurityLockoutAction lockoutAction) {
+                [SFSDKCoreLogger i:[self class] format:@"Passcode validation succeeded, or was not required, on app foreground.  Triggering postAppForeground handler."];
+                [self sendPostAppForegroundIfRequired];
+            }];
+            
+            [SFSecurityLockout validateTimer];
+        }
     }
 }
 
@@ -762,6 +777,19 @@ static NSString* ailtnAppName = nil;
                     toUser:(SFUserAccount *)toUser
 {
     [self.sdkManagerFlow handleUserSwitch:fromUser toUser:toUser];
+}
+
+#pragma mark - SFSecurityLockoutDelegate
+
+- (void)passcodeFlowWillBegin:(SFPasscodeControllerMode)mode
+{
+    self.passcodeDisplayed = YES;
+}
+
+- (void)passcodeFlowDidComplete:(BOOL)success
+{
+    self.passcodeDisplayed = NO;
+    [self sendPostAppForegroundIfRequired];
 }
 
 @end


### PR DESCRIPTION
`SalesforceSDKManager.postAppForeground()` does not get called if the passcode screen was already displayed before backgrounding the app.  This update will ensure the callback gets called after the passcode challenge has completed.