### PR TITLE
Moving management of Auth related properties to SFUserAccountManager

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -212,31 +212,6 @@ extern NSString * const kSFUserLoggedInNotification;
 extern NSString * const kSFAuthenticationManagerFinishedNotification;
 
 /**
-  Default used as last resort
- */
-extern NSString * const kSFUserAccountOAuthLoginHostDefault;
-
-/**
- Key identifying login host
- */
-extern NSString * const kSFUserAccountOAuthLoginHost;
-
-/**
- The key for storing the persisted OAuth scopes.
- */
-extern  NSString * const kOAuthScopesKey;
-
-/**
-The key for storing the persisted OAuth client ID.
- */
-extern  NSString * const kOAuthClientIdKey;
-
-/**
-The key for storing the persisted OAuth redirect URI.
- */
-extern  NSString * const kOAuthRedirectUriKey;
-
-/**
  This class handles all the authentication related tasks, which includes login, logout and session refresh
  */
 @interface SFAuthenticationManager : NSObject <SFOAuthCoordinatorDelegate, SFIdentityCoordinatorDelegate, SFUserAccountManagerDelegate>

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -75,22 +75,7 @@ static NSString * const kAlertRetryButtonKey = @"authAlertRetryButton";
 static NSString * const kAlertDismissButtonKey = @"authAlertDismissButton";
 static NSString * const kAlertConnectionErrorFormatStringKey = @"authAlertConnectionErrorFormatString";
 static NSString * const kAlertVersionMismatchErrorKey = @"authAlertVersionMismatchError";
-static NSString * const kUserNameCookieKey = @"sfdc_lv2";
 static NSString * const kSFUserAccountOAuthRedirectUri = @"SFDCOAuthRedirectUri";
-static NSString * const kDeprecatedLoginHostPrefKey = @"login_host_pref";
-
-// Oauth
-NSString * const kSFUserAccountOAuthLoginHostDefault = @"login.salesforce.com"; // last resort
-NSString * const kSFUserAccountOAuthLoginHost = @"SFDCOAuthLoginHost";
-
-// The key for storing the persisted OAuth scopes.
-NSString * const kOAuthScopesKey = @"oauth_scopes";
-
-// The key for storing the persisted OAuth client ID.
-NSString * const kOAuthClientIdKey = @"oauth_client_id";
-
-// The key for storing the persisted OAuth redirect URI.
-NSString * const kOAuthRedirectUriKey = @"oauth_redirect_uri";
 
 #pragma mark - SFAuthBlockPair
 
@@ -490,10 +475,13 @@ static Class InstanceClass = nil;
     return SFUserAccountManager.sharedInstance.currentUser != nil && SFUserAccountManager.sharedInstance.currentUser.isSessionValid;
 }
 
+- (SFOAuthAdvancedAuthConfiguration) advancedAuthConfiguration {
+    return [SFUserAccountManager sharedInstance].advancedAuthConfiguration;
+}
+
 - (void)setAdvancedAuthConfiguration:(SFOAuthAdvancedAuthConfiguration)advancedAuthConfiguration
 {
-    _advancedAuthConfiguration = advancedAuthConfiguration;
-    self.coordinator.advancedAuthConfiguration = advancedAuthConfiguration;
+    [SFUserAccountManager sharedInstance].advancedAuthConfiguration = advancedAuthConfiguration;
 }
 
 - (BOOL)handleAdvancedAuthenticationResponse:(NSURL *)appUrlResponse
