### PR TITLE
Check for [NSNull null] objects in SFIdentityData.dictRepresentation dictionary

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The ID URL.
  */
-@property (nullable, strong, nonatomic, readonly) NSURL *idUrl;
+@property (nonnull, strong, nonatomic, readonly) NSURL *idUrl;
 
 /**
  * Whether or not this is the asserted user for this session.
@@ -50,17 +50,17 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The User ID of the associated user.
  */
-@property (nullable, strong, nonatomic, readonly) NSString *userId;
+@property (nonnull, strong, nonatomic, readonly) NSString *userId;
 
 /**
  * The Organization ID of the associated user.
  */
-@property (nullable, strong, nonatomic, readonly) NSString *orgId;
+@property (nonnull, strong, nonatomic, readonly) NSString *orgId;
 
 /**
  * The username of the associated user.
  */
-@property (nullable, strong, nonatomic, readonly) NSString *username;
+@property (nonnull, strong, nonatomic, readonly) NSString *username;
 
 /**
  * The nickname of the associated user.
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The email address of the associated user.
  */
-@property (nullable, strong, nonatomic, readonly) NSString *email;
+@property (nonnull, strong, nonatomic, readonly) NSString *email;
 
 /**
  * The first name of the user.
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The last name of the user.
  */
-@property (nullable, strong, nonatomic, readonly) NSString *lastName;
+@property (nonnull, strong, nonatomic, readonly) NSString *lastName;
 
 /**
  * The URL to retrieve the user's picture.
@@ -182,17 +182,17 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The user type.
  */
-@property (nullable, strong, nonatomic, readonly) NSString *userType;
+@property (nonnull, strong, nonatomic, readonly) NSString *userType;
 
 /**
  * The user's configured language.
  */
-@property (nullable, strong, nonatomic, readonly) NSString *language;
+@property (nonnull, strong, nonatomic, readonly) NSString *language;
 
 /**
  * The user's configured locale.
  */
-@property (nullable, strong, nonatomic, readonly) NSString *locale;
+@property (nonnull, strong, nonatomic, readonly) NSString *locale;
 
 /**
  * The UTC offset for this user.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The ID URL.
  */
-@property (nonnull, strong, nonatomic, readonly) NSURL *idUrl;
+@property (nullable, strong, nonatomic, readonly) NSURL *idUrl;
 
 /**
  * Whether or not this is the asserted user for this session.
@@ -50,47 +50,47 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The User ID of the associated user.
  */
-@property (nonnull, strong, nonatomic, readonly) NSString *userId;
+@property (nullable, strong, nonatomic, readonly) NSString *userId;
 
 /**
  * The Organization ID of the associated user.
  */
-@property (nonnull, strong, nonatomic, readonly) NSString *orgId;
+@property (nullable, strong, nonatomic, readonly) NSString *orgId;
 
 /**
  * The username of the associated user.
  */
-@property (nonnull, strong, nonatomic, readonly) NSString *username;
+@property (nullable, strong, nonatomic, readonly) NSString *username;
 
 /**
  * The nickname of the associated user.
  */
-@property (nonnull, strong, nonatomic, readonly) NSString *nickname;
+@property (nullable, strong, nonatomic, readonly) NSString *nickname;
 
 /**
  * The display name of the associated user.
  */
-@property (nonnull, strong, nonatomic, readonly) NSString *displayName;
+@property (nullable, strong, nonatomic, readonly) NSString *displayName;
 
 /**
  * The email address of the associated user.
  */
-@property (nonnull, strong, nonatomic, readonly) NSString *email;
+@property (nullable, strong, nonatomic, readonly) NSString *email;
 
 /**
  * The first name of the user.
  */
-@property (nonnull, strong, nonatomic, readonly) NSString *firstName;
+@property (nullable, strong, nonatomic, readonly) NSString *firstName;
 
 /**
  * The last name of the user.
  */
-@property (nonnull, strong, nonatomic, readonly) NSString *lastName;
+@property (nullable, strong, nonatomic, readonly) NSString *lastName;
 
 /**
  * The URL to retrieve the user's picture.
  */
