### PR TITLE
Setting user agent on REST API requests

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -166,7 +166,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         }
 
         // Sets Mobile SDK user agent on REST API requests, if it hasn't been set already elsewhere.
-        if (self.request.allHTTPHeaderFields && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"User-Agent"]) {
+        if (![self.request.allHTTPHeaderFields.allKeys containsObject:@"User-Agent"]) {
             [self.request setValue:[SFRestAPI userAgentString] forHTTPHeaderField:@"User-Agent"];
         }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -165,8 +165,10 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
             [self.request setValue:bearer forHTTPHeaderField:@"Authorization"];
         }
 
-        // Sets Mobile SDK user agent on all REST API requests.
-        [self.request setValue:[SFRestAPI userAgentString] forHTTPHeaderField:@"User-Agent"];
+        // Sets Mobile SDK user agent on REST API requests, if it hasn't been set already by .
+        if (self.request.allHTTPHeaderFields && self.request.allHTTPHeaderFields.allKeys && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"User-Agent"]) {
+            [self.request setValue:[SFRestAPI userAgentString] forHTTPHeaderField:@"User-Agent"];
+        }
 
         // Adds custom headers to the request if any are set.
         if (self.customHeaders) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -150,6 +150,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
 
         // Adds query parameters to the request if any are set.
         if (self.queryParams) {
+
             // Not using NSUrlQueryItems because of https://stackoverflow.com/questions/41273994/special-characters-not-being-encoded-properly-inside-urlqueryitems
             [fullUrl appendString:[SFRestRequest toQueryString:self.queryParams]];
         }
@@ -163,6 +164,9 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
             NSString *bearer = [NSString stringWithFormat:@"Bearer %@", user.credentials.accessToken];
             [self.request setValue:bearer forHTTPHeaderField:@"Authorization"];
         }
+
+        // Sets Mobile SDK user agent on all REST API requests.
+        [self.request setValue:[SFRestAPI userAgentString] forHTTPHeaderField:@"User-Agent"];
 
         // Adds custom headers to the request if any are set.
         if (self.customHeaders) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -165,7 +165,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
             [self.request setValue:bearer forHTTPHeaderField:@"Authorization"];
         }
 
-        // Sets Mobile SDK user agent on REST API requests, if it hasn't been set already by .
+        // Sets Mobile SDK user agent on REST API requests, if it hasn't been set already elsewhere.
         if (self.request.allHTTPHeaderFields && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"User-Agent"]) {
             [self.request setValue:[SFRestAPI userAgentString] forHTTPHeaderField:@"User-Agent"];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -160,13 +160,13 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         [self.request setHTTPMethod:[SFRestRequest httpMethodFromSFRestMethod:self.method]];
 
         // Sets OAuth Bearer token header on the request (if not already present).
-        if (self.requiresAuthentication && self.request.allHTTPHeaderFields && self.request.allHTTPHeaderFields.allKeys && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"Authorization"]) {
+        if (self.requiresAuthentication && self.request.allHTTPHeaderFields && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"Authorization"]) {
             NSString *bearer = [NSString stringWithFormat:@"Bearer %@", user.credentials.accessToken];
             [self.request setValue:bearer forHTTPHeaderField:@"Authorization"];
         }
 
         // Sets Mobile SDK user agent on REST API requests, if it hasn't been set already by .
-        if (self.request.allHTTPHeaderFields && self.request.allHTTPHeaderFields.allKeys && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"User-Agent"]) {
+        if (self.request.allHTTPHeaderFields && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"User-Agent"]) {
             [self.request setValue:[SFRestAPI userAgentString] forHTTPHeaderField:@"User-Agent"];
         }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -160,7 +160,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         [self.request setHTTPMethod:[SFRestRequest httpMethodFromSFRestMethod:self.method]];
 
         // Sets OAuth Bearer token header on the request (if not already present).
-        if (self.requiresAuthentication && self.request.allHTTPHeaderFields && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"Authorization"]) {
+        if (self.requiresAuthentication && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"Authorization"]) {
             NSString *bearer = [NSString stringWithFormat:@"Bearer %@", user.credentials.accessToken];
             [self.request setValue:bearer forHTTPHeaderField:@"Authorization"];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -1712,16 +1712,16 @@ static NSException *authException = nil;
 - (void)testRequestUserAgent {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearchResultLayout:ACCOUNT];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
-    NSString *userAgent = self.request.allHTTPHeaderFields[@"User-Agent"];
+    NSString *userAgent = request.request.allHTTPHeaderFields[@"User-Agent"];
     XCTAssertEqualObjects(userAgent, [SFRestAPI userAgentString], @"request failed");
 }
 
 // Tests that overridden user agent is set on the request.
 - (void)testRequestUserAgentWithOverride {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearchResultLayout:ACCOUNT];
-    [request setValue:[SFRestAPI userAgentString:@"SmartSync"] forHTTPHeaderField:@"User-Agent"];
+    [request setHeaderValue:[SFRestAPI userAgentString:@"SmartSync"] forHeaderName:@"User-Agent"];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
-    NSString *userAgent = self.request.allHTTPHeaderFields[@"User-Agent"];
+    NSString *userAgent = request.request.allHTTPHeaderFields[@"User-Agent"];
     XCTAssertEqualObjects(userAgent, [SFRestAPI userAgentString:@"SmartSync"], @"request failed");
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -25,6 +25,7 @@
 #import "SalesforceRestAPITests.h"
 #import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import "SFRestAPI+Internal.h"
