### PR TITLE
Logger cleanup - getting the other loggers

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.h
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.h
@@ -67,13 +67,6 @@
 + (nonnull instancetype)sharedInstance;
 
 /**
- * Returns an instance of this class associated with the default component.
- *
- * @return Instance of this class.
- */
-+ (nonnull instancetype)sharedDefaultInstance;
-
-/**
  * Returns an instance of this class associated with the specified component.
  *
  * @param componentName Component name.
@@ -295,5 +288,24 @@
  * @param message Log message.
  */
 + (void)d:(nonnull Class)class message:(nonnull NSString *)message;
+
+/**
+ * Logs a log line of the specified level.
+ *
+ * @param class Class.
+ * @level Log level.
+ * @param format The format message, and optional arguments to expand in the format.
+ * @param ... The arguments to the message format string.
+ */
++ (void)log:(nonnull Class)class level:(DDLogLevel)level format:(nonnull NSString *)format, ...;
+
+/**
+ * Logs a log line of the specified level.
+ *
+ * @param class Class.
+ * @param level Log level.
+ * @param message Log message.
+ */
++ (void)log:(nonnull Class)class level:(DDLogLevel)level message:(nonnull NSString *)message;
 
 @end

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.m
@@ -47,10 +47,6 @@ static NSMutableDictionary<NSString *, SFSDKLogger *> *loggerList = nil;
 
 @implementation SFSDKLogger
 
