### PR TITLE
Deprecated SFAuthenticationManager

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalyticsTests/SFSDKLoggerTests.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalyticsTests/SFSDKLoggerTests.m
@@ -38,7 +38,9 @@ static NSString * const kTestLogLine3 = @"This is test log line 3!";
 static NSString * const kTestLogLine4 = @"This is test log line 4!";
 unsigned long long const kDefaultMaxFileSize = 1024 * 1024; // 1 MB.
 
-@interface SFSDKLoggerTests : XCTestCase
+@interface SFSDKLoggerTests : XCTestCase {
+    DDLogLevel _origLogLevel;
+}
 
 @end
 
@@ -47,13 +49,15 @@ unsigned long long const kDefaultMaxFileSize = 1024 * 1024; // 1 MB.
 - (void)setUp {
     [super setUp];
     [SFSDKLogger flushAllComponents];
+    _origLogLevel = [SFSDKLogger sharedInstanceWithComponent:kTestComponent1].logLevel;
+    [[SFSDKLogger sharedInstanceWithComponent:kTestComponent1] setLogLevel:DDLogLevelInfo];
     [NSThread sleepForTimeInterval:1.0]; // Flushing the log file is asynchronous.
-    
 }
 
 - (void)tearDown {
     [SFSDKLogger flushAllComponents];
     [NSThread sleepForTimeInterval:1.0]; // Flushing the log file is asynchronous.
+    [[SFSDKLogger sharedInstanceWithComponent:kTestComponent1] setLogLevel:_origLogLevel];
     [super tearDown];
 }
 

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFAccountManagerPlugin/SFAccountManagerPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFAccountManagerPlugin/SFAccountManagerPlugin.m
@@ -41,7 +41,7 @@ NSString * const kUserAccountOrgIdDictKey          = @"orgId";
 NSString * const kUserAccountUserIdDictKey         = @"userId";
 NSString * const kUserAccountUsernameDictKey       = @"username";
 NSString * const kUserAccountClientIdDictKey       = @"clientId";
-
+SFSDK_USE_DEPRECATED_BEGIN
 @interface SFAccountManagerPlugin ()
 
 /**
@@ -104,7 +104,7 @@ NSString * const kUserAccountClientIdDictKey       = @"clientId";
             [self.viewController presentViewController:umvc animated:YES completion:NULL];
         } else {
             // Zero accounts configured?  Logout, I guess.
-            [[SFAuthenticationManager sharedManager] logout];
+            [self logout];
         }
     } else {
         // User data was passed in.  Assume API-level user switching.
@@ -129,10 +129,10 @@ NSString * const kUserAccountClientIdDictKey       = @"clientId";
     SFUserAccount *account = [[SFUserAccountManager sharedInstance] userAccountForUserIdentity:accountIdentity];
     if (account == nil || account == [SFUserAccountManager sharedInstance].currentUser) {
         [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"logout: Logging out current user.  App state will reset."]];
-        [[SFAuthenticationManager sharedManager] logout];
+        [self logout];
     } else {
         [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"logout: Logging out user account: %@", account]];
-        [[SFAuthenticationManager sharedManager] logoutUser:account];
+        [self logoutUser:account];
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
     }
@@ -155,4 +155,17 @@ NSString * const kUserAccountClientIdDictKey       = @"clientId";
     return accountDict;
 }
 
+- (void)logout {
+    [self logoutUser:[SFUserAccountManager sharedInstance].currentUser];
+}
+
+- (void)logoutUser:(SFUserAccount *)user {
+    if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
+        [[SFAuthenticationManager sharedManager] logout];
+    } else {
+        [[SFUserAccountManager sharedInstance] logout];
+    }
+}
+
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
@@ -30,7 +30,7 @@
 #import <SalesforceSDKCore/SFAuthenticationManager.h>
 #import <SalesforceSDKCore/SFSDKWebUtils.h>
 #import "SFHybridViewController.h"
-
+SFSDK_USE_DEPRECATED_BEGIN
 @implementation SalesforceOAuthPlugin
 
 #pragma mark - Cordova plugin methods
@@ -111,3 +111,4 @@
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -64,7 +64,7 @@ static NSString * const kVFPingPageUrl = @"/apexpages/utils/ping.apexp";
 
 // App feature constant.
 static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
-
+SFSDK_USE_DEPRECATED_BEGIN
 @interface SFHybridViewController()
 {
     BOOL _foundHomeUrl;
@@ -249,7 +249,7 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
     }
 
     // Remote app. Device is online.
-    [SFAuthenticationManager resetSessionCookie];
+    [SFSDKWebViewStateManager resetSessionCookie];
     [self configureRemoteStartPage];
     [super viewDidLoad];
 }
@@ -803,7 +803,7 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
 - (void)authenticationCompletion:(NSString *)originalUrl authInfo:(SFOAuthInfo *)authInfo
 {
     [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"authenticationCompletion:authInfo: - Initiating post-auth configuration."]];
-    [SFAuthenticationManager resetSessionCookie];
+    [SFSDKWebViewStateManager resetSessionCookie];
 
     // If there's an original URL, load it through frontdoor.
     if (originalUrl != nil) {
@@ -876,3 +876,4 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Classes/AppDelegate.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTestApp/Classes/AppDelegate.m
@@ -26,7 +26,7 @@
 #import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import <SalesforceHybridSDK/SalesforceHybridSDK.h>
 #import "SFTestRunnerPlugin.h"
-
+SFSDK_USE_DEPRECATED_BEGIN
 @interface AppDelegate () <SFAuthenticationManagerDelegate, SFUserAccountManagerDelegate>
 
 @property (nonatomic, strong) SFHybridViewConfig *testAppHybridViewConfig;
@@ -208,3 +208,4 @@ FILE *fopen$UNIX2003(const char *filename, const char *mode) {
 size_t fwrite$UNIX2003(const void *a, size_t b, size_t c, FILE *d) {
     return fwrite(a, b, c, d);
 }
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFOauthReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFOauthReactBridge.m
@@ -35,7 +35,7 @@ NSString * const kOrgIdCredentialsDictKey = @"orgId";
 NSString * const kLoginUrlCredentialsDictKey = @"loginUrl";
 NSString * const kInstanceUrlCredentialsDictKey = @"instanceUrl";
 NSString * const kUserAgentCredentialsDictKey = @"userAgent";
-
+SFSDK_USE_DEPRECATED_BEGIN
 @implementation SFOauthReactBridge
 
 RCT_EXPORT_MODULE();
@@ -75,7 +75,7 @@ RCT_EXPORT_METHOD(authenticate:(NSDictionary *)args callback:(RCTResponseSenderB
 
 - (void)sendAuthCredentials:(RCTResponseSenderBlock) callback
 {
-    SFOAuthCredentials *creds = [SFAuthenticationManager sharedManager].coordinator.credentials;
+    SFOAuthCredentials *creds = [SFUserAccountManager sharedInstance].currentUser.credentials;
     if (nil != creds) {
         NSString *instanceUrl = creds.instanceUrl.absoluteString;
         NSString *loginUrl = [NSString stringWithFormat:@"%@://%@", creds.protocol, creds.domain];
@@ -131,3 +131,4 @@ RCT_EXPORT_METHOD(authenticate:(NSDictionary *)args callback:(RCTResponseSenderB
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -59,8 +59,10 @@ static NSMutableDictionary *analyticsManagerList = nil;
 
 @end
 SFSDK_USE_DEPRECATED_BEGIN
+
 @interface SFSDKSalesforceAnalyticsManager () <SFAuthenticationManagerDelegate>
 
+SFSDK_USE_DEPRECATED_END
 @property (nonatomic, readwrite, strong) SFSDKAnalyticsManager *analyticsManager;
 @property (nonatomic, readwrite, strong) SFSDKEventStoreManager *eventStoreManager;
 @property (nonatomic, readwrite, strong) SFUserAccount *userAccount;
@@ -110,7 +112,9 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (void) dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidEnterBackgroundNotification object:nil];
+    SFSDK_USE_DEPRECATED_BEGIN
     [[SFAuthenticationManager sharedManager] removeDelegate:self];
+    SFSDK_USE_DEPRECATED_END
 }
 
 - (instancetype) initWithUser:(SFUserAccount *) userAccount {
@@ -132,7 +136,9 @@ SFSDK_USE_DEPRECATED_BEGIN
         SFSDKAnalyticsTransformPublisherPair *tpp = [[SFSDKAnalyticsTransformPublisherPair alloc] initWithTransform:[[SFSDKAILTNTransform alloc] init] publisher:[[SFSDKAILTNPublisher alloc] init]];
         [self.remotes addObject:tpp];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(publishOnAppBackground) name:UIApplicationDidEnterBackgroundNotification object:nil];
+        SFSDK_USE_DEPRECATED_BEGIN
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        SFSDK_USE_DEPRECATED_END
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
     }
     return self;
@@ -338,11 +344,15 @@ SFSDK_USE_DEPRECATED_BEGIN
     [[self class] removeSharedInstanceWithUser:user];
 }
 
+SFSDK_USE_DEPRECATED_BEGIN
+
 - (void) authManager:(SFAuthenticationManager *) manager willLogoutUser:(SFUserAccount *) user {
     [self handleLogoutForUser:user];
 }
 
 @end
+
+SFSDK_USE_DEPRECATED_END
 
 @implementation SFSDKAnalyticsTransformPublisherPair
 
@@ -356,4 +366,4 @@ SFSDK_USE_DEPRECATED_BEGIN
 }
 
 @end
-SFSDK_USE_DEPRECATED_END
+

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -37,6 +37,7 @@
 #import "UIDevice+SFHardware.h"
 #import "SFIdentityData.h"
 #import "SFApplicationHelper.h"
+#import "SFAuthenticationManager.h"
 #import <SalesforceAnalytics/SFSDKAILTNTransform.h>
 #import <SalesforceAnalytics/SFSDKDeviceAppAttributes.h>
 #import <SalesforceAnalytics/NSUserDefaults+SFAdditions.h>
@@ -57,7 +58,7 @@ static NSMutableDictionary *analyticsManagerList = nil;
 - (instancetype)initWithTransform:(id<SFSDKTransform>)transform publisher:(id<SFSDKAnalyticsPublisher>)publisher;
 
 @end
-
+SFSDK_USE_DEPRECATED_BEGIN
 @interface SFSDKSalesforceAnalyticsManager () <SFAuthenticationManagerDelegate>
 
 @property (nonatomic, readwrite, strong) SFSDKAnalyticsManager *analyticsManager;
@@ -355,3 +356,4 @@ static NSMutableDictionary *analyticsManagerList = nil;
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWebViewStateManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWebViewStateManager.h
@@ -45,6 +45,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (class, strong, nonatomic, nullable) WKProcessPool *sharedProcessPool;
 
+/**
+ Clears session cookie data from the cookie store, and sets a new session cookie based on the
+ OAuth credentials.
+ */
++ (void)resetSessionCookie;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWebViewStateManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWebViewStateManager.m
@@ -23,7 +23,7 @@
  */
 #import <WebKit/WebKit.h>
 #import "SFSDKWebViewStateManager.h"
