### PR TITLE
parentChildren sync targets in JSON configs are not read

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncDownTarget.m
@@ -147,6 +147,9 @@ ABSTRACT_METHOD
     if ([queryType isEqualToString:kSFSyncTargetQueryTypeRefresh]) {
         return SFSyncDownTargetQueryTypeRefresh;
     }
+    if ([queryType isEqualToString:kSFSyncTargetQueryTypeParentChidlren]) {
+        return SFSyncDownTargetQueryTypeParentChildren;
+    }
     // Must be custom
     return SFSyncDownTargetQueryTypeCustom;
 }


### PR DESCRIPTION
Fixed a bug where parentChildren sync targets defined in the <user/global>syncs.json file are not read properly and the SDK crashes because of nil target.