### PR TITLE
add aes128 encrytion/decrytion utils for push notification

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
@@ -80,6 +80,44 @@ extern NSUInteger const kSFPBKDFDefaultSaltByteLength;
                               keyLength:(NSUInteger)derivedKeyLength;
 
 /**
+ * Encrypt the given data using the AES algorithm.
+ * @param data The data to encrypt.
+ * @param key The encryption key used to encrypt the data.
+ * @param keyLength The encryption key length used for key.
+ * @param iv The initialization vector data used for the encryption.
+ * @return The encrypted data, or `nil` if encryption was not successful.
+ */
++ (nullable NSData *)aesEncryptData:(NSData *)data withKey:(NSData *)key keyLength:(NSInteger)keyLength iv:(NSData *)iv;
+
+/**
+ * Decrypt the given data using the AES algorithm.
+ * @param data The data to decrypt.
+ * @param key The decryption key used to decrypt the data.
+ * @param keyLength The decryption key length used for key.
+ * @param iv The initialization vector data used for the decryption.
+ * @return The decrypted data, or `nil` if decryption was not successful.
+ */
++ (nullable NSData *)aesDecryptData:(NSData *)data withKey:(NSData *)key keyLength:(NSInteger)keyLength iv:(NSData *)iv;
+
+/**
+ * Encrypt the given data using the AES-128 algorithm.
+ * @param data The data to encrypt.
+ * @param key The encryption key used to encrypt the data.
+ * @param iv The initialization vector data used for the encryption.
+ * @return The encrypted data, or `nil` if encryption was not successful.
+ */
++ (nullable NSData *)aes128EncryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv;
+
+/**
+ * Decrypt the given data using the AES-128 algorithm.
+ * @param data The data to decrypt.
+ * @param key The decryption key used to decrypt the data.
+ * @param iv The initialization vector data used for the decryption.
+ * @return The decrypted data, or `nil` if decryption was not successful.
+ */
++ (nullable NSData *)aes128DecryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv;
+
+/**
  * Encrypt the given data using the AES-256 algorithm.
  * @param data The data to encrypt.
  * @param key The encryption key used to encrypt the data.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
@@ -80,26 +80,6 @@ extern NSUInteger const kSFPBKDFDefaultSaltByteLength;
                               keyLength:(NSUInteger)derivedKeyLength;
 
 /**
- * Encrypt the given data using the AES algorithm.
- * @param data The data to encrypt.
- * @param key The encryption key used to encrypt the data.
- * @param keyLength The encryption key length used for key.
- * @param iv The initialization vector data used for the encryption.
- * @return The encrypted data, or `nil` if encryption was not successful.
- */
-+ (nullable NSData *)aesEncryptData:(NSData *)data withKey:(NSData *)key keyLength:(NSInteger)keyLength iv:(NSData *)iv;
-
-/**
- * Decrypt the given data using the AES algorithm.
- * @param data The data to decrypt.
- * @param key The decryption key used to decrypt the data.
- * @param keyLength The decryption key length used for key.
- * @param iv The initialization vector data used for the decryption.
- * @return The decrypted data, or `nil` if decryption was not successful.
- */
-+ (nullable NSData *)aesDecryptData:(NSData *)data withKey:(NSData *)key keyLength:(NSInteger)keyLength iv:(NSData *)iv;
-
-/**
  * Encrypt the given data using the AES-128 algorithm.
  * @param data The data to encrypt.
  * @param key The encryption key used to encrypt the data.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
@@ -82,15 +82,15 @@ NSUInteger const kSFPBKDFDefaultSaltByteLength = 32;
     }
 }
 
-+ (NSData *)aes256EncryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv
++ (NSData *)aesEncryptData:(NSData *)data withKey:(NSData *)key keyLength:(NSInteger)keyLength iv:(NSData *)iv
 {
     // Ensure the proper key, IV sizes.
     if (key == nil) {
-        [SFSDKCoreLogger e:[self class] format:@"aes256EncryptData: encryption key is nil.  Cannot encrypt data."];
+        [SFSDKCoreLogger e:[self class] format:@"aesEncryptData: encryption key is nil.  Cannot encrypt data."];
         return nil;
     }
     NSMutableData *mutableKey = [key mutableCopy];
-    [mutableKey setLength:kCCKeySizeAES256];
+    [mutableKey setLength:keyLength];
     NSMutableData *mutableIv = [iv mutableCopy];
     [mutableIv setLength:kCCBlockSizeAES128];
 	
@@ -113,15 +113,15 @@ NSUInteger const kSFPBKDFDefaultSaltByteLength = 32;
     return (executeCryptSuccess ? resultData : nil);
 }
 
-+ (NSData *)aes256DecryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv
++ (NSData *)aesDecryptData:(NSData *)data withKey:(NSData *)key keyLength:(NSInteger)keyLength iv:(NSData *)iv
 {
     // Ensure the proper key, IV sizes.
     if (key == nil) {
-        [SFSDKCoreLogger e:[self class] format:@"aes256DecryptData: decryption key is nil.  Cannot decrypt data."];
+        [SFSDKCoreLogger e:[self class] format:@"aesDecryptData: decryption key is nil.  Cannot decrypt data."];
         return nil;
     }
     NSMutableData *mutableKey = [key mutableCopy];
-    [mutableKey setLength:kCCKeySizeAES256];
+    [mutableKey setLength:keyLength];
     NSMutableData *mutableIv = [iv mutableCopy];
     [mutableIv setLength:kCCBlockSizeAES128];
 	
@@ -142,6 +142,26 @@ NSUInteger const kSFPBKDFDefaultSaltByteLength = 32;
 	BOOL executeCryptSuccess = [self executeCrypt:data cryptor:cryptor resultData:&resultData];
 	CCCryptorRelease(cryptor);
     return (executeCryptSuccess ? resultData : nil);
+}
+
++ (NSData *)aes128EncryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv
+{
+    return [self aesEncryptData:data withKey:key keyLength:kCCKeySizeAES128 iv:iv];
+}
+
++ (NSData *)aes128DecryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv
+{
+    return [self aesDecryptData:data withKey:key keyLength:kCCKeySizeAES128 iv:iv];
+}
+
++ (NSData *)aes256EncryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv
+{
+    return [self aesEncryptData:data withKey:key keyLength:kCCKeySizeAES256 iv:iv];
+}
+
++ (NSData *)aes256DecryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv
+{
+    return [self aesDecryptData:data withKey:key keyLength:kCCKeySizeAES256 iv:iv];
 }
 
 #pragma mark - Private methods

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
@@ -140,7 +140,7 @@
     XCTAssertFalse([initialPBKDFData.derivedKey isEqualToData:verifyPBKDFData.derivedKey], @"Generated keys with different derived key lengths should not be equal.");
 }
 
-- (void)testAesEncryptionDecryption
+- (void)testAes256EncryptionDecryption
 {
     NSData *origData = [@"The quick brown fox..." dataUsingEncoding:NSUTF8StringEncoding];
     NSData *keyData = [@"My encryption key" dataUsingEncoding:NSUTF8StringEncoding];
@@ -161,6 +161,30 @@
     badDecryptData = [SFSDKCryptoUtils aes256DecryptData:encryptedData withKey:keyData iv:badIv];
     XCTAssertFalse([badDecryptData isEqualToData:origData], @"Wrong initialization vector should return different data on decrypt.");
     badDecryptData = [SFSDKCryptoUtils aes256DecryptData:encryptedData withKey:badKey iv:badIv];
+    XCTAssertFalse([badDecryptData isEqualToData:origData], @"Wrong key and initialization vector should return different data on decrypt.");
+}
+
+- (void)testAes128EncryptionDecryption
+{
+    NSData *origData = [@"The quick brown fox..." dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *keyData = [@"My encryption key" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *ivData = [@"Here's an iv staging string" dataUsingEncoding:NSUTF8StringEncoding];
+    
+    NSData *encryptedData = [SFSDKCryptoUtils aes128EncryptData:origData withKey:keyData iv:ivData];
+    XCTAssertFalse([encryptedData isEqualToData:origData], @"Encrypted data should not be the same as original data.");
+    
+    // Clean decryption should pass.
+    NSData *decryptedData = [SFSDKCryptoUtils aes128DecryptData:encryptedData withKey:keyData iv:ivData];
+    XCTAssertTrue([decryptedData isEqualToData:origData], @"Decrypted data should match original data.");
+    
+    // Bad decryption key data should return different data.
+    NSData *badKey = [@"The wrong key" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *badIv = [@"The wrong iv" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *badDecryptData = [SFSDKCryptoUtils aes128DecryptData:encryptedData withKey:badKey iv:ivData];
+    XCTAssertFalse([badDecryptData isEqualToData:origData], @"Wrong encryption key should return different data on decrypt.");
+    badDecryptData = [SFSDKCryptoUtils aes128DecryptData:encryptedData withKey:keyData iv:badIv];
+    XCTAssertFalse([badDecryptData isEqualToData:origData], @"Wrong initialization vector should return different data on decrypt.");
+    badDecryptData = [SFSDKCryptoUtils aes128DecryptData:encryptedData withKey:badKey iv:badIv];
     XCTAssertFalse([badDecryptData isEqualToData:origData], @"Wrong key and initialization vector should return different data on decrypt.");
 }
 


### PR DESCRIPTION
Add SFSDKPushNotificationCryptoUtils and test class to support AES 128 encryption/decryption. These methods are used for push notification related work. Include the header class in public.
Currently keep them in separate class from SFSDKCryptoUtils class. We can combine them later if needed.

For the private method `+ (BOOL)executeCrypt:(NSData *)inData cryptor:(CCCryptorRef)cryptor resultData:(NSData **)resultData;` in SFSDKCryptoUtils class, I can not make it public since it will require to `#import <CommonCrypto/CommonCrypto.h>` and cause build error "Include of non-modular header inside framework module"