### PR TITLE
Add cancel button to SFLoginViewController

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -43,5 +43,6 @@
 - (void)presentSnapshot;
 - (BOOL)isSnapshotPresented;
 - (void)dismissSnapshot;
+- (void)cancelLaunch;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -256,6 +256,12 @@ static NSString* ailtnAppName = nil;
     return YES;
 }
 
+- (void)cancelLaunch
+{
+    [self logoutCleanup];
+    [self authValidatedToPostAuth: SFSDKLaunchActionNone];
+}
+
 + (NSString *)launchActionsStringRepresentation:(SFSDKLaunchAction)launchActions
 {
     if (launchActions == SFSDKLaunchActionNone)

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.h
@@ -80,6 +80,9 @@
 /** Specifiy the visibility of the settings icon. This property will be used to hide/show the settings icon*/
 @property (nonatomic) BOOL showSettingsIcon;
 
+/** Specifiy the visibility of the cancel button. This property will be used to hide/show the cancel button*/
+@property (nonatomic) BOOL showCancelButton;
+
 /** Applies the view's style attributes to the given navigation bar.
  @param navigationBar The navigation bar that the style is applied to.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -35,6 +35,7 @@
 #import "SFSDKResourceUtils.h"
 #import "SFUserAccountManager.h"
 #import "SFAuthenticationManager.h"
+#import "SalesforceSDKManager+Internal.h"
 
 
 @interface SFLoginViewController () <SFSDKLoginHostDelegate, SFUserAccountManagerDelegate>
@@ -99,6 +100,7 @@
         [self styleNavigationBar:self.navBar];
     }
     [self setupBackButton];
+    [self setupCancelButton];
 }
 
 - (BOOL)prefersStatusBarHidden {
@@ -146,6 +148,18 @@
 - (BOOL)shouldShowBackButton {
     NSInteger totalAccounts = [SFUserAccountManager sharedInstance].allUserAccounts.count;
     return  (totalAccounts > 0);
+}
+
+- (void)setupCancelButton {
+    if (self.showCancelButton) {
+        self.navBar.topItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelButtonPressed)];
+    }
+}
+
+- (void)cancelButtonPressed {
+    [[SalesforceSDKManager sharedManager] cancelLaunch];
+    [[SFAuthenticationManager sharedManager] cancelAuthentication];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 #pragma mark - Action Methods

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Classes/AppDelegate.m
@@ -91,6 +91,8 @@ static NSString * const OAuthRedirectURI        = @"com.salesforce.mobilesdk.sam
     //Uncomment the code below to see how you can customize the color, textcolor, font and fontsize of the navigation bar
     //
     //SFLoginViewController *loginViewController = [SFLoginViewController sharedInstance];
+    // Set showCancelButton to YES if you want to display cancel button
+    //loginViewController.showCancelButton = YES;
     //Set showNavBar to NO if you want to hide the top bar
     //loginViewController.showNavbar = YES;
     //Set showSettingsIcon to NO if you want to hide the settings icon on the nav bar


### PR DESCRIPTION
This PR adds "Cancel" button to `SFLoginViewController`.

Not sure if this is the right way to handle cancel though: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/2250/files#diff-5aa06873c6730e588a76ee1b49c40960R261