### PR TITLE
Fixed handling of back button, user switch for hybrid & an idp related bug. 

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFAccountManagerPlugin/SFAccountManagerPlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFAccountManagerPlugin/SFAccountManagerPlugin.m
@@ -95,7 +95,11 @@ SFSDK_USE_DEPRECATED_BEGIN
         NSArray *userAccounts = [SFUserAccountManager sharedInstance].allUserAccounts;
         if ([userAccounts count] == 1) {
             // Single account configured.  Switch to new user.
-            [[SFUserAccountManager sharedInstance] switchToNewUser];
+            [self loginWithCompletion:^(SFOAuthInfo * authInfo, SFUserAccount * newAccount) {
+                [[SFUserAccountManager sharedInstance] switchToUser:newAccount];
+            } failure:^(SFOAuthInfo * info, NSError * error) {
+                [SFSDKHybridLogger e:[self class] format:@"switchToNewUser: Failed Switching to user account: %@", error.localizedDescription ];
+            }];
         } else if ([userAccounts count] > 1) {
             // Already more than one account.  Let the user choose the account to switch to.
             SFDefaultUserManagementViewController *umvc = [[SFDefaultUserManagementViewController alloc] initWithCompletionBlock:^(SFUserManagementAction action) {
@@ -165,6 +169,14 @@ SFSDK_USE_DEPRECATED_BEGIN
     } else {
         [[SFUserAccountManager sharedInstance] logout];
     }
+}
+
+- (void)loginWithCompletion:(SFOAuthFlowSuccessCallbackBlock)completionBlock failure:(SFOAuthFlowFailureCallbackBlock)failureBlock {
+  if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
+      [[SFAuthenticationManager sharedManager] loginWithCompletion:completionBlock failure:failureBlock];
+  } else {
+      [[SFUserAccountManager sharedInstance] loginWithCompletion:completionBlock failure:failureBlock];
+  }
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -197,7 +197,7 @@ SFSDK_USE_DEPRECATED_END
         return YES;
     }
     NSInteger totalAccounts = [SFUserAccountManager sharedInstance].allUserAccounts.count;
-    return  (totalAccounts > 0);
+    return  (totalAccounts > 0 && [SFUserAccountManager sharedInstance].currentUser);
 }
 
 #pragma mark - Action Methods

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -130,6 +130,10 @@ FOUNDATION_EXTERN NSString * const kSFNotificationUserDidLogIn;
  */
 FOUNDATION_EXTERN NSString * const kSFNotificationUserWillSendIDPRequest;
 
+/**  Notification sent before IDP APP invokes SP APP with auth code
+ */
+FOUNDATION_EXTERN NSString * const kSFNotificationUserWillSendIDPResponse;
+
 /**  Notification sent when  IDP APP receives request for authentication from SP APP
  */
 FOUNDATION_EXTERN NSString * const kSFNotificationUserDidReceiveIDPRequest;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -78,6 +78,7 @@ NSString * const kSFNotificationUserWillShowAuthView = @"SFNotificationUserWillS
 NSString * const kSFNotificationUserCanceledAuth = @"SFNotificationUserCanceledAuthentication";
 //IDP-SP flow Notifications
 NSString * const kSFNotificationUserWillSendIDPRequest      = @"SFNotificationUserWillSendIDPRequest";
+NSString * const kSFNotificationUserWillSendIDPResponse     = @"kSFNotificationUserWillSendIDPResponse";
 NSString * const kSFNotificationUserDidReceiveIDPRequest    = @"SFNotificationUserDidReceiveIDPRequest";
 NSString * const kSFNotificationUserDidReceiveIDPResponse   = @"SFNotificationUserDidReceiveIDPResponse";
 NSString * const kSFNotificationUserIDPInitDidLogIn       = @"SFNotificationUserIDPInitDidLogIn";
@@ -477,6 +478,12 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 
 - (void)authClient:(SFSDKOAuthClient *)client willSendResponseForIDPAuth:(NSDictionary *)options {
     [client dismissAuthViewControllerIfPresent];
+    SFUserAccount *account = [[SFUserAccountManager sharedInstance] accountForCredentials:client.credentials];
+    NSDictionary *userInfo = @{kSFNotificationUserInfoAccountKey:account,kSFUserInfoAddlOptionsKey:options};
+    [[NSNotificationCenter defaultCenter]  postNotificationName:kSFNotificationUserWillSendIDPResponse
+                                                         object:self
+                                                       userInfo:userInfo
+     ];
 }
 
 - (void)authClient:(SFSDKIDPAuthClient *)client willSendRequestForIDPAuth:(NSDictionary *)options {


### PR DESCRIPTION
2 more bugs found while testing.

(Hybrid)
1. The back button for hybrid apps only on loginview controller results in a white screen. Solution is to defer the switch to a user until user login occurs for switch to new user (Fixed)

(Idp)
2. If an IDP app has never logged in, it leaves the  SDKManager in isLaunching mode in a sp initiated login flow. You would have to kill the idp app  and return to be logged-in. Now we post a notification and handle on the SDKManager as a counter measure. 