### PR TITLE
Fix format: log lines

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SDKInfo/SFSDKInfoPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SDKInfo/SFSDKInfoPlugin.m
@@ -79,13 +79,13 @@ static NSString * const kAppFeatureKey   = @"feature";
         NSDictionary *pluginsMap = vc.pluginsMap;
         for (__strong NSString *key in [pluginsMap allKeys]) {
             key = [key lowercaseString];
-            [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"key=%@", key]];
+            [SFSDKHybridLogger d:[self class] format:@"key=%@", key];
             if ([key hasPrefix:kForcePluginPrefix]) {
                 [services addObject:key];
             }
         }
     } else {
-        [SFSDKHybridLogger e:[self class] format:[NSString stringWithFormat:@"??? Expected CDVViewController class for plugin's view controller. Got '%@'.", NSStringFromClass([self.viewController class])]];
+        [SFSDKHybridLogger e:[self class] format:@"??? Expected CDVViewController class for plugin's view controller. Got '%@'.", NSStringFromClass([self.viewController class])];
     }
     return services;
 }

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFAccountManagerPlugin/SFAccountManagerPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFAccountManagerPlugin/SFAccountManagerPlugin.m
@@ -59,7 +59,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (void)getUsers:(CDVInvokedUrlCommand *)command
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"getUsers: arguments: %@", command.arguments]];
+    [SFSDKHybridLogger d:[self class] format:@"getUsers: arguments: %@", command.arguments];
     NSString* callbackId = command.callbackId;
     [self getVersion:@"getUsers" withArguments:command.arguments];
     NSMutableArray *userAccountArray = [NSMutableArray array];
@@ -72,7 +72,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (void)getCurrentUser:(CDVInvokedUrlCommand *)command
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"getCurrentUser: arguments: %@", command.arguments]];
+    [SFSDKHybridLogger d:[self class] format:@"getCurrentUser: arguments: %@", command.arguments];
     NSString* callbackId = command.callbackId;
     /* NSString* jsVersionStr = */[self getVersion:@"getCurrentUser" withArguments:command.arguments];
     
@@ -87,7 +87,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (void)switchToUser:(CDVInvokedUrlCommand *)command
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"switchToUser: arguments: %@", command.arguments]];
+    [SFSDKHybridLogger d:[self class] format:@"switchToUser: arguments: %@", command.arguments];
     [self getVersion:@"switchToUser" withArguments:command.arguments];
     NSDictionary *argsDict = [self getArgument:command.arguments atIndex:0];
     if (argsDict == nil) {
@@ -112,14 +112,14 @@ SFSDK_USE_DEPRECATED_BEGIN
         NSString *orgId = [argsDict nonNullObjectForKey:kUserAccountOrgIdDictKey];
         SFUserAccountIdentity *accountIdentity = [SFUserAccountIdentity identityWithUserId:userId orgId:orgId];
         SFUserAccount *account = [[SFUserAccountManager sharedInstance] userAccountForUserIdentity:accountIdentity];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"switchToUser: Switching to user account: %@", account]];
+        [SFSDKHybridLogger d:[self class] format:@"switchToUser: Switching to user account: %@", account];
         [[SFUserAccountManager sharedInstance] switchToUser:account];
     }
 }
 
 - (void)logout:(CDVInvokedUrlCommand *)command;
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"logout: arguments: %@", command.arguments]];
+    [SFSDKHybridLogger d:[self class] format:@"logout: arguments: %@", command.arguments];
     NSString *callbackId = command.callbackId;
     [self getVersion:@"logout" withArguments:command.arguments];
     NSDictionary *argsDict = [self getArgument:command.arguments atIndex:0];
@@ -128,10 +128,10 @@ SFSDK_USE_DEPRECATED_BEGIN
     SFUserAccountIdentity *accountIdentity = [SFUserAccountIdentity identityWithUserId:userId orgId:orgId];
     SFUserAccount *account = [[SFUserAccountManager sharedInstance] userAccountForUserIdentity:accountIdentity];
     if (account == nil || account == [SFUserAccountManager sharedInstance].currentUser) {
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"logout: Logging out current user.  App state will reset."]];
+        [SFSDKHybridLogger d:[self class] message:@"logout: Logging out current user.  App state will reset."];
         [self logout];
     } else {
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"logout: Logging out user account: %@", account]];
+        [SFSDKHybridLogger d:[self class] format:@"logout: Logging out user account: %@", account];
         [self logoutUser:account];
         CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFAdditions/CDVPlugin+SFAdditions.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFAdditions/CDVPlugin+SFAdditions.m
@@ -57,7 +57,7 @@ NSString * const kPluginSDKVersion = @"pluginSDKVersion";
     if ([self hasVersion:arguments]) {
         jsVersionStr = [arguments[0] substringFromIndex:([kPluginSDKVersion length] + 1)];
     }
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"%@ jsVersion:%@ ", action, jsVersionStr]];
+    [SFSDKHybridLogger d:[self class] format:@"%@ jsVersion:%@ ", action, jsVersionStr];
     return jsVersionStr;
 }
 

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFForcePlugin/SFForcePlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFForcePlugin/SFForcePlugin.m
@@ -33,12 +33,12 @@
     NSString* callbackId = command.callbackId;
     [self getVersion:command.methodName withArguments:command.arguments];
     NSDictionary *argsDict = [self getArgument:command.arguments atIndex:0];
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"%@ called.", command.methodName]];
+    [SFSDKHybridLogger d:[self class] format:@"%@ called.", command.methodName];
     __weak typeof(self) weakSelf = self;
     [self.commandDelegate runInBackground:^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
         CDVPluginResult* result = block(argsDict);
-        [SFSDKHybridLogger d:[strongSelf class] format:[NSString stringWithFormat:@"%@ returning after %f secs.", command.methodName, -[startTime timeIntervalSinceNow]]];
+        [SFSDKHybridLogger d:[strongSelf class] format:@"%@ returning after %f secs.", command.methodName, -[startTime timeIntervalSinceNow]];
         [strongSelf.commandDelegate sendPluginResult:result callbackId:callbackId];
     }];
 }

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFOAuthPlugin/SalesforceOAuthPlugin.m
@@ -37,7 +37,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (void)getAuthCredentials:(CDVInvokedUrlCommand *)command
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"getAuthCredentials: arguments: %@", command.arguments]];
+    [SFSDKHybridLogger d:[self class] format:@"getAuthCredentials: arguments: %@", command.arguments];
     [self getVersion:@"getAuthCredentials" withArguments:command.arguments];
 
     SFHybridViewController *hybridVc = (SFHybridViewController *)self.viewController;