-
+#import "SFUserAccountManager.h"
 static NSString *const SID_COOKIE = @"sid";
 static NSString *const TRUE_STRING = @"TRUE";
 static NSString *const ERR_NO_DOMAIN_NAMES = @"No domain names given for deleting cookies.";
@@ -127,6 +127,13 @@ static WKProcessPool *_processPool = nil;
 
 + (NSArray<NSString *> *) domains {
     return @[@".salesforce.com", @".force.com", @".cloudforce.com"];
+}
+
++ (void)resetSessionCookie
+{
+    BOOL isSecure = [[SFUserAccountManager   sharedInstance].currentUser.credentials.protocol isEqualToString:@"https"];
+    [SFSDKWebViewStateManager resetSessionWithNewAccessToken:[SFUserAccountManager   sharedInstance].currentUser.credentials.accessToken
+                                            isSecureProtocol:isSecure];
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKConstants.h
@@ -65,4 +65,11 @@ __builtin_unreachable(); \
 #define SFSDK_DEPRECATED(dep_version, rem_version, msg) __attribute__((deprecated()))
 #endif
 
+#define SFSDK_USE_DEPRECATED_BEGIN \
+_Pragma("clang diagnostic push") \
+_Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+
+#define SFSDK_USE_DEPRECATED_END \
+_Pragma("clang diagnostic pop")
+
 #endif // SalesforceSDKConstants_h

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -3,7 +3,7 @@
 #import "SFUserAccountManager.h"
 #import "SFUserAccount.h"
 #import "SFSDKAppConfig.h"
-
+#import "SFAuthenticationManager.h"
 @protocol SalesforceSDKManagerFlow <NSObject>
 
 - (void)passcodeValidationAtLaunch;
@@ -26,11 +26,13 @@
 
 @end
 
-@interface SalesforceSDKManager () <SalesforceSDKManagerFlow, SFUserAccountManagerDelegate, SFSecurityLockoutDelegate>
+SFSDK_USE_DEPRECATED_BEGIN
+@interface SalesforceSDKManager () <SalesforceSDKManagerFlow, SFUserAccountManagerDelegate, SFSecurityLockoutDelegate,SFAuthenticationManagerDelegate>
 {
     BOOL _isLaunching;
     UIViewController* _snapshotViewController;
 }
+SFSDK_USE_DEPRECATED_END
 
 @property (nonatomic, assign) SFAppType appType;
 @property (nonatomic, weak, nullable) id<SalesforceSDKManagerFlow> sdkManagerFlow;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -24,8 +24,6 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-
-#import "SFAuthenticationManager.h"
 #import "SalesforceSDKCoreDefines.h"
 
 @class SFUserAccount, SFSDKAppConfig;
@@ -92,7 +90,7 @@ typedef void (^SFSnapshotViewControllerDismissalBlock)(UIViewController* snapsho
  including the orchestration of authentication, passcode displaying, and management of app
  backgrounding and foregrounding state.
  */
-@interface SalesforceSDKManager : NSObject <SFAuthenticationManagerDelegate>
+@interface SalesforceSDKManager : NSObject
 
 /**
  Class instance to be used to instantiate the singleton.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -52,7 +52,7 @@ static Class InstanceClass = nil;
 
 // AILTN app name
 static NSString* ailtnAppName = nil;
-
+SFSDK_USE_DEPRECATED_BEGIN
 @implementation SnapshotViewController
 
 - (void)viewDidLoad {
@@ -842,7 +842,6 @@ static NSString* ailtnAppName = nil;
 }
 
 #pragma mark - SFAuthenticationManagerDelegate
-
 - (void)authManagerDidLogout:(SFAuthenticationManager *)manager
 {
     [self.sdkManagerFlow handlePostLogout];
@@ -855,7 +854,7 @@ static NSString* ailtnAppName = nil;
 
 #pragma mark - SFUserAccountManagerDelegate
 
-- (void)handleUserDidLogout:(NSNotification *)notification{
+- (void)handleUserDidLogout:(NSNotification *)notification {
     [self.sdkManagerFlow handlePostLogout];
 }
 
@@ -880,3 +879,4 @@ static NSString* ailtnAppName = nil;
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -52,7 +52,6 @@ static Class InstanceClass = nil;
 
 // AILTN app name
 static NSString* ailtnAppName = nil;
-SFSDK_USE_DEPRECATED_BEGIN
 @implementation SnapshotViewController
 
 - (void)viewDidLoad {
@@ -136,7 +135,11 @@ SFSDK_USE_DEPRECATED_BEGIN
         self.sdkManagerFlow = self;
         self.delegates = [NSHashTable weakObjectsHashTable];
         [[SFUserAccountManager sharedInstance] addDelegate:self];
+        
+        SFSDK_USE_DEPRECATED_BEGIN
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        SFSDK_USE_DEPRECATED_END
+
         [SFSecurityLockout addDelegate:self];
         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleAppForeground:) name:UIApplicationWillEnterForegroundNotification object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self.sdkManagerFlow selector:@selector(handleAppBackground:) name:UIApplicationDidEnterBackgroundNotification object:nil];
@@ -738,7 +741,12 @@ SFSDK_USE_DEPRECATED_BEGIN
     };
     
     if (self.useLegacyAuthenticationManager) {
+        SFSDK_USE_DEPRECATED_BEGIN
+
         [[SFAuthenticationManager sharedManager] loginWithCompletion:successBlock failure:failureBlock];
+        
+        SFSDK_USE_DEPRECATED_END
+
     } else {
         [[SFUserAccountManager sharedInstance] loginWithCompletion:successBlock failure:failureBlock];
     }
@@ -749,7 +757,12 @@ SFSDK_USE_DEPRECATED_BEGIN
     // If there is a current user (from a previous authentication), we still need to set up the
     // in-memory auth state of that user.
     if ([SFUserAccountManager sharedInstance].currentUser != nil && self.useLegacyAuthenticationManager) {
+        SFSDK_USE_DEPRECATED_BEGIN
+
         [[SFAuthenticationManager sharedManager] setupWithCredentials:[SFUserAccountManager sharedInstance].currentUser.credentials];
+        
+        SFSDK_USE_DEPRECATED_END
+
     }
     
     SFSDKLaunchAction noAuthLaunchAction;
@@ -840,6 +853,7 @@ SFSDK_USE_DEPRECATED_BEGIN
         }
     }
 }
+SFSDK_USE_DEPRECATED_BEGIN
 
 #pragma mark - SFAuthenticationManagerDelegate
 - (void)authManagerDidLogout:(SFAuthenticationManager *)manager
@@ -851,6 +865,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 {
 
 }
+SFSDK_USE_DEPRECATED_END
 
 #pragma mark - SFUserAccountManagerDelegate
 
@@ -879,4 +894,4 @@ SFSDK_USE_DEPRECATED_BEGIN
 }
 
 @end
-SFSDK_USE_DEPRECATED_END
+

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -30,10 +30,10 @@
 #import "SFSDKNewLoginHostViewController.h"
 #import "SFSDKLoginHostStorage.h"
 #import "SFSDKLoginHost.h"
-#import "SFAuthenticationManager.h"
 #import "SFSDKResourceUtils.h"
 #import "SFLoginViewController.h"
 #import "SFManagedPreferences.h"
+#import "SFUserAccountManager.h"
 
 static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCellIdentifier";
 
@@ -66,7 +66,7 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
  * Returns the index of the current login host.
  */
 - (NSUInteger)indexOfCurrentLoginHost {
-    SFAuthenticationManager *m = [SFAuthenticationManager sharedManager];
+    SFUserAccountManager *m = [SFUserAccountManager sharedInstance];
     NSString *currentLoginHost = [m loginHost];
     NSUInteger numberOfLoginHosts = [[SFSDKLoginHostStorage sharedInstance] numberOfLoginHosts];
     for (NSUInteger index = 0; index < numberOfLoginHosts; index++) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -37,8 +37,10 @@
 #import "SFAuthenticationManager.h"
 
 SFSDK_USE_DEPRECATED_BEGIN
+
 @interface SFLoginViewController () <SFSDKLoginHostDelegate, SFUserAccountManagerDelegate>
 
+SFSDK_USE_DEPRECATED_END
 @property (nonatomic, strong) UINavigationBar *navBar;
 
 // Reference to the login host list view controller
@@ -155,7 +157,9 @@ SFSDK_USE_DEPRECATED_BEGIN
 }
 
 - (IBAction)backToPreviousHost:(id)sender {
+    SFSDK_USE_DEPRECATED_BEGIN
     [[SFAuthenticationManager sharedManager] cancelAuthentication];
+    SFSDK_USE_DEPRECATED_END
     if (self.previousUserAccount) {
         [[SFUserAccountManager sharedInstance] switchToUser:self.previousUserAccount];
     }
@@ -282,4 +286,4 @@ SFSDK_USE_DEPRECATED_BEGIN
 }
 
 @end
-SFSDK_USE_DEPRECATED_END
+

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -36,7 +36,7 @@
 #import "SFUserAccountManager.h"
 #import "SFAuthenticationManager.h"
 
-
+SFSDK_USE_DEPRECATED_BEGIN
 @interface SFLoginViewController () <SFSDKLoginHostDelegate, SFUserAccountManagerDelegate>
 
 @property (nonatomic, strong) UINavigationBar *navBar;
@@ -282,4 +282,4 @@
 }
 
 @end
-
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -165,7 +165,7 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
         [SFSDKCoreLogger i:[self class] format:@"Skipping Salesforce push notification registration because push isn't supported on the simulator"];
         return YES;  // "Successful", from this standpoint.
     }
