### PR TITLE
Post param name is not always fileData

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFNetworkPlugin/SFNetworkPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFNetworkPlugin/SFNetworkPlugin.m
@@ -104,7 +104,7 @@ static NSString * const kHttpContentType = @"content-type";
             NSString* fileUrl = [fileParam nonNullObjectForKey:kFileUrl];
             NSString* fileName = [fileParam nonNullObjectForKey:kFileName];
             NSData* fileData = [NSData dataWithContentsOfURL:[NSURL URLWithString:fileUrl]];
-            [request addPostFileData:fileData description:nil fileName:fileName mimeType:fileMimeType];
+            [request addPostFileData:fileData paramName:fileParamName description:nil fileName:fileName mimeType:fileMimeType];
         }
     }
     

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFNetReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFNetReactBridge.m
@@ -86,7 +86,7 @@ RCT_EXPORT_METHOD(sendRequest:(NSDictionary *)argsDict callback:(RCTResponseSend
             NSString* fileUrl = [fileParam nonNullObjectForKey:kFileUrl];
             NSString* fileName = [fileParam nonNullObjectForKey:kFileName];
             NSData* fileData = [NSData dataWithContentsOfURL:[NSURL URLWithString:fileUrl]];
-            [request addPostFileData:fileData description:nil fileName:fileName mimeType:fileMimeType];
+            [request addPostFileData:fileData paramName:fileParamName description:nil fileName:fileName mimeType:fileMimeType];
         }
     }
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
@@ -35,6 +35,7 @@
 #define LINKED_ENTITY_ID @"LinkedEntityId"
 #define SHARE_TYPE @"ShareType"
 #define RENDITION_TYPE @"type"
+#define FILE_DATA @"fileData"
 
 @implementation SFRestAPI (Files)
 
@@ -119,7 +120,7 @@
 - (SFRestRequest *) requestForUploadFile:(NSData *)data name:(NSString *)name description:(NSString *)description mimeType:(NSString *)mimeType {
     NSString *path = [NSString stringWithFormat:@"/%@/connect/files/users/me", self.apiVersion];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
-    [request addPostFileData:data description:description fileName:name mimeType:mimeType];
+    [request addPostFileData:data paramName:FILE_DATA description:description fileName:name mimeType:mimeType];
     return request;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -207,7 +207,7 @@ extern NSString * const kSFDefaultRestEndpoint;
  * @param fileName Name of the file
  * @param mimeType MIME type of the file
  */
-- (void)addPostFileData:(NSData *)fileData paramName:(NSString*)paramName description:(NSString *)description fileName:(NSString *)fileName mimeType:(NSString *)mimeType;
+- (void)addPostFileData:(NSData *)fileData paramName:(NSString*)paramName description:(nullable NSString *)description fileName:(NSString *)fileName mimeType:(NSString *)mimeType;
 
 /**
  * Sets a custom request body based on an NSString representation.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -202,11 +202,12 @@ extern NSString * const kSFDefaultRestEndpoint;
 /**
  * Add file to upload.
  * @param fileData Value of this POST parameter
+ * @param paramName Name of the POST parameter
  * @param description Description of the file
  * @param fileName Name of the file
  * @param mimeType MIME type of the file
  */
-- (void)addPostFileData:(NSData *)fileData description:(nullable NSString *)description fileName:(NSString *)fileName mimeType:(NSString *)mimeType;
+- (void)addPostFileData:(NSData *)fileData paramName:(NSString*)paramName description:(NSString *)description fileName:(NSString *)fileName mimeType:(NSString *)mimeType;
 
 /**
  * Sets a custom request body based on an NSString representation.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -206,7 +206,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
 
 #pragma mark - Upload
 
-- (void)addPostFileData:(NSData *)fileData description:(NSString *)description fileName:(NSString *)fileName mimeType:(NSString *)mimeType {
+- (void)addPostFileData:(NSData *)fileData paramName:(NSString*)paramName description:(NSString *)description fileName:(NSString *)fileName mimeType:(NSString *)mimeType {
     NSString *mpeBoundary = [[NSUUID UUID] UUIDString];
     NSString *mpeSeparator = @"--";
     NSString *newline = @"\r\n";
@@ -236,7 +236,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         if (!mimeType) {
             mimeType = @"application/octet-stream";
         }
-        [body appendData:[self multiPartRequestBodyForkey:@"fileData" mimeType:mimeType fileName:fileName file:fileData]];
+        [body appendData:[self multiPartRequestBodyForkey:paramName mimeType:mimeType fileName:fileName file:fileData]];
         [body appendData:[[NSString stringWithFormat:@"%@%@%@%@", mpeSeparator, mpeBoundary, mpeSeparator, newline] dataUsingEncoding:NSUTF8StringEncoding]];
     }
     


### PR DESCRIPTION
The post param name during binary upload was hard coded in 5.1.0 to always be fileData - but that is not the param name expected for all binary post - for instance when changing user profile picture, the param name expected is fileUpload.

