### PR TITLE
changed hasSuffix to hasPrefix because FMDB appends :<num> to column 

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -1593,7 +1593,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
     for (int i = 0; i < frs.columnCount; i++) {
         NSString* columnName = [frs columnNameForIndex:i];
         id value = valuesMap[columnName];
-        if ([columnName hasSuffix:SOUP_COL] && [value isKindOfClass:[NSString class]]) {
+        if ([columnName hasPrefix:SOUP_COL] && [value isKindOfClass:[NSString class]]) {
             id entry = [SFJsonUtils objectFromJSONString:value];
             if (entry) {
                 [result addObject:entry];


### PR DESCRIPTION
`SFSmartStore.m` Line 1596 checks if the column name has a **suffix** of "soup". If your result set has more than one column of same name e.g. a join query returning 2 or more soups then FMDB appends the column name with :<num> so the result set column names will be soup, soup:1, soup:2. In this case the `hasSuffix` logic fails because of the appended string. So I have changed it to `hasPrefix`