### PR TITLE
 Refactor implementation for NSMutableCopying on context

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.m
@@ -118,7 +118,6 @@
 - (void)beginIDPInitiatedFlow:(SFSDKIDPInitCommand *)command {
     // If no userHint then show selection dialog else Launch IDP App with the hint
     SFSDKMutableOAuthClientContext *context = [self.context mutableCopy];
-    context.currentCommand = command;
     context.userHint = command.userHint;
     self.context = context;
     [self initiateIDPFlowInSPApp];
@@ -128,7 +127,6 @@
     // Should begin IDP Flow in the IDP App?
     self.config.hideSettingsIcon = YES;
     SFSDKMutableOAuthClientContext *context = [self.context mutableCopy];
-    context.currentCommand = request;
     self.context = context;
     [super refreshCredentials];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientContext.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientContext.h
@@ -28,6 +28,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "SFOAuthInfo.h"
 #import "SFOAuthCoordinator.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -70,22 +71,22 @@ typedef void (^SFIdentityFailureCallbackBlock)(SFSDKOAuthClient *,NSError *);
 /** Object representing state of a current authentication context. Provides a means to isolate individual authentication requests
  */
 @interface SFSDKOAuthClientContext : NSObject <NSCopying, NSMutableCopying>
-
 @property (nonatomic, strong, readonly) SFOAuthCredentials *credentials;
 @property (nonatomic, strong, readonly) SFOAuthInfo *authInfo;
 @property (nonatomic, strong, readonly) NSError *authError;
-@property (nonatomic, copy) NSString *userHint;
-@property (nonatomic, strong) SFSDKAuthCommand *currentCommand;
+@property (nonatomic, copy,readonly) NSString *userHint;
 @property (nonatomic,strong,readonly) NSDictionary *callingAppOptions;
-
+- (instancetype)initWithAuthType:(SFOAuthType)oauthType;
 @end
 
 @interface SFSDKMutableOAuthClientContext : SFSDKOAuthClientContext
+
 @property (nonatomic, readwrite, nullable) SFOAuthCredentials *credentials;
 @property (nonatomic, strong, readwrite, nullable) SFOAuthInfo *authInfo;
 @property (nonatomic, strong, readwrite, nullable) NSError *authError;
-@property (nonatomic, strong, readwrite, nullable) SFSDKAuthCommand *currentCommand;
-@property (nonatomic,strong,nonnull) NSDictionary *callingAppOptions;
+@property (nonatomic, copy,readwrite) NSString *userHint;
+@property (nonatomic,strong,readwrite,nonnull) NSDictionary *callingAppOptions;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientContext.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientContext.m
@@ -31,22 +31,26 @@
 #import "SFSDKAuthCommand.h"
 
 @interface SFSDKOAuthClientContext()
-@property (nonatomic, strong) SFOAuthCredentials *credentials;
-@property (nonatomic, strong) SFOAuthInfo *authInfo;
-@property (nonatomic, strong) NSError *authError;
-@property (nonatomic, strong) NSDictionary *callingAppOptions;
+@property (nonatomic, strong,readwrite) SFOAuthCredentials *credentials;
+@property (nonatomic, strong,readwrite) SFOAuthInfo *authInfo;
+@property (nonatomic, strong,readwrite) NSError *authError;
+@property (nonatomic, strong,readwrite) NSDictionary *callingAppOptions;
+@property (nonatomic,copy,readwrite) NSString *userHint;
+@property (nonatomic,strong,readwrite) SFSDKAuthCommand *currentCommand;
 @end
 
 @implementation SFSDKOAuthClientContext
 
+- (instancetype)initWithAuthType:(SFOAuthType)oauthType {
+    if (self = [super init]) {
+        self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:oauthType];
+        self.callingAppOptions = [[NSDictionary alloc] initWithDictionary:self.callingAppOptions copyItems:YES];
+    }
+    return self;
+}
+
 - (id)copyWithZone:(NSZone *)zone {
-    SFSDKOAuthClientContext *ctx = [[[self class] allocWithZone:zone] init];
-    ctx.authError = [self.authError copyWithZone:zone];
-    ctx.authInfo = [[SFOAuthInfo allocWithZone:zone] initWithAuthType:self.authInfo.authType];
-    ctx.credentials = [self.credentials copyWithZone:zone];
-    ctx.callingAppOptions = [[NSDictionary alloc] initWithDictionary:self.callingAppOptions copyItems:YES];
-    
-    return ctx;
+    return self;
 }
 
 - (id)mutableCopyWithZone:(NSZone *)zone {
@@ -54,7 +58,7 @@
     ctx.authError = [self.authError copyWithZone:zone];
     ctx.authInfo = [[SFOAuthInfo allocWithZone:zone] initWithAuthType:self.authInfo.authType];
     ctx.credentials = [self.credentials copyWithZone:zone];
-    ctx.currentCommand = [self.currentCommand copy];
+    ctx.userHint = self.userHint;
     ctx.callingAppOptions = [[NSDictionary alloc] initWithDictionary:self.callingAppOptions copyItems:YES];
     return ctx;
 }
@@ -62,20 +66,9 @@
 @end
 
 @implementation SFSDKMutableOAuthClientContext
-
 @dynamic credentials;
 @dynamic authError;
 @dynamic authInfo;
-@dynamic currentCommand;
 @dynamic callingAppOptions;
-
-- (id)mutableCopyWithZone:(NSZone *)zone {
-    SFSDKMutableOAuthClientContext *mutableContext = [[SFSDKMutableOAuthClientContext alloc] init];
-    mutableContext.authError = [self.authError copyWithZone:zone];
-    mutableContext.authInfo =  [[SFOAuthInfo allocWithZone:zone] initWithAuthType:self.authInfo.authType];
-    mutableContext.credentials =  [self.credentials copyWithZone:zone];
-    mutableContext.currentCommand = [self.currentCommand copy];
-    mutableContext.callingAppOptions = [[NSDictionary alloc] initWithDictionary:self.callingAppOptions copyItems:YES];
-    return mutableContext;
-}
+@dynamic userHint;
 @end


### PR DESCRIPTION
Fixed implementation for NSMutableCopying on context. There was no need to copy for immutable  object. Also removed redundant copy code. 