-    SFOAuthCredentials *credentials = [SFAuthenticationManager sharedManager].coordinator.credentials;
+    SFOAuthCredentials *credentials = [SFUserAccountManager  sharedInstance].currentUser.credentials;
     if (!credentials) {
         [SFSDKCoreLogger e:[self class] format:@"Cannot register for notifications with Salesforce: not authenticated"];
         return NO;
@@ -275,7 +275,7 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
 - (void)onAppWillEnterForeground:(NSNotification *)notification
 {
     // Re-registering with Salesforce if we have a device token unless we are logging out
-    if (![SFAuthenticationManager sharedManager].logoutSettingEnabled && self.deviceToken) {
+    if (![SFUserAccountManager sharedInstance].logoutSettingEnabled && self.deviceToken) {
         [SFSDKCoreLogger i:[self class] format:@"Re-registering for Salesforce notification because application is being foregrounded"];
         [self registerForSalesforceNotifications];
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -42,7 +42,7 @@ NSInteger const kSFRestErrorCode = 999;
 
 static BOOL kIsTestRun;
 static SFSDKSafeMutableDictionary *sfRestApiList = nil;
-
+SFSDK_USE_DEPRECATED_BEGIN
 @interface SFRestAPI () <SFAuthenticationManagerDelegate>
 
 @property (readwrite, assign) BOOL sessionRefreshInProgress;
@@ -686,3 +686,4 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.h
@@ -57,6 +57,7 @@ typedef void (^SFOAuthFlowSuccessCallbackBlock)(SFOAuthInfo *, SFUserAccount *);
  */
 typedef void (^SFOAuthFlowFailureCallbackBlock)(SFOAuthInfo *, NSError *);
 
+SFSDK_DEPRECATED(6.0, 7.0, "Use SFUserAccountManagerDelegate, SFUserAccountManager & its  Notifications instead.")
 /**
  Delegate protocol for SFAuthenticationManager events and callbacks.
  */
@@ -214,6 +215,7 @@ extern NSString * const kSFAuthenticationManagerFinishedNotification;
 /**
  This class handles all the authentication related tasks, which includes login, logout and session refresh
  */
+SFSDK_DEPRECATED(6.0, 7.0, "Use SFUserAccountManager Login/Logout apis instead.")
 @interface SFAuthenticationManager : NSObject <SFOAuthCoordinatorDelegate, SFIdentityCoordinatorDelegate, SFUserAccountManagerDelegate>
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -48,9 +48,9 @@
 #import "SFSDKLoginHostStorage.h"
 #import "SFSDKLoginHost.h"
 #import <SalesforceAnalytics/NSUserDefaults+SFAdditions.h>
-
+SFSDK_USE_DEPRECATED_BEGIN
 static SFAuthenticationManager *sharedInstance = nil;
-
+SFSDK_USE_DEPRECATED_END
 // Public notification name constants
 NSString * const kSFUserWillLogoutNotification = @"kSFUserWillLogoutNotification";
 NSString * const kSFUserLogoutNotification = @"kSFUserLogoutOccurred";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationSafariControllerHandler.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationSafariControllerHandler.h
@@ -32,8 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Block definition for presenting the auth safari controller.
  */
+SFSDK_USE_DEPRECATED_BEGIN
+
 typedef void (^SFAuthSafariControllerPresentBlock)(SFAuthenticationManager *, SFSafariViewController *);
 
+SFSDK_USE_DEPRECATED_END
 /**
  Class encompassing the custom action to take when presenting an auth safari controller during the auth process.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationViewHandler.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationViewHandler.h
@@ -26,7 +26,7 @@
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
-
+SFSDK_USE_DEPRECATED_BEGIN
 @class SFAuthenticationManager;
 @class WKWebView;
 
@@ -63,5 +63,5 @@ typedef void (^SFAuthViewDismissBlock)(SFAuthenticationManager *);
 - (id)initWithDisplayBlock:(SFAuthViewDisplayBlock)displayBlock dismissBlock:(SFAuthViewDismissBlock)dismissBlock;
 
 @end
-
+SFSDK_USE_DEPRECATED_END
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementDetailViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementDetailViewController.m
@@ -32,7 +32,7 @@ static CGFloat const kButtonWidth = 150.0f;
 static CGFloat const kButtonHeight = 40.0f;
 static CGFloat const kButtonPadding = 10.0f;
 static CGFloat const kControlVerticalPadding = 5.0f;
-
+SFSDK_USE_DEPRECATED_BEGIN
 @interface SFDefaultUserManagementDetailViewController ()
 {
     SFUserAccount *_user;
@@ -155,9 +155,14 @@ static CGFloat const kControlVerticalPadding = 5.0f;
     } else {
         // Logging out a different user than the current user.  Clear the account state and go
         // back to the user list.
-        [[SFAuthenticationManager sharedManager] logoutUser:_user];
+        if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
+            [[SFAuthenticationManager sharedManager] logoutUser:_user];
+        } else {
+           [[SFUserAccountManager sharedInstance] logoutUser:_user];
+        }
         [self.navigationController popViewControllerAnimated:YES];
     }
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementDetailViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementDetailViewController.m
@@ -32,7 +32,7 @@ static CGFloat const kButtonWidth = 150.0f;
 static CGFloat const kButtonHeight = 40.0f;
 static CGFloat const kButtonPadding = 10.0f;
 static CGFloat const kControlVerticalPadding = 5.0f;
-SFSDK_USE_DEPRECATED_BEGIN
+
 @interface SFDefaultUserManagementDetailViewController ()
 {
     SFUserAccount *_user;
@@ -155,8 +155,11 @@ SFSDK_USE_DEPRECATED_BEGIN
     } else {
         // Logging out a different user than the current user.  Clear the account state and go
         // back to the user list.
+        
         if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
+            SFSDK_USE_DEPRECATED_BEGIN
             [[SFAuthenticationManager sharedManager] logoutUser:_user];
+            SFSDK_USE_DEPRECATED_END
         } else {
            [[SFUserAccountManager sharedInstance] logoutUser:_user];
         }
@@ -165,4 +168,3 @@ SFSDK_USE_DEPRECATED_BEGIN
 }
 
 @end
-SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementViewController.m
@@ -25,7 +25,7 @@
 #import "SFDefaultUserManagementViewController+Internal.h"
 #import "SFDefaultUserManagementListViewController.h"
 #import "SFAuthenticationManager.h"
-SFSDK_USE_DEPRECATED_BEGIN
+
 @implementation SFDefaultUserManagementViewController
 
 - (id)initWithCompletionBlock:(SFUserManagementCompletionBlock)completionBlock
@@ -70,7 +70,9 @@ SFSDK_USE_DEPRECATED_BEGIN
 {
     // If we got here, logging out the current user is implied.
     if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
+        SFSDK_USE_DEPRECATED_BEGIN
         [[SFAuthenticationManager sharedManager] logout];
+        SFSDK_USE_DEPRECATED_END
     }else {
          [[SFUserAccountManager sharedInstance] logout];
     }
@@ -96,4 +98,4 @@ SFSDK_USE_DEPRECATED_BEGIN
 }
 
 @end
-SFSDK_USE_DEPRECATED_END
+

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementViewController.m
@@ -25,7 +25,7 @@
 #import "SFDefaultUserManagementViewController+Internal.h"
 #import "SFDefaultUserManagementListViewController.h"
 #import "SFAuthenticationManager.h"
-
+SFSDK_USE_DEPRECATED_BEGIN
 @implementation SFDefaultUserManagementViewController
 
 - (id)initWithCompletionBlock:(SFUserManagementCompletionBlock)completionBlock
@@ -69,7 +69,11 @@
 - (void)actionLogout
 {
     // If we got here, logging out the current user is implied.
-    [[SFAuthenticationManager sharedManager] logout];
+    if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
+        [[SFAuthenticationManager sharedManager] logout];
+    }else {
+         [[SFUserAccountManager sharedInstance] logout];
+    }
 }
 
 - (void)actionSwitchUser:(SFUserAccount *)user
@@ -92,3 +96,4 @@
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -73,7 +73,7 @@ static BOOL sValidatePasscodeAtStartup = NO;
 // Flag used to prevent the display of the passcode view controller.
 // Note: it is used by the unit tests only.
 static BOOL _showPasscode = YES;
-SFSDK_USE_DEPRECATED_BEGIN
+
 @implementation SFSecurityLockout
 
 + (void)initialize
@@ -395,7 +395,9 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
         // Clear the SFSecurityLockout passcode state, as it's no longer valid.
         [SFSecurityLockout clearAllPasscodeState];
         if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
+            SFSDK_USE_DEPRECATED_BEGIN
             [[SFAuthenticationManager sharedManager] logoutAllUsers];
+            SFSDK_USE_DEPRECATED_END
         }else {
             [[SFUserAccountManager sharedInstance] logoutAllUsers];
         }
@@ -413,7 +415,9 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
 {
     [SFSecurityLockout setLockScreenFailureCallbackBlock:^{
         if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
+            SFSDK_USE_DEPRECATED_BEGIN
             [[SFAuthenticationManager sharedManager] logout];
+            SFSDK_USE_DEPRECATED_END
         }else {
              [[SFUserAccountManager sharedInstance] logout];
         }
@@ -746,4 +750,4 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
 }
 
 @end
-SFSDK_USE_DEPRECATED_END
+

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -73,7 +73,7 @@ static BOOL sValidatePasscodeAtStartup = NO;
 // Flag used to prevent the display of the passcode view controller.
 // Note: it is used by the unit tests only.
 static BOOL _showPasscode = YES;
-
+SFSDK_USE_DEPRECATED_BEGIN
 @implementation SFSecurityLockout
 
 + (void)initialize
@@ -316,7 +316,7 @@ static BOOL _showPasscode = YES;
 
 + (BOOL)hasValidSession
 {
-    return [[SFAuthenticationManager sharedManager] haveValidSession];
+    return [SFUserAccountManager sharedInstance].currentUser != nil && [SFUserAccountManager sharedInstance].currentUser.isSessionValid;
 }
 
 // For unit tests.
@@ -394,7 +394,11 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
     } else {
         // Clear the SFSecurityLockout passcode state, as it's no longer valid.
         [SFSecurityLockout clearAllPasscodeState];
-        [[SFAuthenticationManager sharedManager] logoutAllUsers];
+        if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
+            [[SFAuthenticationManager sharedManager] logoutAllUsers];
+        }else {
+            [[SFUserAccountManager sharedInstance] logoutAllUsers];
+        }
         [SFSecurityLockout unlockFailurePostProcessing];
     }
     
@@ -408,7 +412,11 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
 + (void)timerExpired:(NSTimer*)theTimer
 {
     [SFSecurityLockout setLockScreenFailureCallbackBlock:^{
-        [[SFAuthenticationManager sharedManager] logout];
+        if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
+            [[SFAuthenticationManager sharedManager] logout];
+        }else {
+             [[SFUserAccountManager sharedInstance] logout];
+        }
     }];
     
     [SFSDKCoreLogger i:[self class] format:@"NSTimer expired, but checking lastUserEvent before locking!"];
@@ -738,3 +746,4 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -253,6 +253,11 @@ FOUNDATION_EXTERN NSString * const kSFUserInfoAddlOptionsKey;
 @property (nonatomic, readonly, getter=isCurrentUserAnonymous) BOOL currentUserAnonymous;
 
 /**
+ Returns YES if the logout is requested by the app settings.
+ */
+@property (nonatomic, readonly) BOOL logoutSettingEnabled;
+
+/**
  Advanced authentication configuration.  Default is SFOAuthAdvancedAuthConfigurationNone.  Leave the
  default value unless you need advanced authentication, as it requires an additional round trip to the
  service to retrieve org authentication configuration.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
@@ -33,7 +33,7 @@ NSString* const kTestRequestStatusDidLoad = @"didLoad";
 NSString* const kTestRequestStatusDidFail = @"didFail";
 NSString* const kTestRequestStatusDidCancel = @"didCancel";
 NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
-
+SFSDK_USE_DEPRECATED_BEGIN
 @interface SFSDKTestRequestListener ()
 {
     SFAccountManagerServiceType _serviceType;
@@ -201,3 +201,4 @@ NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.h
@@ -60,6 +60,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)synchronousAuthRefresh;
 
+/**
+ Performs a synchronous refresh of the OAuth credentials, which will stage the remaining auth
+ data (access token, User ID, Org ID, etc.) in SFUserAccountManager.
+ `populateAuthCredentialsFromConfigFile` is required to run once before this method will attempt
+ to refresh authentication using SFAuthenticationManager.
+ */
++ (void)synchronousAuthRefreshLegacy;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
@@ -30,7 +30,7 @@
 #import "SFJsonUtils.h"
 
 #import "SFAuthenticationManager.h"
-#import "SFUserAccountManager.h"
+#import "SFUserAccountManager+Internal.h"
 #import "SFUserAccount.h"
 #import "SFSDKTestRequestListener.h"
 #import "SFSDKTestCredentialsData.h"
@@ -74,11 +74,11 @@ static SFOAuthCredentials *credentials = nil;
     NSAssert(![credsData.refreshToken isEqualToString:@"__INSERT_TOKEN_HERE__"],
              @"You need to obtain credentials for your test org and replace test_credentials.json");
     [SFUserAccountManager sharedInstance].currentUser = nil;
-    [SFAuthenticationManager sharedManager].oauthClientId = credsData.clientId;
-    [SFAuthenticationManager sharedManager].oauthCompletionUrl = credsData.redirectUri;
-    [SFAuthenticationManager sharedManager].scopes = [NSSet setWithObjects:@"web", @"api", nil];
-    [SFAuthenticationManager sharedManager].loginHost = credsData.loginHost;
-    credentials = [[SFAuthenticationManager sharedManager] createOAuthCredentials];
+    [SFUserAccountManager sharedInstance].oauthClientId = credsData.clientId;
+    [SFUserAccountManager sharedInstance].oauthCompletionUrl = credsData.redirectUri;
+    [SFUserAccountManager sharedInstance].scopes = [NSSet setWithObjects:@"web", @"api", nil];
+    [SFUserAccountManager sharedInstance].loginHost = credsData.loginHost;
+    credentials = [[SFUserAccountManager sharedInstance] newClientCredentials];
     credentials.instanceUrl = [NSURL URLWithString:credsData.instanceUrl];
     credentials.identityUrl = [NSURL URLWithString:credsData.identityUrl];
     NSString *communityUrlString = credsData.communityUrl;
@@ -89,7 +89,7 @@ static SFOAuthCredentials *credentials = nil;
     credentials.refreshToken = credsData.refreshToken;
     return credsData;
 }
-
+SFSDK_USE_DEPRECATED_BEGIN
 + (void)synchronousAuthRefresh
 {
     // All of the setup and validation of prerequisite auth state is done in populateAuthCredentialsFromConfigFile.
@@ -97,6 +97,7 @@ static SFOAuthCredentials *credentials = nil;
     NSAssert(credentials!=nil, @"You must call populateAuthCredentialsFromConfigFileForClass before synchronousAuthRefresh");
     __block SFSDKTestRequestListener *authListener = [[SFSDKTestRequestListener alloc] init];
     __block SFUserAccount *user = nil;
+
     [[SFAuthenticationManager sharedManager]
      refreshCredentials:credentials
      completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
@@ -113,8 +114,7 @@ static SFOAuthCredentials *credentials = nil;
              kTestRequestStatusDidLoad,
              authListener.returnStatus);
 }
-
-
+SFSDK_USE_DEPRECATED_END
 
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPreferencesTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPreferencesTests.m
@@ -50,7 +50,7 @@
 }
 
 - (void)testOrgLevelPreferences {
-    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"happy-user" clientId:[SFAuthenticationManager sharedManager].oauthClientId encrypted:YES];
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"happy-user" clientId:[SFUserAccountManager  sharedInstance].oauthClientId encrypted:YES];
     SFUserAccount *user =[[SFUserAccount alloc] initWithCredentials:credentials];
     NSError *error = nil;
     BOOL success = [[SFUserAccountManager sharedInstance] saveAccountForUser:user error:&error];
@@ -78,7 +78,7 @@
 }
 
 - (void)testUserLevelPreferences {
-    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"happy-user" clientId:[SFAuthenticationManager sharedManager].oauthClientId encrypted:YES];
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"happy-user" clientId:[SFUserAccountManager  sharedInstance].oauthClientId encrypted:YES];
     SFUserAccount *user =[[SFUserAccount alloc] initWithCredentials:credentials];
     user.credentials.identityUrl = [NSURL URLWithString:@"https://login.salesforce.com/id/00D000000000062EA0/005R0000000Dsl0"];
  