@@ -51,7 +51,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (void)authenticate:(CDVInvokedUrlCommand*)command
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"authenticate: arguments: %@", command.arguments]];
+    [SFSDKHybridLogger d:[self class] format:@"authenticate: arguments: %@", command.arguments];
     [self getVersion:@"authenticate" withArguments:command.arguments];
 
     SFOAuthPluginAuthSuccessBlock completionBlock = ^(SFOAuthInfo *authInfo, NSDictionary *authDict) {
@@ -69,19 +69,19 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (void)logoutCurrentUser:(CDVInvokedUrlCommand *)command
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"logoutCurrentUser: arguments: %@", command.arguments]];
+    [SFSDKHybridLogger d:[self class] format:@"logoutCurrentUser: arguments: %@", command.arguments];
     [self getVersion:@"logoutCurrentUser" withArguments:command.arguments];
     [[SFAuthenticationManager sharedManager] logout];
 }
 
 - (void)getAppHomeUrl:(CDVInvokedUrlCommand *)command
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"getAppHomeUrl: arguments: %@", command.arguments]];
+    [SFSDKHybridLogger d:[self class] format:@"getAppHomeUrl: arguments: %@", command.arguments];
     NSString* callbackId = command.callbackId;
     [self getVersion:@"getAppHomeUrl" withArguments:command.arguments];
     NSURL *url = ((SFHybridViewController *)self.viewController).appHomeUrl;
     NSString *urlString = (url == nil ? @"" : [url absoluteString]);
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"AppHomeURL: %@", urlString]];
+    [SFSDKHybridLogger d:[self class] format:@"AppHomeURL: %@", urlString];
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:urlString];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
 }

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
@@ -71,7 +71,7 @@ NSString * const kStoreName           = @"storeName";
 
 - (void)pluginInitialize
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"SFSmartStorePlugin pluginInitialize"]];
+    [SFSDKHybridLogger d:[self class] message:@"SFSmartStorePlugin pluginInitialize"];
     self.cursorCache = [[NSMutableDictionary alloc] init];
     _dispatchQueue = dispatch_queue_create([@"SFSmartStorePlugin CursorCache Queue" UTF8String], DISPATCH_QUEUE_SERIAL);
 }
@@ -106,7 +106,7 @@ NSString * const kStoreName           = @"storeName";
 {
     [self runCommand:^(NSDictionary* argsDict) {
         NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgSoupExists with soup name '%@'.", soupName]];
+        [SFSDKHybridLogger d:[self class] format:@"pgSoupExists with soup name '%@'.", soupName];
         BOOL exists = [[self getStoreInst:argsDict] soupExists:soupName];
         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:exists];
     } command:command];
@@ -126,7 +126,7 @@ NSString * const kStoreName           = @"storeName";
             soupSpec = [SFSoupSpec newSoupSpec:soupName withFeatures:nil];
         }
         NSArray *indexSpecs = [SFSoupIndex asArraySoupIndexes:[argsDict nonNullObjectForKey:kIndexesArg]];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgRegisterSoup with name: %@, soup features: %@, indexSpecs: %@", soupSpec.soupName, soupSpec.features, indexSpecs]];
+        [SFSDKHybridLogger d:[self class] format:@"pgRegisterSoup with name: %@, soup features: %@, indexSpecs: %@", soupSpec.soupName, soupSpec.features, indexSpecs];
         if (smartStore) {
             NSError *error = nil;
             BOOL result = [smartStore registerSoupWithSpec:soupSpec withIndexSpecs:indexSpecs error:&error];
@@ -147,7 +147,7 @@ NSString * const kStoreName           = @"storeName";
 {
     [self runCommand:^(NSDictionary* argsDict) {
         NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgRemoveSoup with name: %@", soupName]];
+        [SFSDKHybridLogger d:[self class] format:@"pgRemoveSoup with name: %@", soupName];
         [[self getStoreInst:argsDict] removeSoup:soupName];
         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"OK"];
     } command:command];
@@ -169,7 +169,7 @@ NSString * const kStoreName           = @"storeName";
             });
             return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[cursor asDictionary]];
         } else {
-            [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"No cursor for query: %@", querySpec]];
+            [SFSDKHybridLogger d:[self class] format:@"No cursor for query: %@", querySpec];
             return [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
         }
     } command:command];
@@ -201,7 +201,7 @@ NSString * const kStoreName           = @"storeName";
     [self runCommand:^(NSDictionary* argsDict) {
         NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
         NSArray *rawIds = [argsDict nonNullObjectForKey:kEntryIdsArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgRetrieveSoupEntries with soup name: %@", soupName]];
+        [SFSDKHybridLogger d:[self class] format:@"pgRetrieveSoupEntries with soup name: %@", soupName];
         NSArray *entries = [[self getStoreInst:argsDict] retrieveEntries:rawIds fromSoup:soupName];
         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:entries];
     } command:command];
