### PR TITLE
Pending requests should not be retried

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -356,7 +356,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
     @synchronized (self) {
         NSSet *pendingRequests = [self.activeRequests copy];
         for (SFRestRequest *request in pendingRequests) {
-            [self send:request delegate:request.delegate shouldRetry:YES];
+            [self send:request delegate:request.delegate shouldRetry:NO];
         }
         self.pendingRequestsBeingProcessed = NO;
     }


### PR DESCRIPTION
`shouldRetry` should be `NO` because this method is triggered only after successful session refresh.