### PR TITLE
Centralized SFSDKLogger code

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.h
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.h
@@ -59,6 +59,14 @@
 @property (nonatomic, readwrite, assign, getter=isFileLoggingEnabled) BOOL fileLoggingEnabled;
 
 /**
+ * By default, returns the default shared instance. Child classes implement this method to return an instance with
+ * their defined component name.
+ *
+ * @return Instance of this class.
+ */
++ (nonnull instancetype)sharedInstance;
+
+/**
  * Returns an instance of this class associated with the default component.
  *
  * @return Instance of this class.
@@ -94,12 +102,30 @@
 - (void)e:(nonnull Class)class message:(nonnull NSString *)message;
 
 /**
+ * Logs an error log line.
+ *
+ * @param class Class.
+ * @param format The format message, and optional arguments to expand in the format.
+ * @param ... The arguments to the message format string.
+ */
+- (void)e:(nonnull Class)class format:(nonnull NSString *)format, ...;
+
+/**
  * Logs a warning log line.
  *
  * @param class Class.
  * @param message Log message.
  */
 - (void)w:(nonnull Class)class message:(nonnull NSString *)message;
+
+/**
+ * Logs a warning log line.
+ *
+ * @param class Class.
+ * @param format The format message, and optional arguments to expand in the format.
+ * @param ... The arguments to the message format string.
+ */
+- (void)w:(nonnull Class)class format:(nonnull NSString *)format, ...;
 
 /**
  * Logs an info log line.
@@ -110,6 +136,15 @@
 - (void)i:(nonnull Class)class message:(nonnull NSString *)message;
 
 /**
+ * Logs an info log line.
+ *
+ * @param class Class.
+ * @param format The format message, and optional arguments to expand in the format.
+ * @param ... The arguments to the message format string.
+ */
+- (void)i:(nonnull Class)class format:(nonnull NSString *)format, ...;
+
+/**
  * Logs a verbose log line.
  *
  * @param class Class.
@@ -118,12 +153,30 @@
 - (void)v:(nonnull Class)class message:(nonnull NSString *)message;
 
 /**
+ * Logs a verbose log line.
+ *
+ * @param class Class.
+ * @param format The format message, and optional arguments to expand in the format.
+ * @param ... The arguments to the message format string.
+ */
+- (void)v:(nonnull Class)class format:(nonnull NSString *)format, ...;
+
+/**
  * Logs a debug log line.
  *
  * @param class Class.
  * @param message Log message.
  */
 - (void)d:(nonnull Class)class message:(nonnull NSString *)message;
+
+/**
+ * Logs a debug log line.
+ *
+ * @param class Class.
+ * @param format The format message, and optional arguments to expand in the format.
+ * @param ... The arguments to the message format string.
+ */
+- (void)d:(nonnull Class)class format:(nonnull NSString *)format, ...;
 
 /**
  * Logs a log line of the specified level.
@@ -143,5 +196,104 @@
  * @param ... The arguments to the message format string.
  */
 - (void)log:(nonnull Class)class level:(DDLogLevel)level format:(nonnull NSString *)format, ...;