@@ -105,7 +105,7 @@
 }
 
 - (void)testCommunityLevelPreferences {
-    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"happy-user" clientId:[SFAuthenticationManager sharedManager].oauthClientId encrypted:YES];
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"happy-user" clientId:[SFUserAccountManager  sharedInstance].oauthClientId encrypted:YES];
     SFUserAccount *user = [[SFUserAccount alloc] initWithCredentials:credentials];
     user.credentials.identityUrl = [NSURL URLWithString:@"https://login.salesforce.com/id/00D000000000062EA0/005R0000000Dsl0"];
     NSError *error = nil;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPushNotificationManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPushNotificationManagerTests.m
@@ -50,7 +50,7 @@ static NSString* const kSFDeviceSalesforceId = @"deviceSalesforceId";
     [super setUp];
     self.manager = [[SFPushNotificationManager alloc] init];
     self.manager.isSimulator = NO;
-    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"happy-user" clientId:[SFAuthenticationManager sharedManager].oauthClientId encrypted:YES];
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"happy-user" clientId:[SFUserAccountManager sharedInstance].oauthClientId encrypted:YES];
     SFUserAccount *user =[[SFUserAccount alloc] initWithCredentials:credentials];
     user.credentials.identityUrl = [NSURL URLWithString:@"https://login.salesforce.com/id/00D000000000062EA0/005R0000000Dsl0"];
     [SFUserAccountManager sharedInstance].currentUser = user;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerNotificationsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerNotificationsTests.m
