### PR TITLE
 Added Auth Notifications to SFUserAccountManager

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Classes/AppDelegate.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Classes/AppDelegate.m
@@ -54,6 +54,7 @@
         // Logout and login host change handlers.
         [[SFAuthenticationManager sharedManager] addDelegate:self];
         [[SFUserAccountManager sharedInstance] addDelegate:self];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserDidLogout:)  name:kSFUserAccountManagerUserDidLogoutNotification object:nil];
     }
     return self;
 }
@@ -110,9 +111,13 @@
 
 - (void)authManagerDidLogout:(SFAuthenticationManager *)manager
 {
+    [self userDidLogout];
+}
+
+- (void)userDidLogout {
     [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"Logout notification received. Resetting app."];
     self.viewController.appHomeUrl = nil;
-
+    
     // Multi-user pattern:
     // - If there are two or more existing accounts after logout, let the user choose the account
     //   to switch to.
@@ -135,6 +140,9 @@
     }
 }
 
+- (void)handleUserDidLogout:(NSNotification *)notification {
+    [self userDidLogout];
+}
 #pragma mark - SFUserAccountManagerDelegate
 
 - (void)userAccountManager:(SFUserAccountManager *)userAccountManager

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Classes/AppDelegate.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Classes/AppDelegate.m
@@ -54,7 +54,7 @@
         // Logout and login host change handlers.
         [[SFAuthenticationManager sharedManager] addDelegate:self];
         [[SFUserAccountManager sharedInstance] addDelegate:self];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserDidLogout:)  name:kSFUserAccountManagerUserDidLogoutNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserDidLogout:)  name:kSFNotificationUserDidLogout object:nil];
     }
     return self;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -132,6 +132,7 @@ static NSMutableDictionary *analyticsManagerList = nil;
         [self.remotes addObject:tpp];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(publishOnAppBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFUserAccountManagerUserWillLogoutNotification object:nil];
     }
     return self;
 }
@@ -324,12 +325,20 @@ static NSMutableDictionary *analyticsManagerList = nil;
 }
 
 #pragma mark - SFAuthenticationManagerDelegate
+- (void)handleUserWillLogout:(NSNotification *)notification {
+    SFUserAccount *user = notification.userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey];
+    [self handleLogoutForUser:user];
+}
 
-- (void) authManager:(SFAuthenticationManager *) manager willLogoutUser:(SFUserAccount *) user {
+- (void)handleLogoutForUser:(SFUserAccount *)user {
     [self.analyticsManager reset];
     NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
     [defs removeObjectForKey:kAnalyticsOnOffKey];
     [[self class] removeSharedInstanceWithUser:user];
+}
+
+- (void) authManager:(SFAuthenticationManager *) manager willLogoutUser:(SFUserAccount *) user {
+    [self handleLogoutForUser:user];
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -132,7 +132,7 @@ static NSMutableDictionary *analyticsManagerList = nil;
         [self.remotes addObject:tpp];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(publishOnAppBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
         [[SFAuthenticationManager sharedManager] addDelegate:self];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFUserAccountManagerUserWillLogoutNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
     }
     return self;
 }
@@ -326,7 +326,7 @@ static NSMutableDictionary *analyticsManagerList = nil;
 
 #pragma mark - SFAuthenticationManagerDelegate
 - (void)handleUserWillLogout:(NSNotification *)notification {
-    SFUserAccount *user = notification.userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey];
+    SFUserAccount *user = notification.userInfo[kSFNotificationUserInfoAccountKey];
     [self handleLogoutForUser:user];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -16,6 +16,8 @@
 - (void)handleAppWillResignActive:(nonnull NSNotification *)notification;
 - (void)handlePostLogout;
 - (void)handleAuthCompleted:(nonnull NSNotification *)notification;
+- (void)handleIDPInitiatedAuthCompleted:(nonnull NSNotification *)notification;
+- (void)handleUserDidLogout:(nonnull NSNotification *)notification;
 - (void)handleUserSwitch:(nullable SFUserAccount *)fromUser toUser:(nullable SFUserAccount *)toUser;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -146,12 +146,12 @@ static NSString* ailtnAppName = nil;
         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleAuthCompleted:) name:kSFAuthenticationManagerFinishedNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow
                                                 selector:@selector(handleAuthCompleted:)
-                                                     name:kSFUserAccountManagerUserDidLogInNotification object:nil];
+                                                     name:kSFNotificationUserDidLogIn object:nil];
         
         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow  selector:@selector(handleIDPInitiatedAuthCompleted:)
-                                                     name:kSFUserAccountManagerIDPInitiatedLoginNotification object:nil];
+                                                     name:kSFNotificationUserIDPInitDidLogIn object:nil];
         
-       [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleUserDidLogout:)  name:kSFUserAccountManagerUserDidLogoutNotification object:nil];
+       [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleUserDidLogout:)  name:kSFNotificationUserDidLogout object:nil];
         
         [SFPasscodeManager sharedManager].preferredPasscodeProvider = kSFPasscodeProviderPBKDF2;
         if (NSClassFromString(@"SFHybridViewController") != nil) {
@@ -582,7 +582,7 @@ static NSString* ailtnAppName = nil;
     [SFSecurityLockout setupTimer];
     [SFSecurityLockout startActivityMonitoring];
     NSDictionary *userInfo = notification.userInfo;
-    SFUserAccount *userAccount = userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey];
+    SFUserAccount *userAccount = userInfo[kSFNotificationUserInfoAccountKey];
     [[SFUserAccountManager sharedInstance] switchToUser:userAccount];
     [self sendPostLaunch];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -144,7 +144,14 @@ static NSString* ailtnAppName = nil;
         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleAppDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleAppWillResignActive:) name:UIApplicationWillResignActiveNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleAuthCompleted:) name:kSFAuthenticationManagerFinishedNotification object:nil];
-         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleIDPInitiatedAuthCompleted:) name:SFUserAccountManagerIDPInitiatedLoginNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow
+                                                selector:@selector(handleAuthCompleted:)
+                                                     name:kSFUserAccountManagerUserDidLogInNotification object:nil];
+        
+        [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow  selector:@selector(handleIDPInitiatedAuthCompleted:)
+                                                     name:kSFUserAccountManagerIDPInitiatedLoginNotification object:nil];
+        
+       [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleUserDidLogout:)  name:kSFUserAccountManagerUserDidLogoutNotification object:nil];
         
         [SFPasscodeManager sharedManager].preferredPasscodeProvider = kSFPasscodeProviderPBKDF2;
         if (NSClassFromString(@"SFHybridViewController") != nil) {
@@ -575,7 +582,7 @@ static NSString* ailtnAppName = nil;
     [SFSecurityLockout setupTimer];
     [SFSecurityLockout startActivityMonitoring];
     NSDictionary *userInfo = notification.userInfo;
-    SFUserAccount *userAccount = userInfo[@"account"];
+    SFUserAccount *userAccount = userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey];
     [[SFUserAccountManager sharedInstance] switchToUser:userAccount];
     [self sendPostLaunch];
 }
