### PR TITLE
Changes to support unauthenticatedStartPage property

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		822272CE19C3A3E500FC537E /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8251CA1516EC3AF900BD1EA2 /* SystemConfiguration.framework */; };
 		822272CF19C3A3FC00FC537E /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8251CA1116EC3AC100BD1EA2 /* MobileCoreServices.framework */; };
 		829DA2B11C12677B0040F5F1 /* SalesforceHybridSDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 829DA2B01C12677B0040F5F1 /* SalesforceHybridSDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		82AB22651F9EB9C100A754C8 /* SFHybridViewConfigTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 82AB22641F9EB9C100A754C8 /* SFHybridViewConfigTestSuite.m */; };
 		82AF5A6B1A0D911D006C7A4B /* CDVLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 82AF5A651A0D911D006C7A4B /* CDVLogger.m */; };
 		82AF5A6F1A0D9277006C7A4B /* console-via-logger.js in Copy cordova-plugin-console plugin */ = {isa = PBXBuildFile; fileRef = 82AF5A691A0D911D006C7A4B /* console-via-logger.js */; };
 		82AF5A701A0D9277006C7A4B /* logger.js in Copy cordova-plugin-console plugin */ = {isa = PBXBuildFile; fileRef = 82AF5A6A1A0D911D006C7A4B /* logger.js */; };
@@ -491,6 +492,7 @@
 		8251CA3816ED008200BD1EA2 /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
 		8251CA3A16ED009700BD1EA2 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		829DA2B01C12677B0040F5F1 /* SalesforceHybridSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SalesforceHybridSDK.h; sourceTree = "<group>"; };
+		82AB22641F9EB9C100A754C8 /* SFHybridViewConfigTestSuite.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFHybridViewConfigTestSuite.m; path = SalesforceHybridSDKTests/SFHybridViewConfigTestSuite.m; sourceTree = SOURCE_ROOT; };
 		82AF5A641A0D911D006C7A4B /* CDVLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVLogger.h; sourceTree = "<group>"; };
 		82AF5A651A0D911D006C7A4B /* CDVLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVLogger.m; sourceTree = "<group>"; };
 		82AF5A691A0D911D006C7A4B /* console-via-logger.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "console-via-logger.js"; sourceTree = "<group>"; };
@@ -777,6 +779,7 @@
 				4F06AFA61C49A77200F70798 /* ForceJSTestSuite.m */,
 				4F06AFA71C49A77200F70798 /* SDKInfoTestSuite.h */,
 				4F06AFA81C49A77200F70798 /* SDKInfoTestSuite.m */,
+				82AB22641F9EB9C100A754C8 /* SFHybridViewConfigTestSuite.m */,
 				4F06AFA91C49A77200F70798 /* SFPluginTestSuite.h */,
 				4F06AFAA1C49A77200F70798 /* SFPluginTestSuite.m */,
 				4F06AFAB1C49A77200F70798 /* SmartStoreLoadTestSuite.h */,
@@ -1453,6 +1456,7 @@
 				4F06AFC11C49A7BF00F70798 /* SmartStoreTestSuite.m in Sources */,
 				4F06AFBD1C49A7BF00F70798 /* ForceJSTestSuite.m in Sources */,
 				4F06AFC21C49A7BF00F70798 /* SmartSyncTestSuite.m in Sources */,