@@ -213,7 +213,7 @@ NSString * const kStoreName           = @"storeName";
         NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
         NSArray *entries = [argsDict nonNullObjectForKey:kEntriesArg];
         NSString *externalIdPath = [argsDict nonNullObjectForKey:kExternalIdPathArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgUpsertSoupEntries with soup name: %@, external ID path: %@", soupName, externalIdPath]];
+        [SFSDKHybridLogger d:[self class] format:@"pgUpsertSoupEntries with soup name: %@, external ID path: %@", soupName, externalIdPath];
         NSError *error = nil;
         NSArray *resultEntries = [[self getStoreInst:argsDict] upsertEntries:entries toSoup:soupName withExternalIdPath:externalIdPath error:&error];
         if (nil != resultEntries) {
@@ -230,7 +230,7 @@ NSString * const kStoreName           = @"storeName";
         NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
         NSArray *entryIds = [argsDict nonNullObjectForKey:kEntryIdsArg];
         NSDictionary *querySpecDict = [argsDict nonNullObjectForKey:kQuerySpecArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgRemoveFromSoup with soup name: %@", soupName]];
+        [SFSDKHybridLogger d:[self class] format:@"pgRemoveFromSoup with soup name: %@", soupName];
         NSError *error = nil;
         if (entryIds) {
             [[self getStoreInst:argsDict] removeEntries:entryIds fromSoup:soupName error:&error];
@@ -252,7 +252,7 @@ NSString * const kStoreName           = @"storeName";
 {
     [self runCommand:^(NSDictionary* argsDict) {
         NSString *cursorId = [argsDict nonNullObjectForKey:kCursorIdArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgCloseCursor with cursor ID: %@", cursorId]];
+        [SFSDKHybridLogger d:[self class] format:@"pgCloseCursor with cursor ID: %@", cursorId];
         [self closeCursorWithId:cursorId withArgs:argsDict];
         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"OK"];
     } command:command];
@@ -263,7 +263,7 @@ NSString * const kStoreName           = @"storeName";
     [self runCommand:^(NSDictionary* argsDict) {
         NSString *cursorId = [argsDict nonNullObjectForKey:kCursorIdArg];
         NSNumber *newPageIndex = [argsDict nonNullObjectForKey:kIndexArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgMoveCursorToPageIndex with cursor ID: %@, page index: %@", cursorId, newPageIndex]];
+        [SFSDKHybridLogger d:[self class] format:@"pgMoveCursorToPageIndex with cursor ID: %@, page index: %@", cursorId, newPageIndex];
         SFStoreCursor *cursor = [self cursorByCursorId:cursorId withArgs:argsDict];
         [cursor setCurrentPageIndex:newPageIndex];
         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[cursor asDictionary]];
@@ -274,7 +274,7 @@ NSString * const kStoreName           = @"storeName";
 {
     [self runCommand:^(NSDictionary* argsDict) {
         NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgClearSoup with name: %@", soupName]];
+        [SFSDKHybridLogger d:[self class] format:@"pgClearSoup with name: %@", soupName];
         [[self getStoreInst:argsDict] clearSoup:soupName];
         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"OK"];
     } command:command];
@@ -306,7 +306,7 @@ NSString * const kStoreName           = @"storeName";
         }
         NSArray *indexSpecs = [SFSoupIndex asArraySoupIndexes:[argsDict nonNullObjectForKey:kIndexesArg]];
         BOOL reIndexData = [[argsDict nonNullObjectForKey:kReIndexDataArg] boolValue];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgAlterSoup with name: %@, soup features: %@, indexSpecs: %@, reIndexData: %@", soupName, soupSpec.features, indexSpecs, reIndexData ? @"true" : @"false"]];
+        [SFSDKHybridLogger d:[self class] format:@"pgAlterSoup with name: %@, soup features: %@, indexSpecs: %@, reIndexData: %@", soupName, soupSpec.features, indexSpecs, reIndexData ? @"true" : @"false"];
         BOOL alterOk = [[self getStoreInst:argsDict] alterSoup:soupName withSoupSpec:soupSpec withIndexSpecs:indexSpecs reIndexData:reIndexData];
         if (alterOk) {
             return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:soupName];
@@ -321,7 +321,7 @@ NSString * const kStoreName           = @"storeName";
     [self runCommand:^(NSDictionary* argsDict) {
         NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
         NSArray *indexPaths = [argsDict nonNullObjectForKey:kPathsArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgReIndexSoup with soup name: %@, indexPaths: %@", soupName, indexPaths]];
+        [SFSDKHybridLogger d:[self class] format:@"pgReIndexSoup with soup name: %@, indexPaths: %@", soupName, indexPaths];
         BOOL regOk = [[self getStoreInst:argsDict] reIndexSoup:soupName withIndexPaths:indexPaths];
         if (regOk) {
             return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:soupName];
@@ -347,7 +347,7 @@ NSString * const kStoreName           = @"storeName";
 {
     [self runCommand:^(NSDictionary* argsDict) {
         NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgGetSoupIndexSpecs with soup name: %@", soupName]];
+        [SFSDKHybridLogger d:[self class] format:@"pgGetSoupIndexSpecs with soup name: %@", soupName];
         NSArray *indexSpecsAsDicts = [SFSoupIndex asArrayOfDictionaries:[[self getStoreInst:argsDict] indicesForSoup:soupName] withColumnName:NO];
         if ([indexSpecsAsDicts count] > 0) {
             return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:indexSpecsAsDicts];
@@ -361,7 +361,7 @@ NSString * const kStoreName           = @"storeName";
     [self runCommand:^(NSDictionary* argsDict) {
         SFSmartStore *store = [self getStoreInst:argsDict];
         NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"pgGetSoupSpec with soup name: %@", soupName]];
+        [SFSDKHybridLogger d:[self class] format:@"pgGetSoupSpec with soup name: %@", soupName];
         SFSoupSpec *soupSpec = [store attributesForSoup:soupName];
         if (soupSpec) {
             return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[soupSpec asDictionary]];

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartSyncPlugin/SFSmartSyncPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartSyncPlugin/SFSmartSyncPlugin.m
@@ -64,7 +64,7 @@ NSString *const kSyncStoreNameArg = @"storeName";
                                                                  options:0 // non-pretty printing
                                                                    error:&error];
             if (error) {
-                [SFSDKHybridLogger e:[self class] format:[NSString stringWithFormat:@"JSON Parsing Error: %@", error]];
+                [SFSDKHybridLogger e:[self class] format:@"JSON Parsing Error: %@", error];
             } else {
                 NSString* detailAsString = [[NSString alloc] initWithData:detailData encoding:NSUTF8StringEncoding];
                 NSString* js = [
@@ -80,7 +80,7 @@ NSString *const kSyncStoreNameArg = @"storeName";
                 [self.commandDelegate evalJs:js];
             }
         } else {
-            [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"Invalid object passed to JSONDataRepresentation???"]];
+            [SFSDKHybridLogger d:[self class] format:@"Invalid object passed to JSONDataRepresentation???"];
         }
     });
 }
@@ -89,9 +89,9 @@ NSString *const kSyncStoreNameArg = @"storeName";
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         if (syncStatus == SFSyncStateStatusDone) {
-            [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"cleanResyncGhosts completed successfully"]];
+            [SFSDKHybridLogger d:[self class] format:@"cleanResyncGhosts completed successfully"];
         } else {
-            [SFSDKHybridLogger e:[self class] format:[NSString stringWithFormat:@"cleanResyncGhosts did not complete successfully"]];
+            [SFSDKHybridLogger e:[self class] format:@"cleanResyncGhosts did not complete successfully"];
         }
     });
 }
@@ -106,11 +106,11 @@ NSString *const kSyncStoreNameArg = @"storeName";
 
         SFSyncState *sync;
         if (syncId) {
-            [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"getSyncStatus with sync id: %@", syncId]];
+            [SFSDKHybridLogger d:[self class] format:@"getSyncStatus with sync id: %@", syncId];
             sync = [[self getSyncManagerInst:argsDict] getSyncStatus:syncId];
         }
         else if (syncName) {
-            [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"getSyncStatus with sync name: %@", syncName]];
+            [SFSDKHybridLogger d:[self class] format:@"getSyncStatus with sync name: %@", syncName];
             sync = [[self getSyncManagerInst:argsDict] getSyncStatusByName:syncName];
         }
         else {
@@ -132,11 +132,11 @@ NSString *const kSyncStoreNameArg = @"storeName";
         NSString *syncName = (NSString *) [argsDict nonNullObjectForKey:kSyncNameArg];
 
         if (syncId) {
-            [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"getSyncStatus with sync id: %@", syncId]];
+            [SFSDKHybridLogger d:[self class] format:@"getSyncStatus with sync id: %@", syncId];
             [[self getSyncManagerInst:argsDict] deleteSyncById:syncId];
         }
         else if (syncName) {
-            [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"getSyncStatus with sync name: %@", syncName]];
+            [SFSDKHybridLogger d:[self class] format:@"getSyncStatus with sync name: %@", syncName];
             [[self getSyncManagerInst:argsDict] deleteSyncByName:syncName];
         }
         else {
@@ -160,7 +160,7 @@ NSString *const kSyncStoreNameArg = @"storeName";
         SFSyncState* sync = [[self getSyncManagerInst:argsDict] syncDownWithTarget:target options:options soupName:soupName syncName:syncName updateBlock:^(SFSyncState* sync) {
             [weakSelf handleSyncUpdate:sync withArgs:argsDict];
         }];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"syncDown # %ld from soup: %@", sync.syncId, soupName]];