@@ -848,7 +855,7 @@ static NSString* ailtnAppName = nil;
 
 #pragma mark - SFUserAccountManagerDelegate
 
-- (void)userAccountManager:(SFUserAccountManager *)userAccountManager didLogout:(SFUserAccount *)userAccount{
+- (void)handleUserDidLogout:(NSNotification *)notification{
     [self.sdkManagerFlow handlePostLogout];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.h
@@ -47,13 +47,13 @@ NS_ASSUME_NONNULL_BEGIN
  Called when the Oauth Client is starting the auth process using IDP APP
  @param client The instance of SFSDKOAuthClient making the call.
  */
-- (void)authClient:(SFSDKIDPAuthClient *_Nonnull)client willSendRequestForIDPAuth:(NSURL *) request;
+- (void)authClient:(SFSDKIDPAuthClient *_Nonnull)client willSendRequestForIDPAuth:(NSDictionary *)options;
 
 /**
  Called when the Oauth Client is starting the auth process using IDP APP
  @param client The instance of SFSDKOAuthClient making the call.
  */
-- (void)authClient:(SFSDKIDPAuthClient *_Nonnull)client didSendRequestForIDPAuth:(NSURL *) request;
+- (void)authClient:(SFSDKIDPAuthClient *_Nonnull)client didSendRequestForIDPAuth:(NSDictionary *)options;
 
 
 /**
@@ -80,13 +80,13 @@ NS_ASSUME_NONNULL_BEGIN
  Called when the Oauth Client is starting the auth process with an auth view.
  @param client The instance of SFSDKOAuthClient making the call.
  */
-- (void)authClient:(SFSDKIDPAuthClient *_Nonnull)client didReceiveResponseForIDPAuth:(NSURL *) request;
+- (void)authClient:(SFSDKIDPAuthClient *_Nonnull)client didReceiveResponseForIDPAuth:(NSDictionary *)options;
 
 /**
  Called when the Oauth Client is starting the auth process with an auth view.
  @param client The instance of SFSDKOAuthClient making the call.
  */
-- (void)authClient:(SFSDKIDPAuthClient *_Nonnull)client willSendResponseForIDPAuth:(NSURL *) response;
+- (void)authClient:(SFSDKIDPAuthClient *_Nonnull)client willSendResponseForIDPAuth:(NSDictionary *)options;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.m
@@ -131,7 +131,6 @@
     [super refreshCredentials];
 }
 
-
 - (void)beginIDPFlowForNewUser {
     [super refreshCredentials];
 }
@@ -146,10 +145,8 @@
     
     BOOL launched  = [SFApplicationHelper openURL:url];
     
-    if (launched) {
-        if ( [self.config.idpDelegate respondsToSelector:@selector(authClient:didSendRequestForIDPAuth:)]) {
-            [self.config.idpDelegate authClient:self didSendRequestForIDPAuth:url];
-        }
+    if (!launched) {
+        [SFSDKCoreLogger e:[self class] format:@"Could not launch spAPP to handle error %@",[error description]];
     }
 }
 
@@ -186,12 +183,12 @@
     NSURL *url = [command requestURL];
     
     if ( [self.config.idpDelegate respondsToSelector:@selector(authClient:willSendRequestForIDPAuth:)]) {
-        [self.config.idpDelegate authClient:self willSendRequestForIDPAuth:url];
+        [self.config.idpDelegate authClient:self willSendRequestForIDPAuth:command.allParams];
     }
     BOOL launched  = [SFApplicationHelper openURL:url];
     if (launched) {
         if ( [self.config.idpDelegate respondsToSelector:@selector(authClient:didSendRequestForIDPAuth:)]) {
-            [self.config.idpDelegate authClient:self willSendRequestForIDPAuth:url];
+            [self.config.idpDelegate authClient:self willSendRequestForIDPAuth:command.allParams];
         }
     }
     
@@ -216,7 +213,7 @@
     
     NSURL *url = [responseCommand requestURL];
     if ( [self.config.idpDelegate respondsToSelector:@selector(authClient:willSendResponseForIDPAuth:)]) {
-        [self.config.idpDelegate authClient:self willSendResponseForIDPAuth:url];
+        [self.config.idpDelegate authClient:self willSendResponseForIDPAuth:responseCommand.allParams];
     }
     
     [self.authWindow disable];
@@ -224,7 +221,7 @@
     BOOL launched  = [SFApplicationHelper openURL:url];
     if (launched) {
         if ( [self.config.idpDelegate respondsToSelector:@selector(authClient:didSendRequestForIDPAuth:)]) {
-            [self.config.idpDelegate authClient:self didSendRequestForIDPAuth:url];
+            [self.config.idpDelegate authClient:self didSendRequestForIDPAuth:responseCommand.allParams];
         }
     }
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -172,7 +172,6 @@ static NSString * const kSFAppFeatureSafariBrowserForLogin      = @"BW";
     _credentials = nil;
     _responseData = nil;
     _scopes = nil;
-    [_view setNavigationDelegate:nil];
     _view = nil;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -408,7 +408,7 @@ static Class InstanceClass = nil;
     }
     
     [SFSDKCoreLogger d:[self class] format:@"Logging out user '%@'.", user.userName];
-    NSDictionary *userInfo = @{ kSFUserAccountManagerNotificationsUserInfoAccountKey : user };
+    NSDictionary *userInfo = @{ @"account" : user };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserWillLogoutNotification
                                                         object:self
                                                       userInfo:userInfo];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -408,7 +408,7 @@ static Class InstanceClass = nil;
     }
     
     [SFSDKCoreLogger d:[self class] format:@"Logging out user '%@'.", user.userName];
-    NSDictionary *userInfo = @{ @"account": user };
+    NSDictionary *userInfo = @{ kSFUserAccountManagerNotificationsUserInfoAccountKey : user };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserWillLogoutNotification
                                                         object:self
                                                       userInfo:userInfo];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+URLHandlers.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+URLHandlers.m
@@ -108,6 +108,10 @@
         }
     }
     
+    NSDictionary *userInfo = @{kSFUserAccountManagerNotificationsUserInfoAddlOptionsTypeKey : request.allParams};
+    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFUserAccountManagerDidReceiveRequestForIDPAuthNotification
+                                                         object:self
+                                                       userInfo:userInfo];
     SFSDKIDPAuthClient  *authClient = nil;
     BOOL showSelection = NO;
 
