### PR TITLE
Fixing navigation issues with back button enablement on SFLoginViewController

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.m
@@ -305,6 +305,7 @@
     
     SFSDKMutableOAuthClientContext *mutableContext = [self.context mutableCopy];
     mutableContext.credentials = userCredentials;
+    self.config.loginViewControllerConfig.showSettingsIcon = NO;
     self.context = mutableContext;
     self.coordinator.credentials = userCredentials;
     SFOAuthCredentials *spAppCredentials = [self spAppCredentials];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.m
@@ -106,7 +106,15 @@
 }
 
 - (BOOL)initiateLocalLoginInSPApp {
+    
+    if (self.isAuthenticating){
+        self.isAuthenticating = NO;
+      
+       [self.coordinator stopAuthentication];
+    }
+    self.config.loginViewControllerConfig.showSettingsIcon = NO;
     return [super refreshCredentials];
+
 }
 
 - (void)initiateIDPFlowInSPApp {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKLoginFlowSelectionViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKLoginFlowSelectionViewController.m
@@ -291,6 +291,7 @@
 
 - (void)hostListViewController:(SFSDKLoginHostListViewController *)hostListViewController didChangeLoginHost:(SFSDKLoginHost *)newLoginHost {
     [SFUserAccountManager sharedInstance].loginHost = newLoginHost.host;
+    [[SFUserAccountManager sharedInstance] switchToNewUser];
 }
 
 + (UIImage *)imageFromColor:(UIColor *)color {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -36,6 +36,8 @@
 #import "SFUserAccountManager.h"
 #import "SFAuthenticationManager.h"
 #import "SFSDKLoginViewControllerConfig.h"
+#import "SFOAuthInfo.h"
+#import "SFSDKWindowManager.h"
 
 SFSDK_USE_DEPRECATED_BEGIN
 
@@ -56,7 +58,6 @@ SFSDK_USE_DEPRECATED_END
 @implementation SFLoginViewController
 @synthesize config = _config;
 @synthesize oauthView = _oauthView;
-
 
 + (instancetype)sharedInstance {
     static dispatch_once_t onceToken;
@@ -192,6 +193,9 @@ SFSDK_USE_DEPRECATED_END
 }
 
 - (BOOL)shouldShowBackButton {
+    if ([SFUserAccountManager sharedInstance].idpEnabled) {
+        return YES;
+    }
     NSInteger totalAccounts = [SFUserAccountManager sharedInstance].allUserAccounts.count;
     return  (totalAccounts > 0);
 }
@@ -203,11 +207,10 @@ SFSDK_USE_DEPRECATED_END
 }
 
 - (IBAction)backToPreviousHost:(id)sender {
-    SFSDK_USE_DEPRECATED_BEGIN
-    [[SFAuthenticationManager sharedManager] cancelAuthentication];
-    SFSDK_USE_DEPRECATED_END
-    if (self.previousUserAccount) {
-        [[SFUserAccountManager sharedInstance] switchToUser:self.previousUserAccount];
+    if ([SFSDKWindowManager sharedManager].authWindow.window.rootViewController!= [SFSDKWindowManager sharedManager].authWindow.viewController) {
+        [[SFSDKWindowManager sharedManager].authWindow disable];
+    }else {
+        [[SFSDKWindowManager sharedManager].authWindow.viewController dismissViewControllerAnimated:NO completion:nil];
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -207,7 +207,7 @@ SFSDK_USE_DEPRECATED_END
 }
 
 - (IBAction)backToPreviousHost:(id)sender {
-    if ([SFSDKWindowManager sharedManager].authWindow.window.rootViewController!= [SFSDKWindowManager sharedManager].authWindow.viewController) {
+    if (![SFUserAccountManager sharedInstance].idpEnabled) {
         [[SFSDKWindowManager sharedManager].authWindow disable];
     }else {
         [[SFSDKWindowManager sharedManager].authWindow.viewController dismissViewControllerAnimated:NO completion:nil];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFSDKLoginViewControllerConfig.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFSDKLoginViewControllerConfig.h
@@ -28,6 +28,7 @@
  */
 
 #import <Foundation/Foundation.h>
+@protocol SFLoginViewControllerDelegate;
 
 @interface SFSDKLoginViewControllerConfig : NSObject
 
@@ -46,6 +47,12 @@
 
 /** Specifiy the visibility of the settings icon. This property will be used to hide/show the settings icon*/
 @property (nonatomic) BOOL showSettingsIcon;
+
+/** Specifiy the visibility of the back icon. This property will be used to hide/show the settings icon*/
+@property (nonatomic) BOOL shouldDisplayBackButton;
+
+/** Specifiy a delegate for LoginViewController. */
+@property (nonatomic, weak, nullable) id<SFLoginViewControllerDelegate> delegate;
 
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -1066,7 +1066,6 @@ static NSString * const kSFECParameter = @"ec";
     
     NSURL *requestUrl = [webView URL];
     NSString *errorUrlString = [NSString stringWithFormat:@"%@://%@%@", [requestUrl scheme], [requestUrl host], [requestUrl relativePath]];
-    [self.delegate oauthCoordinator:self didBeginAuthenticationWithView:self.view];
     if (-999 == error.code) {
         // -999 errors (operation couldn't be completed) occur during normal execution, therefore only log for debugging
         [SFSDKCoreLogger d:[self class] format:@"SFOAuthCoordinator:didFailLoadWithError: error code: %ld, description: %@, URL: %@", (long)error.code, [error localizedDescription], errorUrlString];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -129,13 +129,19 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
                         }
                         strongSelf.config.authViewController.config = strongSelf.config.loginViewControllerConfig;
                         [strongSelf.config.authViewController setOauthView:viewHandler.wkWebView];
-                        if (!strongSelf.authWindow.window.rootViewController || strongSelf.authWindow.window.rootViewController == strongSelf.config.authViewController
-                            ) {
+                        
+                        if (!strongSelf.config.idpEnabled) {
                             strongSelf.authWindow.viewController = strongSelf.config.authViewController;
+                            
                         } else {
-                            [strongSelf.authWindow.window.rootViewController  presentViewController:strongSelf.config.authViewController  animated:YES completion:nil];
+                            if ([strongSelf.authWindow.window.rootViewController isViewLoaded]) {
+                                [strongSelf.authWindow.window.rootViewController  presentViewController:strongSelf.config.authViewController  animated:NO completion:nil];
+                            }else {
+                                strongSelf.authWindow.viewController = strongSelf.config.authViewController;
+                            }
                         }
-                        [strongSelf.authWindow enable];
+                        [[SFSDKWindowManager sharedManager].authWindow enable];
+                        
                     } dismissBlock:^() {
                         __strong typeof(weakSelf) strongSelf = weakSelf;
                         [strongSelf dismissAuthViewControllerIfPresent];
@@ -159,7 +165,6 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
 }
 
 -(void)dismissAuthWindow {
-    [SFSDKWindowManager sharedManager].authWindow.window.rootViewController = nil;
     [[SFSDKWindowManager sharedManager].authWindow disable];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -129,7 +129,12 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
                         }
                         strongSelf.config.authViewController.config = strongSelf.config.loginViewControllerConfig;
                         [strongSelf.config.authViewController setOauthView:viewHandler.wkWebView];
-                        strongSelf.authWindow.viewController = strongSelf.config.authViewController;
+                        if (!strongSelf.authWindow.window.rootViewController || strongSelf.authWindow.window.rootViewController == strongSelf.config.authViewController
+                            ) {
+                            strongSelf.authWindow.viewController = strongSelf.config.authViewController;
+                        } else {
+                            [strongSelf.authWindow.window.rootViewController  presentViewController:strongSelf.config.authViewController  animated:YES completion:nil];
+                        }
                         [strongSelf.authWindow enable];
                     } dismissBlock:^() {
                         __strong typeof(weakSelf) strongSelf = weakSelf;
@@ -154,6 +159,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
 }
 
 -(void)dismissAuthWindow {
+    [SFSDKWindowManager sharedManager].authWindow.window.rootViewController = nil;
     [[SFSDKWindowManager sharedManager].authWindow disable];
 }
 
@@ -243,6 +249,13 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
 #pragma mark - SFLoginViewControllerDelegate
 
 - (void)loginViewController:(SFLoginViewController *)loginViewController didChangeLoginHost:(SFSDKLoginHost *)newLoginHost {
+
+    if ([self.config.delegate respondsToSelector:@selector(authClientDidChangeLoginHost:loginHost:)]) {
+        [self.config.delegate authClientDidChangeLoginHost:self loginHost:newLoginHost.host];
+    }
+}
+
+- (void)loginViewController:(SFLoginViewController *)loginViewController didSelectBackButton:(SFSDKLoginHost *)newLoginHost {
 
     if ([self.config.delegate respondsToSelector:@selector(authClientDidChangeLoginHost:loginHost:)]) {
         [self.config.delegate authClientDidChangeLoginHost:self loginHost:newLoginHost.host];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementViewController.m
@@ -85,7 +85,11 @@
 
 - (void)actionCreateNewUser
 {
-    [[SFUserAccountManager sharedInstance] switchToNewUser];
+    [[SFUserAccountManager sharedInstance] loginWithCompletion:^(SFOAuthInfo * authInfo, SFUserAccount * newUser) {
+        [[SFUserAccountManager sharedInstance] switchToUser:newUser];
+    } failure:^(SFOAuthInfo * authInfo, NSError * error) {
+        [SFSDKCoreLogger e:[self class] format:@"Attempt to add new user failed %@",[error localizedDescription]];
+    }];
 }
 
 - (void)execCompletionBlock:(SFUserManagementAction)action account:(SFUserAccount *)actionAccount

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+URLHandlers.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+URLHandlers.m
@@ -127,7 +127,7 @@
     BOOL showSelection = NO;
     NSString *domain = request.allParams[kSFLoginHostParam]?:idpAppsCredentials.domain;
     SFOAuthCredentials *credentials = foundUserCredentials?:idpAppsCredentials;
-    credentials.domain = domain;
+    authClient.config.loginHost = domain;
     authClient = [self fetchIDPAuthClient:credentials completion:nil failure:nil];
 
     if (self.currentUser!=nil && !foundUserCredentials) {

--- a/shared/classes/IDPLoginViewController.m
+++ b/shared/classes/IDPLoginViewController.m
@@ -115,6 +115,7 @@
 
 - (void)hostListViewController:(SFSDKLoginHostListViewController *)hostListViewController didChangeLoginHost:(SFSDKLoginHost *)newLoginHost {
     [SFUserAccountManager sharedInstance].loginHost = newLoginHost.host;
+    [[SFUserAccountManager sharedInstance] switchToNewUser];
 }
 
 


### PR DESCRIPTION
The back button traditionally would switch between users. In the default user management view controller add user would cause a switch in users prior to any user logging in. Hence it would lead to user not being logged in anymore. Changed the behavior to only dispose the window, and switch to a user  after login occurs.  These weird navigation issues impacted the behavior in IDP flows as well. So had to make minor adjustments to the code. 