### PR TITLE
Updated user agent to include web user agent

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -893,7 +893,7 @@ static NSString* ailtnAppName = nil;
         // App type.
         NSString *appTypeStr = [self getAppTypeAsString];
         NSString *myUserAgent = [NSString stringWithFormat:
-                                 @"SalesforceMobileSDK/%@ %@/%@ (%@) %@/%@ %@%@ uid_%@ ftr_%@",
+                                 @"SalesforceMobileSDK/%@ %@/%@ (%@) %@/%@ %@%@ uid_%@ ftr_%@ %@",
                                  SALESFORCE_SDK_VERSION,
                                  [curDevice systemName],
                                  [curDevice systemVersion],
@@ -904,7 +904,7 @@ static NSString* ailtnAppName = nil;
                                  (qualifier != nil ? qualifier : @""),
                                  uid,
                                  [[[SFSDKAppFeatureMarkers appFeatures].allObjects sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)] componentsJoinedByString:@"."],
-                                 webViewUserAgent,
+                                 webViewUserAgent
                                  ];
         return myUserAgent;
     };

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -888,6 +888,7 @@ static NSString* ailtnAppName = nil;
         NSString *prodAppVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
         NSString *buildNumber = [[NSBundle mainBundle] infoDictionary][(NSString*)kCFBundleVersionKey];
         NSString *appVersion = [NSString stringWithFormat:@"%@(%@)", prodAppVersion, buildNumber];
+        NSString *webViewUserAgent = [self getUIWebViewUserAgent];
 
         // App type.
         NSString *appTypeStr = [self getAppTypeAsString];
@@ -902,10 +903,36 @@ static NSString* ailtnAppName = nil;
                                  appTypeStr,
                                  (qualifier != nil ? qualifier : @""),
                                  uid,
-                                 [[[SFSDKAppFeatureMarkers appFeatures].allObjects sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)] componentsJoinedByString:@"."]
+                                 [[[SFSDKAppFeatureMarkers appFeatures].allObjects sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)] componentsJoinedByString:@"."],
+                                 webViewUserAgent,
                                  ];
         return myUserAgent;
     };
+}
+
+- (NSString *)getUIWebViewUserAgent {
+    static NSString *webViewUserAgent = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once_on_main_thread(&onceToken, ^{
+        // Grabs the current user agent. This is very hackish but WKWebView, which we
+        // want to transition too currently evaluates Javscript asynchronously (11/2/17)
+        UIWebView *webView = [[UIWebView alloc] initWithFrame:CGRectZero];
+        webViewUserAgent = [webView stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"];
+    });
+    
+    return webViewUserAgent;
+}
+
+void dispatch_once_on_main_thread(dispatch_once_t *predicate, dispatch_block_t block) {
+    if ([NSThread isMainThread]) {
+        dispatch_once(predicate, block);
+    } else {
+        if (DISPATCH_EXPECT(*predicate == 0L, NO)) {
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                dispatch_once(predicate, block);
+            });
+        }
+    }
 }
 
 - (NSString *)getAppTypeAsString {


### PR DESCRIPTION
This update is to append a web user agent to the default user agent making it more robust. Currently it uses the UIWebView because the WKWebView evaluates Javascript asynchronously, which would probably require us to use a semaphore and wait on the value. So for now we are using a hack-y method with UIWebView. 