### PR TITLE
Missing UIKit header for UIImage

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.h
@@ -24,6 +24,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Probably shook out from the parallel builds change.  SalesforceHybridSDKStatic was missing the UIKit reference.  Added it at its source.  @brandonpage 