@@ -134,6 +138,15 @@
 {
     NSString *key = [SFSDKOAuthClientCache keyFromIdentifierPrefixWithType:response.state type:SFOAuthClientKeyTypeIDP];
     SFSDKOAuthClient *client =  [[SFSDKOAuthClientCache sharedInstance] clientForKey:key];
+    
+    NSDictionary *userInfo = @{
+                               kSFUserAccountManagerNotificationsUserInfoCredentialsKey : client.credentials,
+                               kSFUserAccountManagerNotificationsUserInfoAddlOptionsTypeKey : response.allParams
+                                };
+    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFUserAccountManagerDidReceiveResponseForIDPAuthNotification
+                                                         object:self
+                                                       userInfo:userInfo];
+    
     return [client handleURLAuthenticationResponse:[response requestURL]];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+URLHandlers.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+URLHandlers.m
@@ -108,8 +108,8 @@
         }
     }
     
-    NSDictionary *userInfo = @{kSFUserAccountManagerNotificationsUserInfoAddlOptionsTypeKey : request.allParams};
-    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFUserAccountManagerDidReceiveRequestForIDPAuthNotification
+    NSDictionary *userInfo = @{kSFUserInfoAddlOptionsKey : request.allParams};
+    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFNotificationUserDidReceiveIDPRequest
                                                          object:self
                                                        userInfo:userInfo];
     SFSDKIDPAuthClient  *authClient = nil;
@@ -140,10 +140,10 @@
     SFSDKOAuthClient *client =  [[SFSDKOAuthClientCache sharedInstance] clientForKey:key];
     
     NSDictionary *userInfo = @{
-                               kSFUserAccountManagerNotificationsUserInfoCredentialsKey : client.credentials,
-                               kSFUserAccountManagerNotificationsUserInfoAddlOptionsTypeKey : response.allParams
+                               kSFNotificationUserInfoCredentialsKey : client.credentials,
+                               kSFUserInfoAddlOptionsKey : response.allParams
                                 };
-    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFUserAccountManagerDidReceiveResponseForIDPAuthNotification
+    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFNotificationUserDidReceiveIDPResponse
                                                          object:self
                                                        userInfo:userInfo];
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -102,20 +102,54 @@ The key for storing the persisted OAuth redirect URI.
  */
 FOUNDATION_EXTERN  NSString * const kOAuthRedirectUriKey;
 
-/** Notification sent user prior to user logout
+/** Notification sent prior to user logout
  */
-FOUNDATION_EXTERN NSString * const SFUserAccountManagerWillLogoutNotification;
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerUserWillLogoutNotification;
 
-/** Notification sent user after user logout
+/** Notification sent after user logout
  */
-FOUNDATION_EXTERN NSString * const SFUserAccountManagerLogoutNotification;
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerUserDidLogoutNotification;
 
-/** Notification sent user after user login
+/** Notification sent prior to user log in
  */
-FOUNDATION_EXTERN NSString * const SFUserAccountManagerLoggedInNotification;
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerUserWillLogInNotification;
 
-FOUNDATION_EXTERN NSString * const  SFUserAccountManagerIDPInitiatedLoginNotification;
-static NSString *const kOptionsClientKey = @"clientIdentifier";
+/** Notification sent after user log in
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerUserDidLogInNotification;
+
+/**  Notification sent before SP APP invokes IDP APP for authentication
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerWillSendRequestForIDPAuthNotification;
+
+/**  Notification sent when  IDP APP receives request for authentication from SP APP
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerDidReceiveRequestForIDPAuthNotification;
+
+/**  Notification sent when  SP APP receives successful response of authentication from IDP APP
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerDidReceiveResponseForIDPAuthNotification;
+
+/**  Notification sent when  SP APP has log in  is successful when initiated from IDP APP
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerIDPInitiatedLoginNotification;
+
+/**  Key to use to lookup userAccount associated with  NSNotification userInfo
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerNotificationsUserInfoAccountKey;
+
+/**  Key to use to lookup credentials associated with  NSNotification userInfo
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerNotificationsUserInfoCredentialsKey;
+
+/**  Key to use to lookup authinfo type associated with  NSNotification userInfo
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerNotificationsUserInfoAuthTypeKey;
+
+/**  Key to use to lookup dictionary of nv-pairs type associated with NSNotification userInfo
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerNotificationsUserInfoAddlOptionsTypeKey;
+
 @protocol SFSDKOAuthClientDelegate;
 @protocol SFSDKOAuthClientSafariViewDelegate;
 @protocol SFSDKOAuthClientWebViewDelegate;
@@ -138,33 +172,6 @@ static NSString *const kOptionsClientKey = @"clientIdentifier";
  @return YES if the network is available, NO otherwise
  */
 - (BOOL)userAccountManagerIsNetworkAvailable:(SFUserAccountManager *)userAccountManager;
-/**
- *
- * @param userAccountManager The instance of SFUserAccountManager making the call.
- * @param credentials The credentials being used
- */
-- (void)userAccountManager:(SFUserAccountManager *)userAccountManager willLogin:(SFOAuthCredentials *)credentials;
-
-/**
- *
- * @param userAccountManager The instance of SFUserAccountManager making the call.
- * @param userAccount The userAccount being used
- */
-- (void)userAccountManager:(SFUserAccountManager *)userAccountManager willLogout:(SFUserAccount *)userAccount;
-
-/**
- *
- * @param userAccountManager The instance of SFUserAccountManager making the call.
- * @param userAccount The userAccount being used
- */
-- (void)userAccountManager:(SFUserAccountManager *)userAccountManager didLogout:(SFUserAccount *)userAccount;
-
-/**
- *
- * @param userAccountManager The instance of SFUserAccountManager
- * @param userAccount The userAccount being used
- */
-- (void)userAccountManager:(SFUserAccountManager *)userAccountManager didLogin:(SFUserAccount *)userAccount;
 
 /**
  *

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -110,6 +110,10 @@ FOUNDATION_EXTERN NSString * const kSFUserAccountManagerUserWillLogoutNotificati
  */
 FOUNDATION_EXTERN NSString * const kSFUserAccountManagerUserDidLogoutNotification;
 