-+ (instancetype)sharedDefaultInstance {
-    return [SFSDKLogger sharedInstanceWithComponent:kDefaultComponentName];
-}
-
 + (instancetype)sharedInstanceWithComponent:(NSString *)componentName {
     static dispatch_once_t pred;
     dispatch_once(&pred, ^{
@@ -332,6 +328,17 @@ static inline DDLogFlag DDLogFlagForLogLevel(DDLogLevel level) {
 
 + (void)d:(Class)class message:(NSString *)message {
     [[self sharedInstance] log:class level:DDLogLevelDebug message:message];
+}
+
++ (void)log:(Class)class level:(DDLogLevel)level format:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    [[self sharedInstance] log:class level:level format:format args:args];
+    va_end(args);
+}
+
++ (void)log:(Class)class level:(DDLogLevel)level message:(NSString *)message {
+    [[self sharedInstance] log:class level:level message:message];
 }
 
 @end

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFSDKHybridLogger.h
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFSDKHybridLogger.h
@@ -29,65 +29,8 @@
 
 #import <SalesforceAnalytics/SFSDKLogger.h>
 
-@interface SFSDKHybridLogger : NSObject
+extern NSString * _Nonnull const kSFSDKHybridComponentName;
 
-/**
- * Returns current log level used by this logger.
- *
- * @return Current log level.
- */
-+ (DDLogLevel)curLogLevel;
-
-/**
- * Sets log level to be used by this logger.
- *
- * @param logLevel Log level.
- */
-+ (void)setLogLevel:(DDLogLevel)logLevel;
-
-/**
- * Logs an error log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)e:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a warning log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)w:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs an info log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)i:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a verbose log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)v:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a debug log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)d:(nonnull Class)class format:(nonnull NSString *)format, ...;
+@interface SFSDKHybridLogger : SFSDKLogger
 
 @end

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFSDKHybridLogger.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFSDKHybridLogger.m
@@ -29,59 +29,12 @@
 
 #import "SFSDKHybridLogger.h"
 
-static NSString * const kComponentName = @"SalesforceHybrid";
+NSString * const kSFSDKHybridComponentName = @"SalesforceHybrid";
 
 @implementation SFSDKHybridLogger
 
-+ (DDLogLevel)curLogLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    return logger.logLevel;
-}
-
-+ (void)setLogLevel:(DDLogLevel)logLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    logger.logLevel = logLevel;
-}
-
-+ (void)e:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKHybridLogger log:DDLogLevelError class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)w:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKHybridLogger log:DDLogLevelWarning class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)i:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKHybridLogger log:DDLogLevelInfo class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)v:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKHybridLogger log:DDLogLevelVerbose class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)d:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKHybridLogger log:DDLogLevelDebug class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)log:(DDLogLevel)level class:(Class)class message:(NSString *)message args:(va_list)args {
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    [logger log:class level:level message:formattedMessage];
++ (instancetype)sharedInstance {
+    return [self sharedInstanceWithComponent:kSFSDKHybridComponentName];
 }
 
 @end

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Classes/AppDelegate.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Classes/AppDelegate.m
@@ -48,7 +48,7 @@
 {
     self = [super init];
     if (self != nil) {
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Setting up auth credentials."];
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug message:@"Setting up auth credentials."];
         self.testAppHybridViewConfig = [self stageTestCredentials];
 
         // Logout and login host change handlers.
@@ -77,9 +77,9 @@
 - (void)applicationDidBecomeActive:(UIApplication *)application
 {
     SFTestRunnerPlugin *runner =  (SFTestRunnerPlugin*)[self.viewController.commandDelegate getCommandInstance:kSFTestRunnerPluginName];
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"runner: %@", runner];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"runner: %@", runner];
     BOOL runningOctest = [self isRunningOctest];
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"octest running: %d", runningOctest];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"octest running: %d", runningOctest];
 }
 
 - (NSString *) evalJS:(NSString *) js {
@@ -95,7 +95,7 @@
                     resultString = [NSString stringWithFormat:@"%@", result];
                 }
             } else {
-                [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"evaluateJavaScript error : %@", error.localizedDescription];
+                [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"evaluateJavaScript error : %@", error.localizedDescription];
             }
             finished = YES;
         }];
@@ -110,7 +110,7 @@
 
 - (void)authManagerDidLogout:(SFAuthenticationManager *)manager
 {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Logout notification received. Resetting app."];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Logout notification received. Resetting app."];
     self.viewController.appHomeUrl = nil;
 
     // Multi-user pattern:
@@ -141,7 +141,7 @@
          didSwitchFromUser:(SFUserAccount *)fromUser
                     toUser:(SFUserAccount *)toUser
 {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"SFUserAccountManager changed from user %@ to %@. Resetting app.",
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"SFUserAccountManager changed from user %@ to %@. Resetting app.",
      fromUser.userName, toUser.userName];
     [self initializeAppViewState];
 }
@@ -166,7 +166,7 @@
     BOOL result = NO;
     NSDictionary *processEnv = [[NSProcessInfo processInfo] environment];
     NSString *injectBundle = [processEnv valueForKey:@"XCInjectBundle"];
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"XCInjectBundle: %@", injectBundle];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"XCInjectBundle: %@", injectBundle];
     if (nil != injectBundle) {
         NSRange found = [injectBundle rangeOfString:@".octest"];
         if (NSNotFound != found.location) {

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Plugins/SFTestRunnerPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Plugins/SFTestRunnerPlugin.m
@@ -60,7 +60,7 @@ NSString * const kSFTestRunnerPluginName = @"com.salesforce.testrunner";
 
 - (void) pluginInitialize {
     _readyToStartTests = NO;
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"SFTestRunnerPlugin pluginInitialize"];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug message:@"SFTestRunnerPlugin pluginInitialize"];
     _testResults = [[NSMutableDictionary alloc] init];
 }
 
@@ -89,9 +89,9 @@ NSString * const kSFTestRunnerPluginName = @"com.salesforce.testrunner";
     BOOL success = [[argsDict valueForKey:@"success"] boolValue];
     NSString *message = [self stringByStrippingHTML:[argsDict valueForKey:@"message"]];
     NSDictionary *testStatus = [argsDict valueForKey:@"testStatus"];
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"testName: %@ success: %d message: %@",testName,success,message];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"testName: %@ success: %d message: %@",testName,success,message];
     if (!success) {
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"### TEST FAILED: %@",testName];
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"### TEST FAILED: %@",testName];
     }
     SFTestResult *testResult = [[SFTestResult alloc] initWithName:testName success:success message:message status:testStatus];
     [self.testResults setObject:testResult forKey:testName];

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTests/SFPluginTestSuite.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTests/SFPluginTestSuite.m
@@ -45,7 +45,7 @@
     // Block until the javascript has notified the container that it's ready
     BOOL timedOut = [self waitForTestRunnerReady];
     if (timedOut) {
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"failed to start test runner..."];
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug message:@"failed to start test runner..."];
     }
 }
 
@@ -69,11 +69,11 @@
     while (![self isTestRunnerReady]) {
         NSTimeInterval elapsed = [[NSDate date] timeIntervalSinceDate:startTime];
         if (elapsed > 15.0) {
-            [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"testRunner took too long (%f) to startup", elapsed];
+            [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"testRunner took too long (%f) to startup", elapsed];
             completionTimedOut = YES;
             break;
         }
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"## waiting to start tests... "];
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"## waiting to start tests... "];
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
     }
     return completionTimedOut;
@@ -86,11 +86,11 @@
     while (![self isTestResultAvailable:testName]) {
         NSTimeInterval elapsed = [[NSDate date] timeIntervalSinceDate:startTime];
         if (elapsed > 30.0) {
-            [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"test took too long (%f) to complete", elapsed];
+            [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"test took too long (%f) to complete", elapsed];
             completionTimedOut = YES;
             break;
         }
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"## sleeping on %@...", self.jsTestName];
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"## sleeping on %@...", self.jsTestName];
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.3]];
     }
     return completionTimedOut;
@@ -113,14 +113,14 @@
                          ,suiteName,testName];
     AppDelegate *app = (AppDelegate*)[SFApplicationHelper sharedApplication].delegate;
     NSString *cmdResult = [app evalJS:testCmd];
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"cmdResult: '%@'", cmdResult];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"cmdResult: '%@'", cmdResult];
     BOOL timedOut = [self waitForOneCompletion:testName];
     XCTAssertFalse(timedOut, @"timed out waiting for %@ to complete",testName);
     if (!timedOut) {
         AppDelegate *appDelegate = (AppDelegate *)[[SFApplicationHelper sharedApplication] delegate];
         SFTestRunnerPlugin *plugin = (SFTestRunnerPlugin*)[appDelegate.viewController.commandDelegate getCommandInstance:kSFTestRunnerPluginName];
         SFTestResult *testResult = [[plugin testResults] objectForKey:testName];
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ completed in %f",testResult.testName, testResult.duration];
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ completed in %f",testResult.testName, testResult.duration];
         XCTAssertEqualObjects(testResult.testName, testName, @"Wrong test completed");
         XCTAssertTrue(testResult.success, @"%@ failed: %@",testResult.testName,testResult.message);
         [[plugin testResults] removeObjectForKey:testName];

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSDKReactLogger.h
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSDKReactLogger.h
@@ -29,65 +29,8 @@
 
 #import <SalesforceAnalytics/SFSDKLogger.h>
 
-@interface SFSDKReactLogger : NSObject
+extern NSString * _Nonnull const kSFSDKReactComponentName;
 
-/**
- * Returns current log level used by this logger.
- *
- * @return Current log level.
- */
-+ (DDLogLevel)curLogLevel;
-
-/**
- * Sets log level to be used by this logger.
- *
- * @param logLevel Log level.
- */
-+ (void)setLogLevel:(DDLogLevel)logLevel;
-
-/**
- * Logs an error log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)e:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a warning log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)w:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs an info log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)i:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a verbose log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)v:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a debug log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)d:(nonnull Class)class format:(nonnull NSString *)format, ...;
+@interface SFSDKReactLogger : SFSDKLogger
 
 @end

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSDKReactLogger.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSDKReactLogger.m
@@ -29,59 +29,12 @@
 
 #import "SFSDKReactLogger.h"
 
-static NSString * const kComponentName = @"SalesforceReact";
+NSString * const kSFSDKReactComponentName = @"SalesforceReact";
 
 @implementation SFSDKReactLogger
 
-+ (DDLogLevel)curLogLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    return logger.logLevel;
-}
-
-+ (void)setLogLevel:(DDLogLevel)logLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    logger.logLevel = logLevel;
-}
-
-+ (void)e:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKReactLogger log:DDLogLevelError class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)w:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKReactLogger log:DDLogLevelWarning class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)i:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKReactLogger log:DDLogLevelInfo class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)v:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKReactLogger log:DDLogLevelVerbose class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)d:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKReactLogger log:DDLogLevelDebug class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)log:(DDLogLevel)level class:(Class)class message:(NSString *)message args:(va_list)args {
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    [logger log:class level:level message:formattedMessage];
++ (instancetype)sharedInstance {
+    return [self sharedInstanceWithComponent:kSFSDKReactComponentName];
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKCoreLogger.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKCoreLogger.h
@@ -29,65 +29,8 @@
 
 #import <SalesforceAnalytics/SFSDKLogger.h>
 
-@interface SFSDKCoreLogger : NSObject
+extern NSString * _Nonnull const kSFSDKCoreComponentName;
 
-/**
- * Returns current log level used by this logger.
- *
- * @return Current log level.
- */
-+ (DDLogLevel)curLogLevel;
-
-/**
- * Sets log level to be used by this logger.
- *
- * @param logLevel Log level.
- */
-+ (void)setLogLevel:(DDLogLevel)logLevel;
-
-/**
- * Logs an error log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)e:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a warning log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)w:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs an info log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)i:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a verbose log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)v:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a debug log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)d:(nonnull Class)class format:(nonnull NSString *)format, ...;
+@interface SFSDKCoreLogger : SFSDKLogger
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKCoreLogger.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKCoreLogger.m
@@ -29,59 +29,12 @@
 
 #import "SFSDKCoreLogger.h"
 
-static NSString * const kComponentName = @"SalesforceSDKCore";
+NSString * const kSFSDKCoreComponentName = @"SalesforceSDKCore";
 
 @implementation SFSDKCoreLogger
 
-+ (DDLogLevel)curLogLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    return logger.logLevel;
-}
-
-+ (void)setLogLevel:(DDLogLevel)logLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    logger.logLevel = logLevel;
-}
-
-+ (void)e:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKCoreLogger log:DDLogLevelError class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)w:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKCoreLogger log:DDLogLevelWarning class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)i:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKCoreLogger log:DDLogLevelInfo class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)v:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKCoreLogger log:DDLogLevelVerbose class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)d:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKCoreLogger log:DDLogLevelDebug class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)log:(DDLogLevel)level class:(Class)class message:(NSString *)message args:(va_list)args {
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    [logger log:class level:level message:formattedMessage];
++ (instancetype)sharedInstance {
+    return [self sharedInstanceWithComponent:kSFSDKCoreComponentName];
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFNativeRestRequestListener.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFNativeRestRequestListener.m
@@ -44,7 +44,7 @@ int class_uid = 0;
         self.request.delegate = self;
         self->uid = class_uid++;
     }
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"## created listener %d", self->uid];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"## created listener %d", self->uid];
     return self;
 }
 
@@ -67,13 +67,13 @@ int class_uid = 0;
 }
 
 - (void)request:(SFRestRequest*)request didFailLoadWithError:(NSError*)error {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"## error for request %d", self->uid];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"## error for request %d", self->uid];
     self.lastError = error;
     self.returnStatus = kTestRequestStatusDidFail;
 }
 
 - (void)requestDidCancelLoad:(SFRestRequest *)request {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"## cancel for request %d", self->uid];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"## cancel for request %d", self->uid];
     self.returnStatus = kTestRequestStatusDidCancel;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlow.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlow.m
@@ -105,7 +105,7 @@
 #pragma mark - SFOAuthCoordinatorFlow
 
 - (void)beginUserAgentFlow {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     self.beginUserAgentFlowCalled = YES;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.timeBeforeUserAgentCompletion * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (self.userAgentFlowIsSuccessful) {
@@ -117,7 +117,7 @@
 }
 
 - (void)beginTokenEndpointFlow:(SFOAuthTokenEndpointFlow)flowType {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     self.beginTokenEndpointFlowCalled = YES;
     self.tokenEndpointFlowType = flowType;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.timeBeforeRefreshTokenCompletion * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
@@ -130,24 +130,24 @@
 }
 
 - (void)beginJwtTokenExchangeFlow {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     self.beginJwtTokenExchangeFlowCalled = YES;
 }
 
 - (void)beginNativeBrowserFlow {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     self.beginNativeBrowserFlowCalled = YES;
 }
 
 - (void)retrieveOrgAuthConfiguration:(void (^)(SFOAuthOrgAuthConfiguration *orgAuthConfig, NSError *error))retrievedAuthConfigBlock {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     if (retrievedAuthConfigBlock) {
         retrievedAuthConfigBlock(self.retrieveOrgConf, self.retrieveOrgConfError);
     }
 }
 
 - (void)handleTokenEndpointResponse:(NSMutableData *) data{
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     self.handleTokenEndpointResponseCalled = YES;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlowCoordinatorDelegate.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlowCoordinatorDelegate.m
@@ -42,62 +42,62 @@ static NSString * const kSafariNotSupportedReasonFormat  = @"%@ SFSafariViewCont
 #pragma mark - SFOAuthCoordinatorDelegate
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(WKWebView *)view {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
     @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator willBeginAuthenticationWithView:(WKWebView *)view {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
     @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didStartLoad:(WKWebView *)view {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
     @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFinishLoad:(WKWebView *)view error:(NSError*)errorOrNil {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     NSString *reason = [NSString stringWithFormat:kWebNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
     @throw [NSException exceptionWithName:kWebNotSupportedExceptionName reason:reason userInfo:nil];
 }
 
 - (void)oauthCoordinatorWillBeginAuthentication:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)info {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     self.willBeginAuthenticationCalled = YES;
     self.authInfo = info;
 }
 
 - (void)oauthCoordinatorDidAuthenticate:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)info {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     self.didAuthenticateCalled = YES;
     self.authInfo = info;
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFailWithError:(NSError *)error authInfo:(SFOAuthInfo *)info {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     self.didFailWithErrorCalled = YES;
     self.didFailWithError = error;
     self.authInfo = info;
 }
 
 - (BOOL)oauthCoordinatorIsNetworkAvailable:(SFOAuthCoordinator*)coordinator {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     self.isNetworkAvailableCalled = YES;
     return self.isNetworkAvailable;
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSafariViewController:(SFSafariViewController *)svc {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     NSString *reason = [NSString stringWithFormat:kSafariNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
     @throw [NSException exceptionWithName:kSafariNotSupportedReasonFormat reason:reason userInfo:nil];
 }
 
 - (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     NSString *reason = [NSString stringWithFormat:kSafariNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
     @throw [NSException exceptionWithName:kSafariNotSupportedReasonFormat reason:reason userInfo:nil];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFTestSDKManagerFlow.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFTestSDKManagerFlow.m
@@ -48,7 +48,7 @@ static NSTimeInterval const kMaxLaunchWaitTime = 30.0;
 - (void)resumeAuth
 {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, self.stepTimeDelaySecs * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Finishing auth."];
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Finishing auth."];
         [[SalesforceSDKManager sharedManager] authValidatedToPostAuth:SFSDKLaunchActionAuthenticated];
     });
 }
@@ -59,7 +59,7 @@ static NSTimeInterval const kMaxLaunchWaitTime = 30.0;
                                       ? SFSDKLaunchActionAlreadyAuthenticated
                                       : SFSDKLaunchActionAuthBypassed);
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, self.stepTimeDelaySecs * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Finishing auth bypass."];
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Finishing auth bypass."];
         [[SalesforceSDKManager sharedManager] authValidatedToPostAuth:launchAction];
     });
 }
@@ -70,11 +70,11 @@ static NSTimeInterval const kMaxLaunchWaitTime = 30.0;
     while ([SalesforceSDKManager sharedManager].isLaunching) {
         NSTimeInterval elapsed = [[NSDate date] timeIntervalSinceDate:startTime];
         if (elapsed > kMaxLaunchWaitTime) {
-            [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Launch took too long (> %f secs) to complete.", elapsed];
+            [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Launch took too long (> %f secs) to complete.", elapsed];
             return NO;
         }
         
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"## waitForLaunch sleeping..."];
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"## waitForLaunch sleeping..."];
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     }
     return YES;
@@ -84,16 +84,16 @@ static NSTimeInterval const kMaxLaunchWaitTime = 30.0;
 
 - (void)passcodeValidationAtLaunch
 {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Entering passcode validation."];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Entering passcode validation."];
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, self.stepTimeDelaySecs * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Finishing passcode validation."];
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Finishing passcode validation."];
         [[SalesforceSDKManager sharedManager] passcodeValidatedToAuthValidation];
     });
 }
 
 - (void)authAtLaunch
 {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Entering auth at launch."];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Entering auth at launch."];
     if (!self.pauseInAuth) {
         [self resumeAuth];
     }
@@ -101,7 +101,7 @@ static NSTimeInterval const kMaxLaunchWaitTime = 30.0;
 
 - (void)authBypassAtLaunch
 {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Entering auth at launch."];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Entering auth at launch."];
     if (!self.pauseInAuth) {
         [self resumeAuthBypass];
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -162,7 +162,7 @@ static NSException *authException = nil;
 - (void)testFullRequestPath {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForResources];
     request.path = [NSString stringWithFormat:@"%@%@", kSFDefaultRestEndpoint, request.path];
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"request.path: %@", request.path];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"request.path: %@", request.path];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
 }
@@ -379,7 +379,7 @@ static NSException *authException = nil;
     // make sure we got an id
     NSString *contactId = ((NSDictionary *)listener.dataResponse)[LID];
     XCTAssertNotNil(contactId, @"id not present");
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"## contact created with id: %@", contactId];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"## contact created with id: %@", contactId];
     
     @try {
         // now query object
@@ -1119,7 +1119,7 @@ static NSException *authException = nil;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForResources];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"latest access token: %@", _currentUser.credentials.accessToken];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"latest access token: %@", _currentUser.credentials.accessToken];
     
     // let's make sure we have another access token
     NSString *newAccessToken = _currentUser.credentials.accessToken;
@@ -1140,7 +1140,7 @@ static NSException *authException = nil;
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
     NSString *contactId = ((NSDictionary *)listener.dataResponse)[LID];
     XCTAssertNotNil(contactId, @"Contact create result should contain an ID value.");
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"latest access token: %@", _currentUser.credentials.accessToken];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"latest access token: %@", _currentUser.credentials.accessToken];
     
     // let's make sure we have another access token
     NSString *newAccessToken = _currentUser.credentials.accessToken;
@@ -1321,14 +1321,14 @@ static NSException *authException = nil;
 #pragma mark - testing block functions
 
 - (BOOL) waitForExpectation {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Waiting for %@ to complete", self.currentExpectation.description];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Waiting for %@ to complete", self.currentExpectation.description];
     __block BOOL timedout;
     [self waitForExpectationsWithTimeout:15 handler:^(NSError *error) {
         if (error) {
             XCTFail(@"%@ took too long to complete", self.currentExpectation.description);
             timedout = YES;
         } else {
-            [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Completed %@", self.currentExpectation.description];
+            [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Completed %@", self.currentExpectation.description];
             timedout = NO;
         }
     }];
@@ -1681,7 +1681,7 @@ static NSException *authException = nil;
     // Ensures we get an ID back.
     NSString *contactId = ((NSDictionary *)listener.dataResponse)[LID];
     XCTAssertNotNil(contactId, @"id not present");
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"## contact created with id: %@", contactId];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"## contact created with id: %@", contactId];
 
     // Creates a long SOQL query.
     NSMutableString *queryString = [[NSMutableString alloc] init];
@@ -1691,7 +1691,7 @@ static NSException *authException = nil;
         [queryString appendString:@"', '"];
     }
     [queryString appendString:@"')"];
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"## length of query: %d", [queryString length]];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"## length of query: %d", [queryString length]];
 
     // Runs the query.
     @try {

--- a/libs/SmartStore/SmartStore/Classes/SFSDKSmartStoreLogger.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSDKSmartStoreLogger.h
@@ -29,65 +29,8 @@
 
 #import <SalesforceAnalytics/SFSDKLogger.h>
 
-@interface SFSDKSmartStoreLogger : NSObject
+extern NSString * _Nonnull const kSFSDKSmartStoreComponentName;
 
-/**
- * Returns current log level used by this logger.
- *
- * @return Current log level.
- */
-+ (DDLogLevel)curLogLevel;
-
-/**
- * Sets log level to be used by this logger.
- *
- * @param logLevel Log level.
- */
-+ (void)setLogLevel:(DDLogLevel)logLevel;
-
-/**
- * Logs an error log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)e:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a warning log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)w:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs an info log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)i:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a verbose log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)v:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a debug log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)d:(nonnull Class)class format:(nonnull NSString *)format, ...;
+@interface SFSDKSmartStoreLogger : SFSDKLogger
 
 @end

--- a/libs/SmartStore/SmartStore/Classes/SFSDKSmartStoreLogger.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSDKSmartStoreLogger.m
@@ -29,59 +29,12 @@
 
 #import "SFSDKSmartStoreLogger.h"
 
-static NSString * const kComponentName = @"SmartStore";
+NSString * const kSFSDKSmartStoreComponentName = @"SmartStore";
 
 @implementation SFSDKSmartStoreLogger
 
-+ (DDLogLevel)curLogLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    return logger.logLevel;
-}
-
-+ (void)setLogLevel:(DDLogLevel)logLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    logger.logLevel = logLevel;
-}
-
-+ (void)e:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKSmartStoreLogger log:DDLogLevelError class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)w:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKSmartStoreLogger log:DDLogLevelWarning class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)i:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKSmartStoreLogger log:DDLogLevelInfo class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)v:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKSmartStoreLogger log:DDLogLevelVerbose class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)d:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKSmartStoreLogger log:DDLogLevelDebug class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)log:(DDLogLevel)level class:(Class)class message:(NSString *)message args:(va_list)args {
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    [logger log:class level:level message:formattedMessage];
++ (instancetype)sharedInstance {
+    return [self sharedInstanceWithComponent:kSFSDKSmartStoreComponentName];
 }
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSDKSmartSyncLogger.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSDKSmartSyncLogger.h
@@ -29,65 +29,8 @@
 
 #import <SalesforceAnalytics/SFSDKLogger.h>
 
-@interface SFSDKSmartSyncLogger : NSObject
+extern NSString * _Nonnull const kSFSDKSmartSyncComponentName;
 
-/**
- * Returns current log level used by this logger.
- *
- * @return Current log level.
- */
-+ (DDLogLevel)curLogLevel;
-
-/**
- * Sets log level to be used by this logger.
- *
- * @param logLevel Log level.
- */
-+ (void)setLogLevel:(DDLogLevel)logLevel;
-
-/**
- * Logs an error log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)e:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a warning log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)w:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs an info log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)i:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a verbose log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)v:(nonnull Class)class format:(nonnull NSString *)format, ...;
-
-/**
- * Logs a debug log line.
- *
- * @param class Class.
- * @param format The format message, and optional arguments to expand in the format.
- * @param ... The arguments to the message format string.
- */
-+ (void)d:(nonnull Class)class format:(nonnull NSString *)format, ...;
+@interface SFSDKSmartSyncLogger : SFSDKLogger
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSDKSmartSyncLogger.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSDKSmartSyncLogger.m
@@ -29,59 +29,12 @@
 
 #import "SFSDKSmartSyncLogger.h"
 
-static NSString * const kComponentName = @"SmartSync";
+NSString * const kSFSDKSmartSyncComponentName = @"SmartSync";
 
 @implementation SFSDKSmartSyncLogger
 
-+ (DDLogLevel)curLogLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    return logger.logLevel;
-}
-
-+ (void)setLogLevel:(DDLogLevel)logLevel {
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    logger.logLevel = logLevel;
-}
-
-+ (void)e:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKSmartSyncLogger log:DDLogLevelError class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)w:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKSmartSyncLogger log:DDLogLevelWarning class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)i:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKSmartSyncLogger log:DDLogLevelInfo class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)v:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKSmartSyncLogger log:DDLogLevelVerbose class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)d:(Class)class format:(NSString *)format, ... {
-    va_list args;
-    va_start(args, format);
-    [SFSDKSmartSyncLogger log:DDLogLevelDebug class:class message:format args:args];
-    va_end(args);
-}
-
-+ (void)log:(DDLogLevel)level class:(Class)class message:(NSString *)message args:(va_list)args {
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];
-    SFSDKLogger *logger = [SFSDKLogger sharedInstanceWithComponent:kComponentName];
-    [logger log:class level:level message:formattedMessage];
++ (instancetype)sharedInstance {
+    return [self sharedInstanceWithComponent:kSFSDKSmartSyncComponentName];
 }
 
 @end

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
@@ -61,12 +61,12 @@ static NSString * const OAuthRedirectURI        = @"com.salesforce.mobilesdk.sam
             //
             //[[SFPushNotificationManager sharedInstance] registerForRemoteNotifications];
             //
