### PR TITLE
Binary download support for react native

### DIFF
--- a/libs/SalesforceReact/SalesforceReact/Classes/SFNetReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFNetReactBridge.m
@@ -58,7 +58,7 @@ RCT_EXPORT_METHOD(sendRequest:(NSDictionary *)argsDict callback:(RCTResponseSend
     NSDictionary* queryParams = [argsDict nonNullObjectForKey:kQueryParams];
     NSMutableDictionary* headerParams = [argsDict nonNullObjectForKey:kHeaderParams];
     NSDictionary* fileParams = [argsDict nonNullObjectForKey:kfileParams];
-    BOOL returnAsBlob = [argsDict nonNullObjectForKey:kReturnBinary] != nil && [[argsDict nonNullObjectForKey:kReturnBinary] boolValue];
+    BOOL returnBinary = [argsDict nonNullObjectForKey:kReturnBinary] != nil && [[argsDict nonNullObjectForKey:kReturnBinary] boolValue];
     SFRestRequest* request = nil;
     
     // Sets HTTP body explicitly for a POST, PATCH or PUT request.
@@ -91,7 +91,7 @@ RCT_EXPORT_METHOD(sendRequest:(NSDictionary *)argsDict callback:(RCTResponseSend
     }
     
     // Disable parsing for binary request
-    if (returnAsBlob) {
+    if (returnBinary) {
         request.parseResponse = NO;
     }
     
@@ -104,7 +104,7 @@ RCT_EXPORT_METHOD(sendRequest:(NSDictionary *)argsDict callback:(RCTResponseSend
                                       id result;
                                       
                                       // Binary response
-                                      if (returnAsBlob) {
+                                      if (returnBinary) {
                                           result = @{
                                                      kEncodedBody:[((NSData*) response) base64EncodedStringWithOptions:0],
                                                      kContentType:((NSHTTPURLResponse*) rawResponse).allHeaderFields[kHttpContentType]

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFNetReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFNetReactBridge.m
@@ -38,7 +38,7 @@ static NSString * const kfileParams      = @"fileParams";
 static NSString * const kFileMimeType    = @"fileMimeType";
 static NSString * const kFileUrl         = @"fileUrl";
 static NSString * const kFileName        = @"fileName";
-static NSString * const kReturnAsBlob    = @"returnResponseAsBlob";
+static NSString * const kReturnBinary    = @"returnBinary";
 static NSString * const kEncodedBody     = @"encodedBody";
 static NSString * const kContentType     = @"contentType";
 static NSString * const kHttpContentType = @"content-type";
@@ -58,7 +58,7 @@ RCT_EXPORT_METHOD(sendRequest:(NSDictionary *)argsDict callback:(RCTResponseSend
     NSDictionary* queryParams = [argsDict nonNullObjectForKey:kQueryParams];
     NSMutableDictionary* headerParams = [argsDict nonNullObjectForKey:kHeaderParams];
     NSDictionary* fileParams = [argsDict nonNullObjectForKey:kfileParams];
-    BOOL returnAsBlob = [argsDict nonNullObjectForKey:kReturnAsBlob] != nil && [[argsDict nonNullObjectForKey:kReturnAsBlob] boolValue];
+    BOOL returnAsBlob = [argsDict nonNullObjectForKey:kReturnBinary] != nil && [[argsDict nonNullObjectForKey:kReturnBinary] boolValue];
     SFRestRequest* request = nil;
     
     // Sets HTTP body explicitly for a POST, PATCH or PUT request.


### PR DESCRIPTION
New flag returnBinary (default false) in network bridge sendRequest method.
When returnBinary is true the bridge will send back the base64 encoded body and the content type.

Related to: https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/pull/52