+/** Notification sent prior to display of Auth View
+ */
+FOUNDATION_EXTERN NSString * const kSFUserAccountManagerWillDisplayAuthViewNotification;
+
 /** Notification sent prior to user log in
  */
 FOUNDATION_EXTERN NSString * const kSFUserAccountManagerUserWillLogInNotification;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -104,55 +104,55 @@ FOUNDATION_EXTERN  NSString * const kOAuthRedirectUriKey;
 
 /** Notification sent prior to user logout
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerUserWillLogoutNotification;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserWillLogout;
 
 /** Notification sent after user logout
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerUserDidLogoutNotification;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserDidLogout;
 
 /** Notification sent prior to display of Auth View
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerWillDisplayAuthViewNotification;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserWillShowAuthView;
 
 /** Notification sent prior to user log in
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerUserWillLogInNotification;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserWillLogIn;
 
 /** Notification sent after user log in
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerUserDidLogInNotification;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserDidLogIn;
 
 /**  Notification sent before SP APP invokes IDP APP for authentication
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerWillSendRequestForIDPAuthNotification;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserWillSendIDPRequest;
 
 /**  Notification sent when  IDP APP receives request for authentication from SP APP
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerDidReceiveRequestForIDPAuthNotification;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserDidReceiveIDPRequest;
 
 /**  Notification sent when  SP APP receives successful response of authentication from IDP APP
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerDidReceiveResponseForIDPAuthNotification;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserDidReceiveIDPResponse;
 
 /**  Notification sent when  SP APP has log in  is successful when initiated from IDP APP
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerIDPInitiatedLoginNotification;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserIDPInitDidLogIn;
 
 /**  Key to use to lookup userAccount associated with  NSNotification userInfo
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerNotificationsUserInfoAccountKey;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserInfoAccountKey;
 
 /**  Key to use to lookup credentials associated with  NSNotification userInfo
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerNotificationsUserInfoCredentialsKey;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserInfoCredentialsKey;
 
 /**  Key to use to lookup authinfo type associated with  NSNotification userInfo
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerNotificationsUserInfoAuthTypeKey;
+FOUNDATION_EXTERN NSString * const kSFNotificationUserInfoAuthTypeKey;
 
 /**  Key to use to lookup dictionary of nv-pairs type associated with NSNotification userInfo
  */
-FOUNDATION_EXTERN NSString * const kSFUserAccountManagerNotificationsUserInfoAddlOptionsTypeKey;
+FOUNDATION_EXTERN NSString * const kSFUserInfoAddlOptionsKey;
 
 @protocol SFSDKOAuthClientDelegate;
 @protocol SFSDKOAuthClientSafariViewDelegate;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -66,25 +66,25 @@ NSString * const SFUserAccountManagerDidChangeUserDataNotification   = @"SFUserA
 NSString * const SFUserAccountManagerDidFinishUserInitNotification   = @"SFUserAccountManagerDidFinishUserInitNotification";
 
 //login & logout notifications
-NSString * const kSFUserAccountManagerUserWillLogInNotification  = @"SFUserAccountManagerUserWillLogInNotification";
-NSString * const kSFUserAccountManagerUserDidLogInNotification   = @"SFUserAccountManagerUserDidLogInNotification";
-NSString * const kSFUserAccountManagerUserWillLogoutNotification = @"SFUserAccountManagerUserWillLogoutNotification";
-NSString * const kSFUserAccountManagerUserDidLogoutNotification  = @"SFUserAccountManagerUserDidLogoutNotification";
+NSString * const kSFNotificationUserWillLogIn  = @"SFNotificationUserWillLogIn";
+NSString * const kSFNotificationUserDidLogIn   = @"SFNotificationUserDidLogIn";
+NSString * const kSFNotificationUserWillLogout = @"SFNotificationUserWillLogout";
+NSString * const kSFNotificationUserDidLogout  = @"SFNotificationUserDidLogout";
 
 //Auth Display Notification
-NSString * const kSFUserAccountManagerWillDisplayAuthViewNotification = @"SFUserAccountManagerWillDisplayAuthViewNotification";
+NSString * const kSFNotificationUserWillShowAuthView = @"SFNotificationUserWillShowAuthView";
 
 //IDP-SP flow Notifications
-NSString * const kSFUserAccountManagerWillSendRequestForIDPAuthNotification      = @"SFUserAccountManagerWillSendRequestForIDPAuthNotification";
-NSString * const kSFUserAccountManagerDidReceiveRequestForIDPAuthNotification    = @"SFUserAccountManagerDidReceiveRequestForIDPAuthNotification";
-NSString * const kSFUserAccountManagerDidReceiveResponseForIDPAuthNotification   = @"SFUserAccountManagerDidReceiveResponseForIDPAuthNotification";
-NSString * const kSFUserAccountManagerIDPInitiatedLoginNotification              = @"SFUserAccountManagerIDPInitiatedLoginNotification";
+NSString * const kSFNotificationUserWillSendIDPRequest      = @"SFNotificationUserWillSendIDPRequest";
+NSString * const kSFNotificationUserDidReceiveIDPRequest    = @"SFNotificationUserDidReceiveIDPRequest";
+NSString * const kSFNotificationUserDidReceiveIDPResponse   = @"SFNotificationUserDidReceiveIDPResponse";
+NSString * const kSFNotificationUserIDPInitDidLogIn       = @"SFNotificationUserIDPInitDidLogIn";
 
 //keys used in notifications
-NSString * const kSFUserAccountManagerNotificationsUserInfoAccountKey      = @"account";
-NSString * const kSFUserAccountManagerNotificationsUserInfoCredentialsKey  = @"credentials";
-NSString * const kSFUserAccountManagerNotificationsUserInfoAuthTypeKey     = @"authType";
-NSString * const kSFUserAccountManagerNotificationsUserInfoAddlOptionsTypeKey     = @"options";
+NSString * const kSFNotificationUserInfoAccountKey      = @"account";
+NSString * const kSFNotificationUserInfoCredentialsKey  = @"credentials";
+NSString * const kSFNotificationUserInfoAuthTypeKey     = @"authType";
+NSString * const kSFUserInfoAddlOptionsKey     = @"options";
 
 NSString * const SFUserAccountManagerUserChangeKey      = @"change";
 NSString * const SFUserAccountManagerUserChangeUserKey      = @"user";
@@ -316,8 +316,8 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
     
     BOOL isCurrentUser = [user isEqual:self.currentUser];
     [SFSDKCoreLogger i:[self class] format:@"Logging out user '%@'.", user.userName];
-    NSDictionary *userInfo = @{ kSFUserAccountManagerNotificationsUserInfoAccountKey : user };
-    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFUserAccountManagerUserWillLogoutNotification
+    NSDictionary *userInfo = @{ kSFNotificationUserInfoAccountKey : user };
+    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFNotificationUserWillLogout
                                                         object:self
                                                       userInfo:userInfo];
     SFSDKOAuthClient *client = [self fetchOAuthClient:user.credentials completion:nil failure:nil];
@@ -334,7 +334,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
         self.currentUser = nil;
     }
    
