### PR TITLE
Notify of user initiated cancel for auth (e.g. advanced auth flow) 

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.h
@@ -176,7 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
  Called when a browser flow authentication is cancelled.
  @param client The instance of SFSDKOAuthClient making the call.
  */
-- (void)authClientDidCancelBrowserFlow:(SFSDKOAuthClient *)client;
+- (BOOL)authClientDidCancelBrowserFlow:(SFSDKOAuthClient *)client;
 
 /**
  Called when the auth client is going to present the safari view controller.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -339,7 +339,11 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
 }
 
 - (BOOL)oauthCoordinatorIsNetworkAvailable:(SFOAuthCoordinator *)coordinator {
-    return YES;
+    BOOL result = YES;
+    if ([self.config.delegate respondsToSelector:@selector(authClientIsNetworkAvailable:)]) {
+        result = [self.config.delegate authClientIsNetworkAvailable:self];
+    }
+    return result;
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator willBeginBrowserAuthentication:(SFOAuthBrowserFlowCallbackBlock)callbackBlock {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -381,14 +381,14 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
         };
         builder.actionTwoCompletion = ^{
             __strong typeof(weakSelf) strongSelf = weakSelf;
+            // Let the OAuth coordinator know whether to proceed or not.
             if ([strongSelf.config.safariViewDelegate respondsToSelector:@selector(authClientDidCancelBrowserFlow:)]) {
                 [strongSelf.config.safariViewDelegate authClientDidCancelBrowserFlow:strongSelf];
             }
-
-            // Let the OAuth coordinator know whether to proceed or not.
             if (strongSelf.authCoordinatorBrowserBlock) {
                 strongSelf.authCoordinatorBrowserBlock(NO);
             }
+            
         };
     }];
     [self.config.delegate authClient:self displayMessage:messageObject];
@@ -462,8 +462,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     __block BOOL handledByDelegate = NO;
     [SFSDKCoreLogger i:[self class] format:@"oauthCoordinatorDidCancelBrowserAuthentication"];
     if ([self.config.safariViewDelegate respondsToSelector:@selector(authClientDidCancelBrowserFlow:)]) {
-        handledByDelegate = YES;
-        [self.config.safariViewDelegate authClientDidCancelBrowserFlow:self];
+        handledByDelegate = [self.config.safariViewDelegate authClientDidCancelBrowserFlow:self];
     }
     // If no delegates implement authManagerDidCancelBrowserFlow, display Login Host List
     if (!handledByDelegate) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -114,6 +114,10 @@ FOUNDATION_EXTERN NSString * const kSFNotificationUserDidLogout;
  */
 FOUNDATION_EXTERN NSString * const kSFNotificationUserWillShowAuthView;
 
+/** Notification sent when user cancels authentication
+ */
+FOUNDATION_EXTERN NSString * const kSFNotificationUserCanceledAuth;
+
 /** Notification sent prior to user log in
  */
 FOUNDATION_EXTERN NSString * const kSFNotificationUserWillLogIn;
@@ -586,9 +590,14 @@ FOUNDATION_EXTERN NSString * const kSFUserInfoAddlOptionsKey;
 @property (nonatomic, strong) SFSDKAuthViewHandler *authViewHandler;
 
 /**
- Change this block to handle all alerts  required by the SFUSerAccountManager.
+ Change this block to handle all alerts  required by the SFUserAccountManager.
  */
 @property (nonatomic, copy, nonnull) void (^alertDisplayBlock)(SFSDKAlertMessage *,SFSDKWindowContainer *);
+
+/**
+ Change this block to customize behavior for user initiated auth cancellation
+ */
+@property (nonatomic, copy, nonnull) void (^authCancelledByUserHandlerBlock)(void);
 
 /**
  Determines whether an error is due to invalid auth credentials.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -75,7 +75,7 @@ NSString * const kSFNotificationUserDidLogout  = @"SFNotificationUserDidLogout";
 
 //Auth Display Notification
 NSString * const kSFNotificationUserWillShowAuthView = @"SFNotificationUserWillShowAuthView";
-
+NSString * const kSFNotificationUserCanceledAuth = @"SFNotificationUserCanceledAuthentication";
 //IDP-SP flow Notifications
 NSString * const kSFNotificationUserWillSendIDPRequest      = @"SFNotificationUserWillSendIDPRequest";
 NSString * const kSFNotificationUserDidReceiveIDPRequest    = @"SFNotificationUserDidReceiveIDPRequest";
@@ -451,6 +451,20 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
                                 kSFNotificationUserInfoAuthTypeKey: client.context.authInfo };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserWillShowAuthView
                                                         object:self userInfo:userInfo];
+}
+
+- (BOOL)authClientDidCancelBrowserFlow:(SFSDKOAuthClient *)client {
+    BOOL result = NO;
+    NSDictionary *userInfo = @{ kSFNotificationUserInfoCredentialsKey: client.credentials,
+                                kSFNotificationUserInfoAuthTypeKey: client.context.authInfo };
+    [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserCanceledAuth
+                                                        object:self userInfo:userInfo];
+    if (self.authCancelledByUserHandlerBlock) {
+        [client cancelAuthentication:YES];
+        result = YES;
+        self.authCancelledByUserHandlerBlock();
+    }
+    return result;
 }
 
 #pragma mark - SFSDKIDPAuthClientDelegate


### PR DESCRIPTION
Allow for users to specify a handler block if needed. Send Notification for cancel.  