+				82AB22651F9EB9C100A754C8 /* SFHybridViewConfigTestSuite.m in Sources */,
 				4F06AFC01C49A7BF00F70798 /* SmartStoreLoadTestSuite.m in Sources */,
 				4F06AFBE1C49A7BF00F70798 /* SDKInfoTestSuite.m in Sources */,
 				4F06AFBF1C49A7BF00F70798 /* SFPluginTestSuite.m in Sources */,

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK.xcodeproj/project.pbxproj
@@ -425,18 +425,18 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		4F06AFA51C49A77200F70798 /* ForceJSTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ForceJSTestSuite.h; path = SalesforceHybridSDKTests/ForceJSTestSuite.h; sourceTree = SOURCE_ROOT; };
-		4F06AFA61C49A77200F70798 /* ForceJSTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ForceJSTestSuite.m; path = SalesforceHybridSDKTests/ForceJSTestSuite.m; sourceTree = SOURCE_ROOT; };
-		4F06AFA71C49A77200F70798 /* SDKInfoTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SDKInfoTestSuite.h; path = SalesforceHybridSDKTests/SDKInfoTestSuite.h; sourceTree = SOURCE_ROOT; };
-		4F06AFA81C49A77200F70798 /* SDKInfoTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDKInfoTestSuite.m; path = SalesforceHybridSDKTests/SDKInfoTestSuite.m; sourceTree = SOURCE_ROOT; };
-		4F06AFA91C49A77200F70798 /* SFPluginTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFPluginTestSuite.h; path = SalesforceHybridSDKTests/SFPluginTestSuite.h; sourceTree = SOURCE_ROOT; };
-		4F06AFAA1C49A77200F70798 /* SFPluginTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFPluginTestSuite.m; path = SalesforceHybridSDKTests/SFPluginTestSuite.m; sourceTree = SOURCE_ROOT; };
-		4F06AFAB1C49A77200F70798 /* SmartStoreLoadTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SmartStoreLoadTestSuite.h; path = SalesforceHybridSDKTests/SmartStoreLoadTestSuite.h; sourceTree = SOURCE_ROOT; };
-		4F06AFAC1C49A77200F70798 /* SmartStoreLoadTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SmartStoreLoadTestSuite.m; path = SalesforceHybridSDKTests/SmartStoreLoadTestSuite.m; sourceTree = SOURCE_ROOT; };
-		4F06AFAD1C49A77200F70798 /* SmartStoreTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SmartStoreTestSuite.h; path = SalesforceHybridSDKTests/SmartStoreTestSuite.h; sourceTree = SOURCE_ROOT; };
-		4F06AFAE1C49A77200F70798 /* SmartStoreTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SmartStoreTestSuite.m; path = SalesforceHybridSDKTests/SmartStoreTestSuite.m; sourceTree = SOURCE_ROOT; };
-		4F06AFAF1C49A77200F70798 /* SmartSyncTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SmartSyncTestSuite.h; path = SalesforceHybridSDKTests/SmartSyncTestSuite.h; sourceTree = SOURCE_ROOT; };
-		4F06AFB01C49A77200F70798 /* SmartSyncTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SmartSyncTestSuite.m; path = SalesforceHybridSDKTests/SmartSyncTestSuite.m; sourceTree = SOURCE_ROOT; };
+		4F06AFA51C49A77200F70798 /* ForceJSTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ForceJSTestSuite.h; sourceTree = "<group>"; };
+		4F06AFA61C49A77200F70798 /* ForceJSTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ForceJSTestSuite.m; sourceTree = "<group>"; };
+		4F06AFA71C49A77200F70798 /* SDKInfoTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDKInfoTestSuite.h; sourceTree = "<group>"; };
+		4F06AFA81C49A77200F70798 /* SDKInfoTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDKInfoTestSuite.m; sourceTree = "<group>"; };
+		4F06AFA91C49A77200F70798 /* SFPluginTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFPluginTestSuite.h; sourceTree = "<group>"; };
+		4F06AFAA1C49A77200F70798 /* SFPluginTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFPluginTestSuite.m; sourceTree = "<group>"; };
+		4F06AFAB1C49A77200F70798 /* SmartStoreLoadTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmartStoreLoadTestSuite.h; sourceTree = "<group>"; };
+		4F06AFAC1C49A77200F70798 /* SmartStoreLoadTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SmartStoreLoadTestSuite.m; sourceTree = "<group>"; };
+		4F06AFAD1C49A77200F70798 /* SmartStoreTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmartStoreTestSuite.h; sourceTree = "<group>"; };
+		4F06AFAE1C49A77200F70798 /* SmartStoreTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SmartStoreTestSuite.m; sourceTree = "<group>"; };
+		4F06AFAF1C49A77200F70798 /* SmartSyncTestSuite.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmartSyncTestSuite.h; sourceTree = "<group>"; };
+		4F06AFB01C49A77200F70798 /* SmartSyncTestSuite.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SmartSyncTestSuite.m; sourceTree = "<group>"; };
 		4F06AFC41C49A88B00F70798 /* SalesforceHybridSDKTests-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "SalesforceHybridSDKTests-Info.plist"; path = "SalesforceHybridSDKTests/SalesforceHybridSDKTests-Info.plist"; sourceTree = SOURCE_ROOT; };
 		4F06AFC51C49A89900F70798 /* SalesforceHybridSDKTests-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SalesforceHybridSDKTests-Prefix.pch"; path = "SalesforceHybridSDKTests/SalesforceHybridSDKTests-Prefix.pch"; sourceTree = SOURCE_ROOT; };
 		4F0C192B18AAFDF3000FD4E9 /* AssetsLibrary.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
@@ -492,7 +492,7 @@
 		8251CA3816ED008200BD1EA2 /* MediaPlayer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
 		8251CA3A16ED009700BD1EA2 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		829DA2B01C12677B0040F5F1 /* SalesforceHybridSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SalesforceHybridSDK.h; sourceTree = "<group>"; };
-		82AB22641F9EB9C100A754C8 /* SFHybridViewConfigTestSuite.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFHybridViewConfigTestSuite.m; path = SalesforceHybridSDKTests/SFHybridViewConfigTestSuite.m; sourceTree = SOURCE_ROOT; };
+		82AB22641F9EB9C100A754C8 /* SFHybridViewConfigTestSuite.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFHybridViewConfigTestSuite.m; sourceTree = "<group>"; };
 		82AF5A641A0D911D006C7A4B /* CDVLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDVLogger.h; sourceTree = "<group>"; };
 		82AF5A651A0D911D006C7A4B /* CDVLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDVLogger.m; sourceTree = "<group>"; };
 		82AF5A691A0D911D006C7A4B /* console-via-logger.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "console-via-logger.js"; sourceTree = "<group>"; };
@@ -790,8 +790,7 @@
 				4F06AFB01C49A77200F70798 /* SmartSyncTestSuite.m */,
 				4F06AFC31C49A87F00F70798 /* Supporting Files */,
 			);
