### PR TITLE
Report Static Analysis on PR

### DIFF
--- a/DangerFile
+++ b/DangerFile
@@ -1,35 +1,72 @@
-junit.parse "test_output/report.junit"
+gem 'plist'
+require 'plist'
+
+# Markdown table character length without any issues
+MAKRDOWN_LENGTH = 138
+
+junit.parse 'test_output/report.junit'
 junit.show_skipped_tests = true
 junit.report
 
 # Warn when there is a big PR
-warn("Big PR, try to keep changes smaller if you can") if git.lines_of_code > 500
+warn('Big PR, try to keep changes smaller if you can') if git.lines_of_code > 500
 
 # Stop skipping some manual testing
-warn("Needs testing on a Phone if change is non-trivial") if git.lines_of_code > 50 && !github.pr_title.include?("📱")
+warn('📱 Needs testing on a real device if change is non-trivial') if git.lines_of_code > 50
 
 # Mainly to encourage writing up some reasoning about the PR, rather than
 # just leaving a title
 if github.pr_body.length < 3
-  warn "Please provide a summary in the Pull Request description"
+  warn 'Please provide a summary in the Pull Request description'
 end
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet.
-has_wip_label = github.pr_labels.any? { |label| label.include? "WIP" }
-has_wip_title = github.pr_title.include? "[WIP]"
-has_dnm_label = github.pr_labels.any? { |label| label.include? "DO NOT MERGE" }
-has_dnm_title = github.pr_title.include? "[DO NOT MERGE]"
+has_wip_label = github.pr_labels.any? { |label| label.include? 'WIP' }
+has_wip_title = github.pr_title.include? '[WIP]'
+has_dnm_label = github.pr_labels.any? { |label| label.include? 'DO NOT MERGE' }
+has_dnm_title = github.pr_title.include? '[DO NOT MERGE]'
 if has_wip_label || has_wip_title
-  warn("PR is classed as Work in Progress")
+  warn('PR is classed as Work in Progress')
 end
 if has_dnm_label || has_dnm_title
-  warn("At the authors request please DO NOT MERGE this PR")
+  warn('At the authors request please DO NOT MERGE this PR')
 end
 
-fail "Please re-submit this PR to dev, we may have already fixed your issue." if github.branch_for_base != "dev"
+fail 'Please re-submit this PR to dev, we may have already fixed your issue.' if github.branch_for_base != 'dev'
 
 xcov.report(
-   scheme: 'UnitTests',
-   workspace: 'SalesforceMobileSDK.xcworkspace', 
-   exclude_targets:'CocoaLumberjack.framework,SalesforceSDKCoreTestApp.app,SmartStoreTestApp.app,SmartSyncTestApp.app,SalesforceHybridSDKTestApp.app,SalesforceAnalyticsTestApp.app,RestAPIExplorer.app,AccountEditor.app,NoteSync.app,SmartSyncExplorerHybrid.app,SmartSyncExplorer.app,SmartSyncExplorerCommon.framework,RecentContactsTodayExtension.appex,Cordova.framework,SalesforceReact.framework'
+    scheme: 'UnitTests',
+    workspace: 'SalesforceMobileSDK.xcworkspace',
+    exclude_targets:'CocoaLumberjack.framework,SalesforceSDKCoreTestApp.app,SmartStoreTestApp.app,SmartSyncTestApp.app,SalesforceHybridSDKTestApp.app,SalesforceAnalyticsTestApp.app,RestAPIExplorer.app,AccountEditor.app,NoteSync.app,SmartSyncExplorerHybrid.app,SmartSyncExplorer.app,SmartSyncExplorerCommon.framework,RecentContactsTodayExtension.appex,Cordova.framework,SalesforceReact.framework'
 )
+
+message = "### Clang Static Analysis Issues\n\n"
+message << "File | Type | Category | Description | Line | Col |\n"
+message << " --- | ---- | -------- | ----------- | ---- | --- |\n"
+
+# Parse Clang Plist files and report issues associated with files modified in this PR.
+clang_libs = Dir['clangReport/StaticAnalyzer/*'].map { | x | x.split('/').last }
+for lib in clang_libs;
+  files = Dir["clangReport/StaticAnalyzer/#{lib}/#{lib}/normal/x86_64/*.plist"].map { | x | x.split('/').last }
+  for file in files;
+    report = Plist.parse_xml("clangReport/StaticAnalyzer/#{lib}/#{lib}/normal/x86_64/#{file}")
+    absolute_file_path = report['files'][0]
+    unless absolute_file_path.nil?
+      file_path = (ENV.has_key?('JENKINS_HOME')) ? absolute_file_path.split('SalesforceMobileSDK-iOS-PR/').last : absolute_file_path.split('SalesforceMobileSDK-iOS/').last
+      if git.modified_files.include?(file_path) || git.added_files.include?(file_path)
+        issues = report['diagnostics']
+        for i in 0..issues.count
+          unless issues[i].nil?
+            message << "#{file_path.split('/').last} | #{issues[0]['type']} | #{issues[0]['category']} | #{issues[0]['description']} | #{issues[0]['location']['line']} | #{issues[0]['location']['col']}\n"
+          end
+        end
+      end
+    end
+  end
+end
+
+# Only print Static Analysis table if there are issues
+if message.length > MAKRDOWN_LENGTH
+  warn('Static Analysis found an issue with one or more files you modified.  Please fix the issue(s).')
+  markdown message
+end

--- a/DangerFile
+++ b/DangerFile
@@ -11,9 +11,6 @@ junit.report
 # Warn when there is a big PR
 warn('Big PR, try to keep changes smaller if you can') if git.lines_of_code > 500
 
-# Stop skipping some manual testing
-warn('📱 Needs testing on a real device if change is non-trivial') if git.lines_of_code > 50
-
 # Mainly to encourage writing up some reasoning about the PR, rather than
 # just leaving a title
 if github.pr_body.length < 3

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -149,15 +149,10 @@ lane :PR do
     schemes = ENV["scheme"].split(',')
   end
 
-  if schemes.include?("SalesforceSDKCore") || schemes.include?("UnitTests")
-    testScheme("UnitTests")
-    doDanger
-  else
-    for scheme in schemes
-      testScheme(scheme)
-      doDanger
-    end
+  for scheme in schemes
+    testScheme(scheme)
   end
+  doDanger
 end
 
 lane :LCL do


### PR DESCRIPTION
- Parse Clang Static Analysis results and report them in the Danger comment.
- Filter out issues that are not from files modified in the current PR.
- Don't run tests for every library if core or unit tests are modified.  