+        [SFSDKHybridLogger d:[self class] format:@"syncDown # %ld from soup: %@", sync.syncId, soupName];
         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[sync asDict]];
     } command:command];
 }
@@ -173,13 +173,13 @@ NSString *const kSyncStoreNameArg = @"storeName";
 
         SFSyncState *sync;
         if (syncId) {
-            [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"reSync with sync id: %@", syncId]];
+            [SFSDKHybridLogger d:[self class] format:@"reSync with sync id: %@", syncId];
             __weak typeof(self) weakSelf = self;
             sync = [[self getSyncManagerInst:argsDict] reSync:syncId updateBlock:^(SFSyncState* sync) {
                 [weakSelf handleSyncUpdate:sync withArgs:argsDict];
             }];
         } else if (syncName) {
-            [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"reSync with sync name: %@", syncName]];
+            [SFSDKHybridLogger d:[self class] format:@"reSync with sync name: %@", syncName];
             __weak typeof(self) weakSelf = self;
             sync = [[self getSyncManagerInst:argsDict] reSyncByName:syncName updateBlock:^(SFSyncState* sync) {
                 [weakSelf handleSyncUpdate:sync withArgs:argsDict];
@@ -201,7 +201,7 @@ NSString *const kSyncStoreNameArg = @"storeName";
 {
     [self runCommand:^(NSDictionary* argsDict) {
         NSNumber* syncId = (NSNumber*) [argsDict nonNullObjectForKey:kSyncIdArg];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"cleanResyncGhosts with sync id: %@", syncId]];
+        [SFSDKHybridLogger d:[self class] format:@"cleanResyncGhosts with sync id: %@", syncId];
         __weak typeof(self) weakSelf = self;
         [[self getSyncManagerInst:argsDict] cleanResyncGhosts:syncId completionStatusBlock:^(SFSyncStateStatus syncStatus) {
             [weakSelf handleGhostSyncUpdate:syncStatus];
@@ -221,7 +221,7 @@ NSString *const kSyncStoreNameArg = @"storeName";
         SFSyncState* sync = [[self getSyncManagerInst:argsDict] syncUpWithTarget:target options:options soupName:soupName syncName:syncName updateBlock:^(SFSyncState* sync) {
             [weakSelf handleSyncUpdate:sync withArgs:argsDict];
         }];
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"syncUp # %ld from soup: %@", sync.syncId, soupName]];
+        [SFSDKHybridLogger d:[self class] format:@"syncUp # %ld from soup: %@", sync.syncId, soupName];
         return [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:[sync asDict]];
     } command:command];
 }

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewConfig.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewConfig.m
@@ -180,7 +180,7 @@ static NSString* const kDefaultErrorPage = @"error.html";
 {
     NSDictionary *hybridConfigDict = [SFHybridViewConfig loadConfigFromFile:configFilePath];
     if (nil == hybridConfigDict) {
-        [SFSDKHybridLogger i:[SFHybridViewConfig class] format:[NSString stringWithFormat:@"Hybrid view config at specified path '%@' not found, or data could not be parsed.", configFilePath]];
+        [SFSDKHybridLogger i:[SFHybridViewConfig class] format:@"Hybrid view config at specified path '%@' not found, or data could not be parsed.", configFilePath];
         return nil;
     }
     SFHybridViewConfig *hybridViewConfig = [[SFHybridViewConfig alloc] initWithDict:hybridConfigDict];
@@ -193,7 +193,7 @@ static NSString* const kDefaultErrorPage = @"error.html";
     NSError *fileReadError = nil;
     NSData *fileContents = [NSData dataWithContentsOfFile:fullPath options:NSDataReadingUncached error:&fileReadError];
     if (fileContents == nil) {
-        [SFSDKHybridLogger i:[SFHybridViewConfig class] format:[NSString stringWithFormat:@"Hybrid view config at specified path '%@' could not be read: %@", configFilePath, fileReadError]];
+        [SFSDKHybridLogger i:[SFHybridViewConfig class] format:@"Hybrid view config at specified path '%@' could not be read: %@", configFilePath, fileReadError];
         return nil;
     }
     NSDictionary *jsonDict = [SFJsonUtils objectFromJSONData:fileContents];

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -311,7 +311,7 @@ SFSDK_USE_DEPRECATED_BEGIN
     SFOAuthFlowFailureCallbackBlock authFailureBlock = ^(SFOAuthInfo *authInfo, NSError *error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if ([strongSelf logoutOnInvalidCredentials:error]) {
-            [SFSDKHybridLogger d:[strongSelf class] format:[NSString stringWithFormat:@"OAuth plugin authentication request failed. Logging out."]];
+            [SFSDKHybridLogger d:[strongSelf class] message:@"OAuth plugin authentication request failed. Logging out."];
             NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
             attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
             attributes[@"errorDescription"] = error.localizedDescription;
@@ -553,13 +553,13 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (void) webView:(WKWebView *) webView decidePolicyForNavigationAction:(WKNavigationAction *) navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy)) decisionHandler
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"webView:decidePolicyForNavigationAction:decisionHandler: Loading URL '%@'",
-             [navigationAction.request.URL redactedAbsoluteString:@[@"sid"]]]];
+    [SFSDKHybridLogger d:[self class] format:@"webView:decidePolicyForNavigationAction:decisionHandler: Loading URL '%@'",
+             [navigationAction.request.URL redactedAbsoluteString:@[@"sid"]]];
     BOOL shouldAllowRequest = YES;
     if ([webView isEqual:self.vfPingPageHiddenWKWebView]) { // Hidden ping page load.
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"Setting up VF web state after plugin-based refresh."]];
+        [SFSDKHybridLogger d:[self class] message:@"Setting up VF web state after plugin-based refresh."];
     } else if ([webView isEqual:self.errorPageWKWebView]) { // Local error page load.
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"Local error page ('%@') is loading.", navigationAction.request.URL.absoluteString]];
+        [SFSDKHybridLogger d:[self class] format:@"Local error page ('%@') is loading.", navigationAction.request.URL.absoluteString];
     } else if ([webView isEqual:self.webView]) { // Cordova web view load.
 
         /*
@@ -568,7 +568,7 @@ SFSDK_USE_DEPRECATED_BEGIN
          */
         NSString *refreshUrl = [self isLoginRedirectUrl:navigationAction.request.URL];
         if (refreshUrl != nil) {
-            [SFSDKHybridLogger w:[self class] format:[NSString stringWithFormat:@"Caught login redirect from session timeout. Reauthenticating."]];
+            [SFSDKHybridLogger w:[self class] message:@"Caught login redirect from session timeout. Reauthenticating."];
             
             /*
              * Reconfigure user agent. Basically this ensures that Cordova whitelisting won't apply to the
@@ -584,7 +584,7 @@ SFSDK_USE_DEPRECATED_BEGIN
              } failure:^(SFOAuthInfo *authInfo, NSError *error) {
                  __strong typeof(weakSelf) strongSelf = weakSelf;
                  if ([strongSelf logoutOnInvalidCredentials:error]) {
-                     [SFSDKHybridLogger e:[strongSelf class] format:[NSString stringWithFormat:@"Could not refresh expired session. Logging out."]];
+                     [SFSDKHybridLogger e:[strongSelf class] message:@"Could not refresh expired session. Logging out."];
                      NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
                      attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
                      attributes[@"errorDescription"] = error.localizedDescription;
@@ -635,17 +635,17 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (BOOL) webView:(UIWebView *) webView shouldStartLoadWithRequest:(NSURLRequest *) request navigationType:(UIWebViewNavigationType) navigationType
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"webView:shouldStartLoadWithRequest:navigationType: Loading URL '%@'", [webView.request.URL redactedAbsoluteString:@[@"sid"]]]];
+    [SFSDKHybridLogger d:[self class] format:@"webView:shouldStartLoadWithRequest:navigationType: Loading URL '%@'", [webView.request.URL redactedAbsoluteString:@[@"sid"]]];
 
     // Hidden ping page load.
     if ([webView isEqual:self.vfPingPageHiddenUIWebView]) {
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"Setting up VF web state after plugin-based refresh."]];
+        [SFSDKHybridLogger d:[self class] message:@"Setting up VF web state after plugin-based refresh."];
         return YES;
     }
 
     // Local error page load.
     if ([webView isEqual:self.errorPageUIWebView]) {
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"Local error page ('%@') is loading.", webView.request.URL.absoluteString]];
+        [SFSDKHybridLogger d:[self class] format:@"Local error page ('%@') is loading.", webView.request.URL.absoluteString];
         return YES;
     }
 
@@ -658,7 +658,7 @@ SFSDK_USE_DEPRECATED_BEGIN
          */
         NSString *refreshUrl = [self isLoginRedirectUrl:webView.request.URL];
         if (refreshUrl != nil) {
-            [SFSDKHybridLogger w:[self class] format:[NSString stringWithFormat:@"Caught login redirect from session timeout. Reauthenticating."]];
+            [SFSDKHybridLogger w:[self class] message:@"Caught login redirect from session timeout. Reauthenticating."];
             
             /*
              * Reconfigure user agent. Basically this ensures that Cordova whitelisting won't apply to the
@@ -675,7 +675,7 @@ SFSDK_USE_DEPRECATED_BEGIN
              } failure:^(SFOAuthInfo *authInfo, NSError *error) {
                  __strong typeof(weakSelf) strongSelf = weakSelf;
                  if ([strongSelf logoutOnInvalidCredentials:error]) {
-                    [SFSDKHybridLogger e:[strongSelf class] format:[NSString stringWithFormat:@"Could not refresh expired session. Logging out."]];
+                    [SFSDKHybridLogger e:[strongSelf class] message:@"Could not refresh expired session. Logging out."];
                      NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
                      attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
                      attributes[@"errorDescription"] = error.localizedDescription;
@@ -750,9 +750,9 @@ SFSDK_USE_DEPRECATED_BEGIN
     }
     NSArray *redactParams = @[@"sid"];
     NSString *redactedUrl = [requestUrl redactedAbsoluteString:redactParams];
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"finishLoadActions: Loaded %@", redactedUrl]];
+    [SFSDKHybridLogger d:[self class] format:@"finishLoadActions: Loaded %@", redactedUrl];
     if ([webView isEqual:self.vfPingPageHiddenUIWebView]) {
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"Finished loading VF ping page '%@'.", redactedUrl]];
+        [SFSDKHybridLogger d:[self class] format:@"Finished loading VF ping page '%@'.", redactedUrl];
         return;
     }
     if ([webView isEqual:self.webView]) {
@@ -763,9 +763,9 @@ SFSDK_USE_DEPRECATED_BEGIN
          * be loaded directly in the event that the app is offline.
          */
         if (_foundHomeUrl == NO) {
-            [SFSDKHybridLogger i:[self class] format:[NSString stringWithFormat:@"Checking %@ as a 'home page' URL candidate for this app.", redactedUrl]];
+            [SFSDKHybridLogger i:[self class] format:@"Checking %@ as a 'home page' URL candidate for this app.", redactedUrl];
             if (![self isReservedUrlValue:requestUrl]) {
-                [SFSDKHybridLogger i:[self class] format:[NSString stringWithFormat:@"Setting %@ as the 'home page' URL for this app.", redactedUrl]];
+                [SFSDKHybridLogger i:[self class] format:@"Setting %@ as the 'home page' URL for this app.", redactedUrl];
                 self.appHomeUrl = requestUrl;
                 _foundHomeUrl = YES;
             }
@@ -791,7 +791,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (void) loadErrorPageWithError:(NSError *) error
 {
-    [SFSDKHybridLogger e:[self class] format:[NSString stringWithFormat:@"Error while attempting to load web page: %@", error]];
+    [SFSDKHybridLogger e:[self class] format:@"Error while attempting to load web page: %@", error];
     if ([[self class] isFatalWebViewError:error]) {
         [self loadErrorPageWithCode:[error code] description:[error localizedDescription] context:kErrorContextAppLoading];
     }
@@ -827,12 +827,12 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (void)authenticationCompletion:(NSString *)originalUrl authInfo:(SFOAuthInfo *)authInfo
 {
-    [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"authenticationCompletion:authInfo: - Initiating post-auth configuration."]];
+    [SFSDKHybridLogger d:[self class] message:@"authenticationCompletion:authInfo: - Initiating post-auth configuration."];
     [SFSDKWebViewStateManager resetSessionCookie];
 
     // If there's an original URL, load it through frontdoor.
     if (originalUrl != nil) {
-        [SFSDKHybridLogger d:[self class] format:[NSString stringWithFormat:@"Authentication complete. Redirecting to '%@' through frontdoor.", [originalUrl stringByURLEncoding]]];
+        [SFSDKHybridLogger d:[self class] format:@"Authentication complete. Redirecting to '%@' through frontdoor.", [originalUrl stringByURLEncoding]];
         BOOL createAbsUrl = YES;
         if (authInfo.authType == SFOAuthTypeRefresh) {
             createAbsUrl = NO;

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFLocalhostSubstitutionCache.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFLocalhostSubstitutionCache.m
@@ -75,13 +75,13 @@ static NSString * const kSFAppFeatureUsesLocalhost = @"LH";
     NSString* mimeType = @"text/plain";
     NSFileManager *manager = [[NSFileManager alloc] init];
     if (![filePath hasPrefix:wwwDirPath]) {
-        [SFSDKHybridLogger e:[self class] format:[NSString stringWithFormat:@"Trying to access files outside www: %@", url]];
+        [SFSDKHybridLogger e:[self class] format:@"Trying to access files outside www: %@", url];
     } else if (![manager fileExistsAtPath:filePath]) {
-        [SFSDKHybridLogger e:[self class] format:[NSString stringWithFormat:@"Trying to access non-existent file: %@", url]];
+        [SFSDKHybridLogger e:[self class] format:@"Trying to access non-existent file: %@", url];
     } else {
         data = [NSData dataWithContentsOfFile:filePath];
         mimeType = [self mimeTypeForPath:filePath];
-        [SFSDKHybridLogger i:[self class] format:[NSString stringWithFormat:@"Loading local file: %@", urlPath]];
+        [SFSDKHybridLogger i:[self class] format:@"Loading local file: %@", urlPath];
     }
     NSURLResponse *response = [[NSURLResponse alloc]
                                initWithURL:[request URL]

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFOauthReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFOauthReactBridge.m
@@ -44,14 +44,14 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(getAuthCredentials:(NSDictionary *)args callback:(RCTResponseSenderBlock)callback)
 {
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"getAuthCredentials: arguments: %@", args]];
+    [SFSDKReactLogger d:[self class] format:@"getAuthCredentials: arguments: %@", args];
     [self getAuthCredentialsWithCallback:callback];
 }
 
 RCT_EXPORT_METHOD(logoutCurrentUser:(NSDictionary *)args callback:(RCTResponseSenderBlock)callback)
 {
     __weak typeof(self) weakSelf = self;
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"logoutCurrentUser: arguments: %@", args]];
+    [SFSDKReactLogger d:[self class] format:@"logoutCurrentUser: arguments: %@", args];
     dispatch_async(dispatch_get_main_queue(), ^{
          __strong typeof(weakSelf) strongSelf = weakSelf;
         [strongSelf logout];
@@ -61,7 +61,7 @@ RCT_EXPORT_METHOD(logoutCurrentUser:(NSDictionary *)args callback:(RCTResponseSe
 RCT_EXPORT_METHOD(authenticate:(NSDictionary *)args callback:(RCTResponseSenderBlock)callback)
 {
     __weak typeof(self) weakSelf = self;
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"authenticate: arguments: %@", args]];
+    [SFSDKReactLogger d:[self class] format:@"authenticate: arguments: %@", args];
     dispatch_async(dispatch_get_main_queue(), ^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
         [strongSelf loginWithCompletion:^(SFOAuthInfo *authInfo,SFUserAccount *userAccount) {

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
@@ -75,7 +75,7 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(soupExists:(NSDictionary *)argsDict callback:(RCTResponseSenderBlock)callback)
 {
     NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"soupExists with soup name '%@'.", soupName]];
+    [SFSDKReactLogger d:[self class] format:@"soupExists with soup name '%@'.", soupName];
     BOOL exists = [[self getStoreInst:argsDict] soupExists:soupName];
     callback(@[[NSNull null],  exists ? @YES : @NO]);
 }
@@ -92,7 +92,7 @@ RCT_EXPORT_METHOD(registerSoup:(NSDictionary *)argsDict callback:(RCTResponseSen
         soupSpec = [SFSoupSpec newSoupSpec:soupName withFeatures:nil];
     }
     NSArray *indexSpecs = [SFSoupIndex asArraySoupIndexes:[argsDict nonNullObjectForKey:kIndexesArg]];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"registerSoup with name: %@, soup features: %@, indexSpecs: %@", soupSpec.soupName, soupSpec.features, indexSpecs]];
+    [SFSDKReactLogger d:[self class] format:@"registerSoup with name: %@, soup features: %@, indexSpecs: %@", soupSpec.soupName, soupSpec.features, indexSpecs];
     if (smartStore) {
         NSError *error = nil;
         BOOL result = [smartStore registerSoupWithSpec:soupSpec withIndexSpecs:indexSpecs error:&error];
@@ -109,7 +109,7 @@ RCT_EXPORT_METHOD(registerSoup:(NSDictionary *)argsDict callback:(RCTResponseSen
 RCT_EXPORT_METHOD(removeSoup:(NSDictionary *)argsDict callback:(RCTResponseSenderBlock)callback)
 {
     NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"removeSoup with name: %@", soupName]];
+    [SFSDKReactLogger d:[self class] format:@"removeSoup with name: %@", soupName];
     [[self getStoreInst:argsDict] removeSoup:soupName];
     callback(@[[NSNull null], @"OK"]);
 }
@@ -119,7 +119,7 @@ RCT_EXPORT_METHOD(querySoup:(NSDictionary *)argsDict callback:(RCTResponseSender
     NSString *soupName = argsDict[kSoupNameArg];
     NSDictionary *querySpecDict = [argsDict nonNullObjectForKey:kQuerySpecArg];
     SFQuerySpec* querySpec = [[SFQuerySpec alloc] initWithDictionary:querySpecDict withSoupName:soupName];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"querySoup with name: %@, querySpec: %@", soupName, querySpecDict]];
+    [SFSDKReactLogger d:[self class] format:@"querySoup with name: %@, querySpec: %@", soupName, querySpecDict];
     NSError* error = nil;
     SFStoreCursor* cursor = [self runQuery:querySpec error:&error argsDict:argsDict];
     if (cursor.cursorId) {
@@ -129,7 +129,7 @@ RCT_EXPORT_METHOD(querySoup:(NSDictionary *)argsDict callback:(RCTResponseSender
         });
         callback(@[[NSNull null], [cursor asDictionary]]);
     } else {
-        [SFSDKReactLogger e:[self class] format:[NSString stringWithFormat:@"No cursor for query: %@", querySpec]];
+        [SFSDKReactLogger e:[self class] format:@"No cursor for query: %@", querySpec];
         callback(@[RCTMakeError(@"No cursor for query", error, nil)]);
     }
 }
@@ -143,7 +143,7 @@ RCT_EXPORT_METHOD(retrieveSoupEntries:(NSDictionary *)argsDict callback:(RCTResp
 {
     NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
     NSArray *rawIds = [argsDict nonNullObjectForKey:kEntryIdsArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"retrieveSoupEntries with soup name: %@", soupName]];
+    [SFSDKReactLogger d:[self class] format:@"retrieveSoupEntries with soup name: %@", soupName];
     NSArray *entries = [[self getStoreInst:argsDict] retrieveEntries:rawIds fromSoup:soupName];
     callback(@[[NSNull null], entries]);
 }
@@ -153,7 +153,7 @@ RCT_EXPORT_METHOD(upsertSoupEntries:(NSDictionary *)argsDict callback:(RCTRespon
     NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
     NSArray *entries = [argsDict nonNullObjectForKey:kEntriesArg];
     NSString *externalIdPath = [argsDict nonNullObjectForKey:kExternalIdPathArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"upsertSoupEntries with soup name: %@, external ID path: %@", soupName, externalIdPath]];
+    [SFSDKReactLogger d:[self class] format:@"upsertSoupEntries with soup name: %@, external ID path: %@", soupName, externalIdPath];
     NSError *error = nil;
     NSArray *resultEntries = [[self getStoreInst:argsDict] upsertEntries:entries toSoup:soupName withExternalIdPath:externalIdPath error:&error];
     if (nil != resultEntries) {
@@ -168,7 +168,7 @@ RCT_EXPORT_METHOD(removeFromSoup:(NSDictionary *)argsDict callback:(RCTResponseS
     NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
     NSArray *entryIds = [argsDict nonNullObjectForKey:kEntryIdsArg];
     NSDictionary *querySpecDict = [argsDict nonNullObjectForKey:kQuerySpecArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"removeFromSoup with soup name: %@", soupName]];
+    [SFSDKReactLogger d:[self class] format:@"removeFromSoup with soup name: %@", soupName];
     NSError* error = nil;
     if (entryIds) {
         [[self getStoreInst:argsDict] removeEntries:entryIds fromSoup:soupName error:&error];
@@ -186,7 +186,7 @@ RCT_EXPORT_METHOD(removeFromSoup:(NSDictionary *)argsDict callback:(RCTResponseS
 RCT_EXPORT_METHOD(closeCursor:(NSDictionary *)argsDict callback:(RCTResponseSenderBlock)callback)
 {
     NSString *cursorId = [argsDict nonNullObjectForKey:kCursorIdArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"closeCursor with cursor ID: %@", cursorId]];
+    [SFSDKReactLogger d:[self class] format:@"closeCursor with cursor ID: %@", cursorId];
     [self closeCursorWithId:cursorId andArgs:argsDict];
     callback(@[[NSNull null], @"OK"]);}
 
@@ -194,7 +194,7 @@ RCT_EXPORT_METHOD(moveCursorToPageIndex:(NSDictionary *)argsDict callback:(RCTRe
 {
     NSString *cursorId = [argsDict nonNullObjectForKey:kCursorIdArg];
     NSNumber *newPageIndex = [argsDict nonNullObjectForKey:kIndexArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"moveCursorToPageIndex with cursor ID: %@, page index: %@", cursorId, newPageIndex]];
+    [SFSDKReactLogger d:[self class] format:@"moveCursorToPageIndex with cursor ID: %@, page index: %@", cursorId, newPageIndex];
     SFStoreCursor *cursor = [self cursorByCursorId:cursorId andArgs:argsDict];
     [cursor setCurrentPageIndex:newPageIndex];
     callback(@[[NSNull null],  [cursor asDictionary]]);
@@ -203,7 +203,7 @@ RCT_EXPORT_METHOD(moveCursorToPageIndex:(NSDictionary *)argsDict callback:(RCTRe
 RCT_EXPORT_METHOD(clearSoup:(NSDictionary *)argsDict callback:(RCTResponseSenderBlock)callback)
 {
     NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"clearSoup with name: %@", soupName]];
+    [SFSDKReactLogger d:[self class] format:@"clearSoup with name: %@", soupName];
     [[self getStoreInst:argsDict] clearSoup:soupName];
     callback(@[[NSNull null], @"OK"]);
 }
@@ -226,7 +226,7 @@ RCT_EXPORT_METHOD(alterSoup:(NSDictionary *)argsDict callback:(RCTResponseSender
     }
     NSArray *indexSpecs = [SFSoupIndex asArraySoupIndexes:[argsDict nonNullObjectForKey:kIndexesArg]];
     BOOL reIndexData = [[argsDict nonNullObjectForKey:kReIndexDataArg] boolValue];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"alterSoup with name: %@, soup features: %@, indexSpecs: %@, reIndexData: %@", soupName, soupSpec.features, indexSpecs, reIndexData ? @"true" : @"false"]];
+    [SFSDKReactLogger d:[self class] format:@"alterSoup with name: %@, soup features: %@, indexSpecs: %@, reIndexData: %@", soupName, soupSpec.features, indexSpecs, reIndexData ? @"true" : @"false"];
     BOOL alterOk = [[self getStoreInst:argsDict] alterSoup:soupName withSoupSpec:soupSpec withIndexSpecs:indexSpecs reIndexData:reIndexData];
     if (alterOk) {
         callback(@[[NSNull null], soupName]);
@@ -239,7 +239,7 @@ RCT_EXPORT_METHOD(reIndexSoup:(NSDictionary *)argsDict callback:(RCTResponseSend
 {
     NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
     NSArray *indexPaths = [argsDict nonNullObjectForKey:kPathsArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"reIndexSoup with soup name: %@, indexPaths: %@", soupName, indexPaths]];
+    [SFSDKReactLogger d:[self class] format:@"reIndexSoup with soup name: %@, indexPaths: %@", soupName, indexPaths];
     BOOL regOk = [[self getStoreInst:argsDict] reIndexSoup:soupName withIndexPaths:indexPaths];
     if (regOk) {
         callback(@[[NSNull null], soupName]);
@@ -251,7 +251,7 @@ RCT_EXPORT_METHOD(reIndexSoup:(NSDictionary *)argsDict callback:(RCTResponseSend
 RCT_EXPORT_METHOD(getSoupIndexSpecs:(NSDictionary *)argsDict callback:(RCTResponseSenderBlock)callback)
 {
     NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"getSoupIndexSpecs with soup name: %@", soupName]];
+    [SFSDKReactLogger d:[self class] format:@"getSoupIndexSpecs with soup name: %@", soupName];
     NSArray *indexSpecsAsDicts = [SFSoupIndex asArrayOfDictionaries:[[self getStoreInst:argsDict] indicesForSoup:soupName] withColumnName:NO];
     if ([indexSpecsAsDicts count] > 0) {
         callback(@[[NSNull null], indexSpecsAsDicts]);
@@ -263,7 +263,7 @@ RCT_EXPORT_METHOD(getSoupIndexSpecs:(NSDictionary *)argsDict callback:(RCTRespon
 RCT_EXPORT_METHOD(getSoupSpec:(NSDictionary *)argsDict callback:(RCTResponseSenderBlock)callback)
 {
     NSString *soupName = [argsDict nonNullObjectForKey:kSoupNameArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"getSoupSpec with soup name: %@", soupName]];
+    [SFSDKReactLogger d:[self class] format:@"getSoupSpec with soup name: %@", soupName];
     SFSmartStore *store = [self getStoreInst:argsDict];
     SFSoupSpec *soupSpec = [store attributesForSoup:soupName];
     if (soupSpec) {

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSmartSyncReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSmartSyncReactBridge.m
@@ -54,11 +54,11 @@ RCT_EXPORT_METHOD(getSyncStatus:(NSDictionary *)args callback:(RCTResponseSender
 
     SFSyncState *sync;
     if (syncId) {
-        [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"getSyncStatus with sync id: %@", syncId]];
+        [SFSDKReactLogger d:[self class] format:@"getSyncStatus with sync id: %@", syncId];
         sync = [[self getSyncManagerInst:args] getSyncStatus:syncId];
     }
     else if (syncName) {
-        [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"getSyncStatus with sync name: %@", syncName]];
+        [SFSDKReactLogger d:[self class] format:@"getSyncStatus with sync name: %@", syncName];
         sync = [[self getSyncManagerInst:args] getSyncStatusByName:syncName];
     }
     else {
@@ -73,11 +73,11 @@ RCT_EXPORT_METHOD(deleteSync:(NSDictionary *)args callback:(RCTResponseSenderBlo
     NSString *syncName = (NSString *) [args nonNullObjectForKey:kSyncNameArg];
 
     if (syncId) {
-        [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"deleteSync with sync id: %@", syncId]];
+        [SFSDKReactLogger d:[self class] format:@"deleteSync with sync id: %@", syncId];
         [[self getSyncManagerInst:args] deleteSyncById:syncId];
     }
     else if (syncName) {
-        [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"deleteSync with sync name: %@", syncName]];
+        [SFSDKReactLogger d:[self class] format:@"deleteSync with sync name: %@", syncName];
         [[self getSyncManagerInst:args] deleteSyncByName:syncName];
     }
     else {
@@ -97,7 +97,7 @@ RCT_EXPORT_METHOD(syncDown:(NSDictionary *)args callback:(RCTResponseSenderBlock
         [weakSelf handleSyncUpdate:sync withArgs:args callback:callback];
     }];
     if (sync) {
-        [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"syncDown # %ld to soup: %@", sync.syncId, soupName]];
+        [SFSDKReactLogger d:[self class] format:@"syncDown # %ld to soup: %@", sync.syncId, soupName];
     }
     else {
         callback(@[RCTMakeError(@"Failed to create sync down", nil, nil)]);
@@ -109,14 +109,14 @@ RCT_EXPORT_METHOD(reSync:(NSDictionary *)args callback:(RCTResponseSenderBlock)c
     NSNumber *syncId = (NSNumber *) [args nonNullObjectForKey:kSyncIdArg];
     SFSyncState* sync;
     if (syncId) {
-        [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"reSync with sync id: %@", syncId]];
+        [SFSDKReactLogger d:[self class] format:@"reSync with sync id: %@", syncId];
         __weak typeof(self) weakSelf = self;
         sync = [[self getSyncManagerInst:args] reSync:syncId updateBlock:^(SFSyncState *sync) {
             [weakSelf handleSyncUpdate:sync withArgs:args callback:callback];
         }];
     }
     else if (syncName) {
-        [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"reSync with sync name: %@", syncName]];
+        [SFSDKReactLogger d:[self class] format:@"reSync with sync name: %@", syncName];
         __weak typeof(self) weakSelf = self;
         sync = [[self getSyncManagerInst:args] reSyncByName:syncName updateBlock:^(SFSyncState *sync) {
             [weakSelf handleSyncUpdate:sync withArgs:args callback:callback];
@@ -134,7 +134,7 @@ RCT_EXPORT_METHOD(reSync:(NSDictionary *)args callback:(RCTResponseSenderBlock)c
 RCT_EXPORT_METHOD(cleanResyncGhosts:(NSDictionary *)args callback:(RCTResponseSenderBlock)callback)
 {
     NSNumber* syncId = (NSNumber*) [args nonNullObjectForKey:kSyncIdArg];
-    [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"cleanResyncGhosts with sync id: %@", syncId]];
+    [SFSDKReactLogger d:[self class] format:@"cleanResyncGhosts with sync id: %@", syncId];
     [[self getSyncManagerInst:args] cleanResyncGhosts:syncId completionStatusBlock:^void(SFSyncStateStatus syncStatus){
         callback(@[[NSNull null], [SFSyncState syncStatusToString:syncStatus]]);
     }];
@@ -152,7 +152,7 @@ RCT_EXPORT_METHOD(syncUp:(NSDictionary *)args callback:(RCTResponseSenderBlock)c
     }];
 
     if (sync) {
-        [SFSDKReactLogger d:[self class] format:[NSString stringWithFormat:@"syncUp # %ld from soup: %@", sync.syncId, soupName]];
+        [SFSDKReactLogger d:[self class] format:@"syncUp # %ld from soup: %@", sync.syncId, soupName];
     }
     else {
         callback(@[RCTMakeError(@"Failed to create sync up", nil, nil)]);

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeProviderManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeProviderManager.m
@@ -70,7 +70,7 @@ static NSMutableDictionary *PasscodeProviderMap;
     id<SFPasscodeProvider> provider = [SFPasscodeProviderManager passcodeProviderForProviderName:providerName];
     if (provider == nil) {
         [SFSDKCoreLogger e:[SFPasscodeProviderManager class]
-                  format:[NSString stringWithFormat:@"No passcode provider exists for provider '%@'.  Use [SFPasscodeProviderManager addPasscodeProvider:] to configure a new provider.", providerName]];
+                  format:@"No passcode provider exists for provider '%@'.  Use [SFPasscodeProviderManager addPasscodeProvider:] to configure a new provider.", providerName];
     } else {
         NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
         [defs setObject:providerName forKey:kSFCurrentPasscodeProviderUserDefaultsKey];
@@ -102,7 +102,7 @@ static NSMutableDictionary *PasscodeProviderMap;
     id<SFPasscodeProvider> existingProvider = PasscodeProviderMap[newProviderName];
     if (existingProvider != nil) {
         [SFSDKCoreLogger e:[SFPasscodeProviderManager class]
-                  format:[NSString stringWithFormat:@"A passcode provider is already configured for '%@'.  Will not overwrite the current provider.", newProviderName]];
+                  format:@"A passcode provider is already configured for '%@'.  Will not overwrite the current provider.", newProviderName];
     } else {
         PasscodeProviderMap[newProviderName] = provider;
     }
@@ -114,7 +114,7 @@ static NSMutableDictionary *PasscodeProviderMap;
     id<SFPasscodeProvider> existingProvider = [SFPasscodeProviderManager passcodeProviderForProviderName:providerName];
     if (existingProvider == nil) {
         [SFSDKCoreLogger w:[SFPasscodeProviderManager class]
-                  format:[NSString stringWithFormat:@"Passcode provider with name '%@' does not exist.  No action will be taken.", providerName]];
+                  format:@"Passcode provider with name '%@' does not exist.  No action will be taken.", providerName];
         return;
     }
     
@@ -122,7 +122,7 @@ static NSMutableDictionary *PasscodeProviderMap;
     NSString *currentProviderName = [SFPasscodeProviderManager currentPasscodeProviderName];
     if ([currentProviderName isEqualToString:providerName]) {
         [SFSDKCoreLogger i:[SFPasscodeProviderManager class]
-                  format:[NSString stringWithFormat:@"Passcode provider with name '%@' was configured as the current provider.  Current provider will be reset to the default.", providerName]];
+                  format:@"Passcode provider with name '%@' was configured as the current provider.  Current provider will be reset to the default.", providerName];
         [SFPasscodeProviderManager resetCurrentPasscodeProviderName];
     }
 }


### PR DESCRIPTION
The pattern of calling the log `format:` methods with no `va_args` arguments has been pretty regularly crashing my app with `EXC_BAD_ACCESS` errors, during development.  They don't happen every time, but it's not a great pattern anyway.

This updates those calls to take out `[NSString stringWithFormat:]`, and converts the calls with no arguments to their `message:` equivalents.