-			name = SalesforceHybridSDKTests;
-			path = SalesforceHybridSDKTestAppTests;
+			path = SalesforceHybridSDKTests;
 			sourceTree = "<group>";
 		};
 		82AF5A621A0D911D006C7A4B /* cordova-plugin-console */ = {

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
@@ -159,7 +159,7 @@ NSString * const kStoreName           = @"storeName";
         NSString *soupName = argsDict[kSoupNameArg];
         NSDictionary *querySpecDict = [argsDict nonNullObjectForKey:kQuerySpecArg];
         SFQuerySpec* querySpec = [[SFQuerySpec alloc] initWithDictionary:querySpecDict withSoupName:soupName];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgQuerySoup with name: %@, querySpec: %@", soupName, querySpecDict]];
+        [SFSDKHybridLogger d:[self class] format:@"pgQuerySoup with name: %@, querySpec: %@", soupName, querySpecDict];
         NSError* error = nil;
         SFStoreCursor* cursor = [self runQuery:querySpec error:&error argsDict:argsDict];
         if (cursor.cursorId) {

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewConfig.h
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewConfig.h
@@ -27,7 +27,9 @@
 
 typedef NS_ENUM(NSInteger, SFSDKHybridAppConfigErrorCode) {
     SFSDKHybridAppConfigErrorCodeNoStartPage = 1066,
-    SFSDKHybridAppConfigErrorCodeLocalPageAbsoluteURL,
+    SFSDKHybridAppConfigErrorCodeStartPageAbsoluteURL,
+    SFSDKHybridAppConfigErrorCodeUnauthenticatedStartPageNotAbsoluteURL,
+    SFSDKHybridAppConfigErrorCodeNoUnauthenticatedStartPage,
     SFSDKHybridAppConfigErrorCodeAbsoluteURLNoAuth,
     SFSDKHybridAppConfigErrorCodeRelativeURLAuth
 };
@@ -50,9 +52,10 @@ static NSString *const SFSDKDefaultHybridAppConfigFilePath = @"/www/bootconfig.j
 @property (nonatomic, copy) NSString *startPage;
 
 /**
- * Whether or not the startPage value is an absolute URL.
+ * In a deferred authentication configuration for remote apps, the page/URL that should
+ * be loaded in an unauthenticated context.
  */
-@property (nonatomic, assign, readonly) BOOL startPageIsAbsoluteUrl;
+@property (nullable, nonatomic, copy) NSString *unauthenticatedStartPage;
 
 /**
  * The error page to navigate to, in the event of an error during the app load process.
@@ -64,6 +67,13 @@ static NSString *const SFSDKDefaultHybridAppConfigFilePath = @"/www/bootconfig.j
  * connectivity.
  */
 @property (nonatomic, assign) BOOL attemptOfflineLoad;
+
+/**
+ * Determines whether an input URL string is an absolute URL or not.
+ * @param urlString The URL string to evaluate.
+ * @return YES if the URL string is absolute, no otherwise.
+ */
++ (BOOL)urlStringIsAbsolute:(nonnull NSString *)urlString;
 
 @end
 

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewConfig.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewConfig.m
@@ -136,13 +136,13 @@ static NSString* const kDefaultErrorPage = @"error.html";
     }
     
     if (self.startPage.length == 0) {
-        [[self class] createError:error withCode:SFSDKHybridAppConfigErrorCodeNoStartPage message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorNoStartPage"]];
+        [SFSDKAppConfig createError:error withCode:SFSDKHybridAppConfigErrorCodeNoStartPage message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorNoStartPage"]];
         return NO;
     }
     
     // startPage must be a relative URL.
-    if ([[self class] urlStringIsAbsolute:self.startPage]) {
-        [[self class] createError:error withCode:SFSDKHybridAppConfigErrorCodeStartPageAbsoluteURL message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorStartPageAbsoluteURL"]];
+    if ([SFHybridViewConfig urlStringIsAbsolute:self.startPage]) {
+        [SFSDKAppConfig createError:error withCode:SFSDKHybridAppConfigErrorCodeStartPageAbsoluteURL message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorStartPageAbsoluteURL"]];
         return NO;
     }
     
@@ -158,13 +158,13 @@ static NSString* const kDefaultErrorPage = @"error.html";
     
     // Lack of unauthenticatedStartPage with remote deferred authentication is an error.
     if (!self.isLocal && !self.shouldAuthenticate && self.unauthenticatedStartPage.length == 0) {
-        [[self class] createError:error withCode:SFSDKHybridAppConfigErrorCodeNoUnauthenticatedStartPage message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorNoUnauthenticatedStartPage"]];
+        [SFSDKAppConfig createError:error withCode:SFSDKHybridAppConfigErrorCodeNoUnauthenticatedStartPage message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorNoUnauthenticatedStartPage"]];
         return NO;
     }
     
     // unauthenticatedStartPage, if present, must be an absolute URL.
-    if (self.unauthenticatedStartPage.length > 0 && ![[self class] urlStringIsAbsolute:self.unauthenticatedStartPage]) {
-        [[self class] createError:error withCode:SFSDKHybridAppConfigErrorCodeUnauthenticatedStartPageNotAbsoluteURL message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorUnauthenticatedStartPageNotAbsoluteURL"]];
+    if (self.unauthenticatedStartPage.length > 0 && ![SFHybridViewConfig urlStringIsAbsolute:self.unauthenticatedStartPage]) {
+        [SFSDKAppConfig createError:error withCode:SFSDKHybridAppConfigErrorCodeUnauthenticatedStartPageNotAbsoluteURL message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorUnauthenticatedStartPageNotAbsoluteURL"]];
         return NO;
     }
     

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewConfig.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewConfig.m
@@ -27,6 +27,7 @@
 #import <SalesforceAnalytics/SFSDKLogger.h>
 #import <SalesforceSDKCore/SFJsonUtils.h>
 #import <SalesforceSDKCore/SFSDKResourceUtils.h>
+#import "SFSDKHybridLogger.h"
 
 @interface SFHybridViewConfig ()
 
@@ -47,6 +48,7 @@
 // Keys used in bootconfig.json.
 static NSString* const kIsLocal = @"isLocal";
 static NSString* const kStartPage = @"startPage";
+static NSString* const kUnauthenticatedStartPage = @"unauthenticatedStartPage";
 static NSString* const kErrorPage = @"errorPage";
 static NSString* const kAttemptOfflineLoad = @"attemptOfflineLoad";
 
@@ -94,9 +96,14 @@ static NSString* const kDefaultErrorPage = @"error.html";
     self.configDict[kStartPage] = [startPage copy];
 }
 
-- (BOOL)startPageIsAbsoluteUrl
+- (NSString *)unauthenticatedStartPage
 {
-    return ([self.startPage hasPrefix:@"http://"] || [self.startPage hasPrefix:@"https://"]);
+    return (self.configDict)[kUnauthenticatedStartPage];
+}
+
+- (void)setUnauthenticatedStartPage:(NSString *)unauthenticatedStartPage
+{
+    self.configDict[kUnauthenticatedStartPage] = [unauthenticatedStartPage copy];
 }
 
 - (NSString *)errorPage
@@ -133,21 +140,31 @@ static NSString* const kDefaultErrorPage = @"error.html";
         return NO;
     }
     
-    // Sanity check local URLs against absolute URL values.
-    if (self.isLocal && self.startPageIsAbsoluteUrl) {
-        [[self class] createError:error withCode:SFSDKHybridAppConfigErrorCodeLocalPageAbsoluteURL message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorLocalAbsoluteURL"]];
+    // startPage must be a relative URL.
+    if ([[self class] urlStringIsAbsolute:self.startPage]) {
+        [[self class] createError:error withCode:SFSDKHybridAppConfigErrorCodeStartPageAbsoluteURL message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorStartPageAbsoluteURL"]];
         return NO;
     }
     
-    // Start page makeup for remote apps beyond this point is subject to conditional configuration.
+    // unauthenticatedStartPage doesn't make sense in a local setup.  Warn accordingly.
+    if (self.isLocal && self.unauthenticatedStartPage.length > 0) {
+        [SFSDKHybridLogger w:[self class] format:@"%@ %@ set for local app, but it will never be used.", NSStringFromSelector(_cmd), kUnauthenticatedStartPage];
+    }
     
-    if (!self.isLocal && self.shouldAuthenticate && self.startPageIsAbsoluteUrl) {
-        [[self class] createError:error withCode:SFSDKHybridAppConfigErrorCodeAbsoluteURLNoAuth message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorAbsoluteURLNoAuth"]];
+    // unauthenticatedStartPage doesn't make sense in a remote setup with authentication.  Warn accordingly.
+    if (!self.isLocal && self.shouldAuthenticate && self.unauthenticatedStartPage.length > 0) {
+        [SFSDKHybridLogger w:[self class] format:@"%@ %@ set for remote app with authentication, but it will never be used.", NSStringFromSelector(_cmd), kUnauthenticatedStartPage];
+    }
+    
+    // Lack of unauthenticatedStartPage with remote deferred authentication is an error.
+    if (!self.isLocal && !self.shouldAuthenticate && self.unauthenticatedStartPage.length == 0) {
+        [[self class] createError:error withCode:SFSDKHybridAppConfigErrorCodeNoUnauthenticatedStartPage message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorNoUnauthenticatedStartPage"]];
         return NO;
     }
     
-    if (!self.isLocal && !self.shouldAuthenticate && !self.startPageIsAbsoluteUrl) {
-        [[self class] createError:error withCode:SFSDKHybridAppConfigErrorCodeRelativeURLAuth message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorRelativeURLAuth"]];
+    // unauthenticatedStartPage, if present, must be an absolute URL.
+    if (self.unauthenticatedStartPage.length > 0 && ![[self class] urlStringIsAbsolute:self.unauthenticatedStartPage]) {
+        [[self class] createError:error withCode:SFSDKHybridAppConfigErrorCodeUnauthenticatedStartPageNotAbsoluteURL message:[SFSDKResourceUtils localizedString:@"appConfigValidationErrorUnauthenticatedStartPageNotAbsoluteURL"]];
         return NO;
     }
     
@@ -181,6 +198,12 @@ static NSString* const kDefaultErrorPage = @"error.html";
     }
     NSDictionary *jsonDict = [SFJsonUtils objectFromJSONData:fileContents];
     return jsonDict;
+}
+
++ (BOOL)urlStringIsAbsolute:(NSString *)urlString
+{
+    NSAssert(urlString.length > 0, @"urlString parameter is required.");
+    return ([urlString hasPrefix:@"http://"] || [urlString hasPrefix:@"https://"]);
 }
 
 - (void)setConfigDefaults

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -249,7 +249,9 @@ SFSDK_USE_DEPRECATED_BEGIN
     }
 
     // Remote app. Device is online.
-    [SFSDKWebViewStateManager resetSessionCookie];
+    if ([self userIsAuthenticated]) {
+        [SFSDKWebViewStateManager resetSessionCookie];
+    }
     [self configureRemoteStartPage];
     [super viewDidLoad];
 }
@@ -511,10 +513,17 @@ SFSDK_USE_DEPRECATED_BEGIN
     
     // Note: You only want this to ever run once in the view controller's lifetime.
     static BOOL startPageConfigured = NO;
-    if (!_hybridViewConfig.startPageIsAbsoluteUrl && _hybridViewConfig.shouldAuthenticate) {
-        self.startPage = [[self frontDoorUrlWithReturnUrl:self.startPage returnUrlIsEncoded:NO createAbsUrl:YES] absoluteString];
+    if ([self userIsAuthenticated]) {
+        self.startPage = [[self frontDoorUrlWithReturnUrl:_hybridViewConfig.startPage returnUrlIsEncoded:NO createAbsUrl:YES] absoluteString];
+    } else {
+        self.startPage = _hybridViewConfig.unauthenticatedStartPage;
     }
     startPageConfigured = YES;
+}
+
+- (BOOL)userIsAuthenticated
+{
+    return ([SFUserAccountManager sharedInstance].currentUser.credentials.accessToken.length > 0);
 }
 
 - (void) webView:(WKWebView *) webView didStartProvisionalNavigation:(WKNavigation *) navigation

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDKTests/SFHybridViewConfigTestSuite.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDKTests/SFHybridViewConfigTestSuite.m
@@ -1,0 +1,81 @@
+/*
+ Copyright (c) 2017-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "SFHybridViewConfig.h"
+
+@interface SFHybridViewConfigTestSuite : XCTestCase
+
+@property (nonnull, nonatomic, strong) SFHybridViewConfig *hybridViewConfig;
+
+@end
+
+@implementation SFHybridViewConfigTestSuite
+
+- (void)setUp {
+    [super setUp];
+    [self setupHybridViewConfig];
+}
+
+- (void)testStartPageMustExist {
+    self.hybridViewConfig.startPage = @"";
+    [self validateViewConfigWithErrorCode:SFSDKHybridAppConfigErrorCodeNoStartPage];
+}
+
+- (void)testStartPageIsRelativeUrl {
+    self.hybridViewConfig.startPage = @"https://www.example.com";
+    [self validateViewConfigWithErrorCode:SFSDKHybridAppConfigErrorCodeStartPageAbsoluteURL];
+}
+
+- (void)testUnauthenticatedStartPageIsAbsoluteURL {
+    self.hybridViewConfig.unauthenticatedStartPage = @"/blah.html";
+    [self validateViewConfigWithErrorCode:SFSDKHybridAppConfigErrorCodeUnauthenticatedStartPageNotAbsoluteURL];
+}
+
+- (void)testRemoteWithDeferredAuthNoUnauthenticatedStartPage {
+    self.hybridViewConfig.isLocal = NO;
+    self.hybridViewConfig.shouldAuthenticate = NO;
+    self.hybridViewConfig.unauthenticatedStartPage = nil;
+    [self validateViewConfigWithErrorCode:SFSDKHybridAppConfigErrorCodeNoUnauthenticatedStartPage];
+}
+
+#pragma mark - Private methods
+
+- (void)setupHybridViewConfig {
+    self.hybridViewConfig = [[SFHybridViewConfig alloc] init];
+    self.hybridViewConfig.remoteAccessConsumerKey = @"testConsumerKey";
+    self.hybridViewConfig.oauthRedirectURI = @"test:///redirectUri";
+    self.hybridViewConfig.oauthScopes = [NSSet setWithArray:@[ @"web", @"api" ]];
+}
+
+- (void)validateViewConfigWithErrorCode:(SFSDKHybridAppConfigErrorCode)expectedCode {
+    NSError *configError = nil;
+    BOOL validateResult = [self.hybridViewConfig validate:&configError];
+    XCTAssertFalse(validateResult, @"Validation should have failed.");
+    XCTAssertNotNil(configError, @"Should be a validation error.");
+    XCTAssertEqualObjects(configError.domain, SFSDKAppConfigErrorDomain, @"Wrong error domain.");
+    XCTAssertEqual(configError.code, expectedCode, @"Wrong error code.");
+}
+
+@end

--- a/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
+++ b/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
@@ -77,7 +77,9 @@
 "appConfigValidationErrorNoRedirectURI" = "Your app config does not specify a Connected App Redirect URI.";
 "appConfigValidationErrorNoOAuthScopes" = "Your app config does not specify any Connected App OAuth Scopes.";
 "appConfigValidationErrorNoStartPage" = "No start page configured.";
-"appConfigValidationErrorLocalAbsoluteURL" = "Local start page should not be absolute URL.";
+"appConfigValidationErrorStartPageAbsoluteURL" = "Start page should not be absolute URL.";
+"appConfigValidationErrorUnauthenticatedStartPageNotAbsoluteURL" = "Unauthenticated start page should be absolute URL.";
+"appConfigValidationErrorNoUnauthenticatedStartPage" = "Unauthenticated start page required for remote app with deferred authentication.";
 "appConfigValidationErrorAbsoluteURLNoAuth" = "Cannot authenticate using an absolute URL for start page.";
 "appConfigValidationErrorRelativeURLAuth" = "Cannot configure relative URL start page with deferred authentication.";
 


### PR DESCRIPTION
Per our updated requirements for deferred authentication in hybrid remote apps:

- New property introduced to bootconfig: `unauthenticatedStartPage`.
    - Required for deferred authentication in hybrid remote apps.
    - Ignored in other configurations (local, remote apps with authentication configured.  Framework will log a warning message in these cases).
    - Must be an absolute URL, if present.
    - Use of `unauthenticatedStartPage` vs. `startPage` in a remote app with deferred authentication will be based on the internal authentication state of a user.
        - If a user has not authenticated, the unauthenticated page will be loaded.
        - If the user has authenticated, the original start page will be used.
- Existing `startPage` property represents the "authenticated" path for remote apps, and all paths for local apps.
    - This property is always required.
    - The URL value must be relative.