### PR TITLE
Names for sync

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTests/SmartSyncTestSuite.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTests/SmartSyncTestSuite.m
@@ -284,4 +284,20 @@
     [self runTest:@"testSyncUpLocallyUpdatedWithGlobalStoreNamed"];
 }
 
+- (void) testSyncDownGetSyncDeleteSyncById {
+    [self runTest:@"testSyncDownGetSyncDeleteSyncById"];
+}
+
+- (void) testSyncDownGetSyncDeleteSyncByName {
+    [self runTest:@"testSyncDownGetSyncDeleteSyncByName"];
+}
+
+- (void) testSyncUpGetSyncDeleteSyncById {
+    [self runTest:@"testSyncUpGetSyncDeleteSyncById"];
+}
+
+- (void) testSyncUpGetSyncDeleteSyncByName {
+    [self runTest:@"testSyncUpGetSyncDeleteSyncByName"];
+}
+
 @end

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
@@ -102,6 +102,28 @@ typedef void (^SFSyncSyncManagerCompletionStatusBlock) (SFSyncStateStatus syncSt
 - (nullable SFSyncState*)getSyncStatus:(NSNumber*)syncId;
 
 /**
+ * Returns details about a sync by name.
+ *
+ * @param syncName Sync name.
+ */
+- (nullable SFSyncState*)getSyncStatusByName:(NSString*)syncName;
+
+/**
+ * Delete a sync.
+ *
+ * @param syncId Sync ID.
+ */
+- (void)deleteSyncById:(NSNumber*)syncId;
+
+/**
+ * Delete a sync by name.
+ *
+ * @param syncName Sync name..
+ */
+- (void)deleteSyncByName:(NSString*)syncName;
+
+
+/**
  * Creates and runs a sync down that will overwrite any modified records.
  */
 - (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
@@ -112,9 +134,20 @@ typedef void (^SFSyncSyncManagerCompletionStatusBlock) (SFSyncStateStatus syncSt
 - (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
 
 /**
+ * Creates and runs a named sync down.
+ */
+- (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName syncName:(NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+
+
+/**
  * Performs a resync.
  */
 - (nullable SFSyncState*) reSync:(NSNumber*)syncId updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+
+/**
+ * Performs a resync by name.
+ */
+- (nullable SFSyncState*) reSyncByName:(NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
 
 /**
  * Creates and runs a sync up with the default SFSyncUpTarget.
@@ -138,6 +171,22 @@ typedef void (^SFSyncSyncManagerCompletionStatusBlock) (SFSyncStateStatus syncSt
 - (SFSyncState*) syncUpWithTarget:(SFSyncUpTarget*)target
                           options:(SFSyncOptions*)options
                          soupName:(NSString*)soupName
+                      updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+
+/**
+ * Creates and runs a named sync up.
+ *
+ * @param target The sync up target that will manage the sync up process.
+ * @param options The options associated with this sync up.
+ * @param soupName The soup name where the local entries are stored.
+ * @param syncName The name for this sync.
+ * @param updateBlock The block to be called with updates.
+ * @return The sync state associated with this sync up.
+ */
+- (SFSyncState*) syncUpWithTarget:(SFSyncUpTarget*)target
+                          options:(SFSyncOptions*)options
+                         soupName:(NSString*)soupName
+                         syncName:(NSString*)syncName
                       updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
 
 /**

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -163,7 +163,7 @@ static NSMutableDictionary *syncMgrList = nil;
     SFSyncState* sync = [SFSyncState newById:syncId store:self.store];
     
     if (sync == nil) {
-        [SFSDKSmartSyncLogger e:[self class] format:@"Sync %@ not found", syncId];
+        [SFSDKSmartSyncLogger d:[self class] format:@"Sync %@ not found", syncId];
     }
     return sync;
 }
@@ -172,7 +172,7 @@ static NSMutableDictionary *syncMgrList = nil;
     SFSyncState* sync = [SFSyncState newByName:syncName store:self.store];
 
     if (sync == nil) {
-        [SFSDKSmartSyncLogger e:[self class] format:@"Sync %@ not found", syncName];
+        [SFSDKSmartSyncLogger d:[self class] format:@"Sync %@ not found", syncName];
     }
     return sync;
 }

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -244,7 +244,7 @@ static NSMutableDictionary *syncMgrList = nil;
 /** Create and run a sync down
  */
 - (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock {
-    SFSyncState* sync = [SFSyncState newSyncDownWithOptions:options target:target soupName:soupName store:self.store];
+    SFSyncState* sync = [SFSyncState newSyncDownWithOptions:options target:target soupName:soupName name:nil store:self.store];
     [SFSDKSmartSyncLogger d:[self class] format:@"syncDown:%@", sync];
     [self runSync:sync updateBlock:updateBlock];
     return [sync copy];
@@ -363,7 +363,7 @@ static NSMutableDictionary *syncMgrList = nil;
                          options:(SFSyncOptions *)options
                         soupName:(NSString *)soupName
                      updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock {
-    SFSyncState *sync = [SFSyncState newSyncUpWithOptions:options target:target soupName:soupName store:self.store];
+    SFSyncState *sync = [SFSyncState newSyncUpWithOptions:options target:target soupName:soupName name:nil store:self.store];
     [self runSync:sync updateBlock:updateBlock];
     return [sync copy];
 }

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -38,6 +38,7 @@ extern NSString * const kSFSyncStateSyncsSoupSyncType;
 
 // Fields in dict representation
 extern NSString * const kSFSyncStateId;
+extern NSString * const kSFSyncStateName;
 extern NSString * const kSFSyncStateType;
 extern NSString * const kSFSyncStateTarget;
 extern NSString * const kSFSyncStateSoupName;
@@ -84,6 +85,7 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 @interface SFSyncState : NSObject <NSCopying>
 
 @property (nonatomic, readonly) NSInteger syncId;
+@property (nonatomic, strong, readonly) NSString* syncName;
 @property (nonatomic, readonly) SFSyncStateSyncType type;
 @property (nonatomic, strong, readonly) NSString* soupName;
 @property (nonatomic, strong, readonly) SFSyncTarget* target;
@@ -104,14 +106,17 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 
 /** Factory methods
  */
-+ (SFSyncState*) newSyncDownWithOptions:(SFSyncOptions*)options target:(SFSyncDownTarget*)target soupName:(NSString*)soupName store:(SFSmartStore*)store;
-+ (SFSyncState*) newSyncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName store:(SFSmartStore*)store;
-+ (nullable SFSyncState*) newSyncUpWithOptions:(SFSyncOptions*)options target:(SFSyncUpTarget*)target soupName:(NSString*)soupName store:(SFSmartStore*)store;
++ (nullable SFSyncState *)newSyncDownWithOptions:(SFSyncOptions *)options target:(SFSyncDownTarget *)target soupName:(NSString *)soupName name:(nullable NSString *) name store:(SFSmartStore*)store;
++ (nullable SFSyncState *)newSyncUpWithOptions:(SFSyncOptions *)options target:(SFSyncUpTarget *)target soupName:(NSString *)soupName name:(nullable NSString *)name store:(SFSmartStore *)store;
++ (nullable SFSyncState*) newSyncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName store:(SFSmartStore*)store;
 
-/** Methods to save/retrieve from smartstore
+/** Methods to save/retrieve/delete from smartstore
  */
 + (nullable SFSyncState*) newById:(NSNumber*)syncId store:(SFSmartStore*)store;
++ (nullable SFSyncState*) newByName:(NSString *)name store:(SFSmartStore*)store;
 - (void) save:(SFSmartStore*)store;
+- (void) deleteById:(NSNumber*)syncId store:(SFSmartStore*)store;
+- (void) deleteByName:(NSString*)name store:(SFSmartStore*)store;
 
 /** Methods to translate to/from dictionary
  */

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -115,8 +115,8 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 + (nullable SFSyncState*) newById:(NSNumber*)syncId store:(SFSmartStore*)store;
 + (nullable SFSyncState*) newByName:(NSString *)name store:(SFSmartStore*)store;
 - (void) save:(SFSmartStore*)store;
-- (void) deleteById:(NSNumber*)syncId store:(SFSmartStore*)store;
-- (void) deleteByName:(NSString*)name store:(SFSmartStore*)store;
++ (void) deleteById:(NSNumber*)syncId store:(SFSmartStore*)store;
++ (void) deleteByName:(NSString*)name store:(SFSmartStore*)store;
 
 /** Methods to translate to/from dictionary
  */

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -28,9 +28,7 @@
 #import "SFSyncUpTarget.h"
 #import <SmartStore/SFSmartStore.h>
 #import <SmartStore/SFSoupIndex.h>
-#import <SmartStore/SFQuerySpec.h>
 #import <SalesforceSDKCore/SFJsonUtils.h>
-#import <Foundation/Foundation.h>
 
 // soups and soup fields
 NSString * const kSFSyncStateSyncsSoupName = @"syncs_soup";
@@ -167,11 +165,11 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     [store upsertEntries:@[ [self asDict] ] toSoup:kSFSyncStateSyncsSoupName];
 }
 
-- (void) deleteById:(NSNumber*)syncId store:(SFSmartStore*)store {
++ (void) deleteById:(NSNumber*)syncId store:(SFSmartStore*)store {
     [store removeEntries:@[syncId] fromSoup:kSFSyncStateSyncsSoupName];
 }
 
-- (void) deleteByName:(NSString*)name store:(SFSmartStore*)store {
++ (void) deleteByName:(NSString*)name store:(SFSmartStore*)store {
     NSNumber *syncId = [store lookupSoupEntryIdForSoupName:kSFSyncStateSyncsSoupName forFieldPath:kSFSyncStateSyncsSoupSyncName fieldValue:name error:nil];
     if (syncId) {
         [self deleteById:syncId store:store];

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -115,6 +115,12 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
             kSFSyncStateEndTime: [NSNumber numberWithInteger:0]
     }];
     if (name) dict[kSFSyncStateName] = name;
+    
+    if (name && [SFSyncState newByName:name store:store]) {
+        [SFSDKSmartSyncLogger e:[self class] format:@"Failed to create sync down: there is already a sync with name:%@", name];
+        return nil;
+    }
+    
     NSArray* savedDicts = [store upsertEntries:@[ dict ] toSoup:kSFSyncStateSyncsSoupName];
     SFSyncState* sync = [SFSyncState newFromDict:savedDicts[0]];
     return sync;
@@ -138,6 +144,12 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
             kSFSyncStateEndTime: [NSNumber numberWithInteger:0]
     }];
     if (name) dict[kSFSyncStateName] = name;
+    
+    if (name && [SFSyncState newByName:name store:store]) {
+        [SFSDKSmartSyncLogger e:[self class] format:@"Failed to create sync up: there is already a sync with name:%@", name];
+        return nil;
+    }
+    
     NSArray* savedDicts = [store upsertEntries:@[ dict ] toSoup:kSFSyncStateSyncsSoupName];
     if (savedDicts == nil || savedDicts.count == 0)
         return nil;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -30,13 +30,16 @@
 #import <SmartStore/SFSoupIndex.h>
 #import <SmartStore/SFQuerySpec.h>
 #import <SalesforceSDKCore/SFJsonUtils.h>
+#import <Foundation/Foundation.h>
 
 // soups and soup fields
 NSString * const kSFSyncStateSyncsSoupName = @"syncs_soup";
 NSString * const kSFSyncStateSyncsSoupSyncType = @"type";
+NSString * const kSFSyncStateSyncsSoupSyncName = @"name";
 
 // Fields in dict representation
 NSString * const kSFSyncStateId = @"_soupEntryId";
+NSString * const kSFSyncStateName = @"name";
 NSString * const kSFSyncStateType = @"type";
 NSString * const kSFSyncStateTarget = @"target";
 NSString * const kSFSyncStateSoupName = @"soupName";
@@ -65,6 +68,7 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
 @interface SFSyncState ()
 
 @property (nonatomic, readwrite) NSInteger syncId;
+@property (nonatomic, readwrite) NSString* name;
 @property (nonatomic, readwrite) SFSyncStateSyncType type;
 @property (nonatomic, strong, readwrite) NSString* soupName;
 @property (nonatomic, strong, readwrite) SFSyncTarget* target;
@@ -79,29 +83,40 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
 # pragma mark - Setup
 
 + (void) setupSyncsSoupIfNeeded:(SFSmartStore*)store {
-    if ([store soupExists:kSFSyncStateSyncsSoupName])
+
+    if ([store soupExists:kSFSyncStateSyncsSoupName] && [store indicesForSoup:kSFSyncStateSyncsSoupName].count == 2) {
         return;
+    }
     NSArray* indexSpecs = @[
-                            [[SFSoupIndex alloc] initWithPath:kSFSyncStateSyncsSoupSyncType indexType:kSoupIndexTypeString columnName:nil]
-                            ];
-    
-    [store registerSoup:kSFSyncStateSyncsSoupName withIndexSpecs:indexSpecs error:nil];
+            [[SFSoupIndex alloc] initWithPath:kSFSyncStateSyncsSoupSyncType indexType:kSoupIndexTypeString columnName:nil],
+            [[SFSoupIndex alloc] initWithPath:kSFSyncStateSyncsSoupSyncName indexType:kSoupIndexTypeString columnName:nil]
+    ];
+
+    // Syncs soup exists but doesn't have all the required indexes
+    if ([store soupExists:kSFSyncStateSyncsSoupName]) {
+        [store alterSoup:kSFSyncStateSyncsSoupName withIndexSpecs:indexSpecs reIndexData:NO];
+    }
+    // Syncs soup does not exist
+    else {
+        [store registerSoup:kSFSyncStateSyncsSoupName withIndexSpecs:indexSpecs error:nil];
+    }
 }
 
 #pragma mark - Factory methods
 
-+ (SFSyncState*) newSyncDownWithOptions:(SFSyncOptions*)options target:(SFSyncDownTarget*)target soupName:(NSString*)soupName store:(SFSmartStore*)store {
-    NSDictionary* dict = @{
-                           kSFSyncStateType: kSFSyncStateTypeDown,
-                           kSFSyncStateTarget: [target asDict],
-                           kSFSyncStateSoupName: soupName,
-                           kSFSyncStateOptions: [options asDict],
-                           kSFSyncStateStatus: kSFSyncStateStatusNew,
-                           kSFSyncStateProgress: [NSNumber numberWithInteger:0],
-                           kSFSyncStateTotalSize: [NSNumber numberWithInteger:-1],
-                           kSFSyncStateStartTime: [NSNumber numberWithInteger:0],
-                           kSFSyncStateEndTime: [NSNumber numberWithInteger:0]
-                           };
++ (SFSyncState *)newSyncDownWithOptions:(SFSyncOptions *)options target:(SFSyncDownTarget *)target soupName:(NSString *)soupName name:(NSString *)name store:(SFSmartStore *)store {
+    NSMutableDictionary* dict = [NSMutableDictionary dictionaryWithDictionary:@{
+            kSFSyncStateType: kSFSyncStateTypeDown,
+            kSFSyncStateTarget: [target asDict],
+            kSFSyncStateSoupName: soupName,
+            kSFSyncStateOptions: [options asDict],
+            kSFSyncStateStatus: kSFSyncStateStatusNew,
+            kSFSyncStateProgress: [NSNumber numberWithInteger:0],
+            kSFSyncStateTotalSize: [NSNumber numberWithInteger:-1],
+            kSFSyncStateStartTime: [NSNumber numberWithInteger:0],
+            kSFSyncStateEndTime: [NSNumber numberWithInteger:0]
+    }];
+    if (name) dict[kSFSyncStateName] = name;
     NSArray* savedDicts = [store upsertEntries:@[ dict ] toSoup:kSFSyncStateSyncsSoupName];
     SFSyncState* sync = [SFSyncState newFromDict:savedDicts[0]];
     return sync;
@@ -109,24 +124,22 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
 
 + (SFSyncState*)newSyncUpWithOptions:(SFSyncOptions *)options soupName:(NSString *)soupName store:(SFSmartStore *)store {
     SFSyncUpTarget *target = [[SFSyncUpTarget alloc] init];
-    return [self newSyncUpWithOptions:options target:target soupName:soupName store:store];
+    return [self newSyncUpWithOptions:options target:target soupName:soupName name:nil store:store];
 }
 
-+ (SFSyncState*) newSyncUpWithOptions:(SFSyncOptions*)options
-                               target:(SFSyncUpTarget*)target
-                             soupName:(NSString*)soupName
-                                store:(SFSmartStore*)store {
-    NSDictionary* dict = @{
-                           kSFSyncStateType: kSFSyncStateTypeUp,
-                           kSFSyncStateTarget: [target asDict],
-                           kSFSyncStateSoupName: soupName,
-                           kSFSyncStateOptions: [options asDict],
-                           kSFSyncStateStatus: kSFSyncStateStatusNew,
-                           kSFSyncStateProgress: [NSNumber numberWithInteger:0],
-                           kSFSyncStateTotalSize: [NSNumber numberWithInteger:-1],
-                           kSFSyncStateStartTime: [NSNumber numberWithInteger:0],
-                           kSFSyncStateEndTime: [NSNumber numberWithInteger:0]
-                           };
++ (SFSyncState *)newSyncUpWithOptions:(SFSyncOptions *)options target:(SFSyncUpTarget *)target soupName:(NSString *)soupName name:(NSString *)name store:(SFSmartStore *)store {
+    NSMutableDictionary* dict = [NSMutableDictionary dictionaryWithDictionary:@{
+            kSFSyncStateType: kSFSyncStateTypeUp,
+            kSFSyncStateTarget: [target asDict],
+            kSFSyncStateSoupName: soupName,
+            kSFSyncStateOptions: [options asDict],
+            kSFSyncStateStatus: kSFSyncStateStatusNew,
+            kSFSyncStateProgress: [NSNumber numberWithInteger:0],
+            kSFSyncStateTotalSize: [NSNumber numberWithInteger:-1],
+            kSFSyncStateStartTime: [NSNumber numberWithInteger:0],
+            kSFSyncStateEndTime: [NSNumber numberWithInteger:0]
+    }];
+    if (name) dict[kSFSyncStateName] = name;
     NSArray* savedDicts = [store upsertEntries:@[ dict ] toSoup:kSFSyncStateSyncsSoupName];
     if (savedDicts == nil || savedDicts.count == 0)
         return nil;
@@ -134,7 +147,7 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     return sync;
 }
 
-#pragma mark - Save/retrieve to/from smartstore
+#pragma mark - Save/retrieve/delete to/from smartstore
 
 + (SFSyncState*) newById:(NSNumber*)syncId store:(SFSmartStore*)store {
     NSArray* retrievedDicts = [store retrieveEntries:@ [ syncId ] fromSoup:kSFSyncStateSyncsSoupName];
@@ -144,9 +157,27 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     return sync;
 }
 
++ (SFSyncState*) newByName:(NSString *)name store:(SFSmartStore*)store {
+    NSNumber *syncId = [store lookupSoupEntryIdForSoupName:kSFSyncStateSyncsSoupName forFieldPath:kSFSyncStateSyncsSoupSyncName fieldValue:name error:nil];
+    return syncId == nil ? nil : [self newById:syncId store:store];
+}
+
+
 - (void) save:(SFSmartStore*) store {
     [store upsertEntries:@[ [self asDict] ] toSoup:kSFSyncStateSyncsSoupName];
 }
+
+- (void) deleteById:(NSNumber*)syncId store:(SFSmartStore*)store {
+    [store removeEntries:@[syncId] fromSoup:kSFSyncStateSyncsSoupName];
+}
+
+- (void) deleteByName:(NSString*)name store:(SFSmartStore*)store {
+    NSNumber *syncId = [store lookupSoupEntryIdForSoupName:kSFSyncStateSyncsSoupName forFieldPath:kSFSyncStateSyncsSoupSyncName fieldValue:name error:nil];
+    if (syncId) {
+        [self deleteById:syncId store:store];
+    }
+}
+
 
 #pragma mark - From/to dictionary
 
@@ -161,6 +192,7 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
 - (void) fromDict:(NSDictionary*) dict {
     self.syncId = [(NSNumber*) dict[kSFSyncStateId] integerValue];
     self.type = [SFSyncState syncTypeFromString:dict[kSFSyncStateType]];
+    self.name = dict[kSFSyncStateName];
     self.target = (self.type == SFSyncStateSyncTypeDown
                    ? [SFSyncDownTarget newFromDict:dict[kSFSyncStateTarget]]
                    : [SFSyncUpTarget newFromDict:dict[kSFSyncStateTarget]]);
@@ -178,6 +210,7 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     NSMutableDictionary* dict = [NSMutableDictionary new];
     dict[SOUP_ENTRY_ID] = [NSNumber numberWithInteger:self.syncId];
     dict[kSFSyncStateType] = [SFSyncState syncTypeToString:self.type];
+    if (self.name) dict[kSFSyncStateName] = self.name;
     if (self.target) dict[kSFSyncStateTarget] = [self.target asDict];
     if (self.options) dict[kSFSyncStateOptions] = [self.options asDict];
     dict[kSFSyncStateSoupName] = self.soupName;

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.h
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.h
@@ -76,7 +76,9 @@
 - (NSDictionary *)sendSyncRequest:(SFRestRequest *)request;
 
 - (NSInteger)trySyncDown:(SFSyncStateMergeMode)mergeMode target:(SFSyncDownTarget *)target soupName:(NSString *)soupName totalSize:(NSUInteger)totalSize numberFetches:(NSUInteger)numberFetches;
+
 - (void)checkStatus:(SFSyncState *)sync expectedType:(SFSyncStateSyncType)expectedType expectedId:(NSInteger)expectedId expectedTarget:(SFSyncTarget *)expectedTarget expectedOptions:(SFSyncOptions *)expectedOptions expectedStatus:(SFSyncStateStatus)expectedStatus expectedProgress:(NSInteger)expectedProgress expectedTotalSize:(NSInteger)expectedTotalSize;
+- (void)checkStatus:(SFSyncState *)sync expectedType:(SFSyncStateSyncType)expectedType expectedId:(NSInteger)expectedId expectedName:(NSString *)expectedName expectedTarget:(SFSyncTarget *)expectedTarget expectedOptions:(SFSyncOptions *)expectedOptions expectedStatus:(SFSyncStateStatus)expectedStatus expectedProgress:(NSInteger)expectedProgress expectedTotalSize:(NSInteger)expectedTotalSize;
 - (void)checkDb:(NSDictionary *)expectedIdToFields soupName:(NSString *)soupName;
 
 - (void)checkDbStateFlags:(NSArray *)ids soupName:(NSString *)soupName expectedLocallyCreated:(bool)expectedLocallyCreated expectedLocallyUpdated:(bool)expectedLocallyUpdated expectedLocallyDeleted:(bool)expectedLocallyDeleted;

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.m
@@ -259,7 +259,7 @@ static NSException *authException = nil;
 
     // Creates sync.
     SFSyncOptions* options = [SFSyncOptions newSyncOptionsForSyncDown:mergeMode];
-    SFSyncState* sync = [SFSyncState newSyncDownWithOptions:options target:target soupName:soupName store:self.store];
+    SFSyncState* sync = [SFSyncState newSyncDownWithOptions:options target:target soupName:soupName name:nil store:self.store];
     NSInteger syncId = sync.syncId;
     [self checkStatus:sync expectedType:SFSyncStateSyncTypeDown expectedId:syncId expectedTarget:target expectedOptions:options expectedStatus:SFSyncStateStatusNew expectedProgress:0 expectedTotalSize:-1];
 
@@ -501,7 +501,7 @@ static NSException *authException = nil;
  completionStatus:(SFSyncStateStatus)completionStatus {
 
     // Creates sync.
-    SFSyncState *sync = [SFSyncState newSyncUpWithOptions:options target:target soupName:ACCOUNTS_SOUP store:self.store];
+    SFSyncState *sync = [SFSyncState newSyncUpWithOptions:options target:target soupName:ACCOUNTS_SOUP name:nil store:self.store];
     NSInteger syncId = sync.syncId;
     [self checkStatus:sync expectedType:SFSyncStateSyncTypeUp expectedId:syncId expectedTarget:target expectedOptions:options expectedStatus:SFSyncStateStatusNew expectedProgress:0 expectedTotalSize:-1];
 

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.m
@@ -282,14 +282,10 @@ static NSException *authException = nil;
     return syncId;
 }
 
-- (void)checkStatus:(SFSyncState*)sync
-       expectedType:(SFSyncStateSyncType)expectedType
-         expectedId:(NSInteger)expectedId
-     expectedTarget:(SFSyncTarget*)expectedTarget
-    expectedOptions:(SFSyncOptions*)expectedOptions
-     expectedStatus:(SFSyncStateStatus)expectedStatus
-   expectedProgress:(NSInteger)expectedProgress
-  expectedTotalSize:(NSInteger)expectedTotalSize {
+- (void)checkStatus:(SFSyncState *)sync expectedType:(SFSyncStateSyncType)expectedType expectedId:(NSInteger)expectedId expectedTarget:(SFSyncTarget *)expectedTarget expectedOptions:(SFSyncOptions *)expectedOptions expectedStatus:(SFSyncStateStatus)expectedStatus expectedProgress:(NSInteger)expectedProgress expectedTotalSize:(NSInteger)expectedTotalSize {
+    [self checkStatus:sync expectedType:expectedType expectedId:expectedId expectedName:nil expectedTarget:expectedTarget expectedOptions:expectedOptions expectedStatus:expectedStatus expectedProgress:expectedProgress expectedTotalSize:expectedTotalSize];
+}
+- (void)checkStatus:(SFSyncState *)sync expectedType:(SFSyncStateSyncType)expectedType expectedId:(NSInteger)expectedId expectedName:(NSString *)expectedName expectedTarget:(SFSyncTarget *)expectedTarget expectedOptions:(SFSyncOptions *)expectedOptions expectedStatus:(SFSyncStateStatus)expectedStatus expectedProgress:(NSInteger)expectedProgress expectedTotalSize:(NSInteger)expectedTotalSize {
     XCTAssertNotNil(sync);
     if (!sync) {
         return;

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -1250,7 +1250,7 @@
     NSString* soql = [@[@"SELECT Id, Name, LastModifiedDate FROM Account WHERE Id IN ", idsClause] componentsJoinedByString:@""];
     SlowSoqlSyncDownTarget* target = [SlowSoqlSyncDownTarget newSyncTarget:soql];
     SFSyncOptions* options = [SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged];
-    SFSyncState* sync = [SFSyncState newSyncDownWithOptions:options target:target soupName:ACCOUNTS_SOUP store:self.store];
+    SFSyncState* sync = [SFSyncState newSyncDownWithOptions:options target:target soupName:ACCOUNTS_SOUP name:nil store:self.store];
     NSNumber* syncId = [NSNumber numberWithInteger:sync.syncId];
 
     // Run sync -- will freeze during fetch

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -1273,6 +1273,102 @@
     while ([queue getNextSyncUpdate].status != SFSyncStateStatusDone);
 }
 
+/**
+* Create sync down, get it by id, delete it by id, make sure it's gone
+*/
+-(void) testCreateGetDeleteSyncDownById {
+    // Create
+    SFSyncState* sync = [SFSyncState newSyncDownWithOptions:[SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged] target:[SFSoqlSyncDownTarget newSyncTarget:@"SELECT Id, Name from Account"] soupName:ACCOUNTS_SOUP name:nil store:self.store];
+    NSNumber* syncId = [NSNumber numberWithInteger:sync.syncId];
+    // Get by id
+    SFSyncState* fetchedSync = [SFSyncState newById:syncId store:self.store];
+    [self checkStatus:fetchedSync expectedType:sync.type expectedId:sync.syncId expectedName:nil expectedTarget:sync.target expectedOptions:sync.options expectedStatus:sync.status expectedProgress:sync.progress expectedTotalSize:sync.totalSize];
+    // Delete by id
+    [SFSyncState deleteById:syncId store:self.store];
+    XCTAssertNil([SFSyncState newById:syncId store:self.store], "Sync should be gone");
+}
+
+/**
+ * Create sync down with a name, get it by name, delete it by name, make sure it's gone
+ */
+-(void) testCreateGetDeleteSyncDownByName {
+    NSString* syncName = @"MyNamedSyncDown";
+    // Create
+    SFSyncState* sync = [SFSyncState newSyncDownWithOptions:[SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged] target:[SFSoqlSyncDownTarget newSyncTarget:@"SELECT Id, Name from Account"] soupName:ACCOUNTS_SOUP name:syncName store:self.store];
+    NSNumber* syncId = [NSNumber numberWithInteger:sync.syncId];
+    // Get by name
+    SFSyncState* fetchedSync = [SFSyncState newByName:syncName store:self.store];
+    [self checkStatus:fetchedSync expectedType:sync.type expectedId:sync.syncId expectedName:syncName expectedTarget:sync.target expectedOptions:sync.options expectedStatus:sync.status expectedProgress:sync.progress expectedTotalSize:sync.totalSize];
+    // Delete by name
+    [SFSyncState deleteByName:syncName store:self.store];
+    XCTAssertNil([SFSyncState newById:syncId store:self.store], "Sync should be gone");
+    XCTAssertNil([SFSyncState newByName:syncName store:self.store], "Sync should be gone");
+}
+
+/**
+* Create sync up, get it by id, delete it by id, make sure it's gone
+*/
+-(void) testCreateGetDeleteSyncUpById {
+    // Create
+    SFSyncState* sync = [SFSyncState newSyncUpWithOptions:[SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged] target:[SFSyncUpTarget new] soupName:ACCOUNTS_SOUP name:nil store:self.store];
+    NSNumber* syncId = [NSNumber numberWithInteger:sync.syncId];
+    // Get by id
+    SFSyncState* fetchedSync = [SFSyncState newById:syncId store:self.store];
+    [self checkStatus:fetchedSync expectedType:sync.type expectedId:sync.syncId expectedName:nil expectedTarget:sync.target expectedOptions:sync.options expectedStatus:sync.status expectedProgress:sync.progress expectedTotalSize:sync.totalSize];
+    // Delete by id
+    [SFSyncState deleteById:syncId store:self.store];
+    XCTAssertNil([SFSyncState newById:syncId store:self.store], "Sync should be gone");
+}
+
+/**
+ * Create sync up with a name, get it by name, delete it by name, make sure it's gone
+ */
+-(void) testCreateGetDeleteSyncUpByName {
+    NSString* syncName = @"MyNamedSyncUp";
+    // Create
+    SFSyncState* sync = [SFSyncState newSyncUpWithOptions:[SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged] target:[SFSyncUpTarget new] soupName:ACCOUNTS_SOUP name:syncName store:self.store];
+    NSNumber* syncId = [NSNumber numberWithInteger:sync.syncId];
+    // Get by name
+    SFSyncState* fetchedSync = [SFSyncState newByName:syncName store:self.store];
+    [self checkStatus:fetchedSync expectedType:sync.type expectedId:sync.syncId expectedName:syncName expectedTarget:sync.target expectedOptions:sync.options expectedStatus:sync.status expectedProgress:sync.progress expectedTotalSize:sync.totalSize];
+    // Delete by name
+    [SFSyncState deleteByName:syncName store:self.store];
+    XCTAssertNil([SFSyncState newById:syncId store:self.store], "Sync should be gone");
+    XCTAssertNil([SFSyncState newByName:syncName store:self.store], "Sync should be gone");
+}
+
+/**
+ * Create sync with a name, make sure a new sync down with the same name cannot be created
+ */
+- (void) testCreateSyncDownWithExistingName {
+    NSString* syncName = @"MyNamedSync";
+    // Create a named sync
+    [SFSyncState newSyncUpWithOptions:[SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged] target:[SFSyncUpTarget new] soupName:ACCOUNTS_SOUP name:syncName store:self.store];
+    // Try to create a sync down with the same name
+    SFSyncState* secondSync = [SFSyncState newSyncDownWithOptions:[SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged] target:[SFSoqlSyncDownTarget newSyncTarget:@"SELECT Id, Name from Account"] soupName:ACCOUNTS_SOUP name:syncName store:self.store];
+    XCTAssertNil(secondSync, @"sync should nil");
+
+    // Delete by name
+    [SFSyncState deleteByName:syncName store:self.store];
+    XCTAssertNil([SFSyncState newByName:syncName store:self.store], "Sync should be gone");
+}
+
+/**
+ * Create sync with a name, make sure a new sync up with the same name cannot be created
+ */
+- (void) testCreateSyncUpWithExistingName {
+    NSString* syncName = @"MyNamedSync";
+    // Create a named sync
+    [SFSyncState newSyncDownWithOptions:[SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged] target:[SFSoqlSyncDownTarget newSyncTarget:@"SELECT Id, Name from Account"] soupName:ACCOUNTS_SOUP name:syncName store:self.store];
+    // Try to create a sync up with the same name
+    SFSyncState* secondSync = [SFSyncState newSyncUpWithOptions:[SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged] target:[SFSyncUpTarget new] soupName:ACCOUNTS_SOUP name:syncName store:self.store];
+    XCTAssertNil(secondSync, @"sync should nil");
+
+    // Delete by name
+    [SFSyncState deleteByName:syncName store:self.store];
+    XCTAssertNil([SFSyncState newByName:syncName store:self.store], "Sync should be gone");
+}
+
 #pragma clang diagnostic pop
 
 #pragma mark - helper methods


### PR DESCRIPTION
Overview of changes:
* sync state has a name field
* sync down and up methods can be named (but it's optional)
* sync can be re-run / deleted or fetched by name
* updated cordova plugin
* updated react native bridge
* updated SmartSyncExplorer native application to use a named sync down

Overview of tests:
* added native tests
* added wrapper for new hybrid tests 
* manually tested SmartSyncExplorer native / hybrid and react native (all three use a named sync down).