-@property (nonnull, strong, nonatomic, readonly) NSURL *pictureUrl;
+@property (nullable, strong, nonatomic, readonly) NSURL *pictureUrl;
 
 /**
  * The URL to retrieve a thumbnail picture for the user.
@@ -182,17 +182,17 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The user type.
  */
-@property (nonnull, strong, nonatomic, readonly) NSString *userType;
+@property (nullable, strong, nonatomic, readonly) NSString *userType;
 
 /**
  * The user's configured language.
  */
-@property (nonnull, strong, nonatomic, readonly) NSString *language;
+@property (nullable, strong, nonatomic, readonly) NSString *language;
 
 /**
  * The user's configured locale.
  */
-@property (nonnull, strong, nonatomic, readonly) NSString *locale;
+@property (nullable, strong, nonatomic, readonly) NSString *locale;
 
 /**
  * The UTC offset for this user.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.m
@@ -23,6 +23,7 @@
  */
 
 #import "SFIdentityData+Internal.h"
+#import "NSDictionary+SFAdditions.h"
 
 // Private constants
 
@@ -102,8 +103,8 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (BOOL)assertedUser
 {
-    NSNumber* value = self.dictRepresentation[kSFIdentityAssertedUserKey];
-    return [value isEqual:[NSNull null]] ? NO : [value boolValue];
+    id value = [self.dictRepresentation nonNullObjectForKey:kSFIdentityAssertedUserKey];
+    return value == nil ? NO : [value boolValue];
 }
 
 - (NSString *)userId