@@ -47,7 +47,7 @@ static NSString * const kSFOAuthCommunityUrl = @"sfdc_community_url";
 @property (nonatomic, strong) SFUserAccountManager *uam;
 
 @end
-
+SFSDK_USE_DEPRECATED_BEGIN
 @implementation SFUserAccountManagerNotificationsTests
 
 - (void)setUp
@@ -83,12 +83,14 @@ static NSString * const kSFOAuthCommunityUrl = @"sfdc_community_url";
     [[NSNotificationCenter defaultCenter] removeObserver:observerMock];
 }
 
+
 - (void)testCommunityIdNotificationPosted
 {
     NSString *notificationName = SFUserAccountManagerDidChangeUserDataNotification;
     id observerMock = [OCMockObject observerMock];
     [[NSNotificationCenter defaultCenter] addMockObserver:observerMock name:notificationName object:nil];
     SFOAuthCoordinator *coordinator = [[SFOAuthCoordinator alloc] initWithCredentials:_user.credentials];
+    
     SFAuthenticationManager * authenticationManager = [SFAuthenticationManager sharedManager];
     authenticationManager.coordinator = coordinator;
     NSDictionary *expectedUserInfo = @{
@@ -104,6 +106,7 @@ static NSString * const kSFOAuthCommunityUrl = @"sfdc_community_url";
     [observerMock verify];
     [[NSNotificationCenter defaultCenter] removeObserver:observerMock];
 }
+
 
 - (void)testInstanceUrlChangeNotificationPosted
 {
@@ -228,3 +231,4 @@ static NSString * const kSFOAuthCommunityUrl = @"sfdc_community_url";
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerPersisterTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerPersisterTests.m
@@ -231,7 +231,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 
 - (SFUserAccount*)createNewUserWithIndex:(NSUInteger)index {
     XCTAssertTrue(index < 10, @"Supports only index up to 9");
-    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:[NSString stringWithFormat:@"identifier-%lu", (unsigned long)index] clientId:[SFAuthenticationManager sharedManager].oauthClientId encrypted:YES];
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:[NSString stringWithFormat:@"identifier-%lu", (unsigned long)index] clientId:[SFUserAccountManager  sharedInstance].oauthClientId encrypted:YES];
     SFUserAccount *user =[[SFUserAccount alloc] initWithCredentials:credentials];
     NSString *userId = [NSString stringWithFormat:kUserIdFormatString, (unsigned long)index];
     NSString *orgId = [NSString stringWithFormat:kOrgIdFormatString, (unsigned long)index];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -611,11 +611,11 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     NSAssert(![credsData.refreshToken isEqualToString:@"__INSERT_TOKEN_HERE__"],
              @"You need to obtain credentials for your test org and replace test_credentials.json");
     [SFUserAccountManager sharedInstance].currentUser = nil;
-    [SFAuthenticationManager sharedManager].oauthClientId = credsData.clientId;
-    [SFAuthenticationManager sharedManager].oauthCompletionUrl = credsData.redirectUri;
-    [SFAuthenticationManager sharedManager].scopes = [NSSet setWithObjects:@"web", @"api", nil];
-    [SFAuthenticationManager sharedManager].loginHost = credsData.loginHost;
-    SFOAuthCredentials *credentials = [[SFAuthenticationManager sharedManager] createOAuthCredentials];
+    [SFUserAccountManager sharedInstance].oauthClientId = credsData.clientId;
+    [SFUserAccountManager sharedInstance].oauthCompletionUrl = credsData.redirectUri;
+    [SFUserAccountManager sharedInstance].scopes = [NSSet setWithObjects:@"web", @"api", nil];
+    [SFUserAccountManager sharedInstance].loginHost = credsData.loginHost;
+    SFOAuthCredentials *credentials = [[SFUserAccountManager sharedInstance] newClientCredentials];
     credentials.instanceUrl = [NSURL URLWithString:credsData.instanceUrl];
     credentials.identityUrl = [NSURL URLWithString:credsData.identityUrl];
     NSString *communityUrlString = credsData.communityUrl;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKIdentityTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKIdentityTests.m
@@ -26,11 +26,11 @@
 #import "SFSDKTestRequestListener.h"
 #import "TestSetupUtils.h"
 #import "SFOAuthCoordinator.h"
-#import "SFAuthenticationManager.h"
+#import "SFAuthenticationManager+Internal.h"
 #import "SFIdentityCoordinator.h"
 #import "SFUserAccountManager.h"
 #import "SFIdentityData.h"
-
+SFSDK_USE_DEPRECATED_BEGIN
 /**
  * Private interface for this tests module.
  */
@@ -167,3 +167,4 @@ static NSException *authException = nil;
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKIdentityTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKIdentityTests.m
@@ -56,7 +56,7 @@ static NSException *authException = nil;
 {
     @try {
         [TestSetupUtils populateAuthCredentialsFromConfigFileForClass:[self class]];
-        [TestSetupUtils synchronousAuthRefresh];
+        [TestSetupUtils synchronousAuthRefreshLegacy];
     }
     @catch (NSException *exception) {
         authException = exception;
@@ -107,7 +107,7 @@ static NSException *authException = nil;
     NSURL *instanceURL = sharedManager.coordinator.credentials.instanceUrl;
     sharedManager.coordinator.credentials.instanceUrl = [NSURL URLWithString:@"https://www.example.com"]; //set to an invalid url
     sharedManager.idCoordinator.credentials.instanceUrl = [NSURL URLWithString:@"https://www.example.com"]; //set to an invalid url
-    [TestSetupUtils synchronousAuthRefresh];
+    [TestSetupUtils synchronousAuthRefreshLegacy];
     XCTAssertEqualObjects(sharedManager.coordinator.credentials.instanceUrl, instanceURL, @"Expect instance URL is also updated");
     XCTAssertEqualObjects(sharedManager.idCoordinator.credentials.instanceUrl, instanceURL, @"Expect instance URL is also updated");
     [self validateIdentityData];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
@@ -399,9 +399,9 @@ static NSString* const kTestAppName = @"OverridenAppName";
 {
     NSString *brandPath = @"/BRAND/";
     [SalesforceSDKManager sharedManager].brandLoginPath = brandPath;
-    XCTAssertTrue([brandPath isEqualToString:[SFAuthenticationManager sharedManager].brandLoginPath]);
+    XCTAssertTrue([brandPath isEqualToString:[SFUserAccountManager  sharedInstance].brandLoginPath]);
 }
-
+SFSDK_USE_DEPRECATED_BEGIN
 - (void)testBrandedLoginPathInAuthManagerAndAuthorizeEndpoint
 {
     NSString *brandPath = @"/BRAND/SUB-BRAND/";
@@ -423,7 +423,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     //should have brand
     XCTAssertTrue([brandedURL containsString:[brandPath substringToIndex:brandPath.length-1]]);
 }
-
+SFSDK_USE_DEPRECATED_END
 #pragma mark - Private helpers
 
 - (void)createStandardPostLaunchBlock
@@ -477,7 +477,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
 - (SFUserAccount *)createUserAccount
 {
     u_int32_t userIdentifier = arc4random();
-    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:[NSString stringWithFormat:@"identifier-%u", userIdentifier] clientId:[SFAuthenticationManager sharedManager].oauthClientId encrypted:YES];
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:[NSString stringWithFormat:@"identifier-%u", userIdentifier]  clientId:SFUserAccountManager .sharedInstance.oauthClientId encrypted:YES];
     SFUserAccount *user =[[SFUserAccount alloc] initWithCredentials:credentials];
     NSString *userId = [NSString stringWithFormat:@"user_%u", userIdentifier];
     NSString *orgId = [NSString stringWithFormat:@"org_%u", userIdentifier];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore+Internal.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore+Internal.h
@@ -37,7 +37,7 @@ typedef NS_ENUM(NSUInteger, SFSmartStoreFtsExtension) {
 };
 
 
-@interface SFSmartStore () <SFAuthenticationManagerDelegate>
+@interface SFSmartStore ()
 
 @property (nonatomic, strong) FMDatabaseQueue *storeQueue;
 @property (nonatomic, strong) SFSmartStoreDatabaseManager *dbMgr;

--- a/libs/SmartStore/SmartStore/Classes/SalesforceSDKManagerWithSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SalesforceSDKManagerWithSmartStore.m
@@ -26,12 +26,29 @@
 #import "SFSmartStore.h"
 #import "SalesforceSDKManagerWithSmartStore.h"
 #import "SFSDKStoreConfig.h"
+SFSDK_USE_DEPRECATED_BEGIN
+@interface SalesforceSDKManager()<SFAuthenticationManagerDelegate>
+@end
 
 @implementation SalesforceSDKManagerWithSmartStore
+
+-(instancetype)init {
+    if (self = [super init]) {
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
+    }
+    return self;
+}
+
 
 - (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user
 {
     [super authManager:manager willLogoutUser:user];
+    [SFSmartStore removeAllStoresForUser:user];
+}
+
+
+- (void)handleUserWillLogout:(NSNotification *)notification {
+    SFUserAccount *user = notification.userInfo[kSFNotificationUserInfoAccountKey];
     [SFSmartStore removeAllStoresForUser:user];
 }
 
@@ -51,3 +68,4 @@
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
@@ -27,7 +27,7 @@
  */
 
 #import "SFMultipleSmartStoresTest.h"
-
+#import <SalesforceSDKCore/SFAuthenticationmanager.h>
 @interface SFMultipleSmartStoresTests()
 
 @property (nonatomic, strong) SFUserAccount *smartStoreUser;
@@ -96,7 +96,7 @@
 - (SFUserAccount*)setUpSmartStoreUser
 {
     u_int32_t userIdentifier = arc4random();
-    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:[NSString stringWithFormat:@"identifier-%u", userIdentifier] clientId:[SFAuthenticationManager sharedManager].oauthClientId encrypted:YES];
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:[NSString stringWithFormat:@"identifier-%u", userIdentifier] clientId:[SFUserAccountManager  sharedInstance].oauthClientId encrypted:YES];
     SFUserAccount *user =[[SFUserAccount alloc] initWithCredentials:credentials];
     NSString *userId = [NSString stringWithFormat:@"user_%u", userIdentifier];
     NSString *orgId = [NSString stringWithFormat:@"org_%u", userIdentifier];

--- a/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
@@ -27,7 +27,6 @@
  */
 
 #import "SFMultipleSmartStoresTest.h"
-#import <SalesforceSDKCore/SFAuthenticationmanager.h>
 @interface SFMultipleSmartStoresTests()
 
 @property (nonatomic, strong) SFUserAccount *smartStoreUser;

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
@@ -79,7 +79,7 @@
 - (SFUserAccount *)createUserAccount
 {
     u_int32_t userIdentifier = arc4random();
-    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:[NSString stringWithFormat:@"identifier-%u", userIdentifier] clientId:[SFAuthenticationManager sharedManager].oauthClientId encrypted:YES];
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:[NSString stringWithFormat:@"identifier-%u", userIdentifier] clientId:[SFUserAccountManager sharedInstance].oauthClientId encrypted:YES];
     SFUserAccount *user =[[SFUserAccount alloc] initWithCredentials:credentials];
     NSString *userId = [NSString stringWithFormat:@"user_%u", userIdentifier];
     NSString *orgId = [NSString stringWithFormat:@"org_%u", userIdentifier];

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
@@ -339,7 +339,7 @@
 - (SFUserAccount*)setUpSmartStoreUser
 {
     u_int32_t userIdentifier = arc4random();
-    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:[NSString stringWithFormat:@"identifier-%u", userIdentifier] clientId:[SFAuthenticationManager sharedManager].oauthClientId encrypted:YES];
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:[NSString stringWithFormat:@"identifier-%u", userIdentifier] clientId:[SFUserAccountManager   sharedInstance].oauthClientId encrypted:YES];
     SFUserAccount *user = [[SFUserAccount alloc] initWithCredentials:credentials];
     NSString *userId = [NSString stringWithFormat:@"user_%u", userIdentifier];
     NSString *orgId = [NSString stringWithFormat:@"org_%u", userIdentifier];

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
@@ -49,6 +49,7 @@ static NSString * const kTypeKey    = @"type";
 SFSDK_USE_DEPRECATED_BEGIN
 @interface SFSmartSyncCacheManager () <SFAuthenticationManagerDelegate>
 