@@ -504,109 +492,44 @@ static Class InstanceClass = nil;
 #pragma mark - Login Host
 
 - (void)setLoginHost:(NSString*)host {
-    NSString *oldLoginHost = [self loginHost];
-
-    if (nil == host) {
-        [[NSUserDefaults msdkUserDefaults] removeObjectForKey:kSFUserAccountOAuthLoginHost];
-    } else {
-        [[NSUserDefaults msdkUserDefaults] setObject:host forKey:kSFUserAccountOAuthLoginHost];
-    }
-
-    [[NSUserDefaults msdkUserDefaults] synchronize];
-
-    // Only post the login host change notification if the host actually changed.
-    if ((oldLoginHost || host) && ![host isEqualToString:oldLoginHost]) {
-        NSDictionary *userInfoDict = @{ kSFLoginHostChangedNotificationOriginalHostKey: (oldLoginHost ?: [NSNull null]),
-                kSFLoginHostChangedNotificationUpdatedHostKey: (host ?: [NSNull null]) };
-        NSNotification *loginHostUpdateNotification = [NSNotification notificationWithName:kSFLoginHostChangedNotification object:self userInfo:userInfoDict];
-        [[NSNotificationCenter defaultCenter] postNotification:loginHostUpdateNotification];
-    }
+    [SFUserAccountManager sharedInstance].loginHost = host;
 }
 
 - (NSString *)loginHost {
-    NSUserDefaults *defaults = [NSUserDefaults msdkUserDefaults];
-
-    // First let's import any previously stored settings, if available.
-    NSString *host = [defaults stringForKey:kDeprecatedLoginHostPrefKey];
-    if (host) {
-        [defaults setObject:host forKey:kSFUserAccountOAuthLoginHost];
-        [defaults removeObjectForKey:kDeprecatedLoginHostPrefKey];
-        [defaults synchronize];
-        return host;
-    }
-
-    // Fetch from the standard defaults or bundle.
-    NSString *loginHost = [defaults stringForKey:kSFUserAccountOAuthLoginHost];
-    if ([loginHost length] > 0) {
-        return loginHost;
-    }
-
-    // Login host not initialized. Set it up.
-    NSString *managedLoginHost = ([SFManagedPreferences sharedPreferences].loginHosts)[0];
-    if (managedLoginHost.length > 0) {
-        loginHost = managedLoginHost;
-    } else {
-
-        /*
-         * Do not fall back to default login host if MDM only permits authorized hosts, even if there are no other hosts.
-         */
-        if (![SFManagedPreferences sharedPreferences].onlyShowAuthorizedHosts) {
-            NSString *bundleLoginHost = [[NSBundle mainBundle] objectForInfoDictionaryKey:kSFUserAccountOAuthLoginHost];
-            if (bundleLoginHost.length > 0) {
-                loginHost = bundleLoginHost;
-            } else {
-                loginHost = kSFUserAccountOAuthLoginHostDefault;
-            }
-        }
-    }
-    [defaults setObject:loginHost forKey:kSFUserAccountOAuthLoginHost];
-    [defaults synchronize];
-    return loginHost;
+    return [SFUserAccountManager sharedInstance].loginHost;
 }
 
 #pragma mark - Default Values
 
 - (NSSet *)scopes
 {
-    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
-    NSArray *scopesArray = [defs objectForKey:kOAuthScopesKey] ?: [NSArray array];
-    return [NSSet setWithArray:scopesArray];
+    return [SFUserAccountManager sharedInstance].scopes;
 }
 
 - (void)setScopes:(NSSet *)newScopes
 {
-    NSArray *scopesArray = [newScopes allObjects];
-    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
-    [defs setObject:scopesArray forKey:kOAuthScopesKey];
-    [defs synchronize];
+    [SFUserAccountManager sharedInstance].scopes = newScopes;
 }
 
 - (NSString *)oauthCompletionUrl
 {
-    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
-    NSString *redirectUri = [defs objectForKey:kOAuthRedirectUriKey];
-    return redirectUri;
+    return [SFUserAccountManager sharedInstance].oauthCompletionUrl;
 }
 
 - (void)setOauthCompletionUrl:(NSString *)newRedirectUri
 {
-    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
-    [defs setObject:newRedirectUri forKey:kOAuthRedirectUriKey];
-    [defs synchronize];
+    [SFUserAccountManager sharedInstance].oauthCompletionUrl = newRedirectUri;
 }
 
 - (NSString *)oauthClientId
 {
-    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
-    NSString *clientId = [defs objectForKey:kOAuthClientIdKey];
-    return clientId;
+    return [SFUserAccountManager sharedInstance].oauthClientId;
+
 }
 
 - (void)setOauthClientId:(NSString *)newClientId
 {
-    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
-    [defs setObject:newClientId forKey:kOAuthClientIdKey];
-    [defs synchronize];
+   [SFUserAccountManager sharedInstance].oauthClientId = newClientId;
 }
 
 + (void)resetSessionCookie

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -26,6 +26,7 @@
 #import "SFOAuthCredentials.h"
 #import "SFUserAccountIdentity.h"
 #import "SFUserAccountConstants.h"
