### PR TITLE
Adding bundleID to push notification registration call

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -186,7 +186,8 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
     [request setHTTPShouldHandleCookies:NO];
     
     // Body
-    NSDictionary* bodyDict = @{@"ConnectionToken":_deviceToken, @"ServiceType":@"Apple"};
+    NSString *bundleId = [NSBundle mainBundle].bundleIdentifier;
+    NSDictionary* bodyDict = @{@"ConnectionToken":_deviceToken, @"ServiceType":@"Apple", @"ApplicationBundle":bundleId};
     [request setHTTPBody:[SFJsonUtils JSONDataRepresentation:bodyDict]];
     
     // Send


### PR DESCRIPTION
`BundleID` is now a part of the PN registration call for `iOS`. This is an optional parameter and we won't be adding this for `Android` (it only makes sense for `APNS`).