### PR TITLE
Changing getAuthCredentials to behave like it does on Android

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.h
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.h
@@ -36,7 +36,7 @@
 #pragma mark - Plugin exported to javascript
 
 /**
- * Cordova plug-in method to obtain the current login credentials, authenticating if needed.
+ * Cordova plug-in method to obtain the current login credentials.
  * @param command Cordova plugin command object, containing input parameters.
  */
 - (void)getAuthCredentials:(CDVInvokedUrlCommand *)command;

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
@@ -31,49 +31,40 @@
 #import <SalesforceSDKCore/SFSDKWebUtils.h>
 #import "SFHybridViewController.h"
 
-// ------------------------------------------
-// Private methods interface
-// ------------------------------------------
-@interface SalesforceOAuthPlugin()
-
-- (void)authenticate:(CDVInvokedUrlCommand*)command getCachedCredentials:(BOOL)getCachedCredentials;
-
-/**
- Method to be called when the OAuth process completes.
- @param authDict The NSDictionary containing the authentication data.
- @param callbackId The plugin callback ID associated with the request.
- */
-- (void)authenticationCompletion:(NSDictionary *)authDict callbackId:(NSString *)callbackId;
-
-/**
- Creates an error dictionary to send back in an auth error case.
- @param error The OAuth error that occurred.
- @param authInfo The OAuth info associated with the auth attempt.
- @return An NSDictionary of error information.
- */
-+ (NSDictionary *)authErrorDictionaryFromError:(NSError *)error authInfo:(SFOAuthInfo *)authInfo;
-
-@end
-
-// ------------------------------------------
-// Main implementation
-// ------------------------------------------
 @implementation SalesforceOAuthPlugin
 
-#pragma mark - Cordova plugin methods and helpers
+#pragma mark - Cordova plugin methods
 
 - (void)getAuthCredentials:(CDVInvokedUrlCommand *)command
 {
     [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"getAuthCredentials: arguments: %@", command.arguments]];
     [self getVersion:@"getAuthCredentials" withArguments:command.arguments];
-    [self authenticate:command getCachedCredentials:YES];
+
+    SFHybridViewController *hybridVc = (SFHybridViewController *)self.viewController;
+    NSDictionary *authDict = [hybridVc credentialsAsDictionary];
+    if ([authDict[kAccessTokenCredentialsDictKey] length] > 0) {
+        [self sendAuthCredentials:command authDict:authDict];
+    } else {
+        [self sendNotAuthenticated:command];
+    }
 }
 
 - (void)authenticate:(CDVInvokedUrlCommand*)command
 {
     [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"authenticate: arguments: %@", command.arguments]];
     [self getVersion:@"authenticate" withArguments:command.arguments];
-    [self authenticate:command getCachedCredentials:NO];
+
+    SFOAuthPluginAuthSuccessBlock completionBlock = ^(SFOAuthInfo *authInfo, NSDictionary *authDict) {
+        [self sendAuthCredentials:command authDict:authDict];
+    };
+
+    SFOAuthFlowFailureCallbackBlock failureBlock = ^(SFOAuthInfo *authInfo, NSError *error) {
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                      messageAsDictionary:[[self class] authErrorDictionaryFromError:error authInfo:authInfo]];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    };
+    SFHybridViewController *hybridVc = (SFHybridViewController *)self.viewController;
+    [hybridVc authenticateWithCompletionBlock:completionBlock failureBlock:failureBlock];
 }
 
 - (void)logoutCurrentUser:(CDVInvokedUrlCommand *)command
@@ -95,24 +86,16 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
 }
 
-- (void)authenticate:(CDVInvokedUrlCommand*)command getCachedCredentials:(BOOL)getCachedCredentials
-{
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"authenticate:getCachedCredentials:"]];
-    NSString* callbackId = command.callbackId;
-    SFOAuthPluginAuthSuccessBlock completionBlock = ^(SFOAuthInfo *authInfo, NSDictionary *authDict) {
-        [self authenticationCompletion:authDict callbackId:callbackId];
-    };
-    SFOAuthFlowFailureCallbackBlock failureBlock = ^(SFOAuthInfo *authInfo, NSError *error) {
-        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-                                                      messageAsDictionary:[[self class] authErrorDictionaryFromError:error authInfo:authInfo]];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
-    };
-    SFHybridViewController *hybridVc = (SFHybridViewController *)self.viewController;
-    if (getCachedCredentials) {
-        [hybridVc getAuthCredentialsWithCompletionBlock:completionBlock failureBlock:failureBlock];
-    } else {
-        [hybridVc authenticateWithCompletionBlock:completionBlock failureBlock:failureBlock];
-    }
+#pragma mark - Cordova plugin helpers
+
+- (void) sendAuthCredentials:(CDVInvokedUrlCommand *)command authDict:(NSDictionary*)authDict {
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:authDict];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void) sendNotAuthenticated:(CDVInvokedUrlCommand *)command {
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Not authenticated"];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 + (NSDictionary *)authErrorDictionaryFromError:(NSError *)error authInfo:(SFOAuthInfo *)authInfo
@@ -125,17 +108,6 @@
         authDict[@"Type"] = (error.userInfo)[@"error"];
     authDict[@"AuthInfo"] = [authInfo description];
     return authDict;
-}
-
-#pragma mark - Salesforce.com login helpers
-
-- (void)authenticationCompletion:(NSDictionary *)authDict callbackId:(NSString *)callbackId
-{
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"authenticationCompletion: Authentication flow succeeded. Initiating post-auth configuration."]];
-
-    // Call back to the client with the authentication credentials.
-    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:authDict];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
 }
 
 @end

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
@@ -111,15 +111,6 @@ typedef void (^SFOAuthPluginAuthSuccessBlock)(SFOAuthInfo *, NSDictionary *);
 - (UIView *)newCordovaViewWithFrameAndEngine:(CGRect)bounds webViewEngine:(NSString *)webViewEngine;
 
 /**
- Method used by the OAuth plugin to obtain the current login credentials, or authenticate if no
- credentials are configured.
- @param completionBlock The OAuth plugin completion block to call upon successful retrieval of
- the credentials.
- @param failureBlock The failure block to call in the event of an authentication failure.
- */
-- (void)getAuthCredentialsWithCompletionBlock:(SFOAuthPluginAuthSuccessBlock)completionBlock failureBlock:(SFOAuthFlowFailureCallbackBlock)failureBlock;
-
-/**
  Used by the OAuth plugin to authenticate the user.
  @param completionBlock The block to call upon successsful authentication.
  @param failureBlock The block to call in the event of an auth failure.

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -330,20 +330,6 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
     }
 }
 
-- (void)getAuthCredentialsWithCompletionBlock:(SFOAuthPluginAuthSuccessBlock)completionBlock failureBlock:(SFOAuthFlowFailureCallbackBlock)failureBlock
-{
-
-    // If authDict does not contain an access token, authenticate first. Otherwise, send current credentials.
-    NSDictionary *authDict = [self credentialsAsDictionary];
-    if ([authDict[kAccessTokenCredentialsDictKey] length] == 0) {
-        [self authenticateWithCompletionBlock:completionBlock failureBlock:failureBlock];
-    } else {
-        if (completionBlock != NULL) {
-            completionBlock(nil, authDict);
-        }
-    }
-}
-
 - (void)loadErrorPageWithCode:(NSInteger)errorCode description:(NSString *)errorDescription context:(NSString *)errorContext
 {
     NSString *errorPage = _hybridViewConfig.errorPage;


### PR DESCRIPTION
Oauth cordova plugins's getAuthCredentials returns error "not authenticated" when not authenticated instead of triggering an authentication