+#import "SFOAuthCoordinator.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -64,6 +65,32 @@ FOUNDATION_EXTERN NSString * const kSFLoginHostChangedNotificationOriginalHostKe
  The key for the updated host in a login host change notification.
  */
 FOUNDATION_EXTERN NSString * const kSFLoginHostChangedNotificationUpdatedHostKey;
+
+/**
+  Default used as last resort
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountOAuthLoginHostDefault;
+
+/**
+ Key identifying login host
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountOAuthLoginHost;
+
+/**
+ The key for storing the persisted OAuth scopes.
+ */
+FOUNDATION_EXTERN  NSString * const kOAuthScopesKey;
+
+/**
+The key for storing the persisted OAuth client ID.
+ */
+FOUNDATION_EXTERN  NSString * const kOAuthClientIdKey;
+
+/**
+The key for storing the persisted OAuth redirect URI.
+ */
+FOUNDATION_EXTERN  NSString * const kOAuthRedirectUriKey;
+
 
 @class SFUserAccountManager;
 
@@ -140,6 +167,56 @@ FOUNDATION_EXTERN NSString * const kSFLoginHostChangedNotificationUpdatedHostKey
 /** Returns YES if the current user is anonymous, no otherwise
   */
 @property (nonatomic, readonly, getter=isCurrentUserAnonymous) BOOL currentUserAnonymous;