-            [[SFSDKLogger sharedDefaultInstance] log:[strongSelf class] level:DDLogLevelInfo format:@"Post-launch: launch actions taken: %@", [SalesforceSDKManager launchActionsStringRepresentation:launchActionList]];
+            [SFSDKLogger log:[strongSelf class] level:DDLogLevelInfo format:@"Post-launch: launch actions taken: %@", [SalesforceSDKManager launchActionsStringRepresentation:launchActionList]];
             [strongSelf setupRootViewController];
         };
         [SalesforceSDKManager sharedManager].launchErrorAction = ^(NSError *error, SFSDKLaunchAction launchActionList) {
             __strong typeof(weakSelf) strongSelf = weakSelf;
-            [[SFSDKLogger sharedDefaultInstance] log:[strongSelf class] level:DDLogLevelError format:@"Error during SDK launch: %@", [error localizedDescription]];
+            [SFSDKLogger log:[strongSelf class] level:DDLogLevelError format:@"Error during SDK launch: %@", [error localizedDescription]];
             [strongSelf initializeAppViewState];
             [[SalesforceSDKManager sharedManager] launch];
         };
@@ -154,7 +154,7 @@ static NSString * const OAuthRedirectURI        = @"com.salesforce.mobilesdk.sam
 
 - (void)handleSdkManagerLogout
 {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"SDK Manager logged out.  Resetting app."];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"SDK Manager logged out.  Resetting app."];
     [self resetViewState:^{
         [self initializeAppViewState];
         
@@ -183,7 +183,7 @@ static NSString * const OAuthRedirectURI        = @"com.salesforce.mobilesdk.sam
 
 - (void)handleUserSwitch:(SFUserAccount *)fromUser toUser:(SFUserAccount *)toUser
 {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelInfo format:@"SFUserAccountManager changed from user %@ to %@.  Resetting app.", fromUser.userName, toUser.userName];
+    [SFSDKLogger log:[self class] level:DDLogLevelInfo format:@"SFUserAccountManager changed from user %@ to %@.  Resetting app.", fromUser.userName, toUser.userName];
     [self resetViewState:^{
         [self initializeAppViewState];
         [[SalesforceSDKManager sharedManager] launch];

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/RestAPIExplorerViewController.m
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/RestAPIExplorerViewController.m
@@ -447,7 +447,7 @@
 
 - (void)clearPopovers:(NSNotification *)note
 {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Passcode screen loading. Clearing popovers."];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Passcode screen loading. Clearing popovers."];
     if (self.popOverController) {
         [self dismissPopoverController];
     }

--- a/native/SampleApps/SmartSyncExplorer/RecentContactsTodayExtension/TodayViewController.m
+++ b/native/SampleApps/SmartSyncExplorer/RecentContactsTodayExtension/TodayViewController.m
@@ -66,7 +66,7 @@ static NSString *simpleTableIdentifier = @"SimpleTableItem";
     [SFSDKDatasharingHelper sharedInstance].appGroupName = config.appGroupName;
     [SFSDKDatasharingHelper sharedInstance].appGroupEnabled = YES;
     if ([self userIsLoggedIn] ) {
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelError format:@"User has logged in"];
+        [SFSDKLogger log:[self class] level:DDLogLevelError format:@"User has logged in"];
         [SalesforceSDKManager setInstanceClass:[SalesforceSDKManagerWithSmartStore class]];
         [SalesforceSDKManager sharedManager].connectedAppId = config.remoteAccessConsumerKey;
         [SalesforceSDKManager sharedManager].connectedAppCallbackUri = config.oauthRedirectURI;

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/AppDelegate.m
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/AppDelegate.m
@@ -79,13 +79,13 @@
             //[[SFPushNotificationManager sharedInstance] registerForRemoteNotifications];
             //
             [strongSelf setUserLoginStatus:YES];
-            [[SFSDKLogger sharedDefaultInstance] log:[strongSelf class] level:DDLogLevelInfo format:@"Post-launch: launch actions taken: %@", [SalesforceSDKManager launchActionsStringRepresentation:launchActionList]];
+            [SFSDKLogger log:[strongSelf class] level:DDLogLevelInfo format:@"Post-launch: launch actions taken: %@", [SalesforceSDKManager launchActionsStringRepresentation:launchActionList]];
             [strongSelf setupRootViewController];
 
         };
         [SalesforceSDKManager sharedManager].launchErrorAction = ^(NSError *error, SFSDKLaunchAction launchActionList) {
             __strong typeof(weakSelf) strongSelf = weakSelf;
-            [[SFSDKLogger sharedDefaultInstance] log:[strongSelf class] level:DDLogLevelError format:@"Error during SDK launch: %@", [error localizedDescription]];
+            [SFSDKLogger log:[strongSelf class] level:DDLogLevelError format:@"Error during SDK launch: %@", [error localizedDescription]];
             [strongSelf initializeAppViewState];
             [[SalesforceSDKManager sharedManager] launch];
         };
@@ -106,7 +106,7 @@
 - (void)setUserLoginStatus :(BOOL) loggedIn {
     [[NSUserDefaults msdkUserDefaults] setBool:loggedIn forKey:@"userLoggedIn"];
     [[NSUserDefaults msdkUserDefaults] synchronize];
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"%d userLoggedIn", [[NSUserDefaults msdkUserDefaults] boolForKey:@"userLoggedIn"] ];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%d userLoggedIn", [[NSUserDefaults msdkUserDefaults] boolForKey:@"userLoggedIn"] ];
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -162,7 +162,7 @@
 
 - (void)handleSdkManagerLogout
 {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"SFAuthenticationManager logged out. Resetting app."];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"SFAuthenticationManager logged out. Resetting app."];
     [self resetViewState:^{
         [self initializeAppViewState];
         
@@ -193,7 +193,7 @@
 - (void)handleUserSwitch:(SFUserAccount *)fromUser
                   toUser:(SFUserAccount *)toUser
 {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"SFUserAccountManager changed from user %@ to %@.  Resetting app.",
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"SFUserAccountManager changed from user %@ to %@.  Resetting app.",
      fromUser.userName, toUser.userName];
     [self resetViewState:^{
         [self initializeAppViewState];

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/ContactListViewController.m
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/ContactListViewController.m
@@ -258,7 +258,7 @@ static NSUInteger const kColorCodesList[] = { 0x1abc9c,  0x2ecc71,  0x3498db,  0
 #pragma mark - UISearchBarDelegate methods
 
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"searching with text: %@", searchText];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"searching with text: %@", searchText];
     self.searchText = searchText;
     [self refreshList];
 }
@@ -624,7 +624,7 @@ static NSUInteger const kColorCodesList[] = { 0x1abc9c,  0x2ecc71,  0x3498db,  0
 
 - (void)clearPopovers:(NSNotification *)note
 {
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Passcode screen loading. Clearing popovers."];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Passcode screen loading. Clearing popovers."];
     if (self.popOverController) {
         [self.popOverController dismissPopoverAnimated:NO];
     }

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorerCommon/SObjectDataManager.m
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorerCommon/SObjectDataManager.m
@@ -151,14 +151,14 @@ static char* const kSearchFilterQueueName = "com.salesforce.smartSyncExplorer.se
     SFQuerySpec *sobjectsQuerySpec = [SFQuerySpec newAllQuerySpec:self.dataSpec.soupName withOrderPath:self.dataSpec.orderByFieldName withOrder:kSFSoupQuerySortOrderAscending withPageSize:kMaxQueryPageSize];
     NSError *queryError = nil;
     NSArray *queryResults = [self.store queryWithQuerySpec:sobjectsQuerySpec pageIndex:0 error:&queryError];
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Got local query results.  Populating data rows."];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Got local query results.  Populating data rows."];
     if (queryError) {
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelError format:@"Error retrieving '%@' data from SmartStore: %@", self.dataSpec.objectType, [queryError localizedDescription]];
+        [SFSDKLogger log:[self class] level:DDLogLevelError format:@"Error retrieving '%@' data from SmartStore: %@", self.dataSpec.objectType, [queryError localizedDescription]];
         return;
     }
     
     self.fullDataRowList = [self populateDataRows:queryResults];
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Finished generating data rows.  Number of rows: %d.  Refreshing view.", [self.fullDataRowList count]];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Finished generating data rows.  Number of rows: %d.  Refreshing view.", [self.fullDataRowList count]];
     self.dataRows = [self.fullDataRowList copy];
     if (completionBlock) completionBlock();
 }
@@ -215,14 +215,14 @@ static char* const kSearchFilterQueueName = "com.salesforce.smartSyncExplorer.se
 - (void)lastModifiedRecords:(int) limit completion:(void (^)(void))completionBlock {
     SFQuerySpec *sobjectsQuerySpec =  [SFQuerySpec newAllQuerySpec:self.dataSpec.soupName withOrderPath:@"_soupLastModifiedDate" withOrder:kSFSoupQuerySortOrderDescending withPageSize:limit];
     NSError *queryError = nil;
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Got local query results.  Populating data rows."];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Got local query results.  Populating data rows."];
     NSArray *queryResults = [self.store queryWithQuerySpec:sobjectsQuerySpec pageIndex:0 error:&queryError];
     if (queryError) {
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelError format:@"Error retrieving '%@' data from SmartStore: %@", self.dataSpec.objectType, [queryError localizedDescription]];
+        [SFSDKLogger log:[self class] level:DDLogLevelError format:@"Error retrieving '%@' data from SmartStore: %@", self.dataSpec.objectType, [queryError localizedDescription]];
         return;
     }
     self.fullDataRowList = [self populateDataRows:queryResults];
