### PR TITLE
Soup column recognized more precisely

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -1593,7 +1593,8 @@ NSString *const EXPLAIN_ROWS = @"rows";
     for (int i = 0; i < frs.columnCount; i++) {
         NSString* columnName = [frs columnNameForIndex:i];
         id value = valuesMap[columnName];
-        if ([columnName hasPrefix:SOUP_COL] && [value isKindOfClass:[NSString class]]) {
+        if ([value isKindOfClass:[NSString class]] &&
+            ([columnName isEqualToString:SOUP_COL] || [columnName hasPrefix:[NSString stringWithFormat:@"%@:", SOUP_COL]])) {
             id entry = [SFJsonUtils objectFromJSONString:value];
             if (entry) {
                 [result addObject:entry];


### PR DESCRIPTION
Just doing hasPrefix:@"soup" is not good enough (e.g. if you select the soupName column)