+
+/**
+ Advanced authentication configuration.  Default is SFOAuthAdvancedAuthConfigurationNone.  Leave the
+ default value unless you need advanced authentication, as it requires an additional round trip to the
+ service to retrieve org authentication configuration.
+ */
+@property (nonatomic, assign) SFOAuthAdvancedAuthConfiguration advancedAuthConfiguration;
+
+/**
+ An array of additional keys (NSString) to parse during OAuth
+ */
+@property (nonatomic, strong) NSArray * additionalOAuthParameterKeys;
+
+/**
+ A dictionary of additional parameters (key value pairs) to send during token refresh
+ */
+@property (nonatomic, strong) NSDictionary * additionalTokenRefreshParams;
+
+/** The host that will be used for login.
+ */
+@property (nonatomic, strong, nullable) NSString *loginHost;
+
+/** Should the login process start again if it fails (default: YES)
+ */
+@property (nonatomic, assign) BOOL retryLoginAfterFailure;
+
+/** OAuth client ID to use for login.  Apps may customize
+ by setting this property before login; otherwise, this
+ value is determined by the SFDCOAuthClientIdPreference
+ configured via the settings bundle.
+ */
+@property (nonatomic, copy, nullable) NSString *oauthClientId;
+
+/** OAuth callback url to use for the OAuth login process.
+ Apps may customize this by setting this property before login.
+ By default this value is picked up from the main
+ bundle property SFDCOAuthRedirectUri
+ default: @"sfdc:///axm/detect/oauth/done")
+ */
+@property (nonatomic, copy, nullable) NSString *oauthCompletionUrl;
+
+/**
+ The Branded Login path configured for this application.
+ */
+@property (nonatomic, nullable, copy) NSString *brandLoginPath;
+
+/**
+ The OAuth scopes associated with the app.
+ */
+@property (nonatomic, copy) NSSet<NSString*> *scopes;
 
 /**  Convenience property to retrieve the current user's identity.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -54,6 +54,20 @@ NSString * const kSFLoginHostChangedNotificationUpdatedHostKey = @"updatedLoginH
 static NSString * const kUserDefaultsLastUserIdentityKey = @"LastUserIdentity";
 static NSString * const kUserDefaultsLastUserCommunityIdKey = @"LastUserCommunityId";
 static NSString * const kSFAppFeatureMultiUser   = @"MU";
+static NSString * const kSFUserAccountOAuthRedirectUri = @"SFDCOAuthRedirectUri";
+static NSString * const kDeprecatedLoginHostPrefKey = @"login_host_pref";
+
+NSString * const kSFUserAccountOAuthLoginHostDefault = @"login.salesforce.com"; // last resort
+NSString * const kSFUserAccountOAuthLoginHost = @"SFDCOAuthLoginHost";
+
+// The key for storing the persisted OAuth scopes.
+NSString * const kOAuthScopesKey = @"oauth_scopes";
+
+// The key for storing the persisted OAuth client ID.
+NSString * const kOAuthClientIdKey = @"oauth_client_id";
+
+// The key for storing the persisted OAuth redirect URI.
+NSString * const kOAuthRedirectUriKey = @"oauth_redirect_uri";
 
 
 @implementation SFUserAccountManager
@@ -88,6 +102,111 @@ static NSString * const kSFAppFeatureMultiUser   = @"MU";
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)setLoginHost:(NSString*)host {
+    NSString *oldLoginHost = [self loginHost];
+    
+    if (nil == host) {
+        [[NSUserDefaults msdkUserDefaults] removeObjectForKey:kSFUserAccountOAuthLoginHost];
+    } else {
+        [[NSUserDefaults msdkUserDefaults] setObject:host forKey:kSFUserAccountOAuthLoginHost];
+    }
+    
+    [[NSUserDefaults msdkUserDefaults] synchronize];
+    
+    // Only post the login host change notification if the host actually changed.
+    if ((oldLoginHost || host) && ![host isEqualToString:oldLoginHost]) {
+        NSDictionary *userInfoDict = @{ kSFLoginHostChangedNotificationOriginalHostKey: (oldLoginHost ?: [NSNull null]),
+                                        kSFLoginHostChangedNotificationUpdatedHostKey: (host ?: [NSNull null]) };
+        NSNotification *loginHostUpdateNotification = [NSNotification notificationWithName:kSFLoginHostChangedNotification object:self userInfo:userInfoDict];
+        [[NSNotificationCenter defaultCenter] postNotification:loginHostUpdateNotification];
+    }
+}
+
+- (NSString *)loginHost {
+    NSUserDefaults *defaults = [NSUserDefaults msdkUserDefaults];
+    
+    // First let's import any previously stored settings, if available.
+    NSString *host = [defaults stringForKey:kDeprecatedLoginHostPrefKey];
+    if (host) {
+        [defaults setObject:host forKey:kSFUserAccountOAuthLoginHost];
+        [defaults removeObjectForKey:kDeprecatedLoginHostPrefKey];
+        [defaults synchronize];
+        return host;
+    }
+    
+    // Fetch from the standard defaults or bundle.
+    NSString *loginHost = [defaults stringForKey:kSFUserAccountOAuthLoginHost];
+    if ([loginHost length] > 0) {
+        return loginHost;
+    }
+    
+    // Login host not initialized. Set it up.
+    NSString *managedLoginHost = ([SFManagedPreferences sharedPreferences].loginHosts)[0];
+    if (managedLoginHost.length > 0) {
+        loginHost = managedLoginHost;
+    } else {
+        
+        /*
+         * Do not fall back to default login host if MDM only permits authorized hosts, even if there are no other hosts.
+         */
+        if (![SFManagedPreferences sharedPreferences].onlyShowAuthorizedHosts) {
+            NSString *bundleLoginHost = [[NSBundle mainBundle] objectForInfoDictionaryKey:kSFUserAccountOAuthLoginHost];
+            if (bundleLoginHost.length > 0) {
+                loginHost = bundleLoginHost;
+            } else {
+                loginHost = kSFUserAccountOAuthLoginHostDefault;
+            }
+        }
+    }
+    [defaults setObject:loginHost forKey:kSFUserAccountOAuthLoginHost];
+    [defaults synchronize];
+    return loginHost;
+}
+
+#pragma mark - persistent properties
+- (NSSet *)scopes
+{
+    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
+    NSArray *scopesArray = [defs objectForKey:kOAuthScopesKey] ?: [NSArray array];
+    return [NSSet setWithArray:scopesArray];
+}
+
+- (void)setScopes:(NSSet *)newScopes
+{
+    NSArray *scopesArray = [newScopes allObjects];
+    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
+    [defs setObject:scopesArray forKey:kOAuthScopesKey];
+    [defs synchronize];
+}
+
+- (NSString *)oauthCompletionUrl
+{
+    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
+    NSString *redirectUri = [defs objectForKey:kOAuthRedirectUriKey];
+    return redirectUri;
+}
+
+- (void)setOauthCompletionUrl:(NSString *)newRedirectUri
+{
+    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
+    [defs setObject:newRedirectUri forKey:kOAuthRedirectUriKey];
+    [defs synchronize];
+}
+
+- (NSString *)oauthClientId
+{
+    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
+    NSString *clientId = [defs objectForKey:kOAuthClientIdKey];
+    return clientId;
+}
+
+- (void)setOauthClientId:(NSString *)newClientId
+{
+    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
+    [defs setObject:newClientId forKey:kOAuthClientIdKey];
+    [defs synchronize];
 }
 
 #pragma mark - SFUserAccountDelegate management

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -308,6 +308,58 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     XCTAssertFalse([self.uam.currentUser.idData.customAttributes isEqualToDictionary:mutableCustomPermissions], @"Permissions dictionaries should not be equal.");
 }
 