-    NSNotification *logoutNotification = [NSNotification notificationWithName:kSFUserAccountManagerUserDidLogoutNotification object:self userInfo:userInfo];
+    NSNotification *logoutNotification = [NSNotification notificationWithName:kSFNotificationUserDidLogout object:self userInfo:userInfo];
     
     [[NSNotificationCenter defaultCenter] postNotification:logoutNotification];
     
@@ -376,9 +376,9 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 #pragma mark - SFSDKOAuthClientDelegate
 - (void)authClientWillBeginAuthentication:(SFSDKOAuthClient *)client{
     
-    NSDictionary *userInfo = @{ kSFUserAccountManagerNotificationsUserInfoCredentialsKey: client.credentials,
-                                kSFUserAccountManagerNotificationsUserInfoAuthTypeKey: client.context.authInfo };
-    [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserAccountManagerUserWillLogInNotification
+    NSDictionary *userInfo = @{ kSFNotificationUserInfoCredentialsKey: client.credentials,
+                                kSFNotificationUserInfoAuthTypeKey: client.context.authInfo };
+    [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserWillLogIn
                                                         object:self
                                                       userInfo:userInfo];
 }
@@ -434,17 +434,17 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 
 #pragma mark - SFSDKOAuthClientWebViewDelegate
 - (void)authClient:(SFSDKOAuthClient *_Nonnull)client willDisplayAuthWebView:(WKWebView *_Nonnull)view {
-    NSDictionary *userInfo = @{ kSFUserAccountManagerNotificationsUserInfoCredentialsKey: client.credentials,
-                                kSFUserAccountManagerNotificationsUserInfoAuthTypeKey: client.context.authInfo };
-    [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserAccountManagerWillDisplayAuthViewNotification
+    NSDictionary *userInfo = @{ kSFNotificationUserInfoCredentialsKey: client.credentials,
+                                kSFNotificationUserInfoAuthTypeKey: client.context.authInfo };
+    [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserWillShowAuthView
                                                         object:self userInfo:userInfo];
 }
 
 #pragma mark - SFSDKOAuthClientSafariViewDelegate
 - (void)authClientWillBeginBrowserAuthentication:(SFSDKOAuthClient *)client completion:(SFOAuthBrowserFlowCallbackBlock)callbackBlock {
-    NSDictionary *userInfo = @{ kSFUserAccountManagerNotificationsUserInfoCredentialsKey: client.credentials,
-                                kSFUserAccountManagerNotificationsUserInfoAuthTypeKey: client.context.authInfo };
-    [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserAccountManagerWillDisplayAuthViewNotification
+    NSDictionary *userInfo = @{ kSFNotificationUserInfoCredentialsKey: client.credentials,
+                                kSFNotificationUserInfoAuthTypeKey: client.context.authInfo };
+    [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserWillShowAuthView
                                                         object:self userInfo:userInfo];
 }
 
@@ -460,8 +460,8 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 }
 
 - (void)authClient:(SFSDKIDPAuthClient *)client willSendRequestForIDPAuth:(NSDictionary *)options {
-    NSDictionary *userInfo = @{kSFUserAccountManagerNotificationsUserInfoAddlOptionsTypeKey:options};
-    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFUserAccountManagerWillSendRequestForIDPAuthNotification
+    NSDictionary *userInfo = @{kSFUserInfoAddlOptionsKey:options};
+    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFNotificationUserWillSendIDPRequest
                                                          object:self
                                                          userInfo:userInfo
      ];
@@ -1255,13 +1255,13 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
         
         [idpClient continueIDPFlow:userAccount.credentials];
     } else {
-        NSDictionary *userInfo = @{kSFUserAccountManagerNotificationsUserInfoAccountKey: userAccount,
-                                   kSFUserAccountManagerNotificationsUserInfoAuthTypeKey: client.context.authInfo};
+        NSDictionary *userInfo = @{kSFNotificationUserInfoAccountKey: userAccount,
+                                   kSFNotificationUserInfoAuthTypeKey: client.context.authInfo};
         if (client.config.isIDPInitiatedFlow) {
-            NSNotification *loggedInNotification = [NSNotification notificationWithName:kSFUserAccountManagerIDPInitiatedLoginNotification object:self  userInfo:userInfo];
+            NSNotification *loggedInNotification = [NSNotification notificationWithName:kSFNotificationUserIDPInitDidLogIn object:self  userInfo:userInfo];
             [[NSNotificationCenter defaultCenter] postNotification:loggedInNotification];
         } else {
-         [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserAccountManagerUserDidLogInNotification
+         [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidLogIn
                                                                 object:self
                                                               userInfo:userInfo];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -61,15 +61,30 @@
 #import "SFSDKWindowContainer.h"
 
 // Notifications
-NSString * const SFUserAccountManagerDidChangeUserNotification   = @"SFUserAccountManagerDidChangeUserNotification";
+NSString * const SFUserAccountManagerDidChangeUserNotification       = @"SFUserAccountManagerDidChangeUserNotification";
 NSString * const SFUserAccountManagerDidChangeUserDataNotification   = @"SFUserAccountManagerDidChangeUserDataNotification";
 NSString * const SFUserAccountManagerDidFinishUserInitNotification   = @"SFUserAccountManagerDidFinishUserInitNotification";
 
-NSString * const SFUserAccountManagerWillLogoutNotification = @"SFUserAccountManagerWillLogoutNotification";
-NSString * const SFUserAccountManagerLogoutNotification = @"SFUserAccountManagerLogoutNotification";
-NSString * const SFUserAccountManagerLoggedInNotification = @"SFUserAccountManagerLoggedInNotification";
+//login & logout notifications
+NSString * const kSFUserAccountManagerUserWillLogInNotification  = @"SFUserAccountManagerUserWillLogInNotification";
+NSString * const kSFUserAccountManagerUserDidLogInNotification   = @"SFUserAccountManagerUserDidLogInNotification";
+NSString * const kSFUserAccountManagerUserWillLogoutNotification = @"SFUserAccountManagerUserWillLogoutNotification";
+NSString * const kSFUserAccountManagerUserDidLogoutNotification  = @"SFUserAccountManagerUserDidLogoutNotification";
 
-NSString * const SFUserAccountManagerIDPInitiatedLoginNotification = @"SFUserAccountManagerIDPInitiatedLoginNotification";
+//Auth Display Notification
+NSString * const kSFUserAccountManagerWillDisplayAuthViewNotification = @"SFUserAccountManagerWillDisplayAuthViewNotification";
+
+//IDP-SP flow Notifications
+NSString * const kSFUserAccountManagerWillSendRequestForIDPAuthNotification      = @"SFUserAccountManagerWillSendRequestForIDPAuthNotification";
+NSString * const kSFUserAccountManagerDidReceiveRequestForIDPAuthNotification    = @"SFUserAccountManagerDidReceiveRequestForIDPAuthNotification";
+NSString * const kSFUserAccountManagerDidReceiveResponseForIDPAuthNotification   = @"SFUserAccountManagerDidReceiveResponseForIDPAuthNotification";
+NSString * const kSFUserAccountManagerIDPInitiatedLoginNotification              = @"SFUserAccountManagerIDPInitiatedLoginNotification";
+
+//keys used in notifications
+NSString * const kSFUserAccountManagerNotificationsUserInfoAccountKey      = @"account";
+NSString * const kSFUserAccountManagerNotificationsUserInfoCredentialsKey  = @"credentials";
+NSString * const kSFUserAccountManagerNotificationsUserInfoAuthTypeKey     = @"authType";
+NSString * const kSFUserAccountManagerNotificationsUserInfoAddlOptionsTypeKey     = @"options";
 
 NSString * const SFUserAccountManagerUserChangeKey      = @"change";
 NSString * const SFUserAccountManagerUserChangeUserKey      = @"user";
@@ -91,6 +106,8 @@ static NSString *const kSFIncompatibleAuthError = @"Cannot use SFUserAccountMana
 static NSString *const kErroredClientKey = @"SFErroredOAuthClientKey";
 static NSString * const kSFSPAppFeatureIDPLogin   = @"SP";
 static NSString * const kSFIDPAppFeatureIDPLogin   = @"IP";
+static NSString *const  kOptionsClientKey          = @"clientIdentifier";
+
 
 @implementation SFUserAccountManager
 
@@ -299,17 +316,10 @@ static NSString * const kSFIDPAppFeatureIDPLogin   = @"IP";
     
     BOOL isCurrentUser = [user isEqual:self.currentUser];
     [SFSDKCoreLogger i:[self class] format:@"Logging out user '%@'.", user.userName];
-    NSDictionary *userInfo = @{ @"account": user };
-    [[NSNotificationCenter defaultCenter] postNotificationName:SFUserAccountManagerWillLogoutNotification
+    NSDictionary *userInfo = @{ kSFUserAccountManagerNotificationsUserInfoAccountKey : user };
+    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFUserAccountManagerUserWillLogoutNotification
                                                         object:self
                                                       userInfo:userInfo];
-    __weak typeof(self) weakSelf = self;
-    [self enumerateDelegates:^(id<SFUserAccountManagerDelegate> delegate) {
-        if ([delegate respondsToSelector:@selector(userAccountManager:willLogout:)]) {
-            [delegate userAccountManager:weakSelf willLogout:user];
-        }
-    }];
-
     SFSDKOAuthClient *client = [self fetchOAuthClient:user.credentials completion:nil failure:nil];
     
     [self deleteAccountForUser:user error:nil];
@@ -324,14 +334,10 @@ static NSString * const kSFIDPAppFeatureIDPLogin   = @"IP";
         self.currentUser = nil;
     }
    
-    NSNotification *logoutNotification = [NSNotification notificationWithName:SFUserAccountManagerLogoutNotification object:self userInfo:userInfo];
+    NSNotification *logoutNotification = [NSNotification notificationWithName:kSFUserAccountManagerUserDidLogoutNotification object:self userInfo:userInfo];
+    
     [[NSNotificationCenter defaultCenter] postNotification:logoutNotification];
     
-    [self enumerateDelegates:^(id<SFUserAccountManagerDelegate> delegate) {
-        if ([delegate respondsToSelector:@selector(userAccountManager:didLogout:)]) {
-            [delegate userAccountManager:self didLogout:user];
-        }
-    }];
     // NB: There's no real action that can be taken if this login state transition fails.  At any rate,
     // it's an unlikely scenario.
     [user transitionToLoginState:SFUserAccountLoginStateNotLoggedIn];
@@ -369,11 +375,12 @@ static NSString * const kSFIDPAppFeatureIDPLogin   = @"IP";
 
 #pragma mark - SFSDKOAuthClientDelegate
 - (void)authClientWillBeginAuthentication:(SFSDKOAuthClient *)client{
-    [self enumerateDelegates:^(id <SFUserAccountManagerDelegate> delegate) {
-        if ([delegate respondsToSelector:@selector(userAccountManager:willLogin:)]) {
-            [delegate userAccountManager:self willLogin:client.credentials];
-        }
-    }];
+    
+    NSDictionary *userInfo = @{ kSFUserAccountManagerNotificationsUserInfoCredentialsKey: client.credentials,
+                                kSFUserAccountManagerNotificationsUserInfoAuthTypeKey: client.context.authInfo };
+    [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserAccountManagerUserWillLogInNotification
+                                                        object:self
+                                                      userInfo:userInfo];
 }
 
 - (void)authClientDidFail:(SFSDKOAuthClient *)client error:(NSError *_Nullable)error{
@@ -425,20 +432,39 @@ static NSString * const kSFIDPAppFeatureIDPLogin   = @"IP";
     self.alertDisplayBlock(message,client.authWindow);
 }
 
-#pragma mark - SFSDKOAuthClientSafariViewDelegate
-- (void)authClientWillBeginBrowserAuthentication:(SFSDKOAuthClient *)client completion:(SFOAuthBrowserFlowCallbackBlock)callbackBlock {
+#pragma mark - SFSDKOAuthClientWebViewDelegate
+- (void)authClient:(SFSDKOAuthClient *_Nonnull)client willDisplayAuthWebView:(WKWebView *_Nonnull)view {
+    NSDictionary *userInfo = @{ kSFUserAccountManagerNotificationsUserInfoCredentialsKey: client.credentials,
+                                kSFUserAccountManagerNotificationsUserInfoAuthTypeKey: client.context.authInfo };
+    [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserAccountManagerWillDisplayAuthViewNotification
+                                                        object:self userInfo:userInfo];
 }
 
+#pragma mark - SFSDKOAuthClientSafariViewDelegate
+- (void)authClientWillBeginBrowserAuthentication:(SFSDKOAuthClient *)client completion:(SFOAuthBrowserFlowCallbackBlock)callbackBlock {
+    NSDictionary *userInfo = @{ kSFUserAccountManagerNotificationsUserInfoCredentialsKey: client.credentials,
+                                kSFUserAccountManagerNotificationsUserInfoAuthTypeKey: client.context.authInfo };
+    [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserAccountManagerWillDisplayAuthViewNotification
+                                                        object:self userInfo:userInfo];
+}
 
 #pragma mark - SFSDKIDPAuthClientDelegate
 - (void)authClient:(SFSDKOAuthClient *)client error:(NSError *)error {
     SFSDKIDPAuthClient *idpClient = (SFSDKIDPAuthClient *) [SFSDKOAuthClient idpAuthInstance:nil];
-    [idpClient launchSPAppWithError:nil reason:@"User cancelled authentication"];
+    [idpClient launchSPAppWithError:error reason:nil];
     [self disposeOAuthClient:idpClient];
 }
 
-- (void)authClient:(SFSDKOAuthClient *)client willSendResponseForIDPAuth:(NSURL *)response {
+- (void)authClient:(SFSDKOAuthClient *)client willSendResponseForIDPAuth:(NSDictionary *)options {
     [client dismissAuthViewControllerIfPresent];
+}
+
+- (void)authClient:(SFSDKIDPAuthClient *)client willSendRequestForIDPAuth:(NSDictionary *)options {
+    NSDictionary *userInfo = @{kSFUserAccountManagerNotificationsUserInfoAddlOptionsTypeKey:options};
+    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFUserAccountManagerWillSendRequestForIDPAuthNotification
+                                                         object:self
+                                                         userInfo:userInfo
+     ];
 }
 
 - (void)authClientDisplayIDPLoginFlowSelection:(SFSDKIDPAuthClient *)client  {
@@ -1229,20 +1255,17 @@ static NSString * const kSFIDPAppFeatureIDPLogin   = @"IP";
         
         [idpClient continueIDPFlow:userAccount.credentials];
     } else {
-        NSDictionary *userInfo = @{ @"account": userAccount };
+        NSDictionary *userInfo = @{kSFUserAccountManagerNotificationsUserInfoAccountKey: userAccount,
+                                   kSFUserAccountManagerNotificationsUserInfoAuthTypeKey: client.context.authInfo};
         if (client.config.isIDPInitiatedFlow) {
-            NSNotification *loggedInNotification = [NSNotification notificationWithName:SFUserAccountManagerIDPInitiatedLoginNotification object:self  userInfo:userInfo];
+            NSNotification *loggedInNotification = [NSNotification notificationWithName:kSFUserAccountManagerIDPInitiatedLoginNotification object:self  userInfo:userInfo];
             [[NSNotificationCenter defaultCenter] postNotification:loggedInNotification];
         } else {
-            NSNotification *loggedInNotification = [NSNotification notificationWithName:SFUserAccountManagerLoggedInNotification object:self  userInfo:userInfo];
-            [[NSNotificationCenter defaultCenter] postNotification:loggedInNotification];
+         [[NSNotificationCenter defaultCenter] postNotificationName:kSFUserAccountManagerUserDidLogInNotification
+                                                                object:self
+                                                              userInfo:userInfo];
         }
-        
-        [self enumerateDelegates:^(id <SFUserAccountManagerDelegate> delegate) {
-            if ([delegate respondsToSelector:@selector(userAccountManager:didLogin:)]) {
-                [delegate userAccountManager:self didLogin:userAccount];
-            }
-        }];
+       
         [client dismissAuthViewControllerIfPresent];
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -407,7 +407,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 {
     SFOAuthCredentials *credentials = [self populateAuthCredentialsFromConfigFileForClass:self.class];
     
-    NSString *notificationName = kSFUserAccountManagerUserWillLogInNotification;
+    NSString *notificationName = kSFNotificationUserWillLogIn;
     
     id observerMock = [OCMockObject observerMock];
     [[NSNotificationCenter defaultCenter] addMockObserver:observerMock name:notificationName object:[SFUserAccountManager sharedInstance]];
@@ -422,7 +422,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
      object:[SFUserAccountManager sharedInstance]
      userInfo:[OCMArg checkWithBlock:
                ^BOOL(NSDictionary *userInfo) {
-                   return userInfo[kSFUserAccountManagerNotificationsUserInfoCredentialsKey]!=nil;
+                   return userInfo[kSFNotificationUserInfoCredentialsKey]!=nil;
                }]];
     
     [[SFUserAccountManager sharedInstance]
@@ -444,7 +444,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 {
     SFOAuthCredentials *credentials = [self populateAuthCredentialsFromConfigFileForClass:self.class];
     
-    NSString *notificationName = kSFUserAccountManagerUserDidLogInNotification;
+    NSString *notificationName = kSFNotificationUserDidLogIn;
     
     id observerMock = [OCMockObject observerMock];
     [[NSNotificationCenter defaultCenter] addMockObserver:observerMock name:notificationName object:[SFUserAccountManager sharedInstance]];
@@ -459,7 +459,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
      object:[SFUserAccountManager sharedInstance]
      userInfo:[OCMArg checkWithBlock:
                ^BOOL(NSDictionary *userInfo) {
-                   return userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey]!=nil;
+                   return userInfo[kSFNotificationUserInfoAccountKey]!=nil;
                }]];
     
     [[SFUserAccountManager sharedInstance]

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -390,38 +390,24 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 - (void)testLogin {
     
     SFOAuthCredentials *credentials = [self populateAuthCredentialsFromConfigFileForClass:self.class];
-    
-    TestUserAccountManagerDelegate *acctDelegate = [[TestUserAccountManagerDelegate alloc] init];
-    [[SFUserAccountManager sharedInstance] addDelegate:acctDelegate];
-    
-    __block SFSDKTestRequestListener *authListener = [[SFSDKTestRequestListener alloc] init];
+    XCTestExpectation *refreshExpectation = [self expectationWithDescription:@"refresh"];
     __block SFUserAccount *user = nil;
     [[SFUserAccountManager sharedInstance]
      refreshCredentials:credentials
      completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
-         authListener.returnStatus = kTestRequestStatusDidLoad;
+         [refreshExpectation fulfill];
          user = userAccount;
      } failure:^(SFOAuthInfo *authInfo, NSError *error) {
-         authListener.lastError = error;
-         authListener.returnStatus = kTestRequestStatusDidFail;
      }];
-    [authListener waitForCompletion];
-    
-    NSAssert([authListener.returnStatus isEqualToString:kTestRequestStatusDidLoad], @"After auth attempt, expected status '%@', got '%@'",
-             kTestRequestStatusDidLoad,
-             authListener.returnStatus);
-    XCTAssertNotNil(acctDelegate.willLoginCredentials, @"Will login credentials should be called");
-    XCTAssertEqual(acctDelegate.didLoginUserAccount,user, @"DidLoginUserAccount should be called.");
-
-    [[SFUserAccountManager sharedInstance] removeDelegate:acctDelegate];
+   
+    [self waitForExpectations:@[refreshExpectation] timeout:20];
     
 }
-
-- (void)testLoginNotificationPosted
+- (void)testWillLoginNotificationPosted
 {
     SFOAuthCredentials *credentials = [self populateAuthCredentialsFromConfigFileForClass:self.class];
     
-    NSString *notificationName = SFUserAccountManagerLoggedInNotification;
+    NSString *notificationName = kSFUserAccountManagerUserWillLogInNotification;
     
     id observerMock = [OCMockObject observerMock];
     [[NSNotificationCenter defaultCenter] addMockObserver:observerMock name:notificationName object:[SFUserAccountManager sharedInstance]];
@@ -436,7 +422,44 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
      object:[SFUserAccountManager sharedInstance]
      userInfo:[OCMArg checkWithBlock:
                ^BOOL(NSDictionary *userInfo) {
-                   return userInfo[@"account"]!=nil;
+                   return userInfo[kSFUserAccountManagerNotificationsUserInfoCredentialsKey]!=nil;
+               }]];
+    
+    [[SFUserAccountManager sharedInstance]
+     refreshCredentials:credentials
+     completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
+         authListener.returnStatus = kTestRequestStatusDidLoad;
+         user = userAccount;
+     } failure:^(SFOAuthInfo *authInfo, NSError *error) {
+         authListener.lastError = error;
+         authListener.returnStatus = kTestRequestStatusDidFail;
+     }];
+    [authListener waitForCompletion];
+    [observerMock verify];
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:observerMock];
+}
+
+- (void)testLoginNotificationPosted
+{
+    SFOAuthCredentials *credentials = [self populateAuthCredentialsFromConfigFileForClass:self.class];
+    
+    NSString *notificationName = kSFUserAccountManagerUserDidLogInNotification;
+    
+    id observerMock = [OCMockObject observerMock];
+    [[NSNotificationCenter defaultCenter] addMockObserver:observerMock name:notificationName object:[SFUserAccountManager sharedInstance]];
+    
+    
+    
+    __block SFSDKTestRequestListener *authListener = [[SFSDKTestRequestListener alloc] init];
+    __block SFUserAccount *user = nil;
+    
+    [[observerMock expect]
+     notificationWithName:notificationName
+     object:[SFUserAccountManager sharedInstance]
+     userInfo:[OCMArg checkWithBlock:
+               ^BOOL(NSDictionary *userInfo) {
+                   return userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey]!=nil;
                }]];
     
     [[SFUserAccountManager sharedInstance]

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
@@ -101,6 +101,8 @@ static NSMutableDictionary *cacheMgrList = nil;
         self.enableInMemoryCache = YES;
         self.user = user;
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFUserAccountManagerUserWillLogoutNotification object:nil];
+
     }
     return self;
 }