+#import "SFRestRequest+Internal.h"
 #import "SFNativeRestRequestListener.h"
  
  // Constants only used in the tests below
@@ -1656,7 +1657,8 @@ static NSException *authException = nil;
                  @"Simple SOSL search does not match.");
     XCTAssertTrue( [complexSearch isEqualToString:[SFRestAPI SOSLSearchWithSearchTerm:@"blah"
                                                                           fieldScope:nil
-                                                                         objectScope:[NSDictionary dictionaryWithObject:@"id, name order by lastname asc limit 5"                                      forKey:@"User"]
+                                                                         objectScope:[NSDictionary dictionaryWithObject:@"id, name order by lastname asc limit 5"
+                                                                                                                 forKey:@"User"]
                                                                                limit:200]],
                  @"Complex SOSL search does not match.");
 }
@@ -1711,7 +1713,7 @@ static NSException *authException = nil;
 // Tests that stock Mobile SDK user agent is set on the request.
 - (void)testRequestUserAgent {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearchResultLayout:ACCOUNT];
-    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    [self sendSyncRequest:request];
     NSString *userAgent = request.request.allHTTPHeaderFields[@"User-Agent"];
     XCTAssertEqualObjects(userAgent, [SFRestAPI userAgentString], @"request failed");
 }
@@ -1720,7 +1722,7 @@ static NSException *authException = nil;
 - (void)testRequestUserAgentWithOverride {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearchResultLayout:ACCOUNT];
     [request setHeaderValue:[SFRestAPI userAgentString:@"SmartSync"] forHeaderName:@"User-Agent"];
-    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    [self sendSyncRequest:request];
     NSString *userAgent = request.request.allHTTPHeaderFields[@"User-Agent"];
     XCTAssertEqualObjects(userAgent, [SFRestAPI userAgentString:@"SmartSync"], @"request failed");
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -1715,7 +1715,7 @@ static NSException *authException = nil;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearchResultLayout:ACCOUNT];
     [self sendSyncRequest:request];
     NSString *userAgent = request.request.allHTTPHeaderFields[@"User-Agent"];
-    XCTAssertEqualObjects(userAgent, [SFRestAPI userAgentString], @"request failed");
+    XCTAssertEqualObjects(userAgent, [SFRestAPI userAgentString], @"Incorrect user agent");
 }
 
 // Tests that overridden user agent is set on the request.
@@ -1724,7 +1724,7 @@ static NSException *authException = nil;
     [request setHeaderValue:[SFRestAPI userAgentString:@"SmartSync"] forHeaderName:@"User-Agent"];
     [self sendSyncRequest:request];
     NSString *userAgent = request.request.allHTTPHeaderFields[@"User-Agent"];
-    XCTAssertEqualObjects(userAgent, [SFRestAPI userAgentString:@"SmartSync"], @"request failed");
+    XCTAssertEqualObjects(userAgent, [SFRestAPI userAgentString:@"SmartSync"], @"Incorrect user agent");
 }
 
 #pragma mark - custom rest requests

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -235,7 +235,6 @@ static NSException *authException = nil;
 
 // simple: just invoke requestForSearchResultLayout:@"Account"
 - (void)testGetSearchResultLayout {
-     
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearchResultLayout:ACCOUNT];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
@@ -1709,12 +1708,28 @@ static NSException *authException = nil;
     }
 }
 
+// Tests that stock Mobile SDK user agent is set on the request.
+- (void)testRequestUserAgent {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearchResultLayout:ACCOUNT];
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    NSString *userAgent = self.request.allHTTPHeaderFields[@"User-Agent"];
+    XCTAssertEqualObjects(userAgent, [SFRestAPI userAgentString], @"request failed");
+}
+
+// Tests that overridden user agent is set on the request.
+- (void)testRequestUserAgentWithOverride {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearchResultLayout:ACCOUNT];
+    [request setValue:[SFRestAPI userAgentString:@"SmartSync"] forHTTPHeaderField:@"User-Agent"];
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    NSString *userAgent = self.request.allHTTPHeaderFields[@"User-Agent"];
+    XCTAssertEqualObjects(userAgent, [SFRestAPI userAgentString:@"SmartSync"], @"request failed");
+}
+
 #pragma mark - custom rest requests
 
 - (void)testCustomBaseURLRequest {
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodGET baseURL:@"http://www.apple.com" path:@"/test/testing" queryParams:nil];
     XCTAssertEqual(request.baseURL, @"http://www.apple.com", @"Base URL should match");
-    
     NSURLRequest *finalRequest = [request prepareRequestForSend];
     NSString *expectedURL = [NSString stringWithFormat:@"http://www.apple.com%@%@", kSFDefaultRestEndpoint, @"/test/testing"];
     XCTAssertEqualObjects(finalRequest.URL.absoluteString, expectedURL, @"Final URL should utilize base URL that was passed in");


### PR DESCRIPTION
Previously we were relying on `CSFAction` to set the `User-Agent` header. Now we have to set it at the `RestAPI` layer.