+SFSDK_USE_DEPRECATED_END
 @property (nonatomic, strong) SFUserAccount *user;
 @property (nonatomic, readonly) SFSmartStore *store;
 @property (nonatomic, strong) NSCache *inMemCache;
@@ -100,7 +101,9 @@ static NSMutableDictionary *cacheMgrList = nil;
         self.inMemCache = [[NSCache alloc] init];
         self.enableInMemoryCache = YES;
         self.user = user;
+        SFSDK_USE_DEPRECATED_BEGIN
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        SFSDK_USE_DEPRECATED_END
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
 
     }
@@ -112,7 +115,9 @@ static NSMutableDictionary *cacheMgrList = nil;
 }
 
 - (void)dealloc {
+    SFSDK_USE_DEPRECATED_BEGIN
     [[SFAuthenticationManager sharedManager] removeDelegate:self];
+    SFSDK_USE_DEPRECATED_END
 }
 
 #pragma mark - Private Methods
@@ -302,10 +307,14 @@ static NSMutableDictionary *cacheMgrList = nil;
 }
 
 #pragma mark - SFAuthenticationManagerDelegate
+SFSDK_USE_DEPRECATED_BEGIN
 
 - (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user {
     [[self class] removeSharedInstance:user];
 }
+
+SFSDK_USE_DEPRECATED_END
+
 - (void)handleUserWillLogout:(NSNotification *)notification {
     SFUserAccount *user = notification.userInfo[kSFNotificationUserInfoAccountKey];
     [[self class] removeSharedInstance:user];

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.m
@@ -46,7 +46,7 @@ static NSString * const kSmartStoreCacheDataPath       = @"cache_data";
 // Store data keys
 static NSString * const kRawDataKey = @"rawData";
 static NSString * const kTypeKey    = @"type";
-
+SFSDK_USE_DEPRECATED_BEGIN
 @interface SFSmartSyncCacheManager () <SFAuthenticationManagerDelegate>
 
 @property (nonatomic, strong) SFUserAccount *user;
@@ -491,3 +491,4 @@ static NSMutableDictionary *cacheMgrList = nil;
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.m
@@ -62,6 +62,7 @@ static NSString *const kSFMetadataRestApiPath = @"services/data";
 SFSDK_USE_DEPRECATED_BEGIN
 @interface SFSmartSyncMetadataManager () <SFAuthenticationManagerDelegate>
 
+SFSDK_USE_DEPRECATED_END
 @property (nonatomic, strong) SFUserAccount *user;
 @property (nonatomic, readonly) SFRestAPI *restClient;
 @property (nonatomic, assign) BOOL cacheEnabled;
@@ -130,14 +131,18 @@ static NSMutableDictionary *metadataMgrList = nil;
         self.apiVersion = kDefaultApiVersion;
         self.cacheEnabled = YES;
         self.encryptCache = YES;
+        SFSDK_USE_DEPRECATED_BEGIN
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        SFSDK_USE_DEPRECATED_END
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
     }
     return self;
 }
 
 - (void)dealloc {
+    SFSDK_USE_DEPRECATED_BEGIN
     [[SFAuthenticationManager sharedManager] removeDelegate:self];
+    SFSDK_USE_DEPRECATED_END
 }
 
 - (SFRestAPI *) restClient {
@@ -1021,10 +1026,13 @@ refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan
 }
 
 #pragma mark - SFAuthenticationManagerDelegate