@@ -302,6 +304,10 @@ static NSMutableDictionary *cacheMgrList = nil;
 #pragma mark - SFAuthenticationManagerDelegate
 
 - (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user {
+    [[self class] removeSharedInstance:user];
+}
+- (void)handleUserWillLogout:(NSNotification *)notification {
+    SFUserAccount *user = notification.userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey];
     [[self class] removeSharedInstance:user];
 }
 

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
@@ -101,7 +101,7 @@ static NSMutableDictionary *cacheMgrList = nil;
         self.enableInMemoryCache = YES;
         self.user = user;
         [[SFAuthenticationManager sharedManager] addDelegate:self];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFUserAccountManagerUserWillLogoutNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
 
     }
     return self;
@@ -307,7 +307,7 @@ static NSMutableDictionary *cacheMgrList = nil;
     [[self class] removeSharedInstance:user];
 }
 - (void)handleUserWillLogout:(NSNotification *)notification {
-    SFUserAccount *user = notification.userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey];
+    SFUserAccount *user = notification.userInfo[kSFNotificationUserInfoAccountKey];
     [[self class] removeSharedInstance:user];
 }
 

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.m
@@ -131,7 +131,7 @@ static NSMutableDictionary *metadataMgrList = nil;
         self.cacheEnabled = YES;
         self.encryptCache = YES;
         [[SFAuthenticationManager sharedManager] addDelegate:self];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFUserAccountManagerUserWillLogoutNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
     }
     return self;
 }
