### PR TITLE
User Switching &  Passcode timer issues 

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -18,7 +18,8 @@
 - (void)handleAuthCompleted:(nonnull NSNotification *)notification;
 - (void)handleIDPInitiatedAuthCompleted:(nonnull NSNotification *)notification;
 - (void)handleUserDidLogout:(nonnull NSNotification *)notification;
-- (void)handleUserSwitch:(nullable SFUserAccount *)fromUser toUser:(nullable SFUserAccount *)toUser;
+- (void)handleUserWillSwitch:(nullable SFUserAccount *)fromUser toUser:(nullable SFUserAccount *)toUser;
+- (void)handleUserDidSwitch:(nullable SFUserAccount *)fromUser toUser:(nullable SFUserAccount *)toUser;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -744,10 +744,8 @@ static NSString *const SFSDKShowDevDialogNotification = @"SFSDKShowDevDialogNoti
 
 - (void)handleUserSwitch:(SFUserAccount *)fromUser toUser:(SFUserAccount *)toUser
 {
-    // Close the passcode screen and reset passcode monitoring.
-    [SFSecurityLockout cancelPasscodeScreen];
-    [SFSecurityLockout stopActivityMonitoring];
-    [SFSecurityLockout removeTimer];
+    [SFSecurityLockout setupTimer];
+    [SFSecurityLockout startActivityMonitoring];
     [self sendUserAccountSwitch:fromUser toUser:toUser];
 }
 
@@ -1046,6 +1044,15 @@ SFSDK_USE_DEPRECATED_END
 
 - (void)handleUserDidLogout:(NSNotification *)notification {
     [self.sdkManagerFlow handlePostLogout];
+}
+
+- (void)userAccountManager:(SFUserAccountManager *)userAccountManager
+         willSwitchFromUser:(SFUserAccount *)fromUser
+                    toUser:(SFUserAccount *)toUser
+{
+    [SFSecurityLockout cancelPasscodeScreen];
+    [SFSecurityLockout stopActivityMonitoring];
+    [SFSecurityLockout removeTimer];
 }
 
 - (void)userAccountManager:(SFUserAccountManager *)userAccountManager

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -742,7 +742,14 @@ static NSString *const SFSDKShowDevDialogNotification = @"SFSDKShowDevDialogNoti
     [self sendPostLogout];
 }
 
-- (void)handleUserSwitch:(SFUserAccount *)fromUser toUser:(SFUserAccount *)toUser
+- (void)handleUserWillSwitch:(SFUserAccount *)fromUser toUser:(SFUserAccount *)toUser
+{
+    [SFSecurityLockout cancelPasscodeScreen];
+    [SFSecurityLockout stopActivityMonitoring];
+    [SFSecurityLockout removeTimer];
+}
+
+- (void)handleUserDidSwitch:(SFUserAccount *)fromUser toUser:(SFUserAccount *)toUser
 {
     [SFSecurityLockout setupTimer];
     [SFSecurityLockout startActivityMonitoring];
@@ -1050,16 +1057,14 @@ SFSDK_USE_DEPRECATED_END
          willSwitchFromUser:(SFUserAccount *)fromUser
                     toUser:(SFUserAccount *)toUser
 {
-    [SFSecurityLockout cancelPasscodeScreen];
-    [SFSecurityLockout stopActivityMonitoring];
-    [SFSecurityLockout removeTimer];
+    [self.sdkManagerFlow handleUserWillSwitch:fromUser toUser:toUser];
 }
 
 - (void)userAccountManager:(SFUserAccountManager *)userAccountManager
          didSwitchFromUser:(SFUserAccount *)fromUser
                     toUser:(SFUserAccount *)toUser
 {
-    [self.sdkManagerFlow handleUserSwitch:fromUser toUser:toUser];
+    [self.sdkManagerFlow handleUserDidSwitch:fromUser toUser:toUser];
 }
 
 #pragma mark - SFSecurityLockoutDelegate

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -357,7 +357,6 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
         }
     }
     [self logoutUser:[SFUserAccountManager sharedInstance].currentUser];
-    [[SFSDKOAuthClientCache sharedInstance] removeAllClients];
 }
 
 - (void)dismissAuthViewControllerIfPresent

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFTestSDKManagerFlow.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFTestSDKManagerFlow.h
@@ -33,5 +33,7 @@
 - (id)initWithStepTimeDelaySecs:(NSTimeInterval)timeDelayInSecs;
 - (void)resumeAuth;
 - (BOOL)waitForLaunchCompletion;