+
+/**
+ * Returns current log level used by this logger.
+ *
+ * @return Current log level.
+ */
++ (DDLogLevel)logLevel;
+
+/**
+ * Sets log level to be used by this logger.
+ *
+ * @param logLevel Log level.
+ */
++ (void)setLogLevel:(DDLogLevel)logLevel;
+
+/**
+ * Logs an error log line.
+ *
+ * @param class Class.
+ * @param format The format message, and optional arguments to expand in the format.
+ * @param ... The arguments to the message format string.
+ */
++ (void)e:(nonnull Class)class format:(nonnull NSString *)format, ...;
+
+/**
+ * Logs an error log line.
+ *
+ * @param class Class.
+ * @param message Log message.
+ */
++ (void)e:(nonnull Class)class message:(nonnull NSString *)message;
+
+/**
+ * Logs a warning log line.
+ *
+ * @param class Class.
+ * @param format The format message, and optional arguments to expand in the format.
+ * @param ... The arguments to the message format string.
+ */
++ (void)w:(nonnull Class)class format:(nonnull NSString *)format, ...;
+
+/**
+ * Logs a warning log line.
+ *
+ * @param class Class.
+ * @param message Log message.
+ */
++ (void)w:(nonnull Class)class message:(nonnull NSString *)message;
+
+/**
+ * Logs an info log line.
+ *
+ * @param class Class.
+ * @param format The format message, and optional arguments to expand in the format.
+ * @param ... The arguments to the message format string.
+ */
++ (void)i:(nonnull Class)class format:(nonnull NSString *)format, ...;
+
+/**
+ * Logs an info log line.
+ *
+ * @param class Class.
+ * @param message Log message.
+ */
++ (void)i:(nonnull Class)class message:(nonnull NSString *)message;
+
+/**
+ * Logs a verbose log line.
+ *
+ * @param class Class.
+ * @param format The format message, and optional arguments to expand in the format.
+ * @param ... The arguments to the message format string.
+ */
++ (void)v:(nonnull Class)class format:(nonnull NSString *)format, ...;
+
+/**
+ * Logs a verbose log line.
+ *
+ * @param class Class.
+ * @param message Log message.
+ */
++ (void)v:(nonnull Class)class message:(nonnull NSString *)message;
+
+/**
+ * Logs a debug log line.
+ *
+ * @param class Class.
+ * @param format The format message, and optional arguments to expand in the format.
+ * @param ... The arguments to the message format string.
+ */
++ (void)d:(nonnull Class)class format:(nonnull NSString *)format, ...;
+
+/**
+ * Logs a debug log line.
+ *
+ * @param class Class.
+ * @param message Log message.
+ */
++ (void)d:(nonnull Class)class message:(nonnull NSString *)message;
 
 @end

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.m
@@ -69,6 +69,10 @@ static NSMutableDictionary<NSString *, SFSDKLogger *> *loggerList = nil;
     }
 }
 
++ (instancetype)sharedInstance {
+    return [self sharedInstanceWithComponent:kDefaultComponentName];
+}
+
 + (void)flushAllComponents {
     @synchronized ([SFSDKLogger class]) {
         for (NSString *loggerKey in loggerList.allKeys) {
@@ -132,20 +136,55 @@ static NSMutableDictionary<NSString *, SFSDKLogger *> *loggerList = nil;
     [self.logger addLogger:self.fileLogger withLevel:logLevel];
 }
 
+- (void)e:(Class)class format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    [self log:class level:DDLogLevelError format:format args:args];
+    va_end(args);
+}
+
 - (void)e:(Class)class message:(NSString *)message {
     [self log:class level:DDLogLevelError message:message];
+}
+
+- (void)w:(Class)class format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    [self log:class level:DDLogLevelWarning format:format args:args];
+    va_end(args);
 }
 
 - (void)w:(Class)class message:(NSString *)message {
     [self log:class level:DDLogLevelWarning message:message];
 }
 
+- (void)i:(Class)class format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    [self log:class level:DDLogLevelInfo format:format args:args];
+    va_end(args);
+}
+
 - (void)i:(Class)class message:(NSString *)message {
     [self log:class level:DDLogLevelInfo message:message];
 }
 
