### PR TITLE
Init cursorCache to prevent getting nil cursor

### DIFF
--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
@@ -62,6 +62,9 @@ NSString * const kStoreName           = @"storeName";
     if( self ) {
         _dispatchQueue = dispatch_queue_create([@"SFSmartStoreReactBridge CursorCache Queue" UTF8String], DISPATCH_QUEUE_SERIAL);
     }
+  
+    //Fix moveCursorToPageIndex getting nil as cursor bug
+    self.cursorCache = [[NSMutableDictionary alloc] init];
     return self;
 }
 


### PR DESCRIPTION
Fixing the problem of inserting cursor to a nil object
No failure on inserting cursor to a nil object but lead to failure when trying to  manipulate cursor afterwards