### PR TITLE
Parallel builds off for framework targets

### DIFF
--- a/libs/SalesforceReact/SalesforceReact.xcodeproj/xcshareddata/xcschemes/SalesforceReact.xcscheme
+++ b/libs/SalesforceReact/SalesforceReact.xcodeproj/xcshareddata/xcschemes/SalesforceReact.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/libs/SmartStore/SmartStore.xcodeproj/xcshareddata/xcschemes/SmartStore.xcscheme
+++ b/libs/SmartStore/SmartStore.xcodeproj/xcshareddata/xcschemes/SmartStore.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer.xcodeproj/xcshareddata/xcschemes/SmartSyncExplorerCommon.xcscheme
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer.xcodeproj/xcshareddata/xcschemes/SmartSyncExplorerCommon.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "0900"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
+      parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry


### PR DESCRIPTION
These were basically causing Carthage builds to be unstable, from build to build.  Usually something in the form of PCH files being modified since the target build started.