+- (void)v:(Class)class format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    [self log:class level:DDLogLevelVerbose format:format args:args];
+    va_end(args);
+}
+
 - (void)v:(Class)class message:(NSString *)message {
     [self log:class level:DDLogLevelVerbose message:message];
+}
+
+- (void)d:(Class)class format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    [self log:class level:DDLogLevelDebug format:format args:args];
+    va_end(args);
 }
 
 - (void)d:(Class)class message:(NSString *)message {
@@ -161,9 +200,13 @@ static NSMutableDictionary<NSString *, SFSDKLogger *> *loggerList = nil;
 - (void)log:(Class)class level:(DDLogLevel)level format:(NSString *)format, ... {
     va_list args;
     va_start(args, format);
+    [self log:class level:level format:format args:args];
+    va_end(args);
+}
+
+- (void)log:(Class)class level:(DDLogLevel)level format:(NSString *)format args:(va_list)args {
     NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
     [self log:class level:level message:formattedMessage];
-    va_end(args);
 }
 
 - (void)storeFileLoggingPolicy:(BOOL)enabled {
@@ -224,6 +267,71 @@ static inline DDLogFlag DDLogFlagForLogLevel(DDLogLevel level) {
         default:
             return DDLogFlagDebug;
     }
+}
+
+#pragma mark - Class-level convenience methods
+
++ (DDLogLevel)logLevel {
+    return ((SFSDKLogger *)[self sharedInstance]).getLogLevel;
+}
+
++ (void)setLogLevel:(DDLogLevel)logLevel {
+    ((SFSDKLogger *)[self sharedInstance]).logLevel = logLevel;
+}
+
++ (void)e:(Class)class format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    [[self sharedInstance] log:class level:DDLogLevelError format:format args:args];
+    va_end(args);
+}
+
++ (void)e:(Class)class message:(NSString *)message {
+    [[self sharedInstance] log:class level:DDLogLevelError message:message];
+}
+
++ (void)w:(Class)class format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    [[self sharedInstance] log:class level:DDLogLevelWarning format:format args:args];
+    va_end(args);
+}
+
++ (void)w:(Class)class message:(NSString *)message {
+    [[self sharedInstance] log:class level:DDLogLevelWarning message:message];
+}
+
++ (void)i:(Class)class format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    [[self sharedInstance] log:class level:DDLogLevelInfo format:format args:args];
+    va_end(args);
+}
+
++ (void)i:(Class)class message:(NSString *)message {
+    [[self sharedInstance] log:class level:DDLogLevelInfo message:message];
+}
+
++ (void)v:(Class)class format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    [[self sharedInstance] log:class level:DDLogLevelVerbose format:format args:args];
+    va_end(args);
+}
+
++ (void)v:(Class)class message:(NSString *)message {
+    [[self sharedInstance] log:class level:DDLogLevelVerbose message:message];
+}
+
++ (void)d:(Class)class format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    [[self sharedInstance] log:class level:DDLogLevelDebug format:format args:args];
+    va_end(args);
+}
+
++ (void)d:(Class)class message:(NSString *)message {
+    [[self sharedInstance] log:class level:DDLogLevelDebug message:message];
 }
 
 @end

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Util/SFSDKAnalyticsLogger.h
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Util/SFSDKAnalyticsLogger.h
@@ -29,65 +29,8 @@
 
 #import "SFSDKLogger.h"
 
-@interface SFSDKAnalyticsLogger : NSObject
+extern NSString * _Nonnull const kSFSDKAnalyticsComponentName;
 
-/**
- * Returns current log level used by this logger.
- *
- * @return Current log level.
- */
-+ (DDLogLevel)curLogLevel;
-
-/**
- * Sets log level to be used by this logger.
- *
- * @param logLevel Log level.
- */
-+ (void)setLogLevel:(DDLogLevel)logLevel;
-
-/**
- * Logs an error log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)e:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a warning log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)w:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs an info log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)i:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a verbose log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)v:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a debug log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)d:(nonnull Class)class format:(nonnull NSString *)format, ...;
+@interface SFSDKAnalyticsLogger : SFSDKLogger
 
 @end

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Util/SFSDKAnalyticsLogger.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Util/SFSDKAnalyticsLogger.m
@@ -29,59 +29,12 @@
 
 #import "SFSDKAnalyticsLogger.h"
 
-static NSString * const kComponentName = @"SalesforceAnalytics";
+NSString * const kSFSDKAnalyticsComponentName = @"SalesforceAnalytics";
 
 @implementation SFSDKAnalyticsLogger
 
-+ (DDLogLevel)curLogLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    return logger.logLevel;
-}
-
-+ (void)setLogLevel:(DDLogLevel)logLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    logger.logLevel = logLevel;
-}
-
-+ (void)e:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKAnalyticsLogger log:DDLogLevelError class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)w:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKAnalyticsLogger log:DDLogLevelWarning class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)i:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKAnalyticsLogger log:DDLogLevelInfo class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)v:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKAnalyticsLogger log:DDLogLevelVerbose class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)d:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKAnalyticsLogger log:DDLogLevelDebug class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)log:(DDLogLevel)level class:(Class)class message:(NSString *)message args:(va_list)args {
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    [logger log:class level:level message:formattedMessage];
++ (instancetype)sharedInstance {
+    return [self sharedInstanceWithComponent:kSFSDKAnalyticsComponentName];
 }
 
 @end


### PR DESCRIPTION
For the team's consideration.  We have a lot of duplicated logger code in the new logging system, that seems ripe for centralizing through an inheritance model.  This code implements that approach with `SFSDKAnalyticsLogger`.  If this is agreeable, I can pretty quickly bang out the rest of the logging to follow suit.