### PR TITLE
Fixing token revocation tests

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
@@ -44,6 +44,9 @@ extern NSException * SFOAuthInvalidIdentifierException();
 
 @property (nonatomic, strong) NSDictionary * additionalOAuthFields;
 
+// Facilitates NSCopying implementation.
+@property (nonatomic, readwrite) NSDictionary *legacyIdentityInformation;
+
 /** Holds the attributes that have changed during auth flow.
  */
 @property (nonatomic) NSMutableDictionary * credentialsChangeSet;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
@@ -61,7 +61,7 @@ typedef NS_ENUM(NSInteger, SFOAuthCredentialsStorageType){
 
  @see SFOAuthCoordinator
  */
-@interface SFOAuthCredentials : NSObject <NSSecureCoding>
+@interface SFOAuthCredentials : NSObject <NSSecureCoding, NSCopying>
 
 /** Protocol scheme for authenticating this account.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -47,7 +47,7 @@ NSException * SFOAuthInvalidIdentifierException() {
 
 //This property is intentionally readonly in the public header files.
 @property (nonatomic, readwrite, strong) NSString *protocol;
-    
+
 @end
 
 @implementation SFOAuthCredentials
@@ -169,6 +169,33 @@ NSException * SFOAuthInvalidIdentifierException() {
     }
     _credentialsChangeSet = [NSMutableDictionary new];
     return self;
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(nullable NSZone *)zone {
+    SFOAuthCredentials *copyCreds = [[[self class] allocWithZone:zone] initWithIdentifier:self.identifier clientId:self.clientId encrypted:self.encrypted];
+    copyCreds.protocol = self.protocol;
+    copyCreds.domain = self.domain;
+    copyCreds.redirectUri = self.redirectUri;
+    copyCreds.jwt = self.jwt;
+    copyCreds.refreshToken = self.refreshToken;
+    copyCreds.accessToken = self.accessToken;
+    copyCreds.instanceUrl = self.instanceUrl;
+    copyCreds.communityId = self.communityId;
+    copyCreds.communityUrl = self.communityUrl;
+    copyCreds.issuedAt = self.issuedAt;
+    
+    // NB: Intentionally ordering the copying of these, because setting the identity URL automatically
+    // sets the OrgID and UserID.  This ensures the values stay in sync.
+    copyCreds.identityUrl = self.identityUrl;
+    copyCreds.organizationId = self.organizationId;
+    copyCreds.userId = self.userId;
+    
+    copyCreds.legacyIdentityInformation = [self.legacyIdentityInformation copy];
+    copyCreds.additionalOAuthFields = [self.additionalOAuthFields copy];
+    
+    return copyCreds;
 }
 
 #pragma mark - Public Methods

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -268,6 +268,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
                         __strong typeof(weakSelf) strongSelf = weakSelf;
                         [SFSDKCoreLogger i:[strongSelf class] format:@"%@: Credentials refresh successful. Replaying original REST request.", NSStringFromSelector(_cmd)];
                         strongSelf.sessionRefreshInProgress = NO;
+                        strongSelf.oauthSessionRefresher = nil;
                         [strongSelf send:request delegate:delegate shouldRetry:NO];
                     } error:^(NSError *refreshError) {
                         __strong typeof(weakSelf) strongSelf = weakSelf;
@@ -276,6 +277,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
                         strongSelf.pendingRequestsBeingProcessed = YES;
                         [strongSelf flushPendingRequestQueue:refreshError];
                         strongSelf.sessionRefreshInProgress = NO;
+                        strongSelf.oauthSessionRefresher = nil;
                         if ([refreshError.domain isEqualToString:kSFOAuthErrorDomain] && refreshError.code == kSFOAuthErrorInvalidGrant) {
                             [SFSDKCoreLogger i:[strongSelf class] format:@"%@ Invalid grant error received, triggering logout.", NSStringFromSelector(_cmd)];
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
@@ -151,6 +151,93 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     credsIn = nil;
 }
 
+- (void)testCredentialsCopying {
+    NSString *domainToCheck = @"login.salesforce.com";
+    NSString *redirectUriToCheck = @"redirectUri://done";
+    NSString *jwtToCheck = @"jwtToken";
+    NSString *refreshTokenToCheck = @"refreshToken";
+    NSString *accessTokenToCheck = @"accessToken";
+    NSString *orgIdToCheck = @"orgID";
+    NSURL *instanceUrlToCheck = [NSURL URLWithString:@"https://na1.salesforce.com"];
+    NSString *communityIdToCheck = @"communityID";
+    NSURL *communityUrlToCheck = [NSURL URLWithString:@"https://mycomm.my.salesforce.com/customers"];
+    NSDate *issuedAtToCheck = [NSDate date];
+    NSURL *identityUrlToCheck = [NSURL URLWithString:@"https://login.salesforce.com/id/someOrg/someUser"];
+    NSString *userIdToCheck = @"userID";
+    NSDictionary *additionalFieldsToCheck = @{ @"field1": @"field1Val" };
+    NSDictionary *legacyIdInfoToCheck = @{ @"idInfo1": @"idInfo1Val" };
+    
+    SFOAuthCredentials *origCreds = [[SFOAuthCredentials alloc] initWithIdentifier:kIdentifier clientId:kClientId encrypted:YES];
+    origCreds.domain = domainToCheck;
+    origCreds.redirectUri = redirectUriToCheck;
+    origCreds.jwt = jwtToCheck;
+    origCreds.refreshToken = refreshTokenToCheck;
+    origCreds.accessToken = accessTokenToCheck;
+    origCreds.instanceUrl = instanceUrlToCheck;
+    origCreds.communityId = communityIdToCheck;
+    origCreds.communityUrl = communityUrlToCheck;
+    origCreds.issuedAt = issuedAtToCheck;
+    
+    // NB: Intentionally ordering the setting of these, because setting the identity URL automatically
+    // sets the OrgID and UserID.  This ensures the values stay in sync.
+    origCreds.identityUrl = identityUrlToCheck;
+    origCreds.organizationId = orgIdToCheck;
+    origCreds.userId = userIdToCheck;
+    
+    origCreds.additionalOAuthFields = additionalFieldsToCheck;
+    origCreds.legacyIdentityInformation = legacyIdInfoToCheck;
+    
+    SFOAuthCredentials *copiedCreds = [origCreds copy];
+    
+    origCreds.domain = nil;
+    origCreds.redirectUri = nil;
+    origCreds.jwt = nil;
+    origCreds.refreshToken = nil;
+    origCreds.accessToken = nil;
+    origCreds.organizationId = nil;
+    origCreds.instanceUrl = nil;
+    origCreds.communityId = nil;
+    origCreds.communityUrl = nil;
+    origCreds.issuedAt = nil;
+    origCreds.identityUrl = nil;
+    origCreds.userId = nil;
+    origCreds.additionalOAuthFields = nil;
+    origCreds.legacyIdentityInformation = nil;
+    
+    XCTAssertNotEqual(origCreds, copiedCreds);
+    XCTAssertEqual(copiedCreds.domain, domainToCheck);
+    XCTAssertNotEqual(origCreds.domain, copiedCreds.domain);
+    XCTAssertEqual(copiedCreds.redirectUri, redirectUriToCheck);
+    XCTAssertNotEqual(origCreds.redirectUri, copiedCreds.redirectUri);
+    XCTAssertEqual(copiedCreds.jwt, jwtToCheck);
+    XCTAssertNotEqual(origCreds.jwt, copiedCreds.jwt);
+    
+    // NB: Access and refresh tokens cannot be distinct after copy and change, because of the keychain.
+    XCTAssertNotEqual(copiedCreds.refreshToken, refreshTokenToCheck);
+    XCTAssertEqual(origCreds.refreshToken, copiedCreds.refreshToken);
+    XCTAssertNotEqual(copiedCreds.accessToken, accessTokenToCheck);
+    XCTAssertEqual(origCreds.accessToken, copiedCreds.accessToken);
+    
+    XCTAssertEqual(copiedCreds.organizationId, orgIdToCheck);
+    XCTAssertNotEqual(origCreds.organizationId, copiedCreds.organizationId);
+    XCTAssertEqual(copiedCreds.instanceUrl, instanceUrlToCheck);
+    XCTAssertNotEqual(origCreds.instanceUrl, copiedCreds.instanceUrl);
+    XCTAssertEqual(copiedCreds.communityId, communityIdToCheck);
+    XCTAssertNotEqual(origCreds.communityId, copiedCreds.communityId);
+    XCTAssertEqual(copiedCreds.communityUrl, communityUrlToCheck);
+    XCTAssertNotEqual(origCreds.communityUrl, copiedCreds.communityUrl);
+    XCTAssertEqual(copiedCreds.issuedAt, issuedAtToCheck);
+    XCTAssertNotEqual(origCreds.issuedAt, copiedCreds.issuedAt);
+    XCTAssertEqual(copiedCreds.identityUrl, identityUrlToCheck);
+    XCTAssertNotEqual(origCreds.identityUrl, copiedCreds.identityUrl);
+    XCTAssertEqual(copiedCreds.userId, userIdToCheck);
+    XCTAssertNotEqual(origCreds.userId, copiedCreds.userId);
+    XCTAssertEqual(copiedCreds.additionalOAuthFields, additionalFieldsToCheck);
+    XCTAssertNotEqual(origCreds.additionalOAuthFields, copiedCreds.additionalOAuthFields);
+    XCTAssertEqual(copiedCreds.legacyIdentityInformation, legacyIdInfoToCheck);
+    XCTAssertNotEqual(origCreds.legacyIdentityInformation, copiedCreds.legacyIdentityInformation);
+}
+
 /** Test the SFOAuthCoordinator
  */
 - (void)testCoordinator {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -1176,12 +1176,12 @@ static NSException *authException = nil;
 // - sets an invalid refreshToken
 // - issue a valid REST request
 // - ensure all requests are failed with the proper error
-- (void)FIXMEtestInvalidAccessAndRefreshToken {
+- (void)testInvalidAccessAndRefreshToken {
 
     // save valid tokens and current user
     NSString *origAccessToken = _currentUser.credentials.accessToken;
     NSString *origRefreshToken = _currentUser.credentials.refreshToken;
-    SFUserAccount *curUser = _currentUser;
+    SFOAuthCredentials *origCreds = [_currentUser.credentials copy];
     
     // set invalid tokens
     NSString *invalidAccessToken = @"xyz";
@@ -1198,8 +1198,11 @@ static NSException *authException = nil;
         XCTAssertNotNil(listener.lastError.userInfo);
     }
     @finally {
-        _currentUser = curUser;
-        [self changeOauthTokens:origAccessToken refreshToken:origRefreshToken];
+        origCreds.accessToken = origAccessToken;
+        origCreds.refreshToken = origRefreshToken;
+        _currentUser.credentials = origCreds;
+        [[SFUserAccountManager sharedInstance] saveAccountForUser:_currentUser error:nil];
+        [SFUserAccountManager sharedInstance].currentUser = _currentUser;
     }
 }
 
@@ -1257,12 +1260,12 @@ static NSException *authException = nil;
 // - issue multiple valid requests
 // - make sure the token exchange failed
 // - ensure all requests are failed with the proper error code
-- (void)FIXMEtestInvalidAccessAndRefreshToken_MultipleRequests {
+- (void)testInvalidAccessAndRefreshToken_MultipleRequests {
 
     // save valid tokens and current user
     NSString *origAccessToken = _currentUser.credentials.accessToken;
     NSString *origRefreshToken = _currentUser.credentials.refreshToken;
-    SFUserAccount *curUser = _currentUser;
+    SFOAuthCredentials *origCreds = [_currentUser.credentials copy];
     
     // set invalid tokens
     NSString *invalidAccessToken = @"xyz";
@@ -1317,8 +1320,11 @@ static NSException *authException = nil;
         XCTAssertNotNil(listener4.lastError.userInfo,@"userInfo should not be nil");
     }
     @finally {
-        _currentUser = curUser;
-        [self changeOauthTokens:origAccessToken refreshToken:origRefreshToken];
+        origCreds.accessToken = origAccessToken;
+        origCreds.refreshToken = origRefreshToken;
+        _currentUser.credentials = origCreds;
+        [[SFUserAccountManager sharedInstance] saveAccountForUser:_currentUser error:nil];
+        [SFUserAccountManager sharedInstance].currentUser = _currentUser;
     }
 }
 


### PR DESCRIPTION
The ultimate issue with the (refresh) token revocation tests is that `currentUser` would be torn down in a way that was tough to rehydrate its state.  So I implemented `NSCopying` on `SFOAuthCredentials`, and rehydrated the torn-down user from that.

Also unearthed a couple of items missed on the replay fix earlier.

@bhariharan 