### PR TITLE
Update login failure to equate with Android

### DIFF
--- a/libs/SalesforceReact/SalesforceReact/Classes/SFOauthReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFOauthReactBridge.m
@@ -100,11 +100,11 @@ RCT_EXPORT_METHOD(authenticate:(NSDictionary *)args callback:(RCTResponseSenderB
     SFOAuthCredentials *creds = [SFAuthenticationManager sharedManager].coordinator.credentials;
     NSString *accessToken = creds.accessToken;
     
-    // If access token is not present, authenticate first. Otherwise, send current credentials.
+    // If access token is not present, send error so user can manually authenticate. Otherwise, send current credentials.
     if (accessToken) {
         [self sendAuthCredentials:callback];
     } else {
-        [self authenticate:nil callback:callback];
+        [self sendNotAuthenticatedError:callback];
     }
 }
 


### PR DESCRIPTION
Login on Android does not automatically auth on failure.  This brings them together.  See https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/issues/33