+SFSDK_USE_DEPRECATED_BEGIN
 
 - (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user {
     [[self class] removeSharedInstance:user];
 }
+
+SFSDK_USE_DEPRECATED_END
 
 - (void)handleUserWillLogout:(NSNotification *)notification {
     SFUserAccount *user = notification.userInfo[kSFNotificationUserInfoAccountKey];

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.m
@@ -59,7 +59,7 @@ NSString * const kSFObjectLayoutByType = @"object_layout_%@";
 
 // REST request constants.
 static NSString *const kSFMetadataRestApiPath = @"services/data";
-
+SFSDK_USE_DEPRECATED_BEGIN
 @interface SFSmartSyncMetadataManager () <SFAuthenticationManagerDelegate>
 
 @property (nonatomic, strong) SFUserAccount *user;
@@ -1032,3 +1032,4 @@ refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -45,6 +45,7 @@ typedef void (^SyncFailBlock) (NSString* message, NSError* error);
 SFSDK_USE_DEPRECATED_BEGIN
 @interface SFSmartSyncSyncManager () <SFAuthenticationManagerDelegate>
 
+SFSDK_USE_DEPRECATED_END
 @property (nonatomic, strong) SFSmartStore *store;
 @property (nonatomic, strong) dispatch_queue_t queue;
 @property (nonatomic, strong) NSMutableSet *runningSyncIds;
@@ -139,7 +140,9 @@ static NSMutableDictionary *syncMgrList = nil;
         self.runningSyncIds = [NSMutableSet new];
         self.store = store;
         self.queue = dispatch_queue_create(kSyncManagerQueue,  DISPATCH_QUEUE_SERIAL);
+        SFSDK_USE_DEPRECATED_BEGIN
         [[SFAuthenticationManager sharedManager] addDelegate:self];
+        SFSDK_USE_DEPRECATED_END
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
         [SFSyncState setupSyncsSoupIfNeeded:self.store];
     }
@@ -149,7 +152,9 @@ static NSMutableDictionary *syncMgrList = nil;
 
 
 - (void)dealloc {
+    SFSDK_USE_DEPRECATED_BEGIN
     [[SFAuthenticationManager sharedManager] removeDelegate:self];
+    SFSDK_USE_DEPRECATED_END
 }
 
 #pragma mark - get sync / run sync methods
@@ -612,15 +617,15 @@ static NSMutableDictionary *syncMgrList = nil;
 }
 
 #pragma mark - SFAuthenticationManagerDelegate