+- (void)setUpUserSwitchState:(SFUserAccount *)fromUser toUser:(SFUserAccount *)fromUser completion:(void (^)(SFUserAccount *,SFUserAccount *,BOOL before))switchUserCompletionBlock;
+- (void)clearUserSwitchState;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFTestSDKManagerFlow.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFTestSDKManagerFlow.m
@@ -24,12 +24,13 @@
 
 #import "SFTestSDKManagerFlow.h"
 
+
 static NSTimeInterval const kMaxLaunchWaitTime = 30.0;
 
 @interface SFTestSDKManagerFlow ()
 
 @property (nonatomic, assign) NSTimeInterval stepTimeDelaySecs;
-
+@property (nonatomic,copy,nullable) void (^switchUserCompletionBlock)(SFUserAccount *,SFUserAccount *,BOOL before);
 @end
 
 @implementation SFTestSDKManagerFlow
@@ -78,6 +79,14 @@ static NSTimeInterval const kMaxLaunchWaitTime = 30.0;
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     }
     return YES;
+}
+
+- (void)setUpUserSwitchState:(SFUserAccount *) fromUser toUser:(SFUserAccount *) toUser completion:(void (^)(SFUserAccount *,SFUserAccount *,BOOL before))switchUserCompletionBlock {
+    self.switchUserCompletionBlock = switchUserCompletionBlock;
+}
+
+- (void)clearUserSwitchState {
+    self.switchUserCompletionBlock = nil;
 }
 
 #pragma mark - SalesforceSDKManagerFlow
@@ -142,17 +151,26 @@ static NSTimeInterval const kMaxLaunchWaitTime = 30.0;
     
 }
 
-- (void)handleUserSwitch:(SFUserAccount *)fromUser toUser:(SFUserAccount *)toUser
+- (void)handleUserWillSwitch:(SFUserAccount *)fromUser toUser:(SFUserAccount *)toUser
 {
-    
+    if (self.switchUserCompletionBlock) {
+        self.switchUserCompletionBlock(fromUser, toUser,YES);
+    }
+}
+
+- (void)handleUserDidSwitch:(SFUserAccount *)fromUser toUser:(SFUserAccount *)toUser
+{
+    if (self.switchUserCompletionBlock) {
+        self.switchUserCompletionBlock(fromUser, toUser,NO);
+    }
 }
 
 - (void)handleIDPInitiatedAuthCompleted:(nonnull NSNotification *)notification {
-    
+
 }
 
 - (void)handleUserDidLogout:(nonnull NSNotification *)notification {
-    
+
 }
 
 

--- a/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/ContactListViewController.m
+++ b/native/SampleApps/SmartSyncExplorer/SmartSyncExplorer/Classes/ContactListViewController.m
@@ -446,14 +446,20 @@ static NSUInteger const kColorCodesList[] = { 0x1abc9c,  0x2ecc71,  0x3498db,  0
 {
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:Nil
                                                                    message:@"Are you sure you want to log out?"
-                                                            preferredStyle:UIAlertControllerStyleAlert];
-    UIAlertAction *logoutAction = [UIAlertAction actionWithTitle:@"Confirm Logout"
-                                                           style:UIAlertActionStyleDefault
+                                                          preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction *logoutAction = [UIAlertAction actionWithTitle:@"Logout"
+                                                           style:UIAlertActionStyleDestructive
                                                          handler:^(UIAlertAction * action) {
                                                             self.logoutActionSheet = nil;
                                                             [[SFUserAccountManager sharedInstance] logout];
                                                         }];
+    
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel"
+                                                           style:UIAlertActionStyleCancel
+                                                         handler:^(UIAlertAction * action) {
+                                                         }];
     [alert addAction:logoutAction];
+    [alert addAction:cancelAction];
     self.logoutActionSheet = alert;
     [self presentViewController:alert animated:YES completion:nil];
 }


### PR DESCRIPTION
This PR fixes a few minor issues related to the following bugs. 

1. User switching and the removal of timer as reported by @xyang. Now we simply remove the timer   in the willSwitch and kick it off in the didSwitch in the SFUserAccountManagerDelegate  implementation within SalesforceSDKManager
2. Simple Bug fix for removeallclients & forgot passcode.
3. Added cancel button to the confirm dialog for logout in SmartSyncExplorer.