@@ -123,14 +124,12 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSString *)nickname
 {
-    NSString *value = self.dictRepresentation[kSFIdentityNicknameKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return [self.dictRepresentation nonNullObjectForKey:kSFIdentityNicknameKey];
 }
 
 - (NSString *)displayName
 {
-    NSString *value = self.dictRepresentation[kSFIdentityDisplayNameKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return [self.dictRepresentation nonNullObjectForKey:kSFIdentityDisplayNameKey];
 }
 
 - (NSString *)email
@@ -140,8 +139,7 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSString *)firstName
 {
-    NSString *value = self.dictRepresentation[kSFIdentityFirstNameKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return [self.dictRepresentation nonNullObjectForKey:kSFIdentityFirstNameKey];
 }
 
 - (NSString *)lastName
@@ -249,33 +247,22 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (int)utcOffset
 {
-    NSNumber *value = self.dictRepresentation[kSFIdentityUtcOffsetKey];
-    
-    if (value != nil && ![value isEqual:[NSNull null]]) {
-        return [value intValue];
-    } else {
-        return -1;
-    }
+    id value = [self.dictRepresentation nonNullObjectForKey:kSFIdentityUtcOffsetKey];
+    return value == nil ? -1 : [value intValue];
 }
 
 - (BOOL)mobilePoliciesConfigured
 {
-    NSNumber *value = self.dictRepresentation[kSFIdentityMobilePolicyKey];
-    
-    if (value != nil && ![value isEqual:[NSNull null]]) {
-        return [value boolValue];
-    } else {
-        return NO;
-    }
+    id value = [self.dictRepresentation nonNullObjectForKey:kSFIdentityMobilePolicyKey];
+    return value == nil ? NO : [value boolValue];
 }
 
 - (int)mobileAppPinLength
 {
-    NSDictionary *mobilePolicy = self.dictRepresentation[kSFIdentityMobilePolicyKey];
-    if (mobilePolicy != nil && ![mobilePolicy isEqual:[NSNull null]]) {
-        id pinLength = mobilePolicy[kSFIdentityMobileAppPinLengthKey];
-        BOOL valiPinLength = pinLength != nil && ![pinLength isEqual:[NSNull null]];
-        return (valiPinLength ? [pinLength intValue] : 0);
+    NSDictionary *mobilePolicy = [self.dictRepresentation nonNullObjectForKey:kSFIdentityMobilePolicyKey];
+    if (mobilePolicy != nil) {
+        id pinLength = [mobilePolicy nonNullObjectForKey:kSFIdentityMobileAppPinLengthKey];
+        return (pinLength != nil ? [pinLength intValue] : 0);
     } else {
         return 0;
     }
@@ -283,11 +270,10 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (int)mobileAppScreenLockTimeout
 {
-    NSDictionary *mobilePolicy = (self.dictRepresentation)[kSFIdentityMobilePolicyKey];
-    if (mobilePolicy != nil && ![mobilePolicy isEqual:[NSNull null]]) {
-        id screenLockTimeout = mobilePolicy[kSFIdentityMobileAppScreenLockTimeoutKey];
-        BOOL validScreenLockTimeout = screenLockTimeout != nil && ![screenLockTimeout isEqual:[NSNull null]];
-        return (validScreenLockTimeout ? [screenLockTimeout intValue] : 0);
+    NSDictionary *mobilePolicy = [self.dictRepresentation nonNullObjectForKey:kSFIdentityMobilePolicyKey];
+    if (mobilePolicy != nil) {
+        id screenLockTimeout = [mobilePolicy nonNullObjectForKey:kSFIdentityMobileAppScreenLockTimeoutKey];
+        return (screenLockTimeout != nil ? [screenLockTimeout intValue] : 0);
     } else {
         return 0;
     }
@@ -295,10 +281,9 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSDictionary *)customAttributes
 {
-    NSDictionary *attributes = (self.dictRepresentation)[kSFIdentityCustomAttributesKey];
+    NSDictionary *attributes = [self.dictRepresentation nonNullObjectForKey:kSFIdentityCustomAttributesKey];
 
-    // sometimes attributes returned as NSNull
-    if ([attributes isEqual:[NSNull null]] || ![attributes isKindOfClass:[NSDictionary class]]) {
+    if (![attributes isKindOfClass:[NSDictionary class]]) {
         attributes = nil;
     }
     return attributes;
@@ -313,8 +298,7 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSDictionary *)customPermissions
 {
-    NSDictionary *value = self.dictRepresentation[kSFIdentityCustomPermissionsKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return [self.dictRepresentation nonNullObjectForKey:kSFIdentityCustomPermissionsKey];
 }
 
 - (void)setCustomPermissions:(NSDictionary *)customPermissions
@@ -326,8 +310,8 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSDate *)lastModifiedDate
 {
-    NSString *value = self.dictRepresentation[kSFIdentityLastModifiedDateKey];
-    if (value != nil && ![value isEqual:[NSNull null]])
+    NSString *value = [self.dictRepresentation nonNullObjectForKey:kSFIdentityLastModifiedDateKey];
+    if (value != nil)
         return [[self class] dateFromRfc822String:value];
     else
         return nil;
@@ -337,24 +321,19 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSURL *)parentExistsOrNilForUrl:(NSString *)parentKey childKey:(NSString *)childKey
 {
-    NSDictionary *parentDict = (self.dictRepresentation)[parentKey];
-    if (parentDict != nil && ![parentDict isEqual:[NSNull null]]) {
-        NSString *value = parentDict[childKey];
-        return [value isEqual:[NSNull null]] ? nil : [NSURL URLWithString:value];
-    }
-    else
-        return nil;
+    NSString *value = [self parentExistsOrNilForString:parentKey childKey:childKey];
+    return value != nil ? [NSURL URLWithString:value] : nil;
 }
 
 - (NSString *)parentExistsOrNilForString:(NSString *)parentKey childKey:(NSString *)childKey
 {
-    NSDictionary *parentDict = (self.dictRepresentation)[parentKey];
-    if (parentDict != nil && ![parentDict isEqual:[NSNull null]]) {
-        NSString *value = parentDict[childKey];
-        return [value isEqual:[NSNull null]] ? nil : value;
-    }
-    else
+    NSDictionary *parentDict = [self.dictRepresentation nonNullObjectForKey:parentKey];
+    if (parentDict != nil) {
+        NSString *value = [parentDict nonNullObjectForKey:childKey];
+        return [value isKindOfClass:[NSString class]] ? value : nil;
+    } else {
         return nil;
+    }
 }
 
 + (NSDate *)dateFromRfc822String:(NSString *)dateString

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.m
@@ -81,6 +81,7 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
     self = [super init];
     if (self) {
         NSAssert(jsonDict != nil, @"Data dictionary must not be nil.");
+        NSAssert([jsonDict isKindOfClass:[NSDictionary class]], @"Data dictionary must be a NSDictionary or sublcass");
         self.dictRepresentation = jsonDict;
     }
     
@@ -96,55 +97,62 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSURL *)idUrl
 {
-    return [NSURL URLWithString:(self.dictRepresentation)[kSFIdentityIdUrlKey]];
+    NSString *value = self.dictRepresentation[kSFIdentityIdUrlKey];
+    return [value isEqual:[NSNull null]] ? nil : [NSURL URLWithString:value];
 }
 
 - (BOOL)assertedUser
 {
-    if ((self.dictRepresentation)[kSFIdentityAssertedUserKey] != nil)
-        return [(self.dictRepresentation)[kSFIdentityAssertedUserKey] boolValue];
-    else
-        return NO;
+    NSNumber* value = self.dictRepresentation[kSFIdentityAssertedUserKey];
+    return [value isEqual:[NSNull null]] ? NO : [value boolValue];
 }
 
 - (NSString *)userId
 {
-    return (self.dictRepresentation)[kSFIdentityUserIdKey];
+    NSString *value = self.dictRepresentation[kSFIdentityUserIdKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (NSString *)orgId
 {
-    return (self.dictRepresentation)[kSFIdentityOrgIdKey];
+    NSString *value = self.dictRepresentation[kSFIdentityOrgIdKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (NSString *)username
 {
-    return (self.dictRepresentation)[kSFIdentityUsernameKey];
+    NSString *value = self.dictRepresentation[kSFIdentityUsernameKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (NSString *)nickname
 {
-    return (self.dictRepresentation)[kSFIdentityNicknameKey];
+    NSString *value = self.dictRepresentation[kSFIdentityNicknameKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (NSString *)displayName
 {
-    return (self.dictRepresentation)[kSFIdentityDisplayNameKey];
+    NSString *value = self.dictRepresentation[kSFIdentityDisplayNameKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (NSString *)email
 {
-    return (self.dictRepresentation)[kSFIdentityEmailKey];
+    NSString *value = self.dictRepresentation[kSFIdentityEmailKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (NSString *)firstName
 {
-    return (self.dictRepresentation)[kSFIdentityFirstNameKey];
+    NSString *value = self.dictRepresentation[kSFIdentityFirstNameKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (NSString *)lastName
 {
-    return (self.dictRepresentation)[kSFIdentityLastNameKey];
+    NSString *value = self.dictRepresentation[kSFIdentityLastNameKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (NSURL *)pictureUrl
@@ -232,38 +240,51 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSString *)userType
 {
-    return (self.dictRepresentation)[kSFIdentityUserTypeKey];
+    NSString *value = self.dictRepresentation[kSFIdentityUserTypeKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (NSString *)language
 {
-    return (self.dictRepresentation)[kSFIdentityLanguageKey];
+    NSString *value = self.dictRepresentation[kSFIdentityLanguageKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (NSString *)locale
 {
-    return (self.dictRepresentation)[kSFIdentityLocaleKey];
+    NSString *value = self.dictRepresentation[kSFIdentityLocaleKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (int)utcOffset
 {
-    if ((self.dictRepresentation)[kSFIdentityUtcOffsetKey] != nil)
-        return [(self.dictRepresentation)[kSFIdentityUtcOffsetKey] intValue];
-    else
+    NSNumber *value = self.dictRepresentation[kSFIdentityUtcOffsetKey];
+    
+    if (value != nil && ![value isEqual:[NSNull null]]) {
+        return [value intValue];
+    } else {
         return -1;
+    }
 }
 
 - (BOOL)mobilePoliciesConfigured
 {
-    return ((self.dictRepresentation)[kSFIdentityMobilePolicyKey] != nil);
+    NSNumber *value = self.dictRepresentation[kSFIdentityMobilePolicyKey];
+    
+    if (value != nil && ![value isEqual:[NSNull null]]) {
+        return [value boolValue];
+    } else {
+        return NO;
+    }
 }
 
 - (int)mobileAppPinLength
 {
-    NSDictionary *mobilePolicy = (self.dictRepresentation)[kSFIdentityMobilePolicyKey];
-    if (mobilePolicy != nil) {
+    NSDictionary *mobilePolicy = self.dictRepresentation[kSFIdentityMobilePolicyKey];
+    if (mobilePolicy != nil && ![mobilePolicy isEqual:[NSNull null]]) {
         id pinLength = mobilePolicy[kSFIdentityMobileAppPinLengthKey];
-        return (pinLength != nil ? [pinLength intValue] : 0);
+        BOOL valiPinLength = pinLength != nil && ![pinLength isEqual:[NSNull null]];
+        return (valiPinLength ? [pinLength intValue] : 0);
     } else {
         return 0;
     }
@@ -272,9 +293,10 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 - (int)mobileAppScreenLockTimeout
 {
     NSDictionary *mobilePolicy = (self.dictRepresentation)[kSFIdentityMobilePolicyKey];
-    if (mobilePolicy != nil) {
+    if (mobilePolicy != nil && ![mobilePolicy isEqual:[NSNull null]]) {
         id screenLockTimeout = mobilePolicy[kSFIdentityMobileAppScreenLockTimeoutKey];
-        return (screenLockTimeout != nil ? [screenLockTimeout intValue] : 0);
+        BOOL validScreenLockTimeout = screenLockTimeout != nil && ![screenLockTimeout isEqual:[NSNull null]];
+        return (validScreenLockTimeout ? [screenLockTimeout intValue] : 0);
     } else {
         return 0;
     }
@@ -285,7 +307,7 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
     NSDictionary *attributes = (self.dictRepresentation)[kSFIdentityCustomAttributesKey];
 
     // sometimes attributes returned as NSNull
-    if (((NSObject *)attributes) == [NSNull null] || ![attributes isKindOfClass:[NSDictionary class]]) {
+    if ([attributes isEqual:[NSNull null]] || ![attributes isKindOfClass:[NSDictionary class]]) {
         attributes = nil;
     }
     return attributes;
@@ -300,7 +322,8 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSDictionary *)customPermissions
 {
-    return (self.dictRepresentation)[kSFIdentityCustomPermissionsKey];
+    NSDictionary *value = self.dictRepresentation[kSFIdentityCustomPermissionsKey];
+    return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 - (void)setCustomPermissions:(NSDictionary *)customPermissions
@@ -312,8 +335,9 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSDate *)lastModifiedDate
 {
-    if ((self.dictRepresentation)[kSFIdentityLastModifiedDateKey] != nil)
-        return [[self class] dateFromRfc822String:(self.dictRepresentation)[kSFIdentityLastModifiedDateKey]];
+    NSString *value = self.dictRepresentation[kSFIdentityLastModifiedDateKey];
+    if (value != nil && ![value isEqual:[NSNull null]])
+        return [[self class] dateFromRfc822String:value];
     else
         return nil;
 }
@@ -323,8 +347,10 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 - (NSURL *)parentExistsOrNilForUrl:(NSString *)parentKey childKey:(NSString *)childKey
 {
     NSDictionary *parentDict = (self.dictRepresentation)[parentKey];
-    if (parentDict != nil)
-        return [NSURL URLWithString:parentDict[childKey]];
+    if (parentDict != nil && ![parentDict isEqual:[NSNull null]]) {
+        NSString *value = parentDict[childKey];
+        return [value isEqual:[NSNull null]] ? nil : [NSURL URLWithString:value];
+    }
     else
         return nil;
 }
@@ -332,8 +358,10 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 - (NSString *)parentExistsOrNilForString:(NSString *)parentKey childKey:(NSString *)childKey
 {
     NSDictionary *parentDict = (self.dictRepresentation)[parentKey];
-    if (parentDict != nil)
-        return parentDict[childKey];
+    if (parentDict != nil && ![parentDict isEqual:[NSNull null]]) {
+        NSString *value = parentDict[childKey];
+        return [value isEqual:[NSNull null]] ? nil : value;
+    }
     else
         return nil;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityData.m
@@ -97,8 +97,7 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSURL *)idUrl
 {
-    NSString *value = self.dictRepresentation[kSFIdentityIdUrlKey];
-    return [value isEqual:[NSNull null]] ? nil : [NSURL URLWithString:value];
+    return [NSURL URLWithString:(self.dictRepresentation)[kSFIdentityIdUrlKey]];
 }
 
 - (BOOL)assertedUser
@@ -109,20 +108,17 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSString *)userId
 {
-    NSString *value = self.dictRepresentation[kSFIdentityUserIdKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return (self.dictRepresentation)[kSFIdentityUserIdKey];
 }
 
 - (NSString *)orgId
 {
-    NSString *value = self.dictRepresentation[kSFIdentityOrgIdKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return (self.dictRepresentation)[kSFIdentityOrgIdKey];
 }
 
 - (NSString *)username
 {
-    NSString *value = self.dictRepresentation[kSFIdentityUsernameKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return (self.dictRepresentation)[kSFIdentityUsernameKey];
 }
 
 - (NSString *)nickname
@@ -139,8 +135,7 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSString *)email
 {
-    NSString *value = self.dictRepresentation[kSFIdentityEmailKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return (self.dictRepresentation)[kSFIdentityEmailKey];
 }
 
 - (NSString *)firstName
@@ -151,8 +146,7 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSString *)lastName
 {
-    NSString *value = self.dictRepresentation[kSFIdentityLastNameKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return (self.dictRepresentation)[kSFIdentityLastNameKey];
 }
 
 - (NSURL *)pictureUrl
@@ -240,20 +234,17 @@ NSString * const kIdJsonDictKey                           = @"dictRepresentation
 
 - (NSString *)userType
 {
-    NSString *value = self.dictRepresentation[kSFIdentityUserTypeKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return (self.dictRepresentation)[kSFIdentityUserTypeKey];
 }
 
 - (NSString *)language
 {
-    NSString *value = self.dictRepresentation[kSFIdentityLanguageKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return (self.dictRepresentation)[kSFIdentityLanguageKey];
 }
 
 - (NSString *)locale
 {
-    NSString *value = self.dictRepresentation[kSFIdentityLocaleKey];
-    return [value isEqual:[NSNull null]] ? nil : value;
+    return (self.dictRepresentation)[kSFIdentityLocaleKey];
 }
 
 - (int)utcOffset


### PR DESCRIPTION
Check that values stored in SFIdentityData.dictRepresentation dictionary are not [NSNull null] object. This can cause a crash in consumer, specially in Swift where header file declared properties as nonnull.

Cheat sheet:
```
NSDictionary *dict = @{
                           @"key1": @"value1",
                           @"key2": [NSNull null],
               //           @"key3": nil // Not allowed by compiler
                           };

    NSString *value3 = dict[@"key3"]; // nil
    BOOL isNull = dict[@"key3"] == [NSNull null]; // NO
    
    BOOL isNill = dict[@"key2"] == nil; // **NO**
    BOOL isNull1 = dict[@"key2"] == [NSNull null]; // YES
    BOOL isNull2 = [dict[@"key2"] isEqual:[NSNull null]]; // YES
    BOOL isNotNull = dict[@"key2"] != [NSNull null]; // NO
    BOOL isClass = [dict[@"key"] isKindOfClass:[NSString class]]; // NO
```