-
+SFSDK_USE_DEPRECATED_BEGIN
 - (void)authManager:(SFAuthenticationManager *)manager willLogoutUser:(SFUserAccount *)user {
     [[self class] removeSharedInstance:user];
 }
-
+SFSDK_USE_DEPRECATED_END
 - (void)handleUserWillLogout:(NSNotification *)notification {
     SFUserAccount *user = notification.userInfo[kSFNotificationUserInfoAccountKey];
      [[self class] removeSharedInstance:user];
 }
 
 @end
-SFSDK_USE_DEPRECATED_END
+

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -42,7 +42,7 @@ char * const kSyncManagerQueue = "com.salesforce.smartsync.manager.syncmanager.Q
 // block type
 typedef void (^SyncUpdateBlock) (NSString* status, NSInteger progress, NSInteger totalSize, long long maxTimeStamp);
 typedef void (^SyncFailBlock) (NSString* message, NSError* error);
-
+SFSDK_USE_DEPRECATED_BEGIN
 @interface SFSmartSyncSyncManager () <SFAuthenticationManagerDelegate>
 
 @property (nonatomic, strong) SFSmartStore *store;
@@ -623,3 +623,4 @@ static NSMutableDictionary *syncMgrList = nil;
 }
 
 @end
+SFSDK_USE_DEPRECATED_END

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
@@ -48,6 +48,7 @@ static NSString * const OAuthRedirectURI        = @"com.salesforce.mobilesdk.sam
     self = [super init];
     if (self) {
         [SFAuthenticationManager sharedManager].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        [SFUserAccountManager sharedInstance].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
         [SalesforceSDKManager sharedManager].connectedAppId = RemoteAccessConsumerKey;
         [SalesforceSDKManager sharedManager].connectedAppCallbackUri = OAuthRedirectURI;
         [SalesforceSDKManager sharedManager].authScopes = @[ @"web", @"api" ];
@@ -197,6 +198,7 @@ static NSString * const OAuthRedirectURI        = @"com.salesforce.mobilesdk.sam
     SFOAuthCredentials *creds = [SFUserAccountManager sharedInstance].currentUser.credentials;
     NSMutableDictionary *configDict = [NSMutableDictionary dictionaryWithDictionary:@{@"test_client_id": RemoteAccessConsumerKey,
                                                                                       @"test_login_domain": [SFAuthenticationManager sharedManager].loginHost,
+                                                                                      @"test_login_domain": [SFUserAccountManager  sharedInstance].loginHost,
                                                                                       @"test_redirect_uri": OAuthRedirectURI,
                                                                                       @"refresh_token": creds.refreshToken,
                                                                                       @"instance_url": [creds.instanceUrl absoluteString],

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
@@ -47,7 +47,6 @@ static NSString * const OAuthRedirectURI        = @"com.salesforce.mobilesdk.sam
 {
     self = [super init];
     if (self) {
-        [SFAuthenticationManager sharedManager].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
         [SFUserAccountManager sharedInstance].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
         [SalesforceSDKManager sharedManager].connectedAppId = RemoteAccessConsumerKey;
         [SalesforceSDKManager sharedManager].connectedAppCallbackUri = OAuthRedirectURI;

--- a/native/SampleApps/SmartSyncExplorer/RecentContactsTodayExtension/TodayViewController.m
+++ b/native/SampleApps/SmartSyncExplorer/RecentContactsTodayExtension/TodayViewController.m
@@ -31,6 +31,7 @@
 #import <SalesforceSDKCore/SFRestAPI.h>
 #import <SalesforceAnalytics/SFSDKLogger.h>
 #import <SmartStore/SFQuerySpec.h>
+#import <SalesforceSDKCore/SFUserAccountManager.h>
 
 @interface TodayViewController () <NCWidgetProviding, UITableViewDelegate, UITableViewDataSource>
 


### PR DESCRIPTION
This PR takes care of deprecating SFAuthenticationManager. I have tested AccountEditor, SmartSyncExplorer, RestAPIExplorer & IDP situations as well. All tests were running locally except for one [SmartSyncTestSuite testFetchSObjects]. Its expecting 2 objects but gets three. Needs more scrutiny.

- There is still code in the SDK that needs to use the component if useLegacyAuthentication has been set. I have added 2 simple macros to SUPPRESS warnings.  (SFSDK_USE_DEPRECATED_BEGIN , SFSDK_USE_DEPRECATED_END)

- A few blocks of code where SFAuthenticationManager was being used was easily swapped out for SFUserAccountManager had to do with reading mostly properties that are being set into the SFUserAccountManager anyway.

- Tests that use  SFAuthenticationManager will continue to do so until we do away with it.  I've added the same macros to these blocks to suppress warnings.

Some more  refactoring efforts were needed.
- Additionally added moved resetCookie to the SFSDKWebViewStateManager.
- Missing properties in SFUserAccountManager.
- Hybrid plugin was upgraded to use SFUserAccountManager.
- Code using coordinator to fetch credentials have been swapped out  to use current user's credentials instead.
- SalesforceSDKManager was implementing SFAuthenticationManager delegate in its public header.  Now has been moved to private.
 

