### PR TITLE
Removing malformed Xcode check

### DIFF
--- a/shared/common/build/tools/generate_headers.sh
+++ b/shared/common/build/tools/generate_headers.sh
@@ -48,12 +48,6 @@ shift $((OPTIND-1))
 
 [[ -z $OPT_OUTPUT ]] && usage "You must specify an output filename"
 
-if [[ 0$XCODE_VERSION_MINOR -lt 0400 ]]; then
-    if [[ $OPT_FORCE -ne 1 ]]; then
-        usage "Generating headers needs to be run from within an Xcode shell environment"
-    fi
-fi
-
 if [[ -z $OPT_NAME ]]; then
     OPT_NAME=$(basename "$OPT_OUTPUT" | awk -F. '{print $1}')
 fi


### PR DESCRIPTION
This one was driving me crazy.  The check is inadvertently for an octal value, which is fine until you get into values greater than 7.  Given that this check was for some ancient version of Xcode, I simply removed it.