@@ -1027,7 +1027,7 @@ refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan
 }
 
 - (void)handleUserWillLogout:(NSNotification *)notification {
-    SFUserAccount *user = notification.userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey];
+    SFUserAccount *user = notification.userInfo[kSFNotificationUserInfoAccountKey];
     [[self class] removeSharedInstance:user];
 }
 

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.m
@@ -131,6 +131,7 @@ static NSMutableDictionary *metadataMgrList = nil;
         self.cacheEnabled = YES;
         self.encryptCache = YES;
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFUserAccountManagerUserWillLogoutNotification object:nil];
     }
     return self;
 }
@@ -1022,6 +1023,11 @@ refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan
 #pragma mark - SFAuthenticationManagerDelegate
 
 - (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user {
+    [[self class] removeSharedInstance:user];
+}
+
+- (void)handleUserWillLogout:(NSNotification *)notification {
+    SFUserAccount *user = notification.userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey];
     [[self class] removeSharedInstance:user];
 }
 

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -140,6 +140,7 @@ static NSMutableDictionary *syncMgrList = nil;
         self.store = store;
         self.queue = dispatch_queue_create(kSyncManagerQueue,  DISPATCH_QUEUE_SERIAL);
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFUserAccountManagerUserWillLogoutNotification object:nil];
         [SFSyncState setupSyncsSoupIfNeeded:self.store];
     }
     return self;