+- (void)testUserAccountManagerPersistentProperties {
+    
+    SFOAuthAdvancedAuthConfiguration oldAdvancedAuthConfiguration = [SFUserAccountManager sharedInstance].advancedAuthConfiguration;
+    [SFUserAccountManager sharedInstance].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+    XCTAssertEqual([SFUserAccountManager sharedInstance].advancedAuthConfiguration, SFOAuthAdvancedAuthConfigurationRequire, @"SFUserAccountManager advancedAuthConfiguration should be set correctly");
+    [SFUserAccountManager sharedInstance].advancedAuthConfiguration = oldAdvancedAuthConfiguration;
+    XCTAssertEqual([SFUserAccountManager sharedInstance].advancedAuthConfiguration, oldAdvancedAuthConfiguration, @"SFUserAccountManager advancedAuthConfiguration should be set back correctly");
+    
+    NSArray *oldAdditionalOAuthParameterKeys = [SFUserAccountManager sharedInstance].additionalOAuthParameterKeys;
+    NSArray *addlKeys = @[@"A", @"__B", @"123", @""];
+    [SFUserAccountManager sharedInstance].additionalOAuthParameterKeys = addlKeys;
+    XCTAssertNotNil([SFUserAccountManager sharedInstance].additionalOAuthParameterKeys,"SFUserAccountManager additionalOAuthParameterKeys should not be nil");
+    XCTAssertTrue([[SFUserAccountManager sharedInstance].additionalOAuthParameterKeys count] == [addlKeys count],"SFUserAccountManager additionalOAuthParameterKeys should not be nil");
+    [SFUserAccountManager sharedInstance].additionalOAuthParameterKeys = oldAdditionalOAuthParameterKeys;
+    
+    NSDictionary *oldAdditionalTokenRefreshParams = [SFUserAccountManager sharedInstance].additionalTokenRefreshParams;
+    NSDictionary *addlRefreshParams = @ {@"A":@"A",@"B":@"B", @"C":@"C"};
+    [SFUserAccountManager sharedInstance].additionalTokenRefreshParams = addlRefreshParams;
+    XCTAssertNotNil([SFUserAccountManager sharedInstance].additionalTokenRefreshParams,"SFUserAccountManager additionalTokenRefreshParams should not be nil");
+    XCTAssertTrue([[SFUserAccountManager sharedInstance].additionalTokenRefreshParams count] == [addlRefreshParams count],"SFUserAccountManager additionalOAuthParameterKeys should not be nil");
+    [SFUserAccountManager sharedInstance].additionalTokenRefreshParams = oldAdditionalTokenRefreshParams;
+    
+    NSString *oldLoginHost = [SFUserAccountManager sharedInstance].loginHost;;
+    NSString *newLoginHost = @"https://sample.test";
+    [SFUserAccountManager sharedInstance].loginHost = newLoginHost;
+    XCTAssertEqualObjects([SFUserAccountManager sharedInstance].loginHost, newLoginHost, @"SFUserAccountManager loginHost should be set correctly");
+    [SFUserAccountManager sharedInstance].loginHost = oldLoginHost;
+    XCTAssertEqualObjects([SFUserAccountManager sharedInstance].loginHost, oldLoginHost, @"SFUserAccountManager loginHost should be set back correctly");
+    
+    NSString *oldOauthCompletionUrl = [SFUserAccountManager sharedInstance].oauthCompletionUrl;;
+    NSString *newOauthCompletionUrl = @"new://new.url";
+    [SFUserAccountManager sharedInstance].oauthCompletionUrl = newOauthCompletionUrl;
+    XCTAssertEqualObjects([SFUserAccountManager sharedInstance].oauthCompletionUrl, newOauthCompletionUrl, @"SFUserAccountManager oauthCompletionUrl should be set correctly");
+    [SFUserAccountManager sharedInstance].oauthCompletionUrl = oldOauthCompletionUrl;
+    XCTAssertEqualObjects([SFUserAccountManager sharedInstance].oauthCompletionUrl, oldOauthCompletionUrl, @"SFUserAccountManager oauthCompletionUrl should be set back correctly");
+    
+    NSString *oldOauthClientId = [SFUserAccountManager sharedInstance].oauthClientId;;
+    NSString *newOauthClientId = @"NEW_OAUTH_CLIENT_ID";
+    [SFUserAccountManager sharedInstance].oauthClientId = newOauthClientId;
+    XCTAssertEqualObjects([SFUserAccountManager sharedInstance].oauthClientId, newOauthClientId, @"SFUserAccountManager oAuthClientId should be set correctly");
+    [SFUserAccountManager sharedInstance].oauthClientId = oldOauthClientId;
+    XCTAssertEqualObjects([SFUserAccountManager sharedInstance].oauthClientId, oldOauthClientId, @"SFUserAccountManager oAuthClientId should be set back correctly");
+    
+    NSString *oldBrandLoginPath = [SFUserAccountManager sharedInstance].brandLoginPath;;
+    NSString *newBrandLoginPath = @"NEW_BRAND";
+    [SFUserAccountManager sharedInstance].brandLoginPath = newBrandLoginPath;
+    XCTAssertEqualObjects([SFUserAccountManager sharedInstance].brandLoginPath, newBrandLoginPath, @"SFUserAccountManager brandLoginPath should be set correctly");
+    [SFUserAccountManager sharedInstance].brandLoginPath = oldBrandLoginPath;
+    XCTAssertEqualObjects([SFUserAccountManager sharedInstance].brandLoginPath, oldBrandLoginPath, @"SFUserAccountManager brandLoginPath should be set back correctly");
+}
+
+
 
 #pragma mark - Helper methods
 


### PR DESCRIPTION
Lift and shift of some persistent properties to SFUserAccountManager. In anticipation for changes w.r.t moving login/logout functionality to SFUserAccountManager.  