-    [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Finished generating data rows.  Number of rows: %d.  Refreshing view.", [self.fullDataRowList count]];
+    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Finished generating data rows.  Number of rows: %d.  Refreshing view.", [self.fullDataRowList count]];
     self.dataRows = [self.fullDataRowList copy];
     completionBlock();
 }

--- a/shared/hybrid/AppDelegate+SalesforceHybridSDK.m
+++ b/shared/hybrid/AppDelegate+SalesforceHybridSDK.m
@@ -65,12 +65,12 @@
     __weak __typeof(self) weakSelf = self;
     [SalesforceSDKManager sharedManager].postLaunchAction = ^(SFSDKLaunchAction launchActionList) {
         __strong __typeof(weakSelf) strongSelf = weakSelf;
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelInfo format:@"Post-launch: launch actions taken: %@", [SalesforceSDKManager launchActionsStringRepresentation:launchActionList]];
+        [SFSDKLogger log:[self class] level:DDLogLevelInfo format:@"Post-launch: launch actions taken: %@", [SalesforceSDKManager launchActionsStringRepresentation:launchActionList]];
         [strongSelf setupRootViewController];
     };
     [SalesforceSDKManager sharedManager].launchErrorAction = ^(NSError *error, SFSDKLaunchAction launchActionList) {
         __strong __typeof(weakSelf) strongSelf = weakSelf;
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelError format:@"Error during SDK launch: %@", [error localizedDescription]];
+        [SFSDKLogger log:[self class] level:DDLogLevelError format:@"Error during SDK launch: %@", [error localizedDescription]];
         [strongSelf initializeAppViewState];
         [[SalesforceSDKManager sharedManager] launch];
     };
@@ -128,7 +128,7 @@
 - (void)handleSdkManagerLogout
 {
     [self resetViewState:^{
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"Logout notification received. Resetting app."];
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Logout notification received. Resetting app."];
         ((SFHybridViewController*)self.viewController).appHomeUrl = nil;
         [self initializeAppViewState];
         
@@ -159,7 +159,7 @@
                   toUser:(SFUserAccount *)toUser
 {
     [self resetViewState:^{
-        [[SFSDKLogger sharedDefaultInstance] log:[self class] level:DDLogLevelDebug format:@"SFUserAccountManager changed from user %@ to %@. Resetting app.",
+        [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"SFUserAccountManager changed from user %@ to %@. Resetting app.",
          fromUser.userName, toUser.userName];
         [self initializeAppViewState];
         [[SalesforceSDKManager sharedManager] launch];


### PR DESCRIPTION
- Updated the other loggers to follow the pattern from the previous PR.
- Removed `sharedDefaultInstance` and reworked consumption, as it's superfluous now.
- Some minor cleanup of interfaces that I missed before.

The `Everything` scheme passes, and I've run a number of sample targets and verified that they're working.