@@ -614,6 +615,11 @@ static NSMutableDictionary *syncMgrList = nil;
 
 - (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user {
     [[self class] removeSharedInstance:user];
+}
+
+- (void)handleUserWillLogout:(NSNotification *)notification {
+    SFUserAccount *user = notification.userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey];
+     [[self class] removeSharedInstance:user];
 }
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -140,7 +140,7 @@ static NSMutableDictionary *syncMgrList = nil;
         self.store = store;
         self.queue = dispatch_queue_create(kSyncManagerQueue,  DISPATCH_QUEUE_SERIAL);
         [[SFAuthenticationManager sharedManager] addDelegate:self];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFUserAccountManagerUserWillLogoutNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
         [SFSyncState setupSyncsSoupIfNeeded:self.store];
     }
     return self;
@@ -618,7 +618,7 @@ static NSMutableDictionary *syncMgrList = nil;
 }
 
 - (void)handleUserWillLogout:(NSNotification *)notification {
-    SFUserAccount *user = notification.userInfo[kSFUserAccountManagerNotificationsUserInfoAccountKey];
+    SFUserAccount *user = notification.userInfo[kSFNotificationUserInfoAccountKey];
      [[self class] removeSharedInstance:user];
 }
 


### PR DESCRIPTION

- Added Auth notifications to the SFUserAccountManager.
- Removed delegate calls for userWill/DidLogin & userWill/DidLogout from the SFUserAccountManagerDelegate. The notifications fired by the SDK should be sufficient.
- Changes across some of the SDK to consume the Will/Did Logout/Login notifications.