### PR TITLE
SmartStore Api wrapped in promises

### DIFF
--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		B77795891FE0AEE5009C10FB /* SmartStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B777958A1FE0AEE5009C10FB /* SmartStore.framework */; };
 		B777958B1FE0AEE5009C10FB /* SmartSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7DA7AEB1FCDE2540098C1EA /* SmartSync.framework */; };
 		B77795C01FE0AF5E009C10FB /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7DA7B491FCDECA70098C1EA /* PromiseKit.framework */; };
+		B79119042012846900516791 /* SFSmartStoreExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79119032012846900516791 /* SFSmartStoreExtensions.swift */; };
+		B79119542012E18100516791 /* SmartStoreClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79119532012E18100516791 /* SmartStoreClientTests.swift */; };
+		B791195C2017A20B00516791 /* SalesforceSwiftSDKBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B791195B2017A20B00516791 /* SalesforceSwiftSDKBaseTest.swift */; };
 		B7980CC01FD49B3C009CFDE1 /* SFUserAccountManagerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7980CBF1FD49B3C009CFDE1 /* SFUserAccountManagerExtensions.swift */; };
 		B7980CC21FD49B63009CFDE1 /* SFRestAPIExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7980CC11FD49B63009CFDE1 /* SFRestAPIExtensions.swift */; };
 		B799B46D1FD60528001DC6ED /* SFRestAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B799B46C1FD60527001DC6ED /* SFRestAPITests.swift */; };
@@ -156,6 +159,9 @@
 		B77795881FE0AEDB009C10FB /* SalesforceAnalytics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SalesforceAnalytics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B777958A1FE0AEE5009C10FB /* SmartStore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SmartStore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B77795B71FE0AF56009C10FB /* CocoaLumberjackSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CocoaLumberjackSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B79119032012846900516791 /* SFSmartStoreExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSmartStoreExtensions.swift; sourceTree = "<group>"; };
+		B79119532012E18100516791 /* SmartStoreClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartStoreClientTests.swift; sourceTree = "<group>"; };
+		B791195B2017A20B00516791 /* SalesforceSwiftSDKBaseTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SalesforceSwiftSDKBaseTest.swift; sourceTree = "<group>"; };
 		B7980CBF1FD49B3C009CFDE1 /* SFUserAccountManagerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFUserAccountManagerExtensions.swift; sourceTree = "<group>"; };
 		B7980CC11FD49B63009CFDE1 /* SFRestAPIExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFRestAPIExtensions.swift; sourceTree = "<group>"; };
 		B799B46C1FD60527001DC6ED /* SFRestAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFRestAPITests.swift; sourceTree = "<group>"; };
@@ -241,6 +247,7 @@
 				B7CFC4D31FD1D0390013534D /* SwiftExtensions.swift */,
 				B7980CBF1FD49B3C009CFDE1 /* SFUserAccountManagerExtensions.swift */,
 				B7980CC11FD49B63009CFDE1 /* SFRestAPIExtensions.swift */,
+				B79119032012846900516791 /* SFSmartStoreExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -293,6 +300,8 @@
 				B7CFC47C1FD04A950013534D /* SalesforceTestExtensions.swift */,
 				B799B46C1FD60527001DC6ED /* SFRestAPITests.swift */,
 				B71343DE1FDDF2B1008ABF1A /* SalesforceTestCodables.swift */,
+				B79119532012E18100516791 /* SmartStoreClientTests.swift */,
+				B791195B2017A20B00516791 /* SalesforceSwiftSDKBaseTest.swift */,
 			);
 			path = SalesforceSwiftSDKTests;
 			sourceTree = "<group>";
@@ -611,6 +620,7 @@
 				B7CFC47B1FD04A270013534D /* SalesforceSwiftLogger.swift in Sources */,
 				B7CFC4D41FD1D0390013534D /* SwiftExtensions.swift in Sources */,
 				B7980CC21FD49B63009CFDE1 /* SFRestAPIExtensions.swift in Sources */,
+				B79119042012846900516791 /* SFSmartStoreExtensions.swift in Sources */,
 				B7980CC01FD49B3C009CFDE1 /* SFUserAccountManagerExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -624,8 +634,10 @@
 				CE57D9061FD7B54900A0930F /* SalesforceSwiftLogger.swift in Sources */,
 				B7CFC47D1FD04A950013534D /* SalesforceTestExtensions.swift in Sources */,
 				4F0F31DA1FDF2E7700CF6926 /* SalesforceSwiftSDKManager.swift in Sources */,
+				B79119542012E18100516791 /* SmartStoreClientTests.swift in Sources */,
 				CE57D9031FD7B4AB00A0930F /* SwiftExtensions.swift in Sources */,
 				B7DA7ACA1FCDE08F0098C1EA /* SalesforceSwiftSDKTests.swift in Sources */,
+				B791195C2017A20B00516791 /* SalesforceSwiftSDKBaseTest.swift in Sources */,
 				CE57D9021FD7B4A600A0930F /* SalesforceSDKManagerExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
@@ -1,0 +1,261 @@
+/*
+ SFSmartStoreClient
+ Created by Raj Rao on 01/19/18.
+ 
+ Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import Foundation
+import SmartStore
+import PromiseKit
+
+enum SmartStoreError : Error {
+    case StoreNotFoundError
+    case SoupNotFoundError
+    case IndicesNotFoundError
+}
+
+extension SFSmartStore {
+    
+    public var Promises : SFSmartStorePromises {
+        return SFSmartStorePromises(api: self)
+    }
+    
+    public class SFSmartStorePromises {
+        
+        weak var api: SFSmartStore?
+        
+        init(api: SFSmartStore) {
+            self.api = api
+        }
+        
+        public func attributes(forSoup soupName: String) -> Promise<SFSoupSpec> {
+            return Promise(.pending) {  resolver in
+                let soupSpec : SFSoupSpec?  = self.api!.attributes(forSoup: soupName)
+                if let spec = soupSpec {
+                     resolver.fulfill(spec)
+                } else {
+                    resolver.reject(SmartStoreError.SoupNotFoundError)
+                }
+            }
+        }
+        
+        public func indices(forSoup soupName: String) -> Promise<[Any]> {
+            return Promise(.pending) {  resolver in
+                let indices : [Any]?  = self.api!.indices(forSoup: soupName)
+                if let indices = indices {
+                    resolver.fulfill(indices)
+                } else {
+                    resolver.reject(SmartStoreError.IndicesNotFoundError)
+                }
+            }
+        }
+        
+        public func soupExists(soupName: String) -> Promise<Bool> {
+            return Promise(.pending) {  resolver in
+                let result  = self.api!.soupExists(soupName)
+                resolver.fulfill(result)
+            }
+        }
+        
+        public func registerSoup(soupName: String, indexSpecs: [Any]) -> Promise<Bool> {
+            return Promise(.pending) {  resolver in
+                do {
+                   try self.api!.registerSoup(soupName, withIndexSpecs: indexSpecs, error: ())
+                   resolver.fulfill(true)
+                } catch let error {
+                    resolver.reject(error)
+                }
+            }
+        }
+        
+        public func registerSoup(with soupSpec: SFSoupSpec, withIndexSpecs indexSpecs: [Any]) -> Promise<Bool> {
+            return Promise(.pending) {  resolver in
+                do {
+                    try self.api!.registerSoup(with: soupSpec, withIndexSpecs: indexSpecs)
+                    resolver.fulfill(true)
+                } catch  let error {
+                    resolver.reject(error)
+                }
+            }
+        }
+        
+        public func count(with querySpec: SFQuerySpec) -> Promise<UInt> {
+            return Promise(.pending) {  resolver in
+                var count: UInt = 0
+                var error: NSError?
+                count = self.api!.count(with: querySpec, error: &error)
+                if let error = error {
+                    resolver.reject(error)
+                }else {
+                    resolver.fulfill(count)
+                }
+            }
+        }
+        
+        public func query(with querySpec: SFQuerySpec, pageIndex: UInt) throws -> Promise<[Any]> {
+            return Promise(.pending) {  resolver in
+                var result: [Any]?
+                var error: NSError?
+                result = self.api!.query(with: querySpec, pageIndex: pageIndex, error: &error)
+                if let error = error {
+                    resolver.reject(error)
+                }else {
+                    if let result = result {
+                        resolver.fulfill(result)
+                    } else {
+                         resolver.fulfill([])
+                    }
+                }
+            }
+        }
+        
+        public func upsertEntries(_ entries: [Any], toSoup soupName: String) -> Promise<[Any]> {
+            return Promise(.pending) {  resolver in
+                var result: [Any] = []
+                result = self.api!.upsertEntries(entries, toSoup: soupName)
+                resolver.fulfill(result)
+            }
+        }
+        
+        public func upsertEntries(_ entries: [Any], toSoup soupName: String, withExternalIdPath externalIdPath: String)  -> Promise<[Any]> {
+            return Promise(.pending) {  resolver in
+                 var result: [Any] = []
+                 var error: NSError?
+                 result = self.api!.upsertEntries(entries, toSoup: soupName, withExternalIdPath: externalIdPath, error: &error)
+                if let error = error {
+                    resolver.reject(error)
+                } else {
+                    resolver.fulfill(result)
+                }
+            }
+        }
+        
+        public func lookupSoupEntryId(forSoupName soupName: String, forFieldPath fieldPath: String, fieldValue: String) throws -> Promise<NSNumber> {
+            return Promise(.pending) {  resolver in
+                var result: NSNumber = -1
+                var error: NSError?
+                result = self.api!.lookupSoupEntryId(forSoupName: soupName, forFieldPath: fieldPath, fieldValue: fieldValue, error: &error)
+                if let error = error {
+                    resolver.reject(error)
+                } else {
+                    resolver.fulfill(result)
+                }
+            }
+        }
+        
+        public func removeEntries(entryIds: [Any], fromSoup soupName: String) -> Promise<Void> {
+            return Promise(.pending) {  resolver in
+                self.api!.removeEntries(entryIds, fromSoup: soupName)
+                resolver.fulfill(())
+            }
+        }
+        
+        public func removeEntries(byQuery querySpec: SFQuerySpec, fromSoup soupName: String) -> Promise<Void> {
+            return Promise(.pending) {  resolver in
+                self.api!.removeEntries(byQuery: querySpec, fromSoup: soupName)
+                resolver.fulfill(())
+            }
+        }
+        
+        public func clearSoup(soupName: String) -> Promise<Void> {
+            return Promise(.pending) {  resolver in
+                self.api!.clearSoup(soupName)
+                resolver.fulfill(())
+            }
+        }
+        
+        public func removeSoup(soupName: String) -> Promise<Void>{
+            return Promise(.pending) {  resolver in
+                self.api!.removeSoup(soupName)
+                resolver.fulfill(())
+            }
+        }
+        
+        public func removeAllSoups() -> Promise<Void>{
+            return Promise(.pending) {  resolver in
+                self.api!.removeAllSoups()
+                resolver.fulfill(())
+            }
+        }
+    }
+    
+    
+
+}
+
+public class SFSmartStoreClient {
+    
+    public class func store(withName: String) -> Promise<SFSmartStore> {
+        return Promise(.pending) { resolver in
+            let smartStore = SFSmartStore.sharedStore(withName : withName)
+            guard let _ = smartStore else {
+                return resolver.reject(SmartStoreError.StoreNotFoundError)
+            }
+            resolver.fulfill(smartStore as! SFSmartStore)
+        }
+    }
+    
+    public class func store(withName: String,user: SFUserAccount) -> Promise<SFSmartStore> {
+        return Promise(.pending) { resolver in
+            let smartStore = SFSmartStore.sharedStore(withName : withName,user: user)
+            guard let _ = smartStore else {
+                return resolver.reject(SmartStoreError.StoreNotFoundError)
+            }
+            resolver.fulfill(smartStore as! SFSmartStore)
+        }
+    }
+    
+    public class func globalStore(withName: String) -> Promise<SFSmartStore> {
+        return Promise(.pending) { resolver in
+            let smartStore = SFSmartStore.sharedGlobalStore(withName : withName)
+            resolver.fulfill(smartStore as! SFSmartStore)
+        }
+    }
+    
+    public class func removeGlobalStore(withName: String) -> Promise<Void> {
+        return Promise(.pending) { resolver in
+            SFSmartStore.removeSharedGlobalStore(withName:  withName)
+            resolver.fulfill(())
+        }
+    }
+    
+    public class func removeSharedStore(withName: String) -> Promise<Void> {
+        return Promise(.pending) { resolver in
+            SFSmartStore.removeSharedStore(withName:  withName)
+            resolver.fulfill(())
+        }
+    }
+    
+    public class func removeAllSharedStores() -> Promise<Void> {
+        return Promise(.pending) { resolver in
+            SFSmartStore.removeAllStores()
+            resolver.fulfill(())
+        }
+    }
+    
+    public class func removeAllGlobalStores() -> Promise<Void> {
+        return Promise(.pending) { resolver in
+            SFSmartStore.removeAllGlobalStores()
+            resolver.fulfill(())
+        }
+    }
+}
+

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
@@ -1,5 +1,5 @@
 /*
- SFSmartStoreClient
+ SFSmartStoreExtensions
  Created by Raj Rao on 01/19/18.
  
  Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
@@ -86,7 +86,7 @@ extension SFSmartStore {
             }
         }
         
-        public func registerSoup(with soupSpec: SFSoupSpec, withIndexSpecs indexSpecs: [Any]) -> Promise<Bool> {
+        public func registerSoup(soupSpec: SFSoupSpec,indexSpecs: [Any]) -> Promise<Bool> {
             return Promise(.pending) {  resolver in
                 do {
                     try self.api!.registerSoup(with: soupSpec, withIndexSpecs: indexSpecs)
@@ -97,7 +97,7 @@ extension SFSmartStore {
             }
         }
         
-        public func count(with querySpec: SFQuerySpec) -> Promise<UInt> {
+        public func count(querySpec: SFQuerySpec) -> Promise<UInt> {
             return Promise(.pending) {  resolver in
                 var count: UInt = 0
                 var error: NSError?
@@ -110,7 +110,7 @@ extension SFSmartStore {
             }
         }
         
-        public func query(with querySpec: SFQuerySpec, pageIndex: UInt) throws -> Promise<[Any]> {
+        public func query(querySpec: SFQuerySpec, pageIndex: UInt) throws -> Promise<[Any]> {
             return Promise(.pending) {  resolver in
                 var result: [Any]?
                 var error: NSError?
@@ -127,7 +127,7 @@ extension SFSmartStore {
             }
         }
         
-        public func upsertEntries(_ entries: [Any], toSoup soupName: String) -> Promise<[Any]> {
+        public func upsertEntries(entries: [Any], toSoup soupName: String) -> Promise<[Any]> {
             return Promise(.pending) {  resolver in
                 var result: [Any] = []
                 result = self.api!.upsertEntries(entries, toSoup: soupName)
@@ -135,7 +135,7 @@ extension SFSmartStore {
             }
         }
         
-        public func upsertEntries(_ entries: [Any], toSoup soupName: String, withExternalIdPath externalIdPath: String)  -> Promise<[Any]> {
+        public func upsertEntries(entries: [Any], soupName: String, externalIdPath: String)  -> Promise<[Any]> {
             return Promise(.pending) {  resolver in
                  var result: [Any] = []
                  var error: NSError?
@@ -148,7 +148,7 @@ extension SFSmartStore {
             }
         }
         
-        public func lookupSoupEntryId(forSoupName soupName: String, forFieldPath fieldPath: String, fieldValue: String) throws -> Promise<NSNumber> {
+        public func lookupSoupEntryId(soupName: String, fieldPath: String, fieldValue: String) throws -> Promise<NSNumber> {
             return Promise(.pending) {  resolver in
                 var result: NSNumber = -1
                 var error: NSError?
@@ -161,14 +161,14 @@ extension SFSmartStore {
             }
         }
         
-        public func removeEntries(entryIds: [Any], fromSoup soupName: String) -> Promise<Void> {
+        public func removeEntries(entryIds: [Any], soupName: String) -> Promise<Void> {
             return Promise(.pending) {  resolver in
                 self.api!.removeEntries(entryIds, fromSoup: soupName)
                 resolver.fulfill(())
             }
         }
         
-        public func removeEntries(byQuery querySpec: SFQuerySpec, fromSoup soupName: String) -> Promise<Void> {
+        public func removeEntries(querySpec: SFQuerySpec, soupName: String) -> Promise<Void> {
             return Promise(.pending) {  resolver in
                 self.api!.removeEntries(byQuery: querySpec, fromSoup: soupName)
                 resolver.fulfill(())

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SFRestAPITests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SFRestAPITests.swift
@@ -28,42 +28,14 @@ import SalesforceSDKCore
 import PromiseKit
 @testable import SalesforceSwiftSDK
 
-class SFRestAPITests: XCTestCase {
-    static var testCredentials: SFOAuthCredentials?
-    static var testConfig: TestConfig?
-    static var setupComplete = false
-    
+class SFRestAPITests: SalesforceSwiftSDKBaseTest {
+  
     override class func setUp() {
         super.setUp()
-        SalesforceSwiftSDKManager.initSDK().shared().saveState()
-        
-        _ = SalesforceSwiftSDKTests.readConfigFromFile(configFile: nil)
-            .then { testJsonConfig -> Promise<SFUserAccount> in
-                SalesforceSwiftSDKTests.testConfig = testJsonConfig
-                SalesforceSwiftSDKTests.testCredentials?.accessToken = nil
-                SalesforceSwiftSDKTests.testCredentials = SFOAuthCredentials(identifier: testJsonConfig.testClientId, clientId: testJsonConfig.testClientId, encrypted: true)
-                SalesforceSwiftSDKTests.testCredentials?.refreshToken = SalesforceSwiftSDKTests.testConfig?.refreshToken
-                SalesforceSwiftSDKTests.testCredentials?.redirectUri = SalesforceSwiftSDKTests.testConfig?.testRedirectUri
-                SalesforceSwiftSDKTests.testCredentials?.domain = SalesforceSwiftSDKTests.testConfig?.testLoginDomain
-                SalesforceSwiftSDKTests.testCredentials?.identityUrl = URL(string: (SalesforceSwiftSDKTests.testConfig?.identityUrl)!)
-                SFUserAccountManager.sharedInstance().loginHost = SalesforceSwiftSDKTests.testConfig?.testLoginDomain
-                return SalesforceSwiftSDKTests.refreshCredentials(credentials:(SalesforceSwiftSDKTests.testCredentials)!)
-            }.done { userAccount in
-                SFUserAccountManager.sharedInstance().currentUser = userAccount
-                setupComplete = true
-            }.catch { error  in
-                setupComplete = true
-        }
     }
     
     override func setUp() {
         super.setUp()
-        SalesforceSwiftSDKTests.waitForCompletion(maxWaitTime: 5) { () -> Bool in
-            if (SalesforceSwiftSDKTests.setupComplete) {
-                return true
-            }
-            return false
-        }
     }
     
     override func tearDown() {
@@ -74,7 +46,6 @@ class SFRestAPITests: XCTestCase {
     
     override class func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
-        SalesforceSwiftSDKManager.shared().restoreState()
         super.tearDown()
     }
     

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SalesforceSwiftSDKBaseTest.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SalesforceSwiftSDKBaseTest.swift
@@ -1,5 +1,5 @@
 /*
- SmartStoreClientTests
+ SalesforceSwiftSDKBaseTest
  Created by Raj Rao on 01/19/18.
  
  Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SalesforceSwiftSDKBaseTest.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SalesforceSwiftSDKBaseTest.swift
@@ -1,0 +1,90 @@
+/*
+ SmartStoreClientTests
+ Created by Raj Rao on 01/19/18.
+ 
+ Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import XCTest
+import SalesforceSDKCore
+import PromiseKit
+import SmartStore
+@testable import SalesforceSwiftSDK
+
+class SalesforceSwiftSDKBaseTest: XCTestCase {
+    
+    static var testCredentials: SFOAuthCredentials?
+    static var testConfig: TestConfig?
+    static var setupComplete = false
+    
+    override class func setUp() {
+        super.setUp()
+        SalesforceSwiftSDKManager.initSDK().shared().saveState()
+        
+        _ = SalesforceSwiftSDKTests.readConfigFromFile(configFile: nil)
+            .then { testJsonConfig -> Promise<SFUserAccount> in
+                SalesforceSwiftSDKTests.testConfig = testJsonConfig
+                SalesforceSwiftSDKTests.testCredentials?.accessToken = nil
+                SalesforceSwiftSDKTests.testCredentials = SFOAuthCredentials(identifier: testJsonConfig.testClientId, clientId: testJsonConfig.testClientId, encrypted: true)
+                SalesforceSwiftSDKTests.testCredentials?.refreshToken = SalesforceSwiftSDKTests.testConfig?.refreshToken
+                SalesforceSwiftSDKTests.testCredentials?.redirectUri = SalesforceSwiftSDKTests.testConfig?.testRedirectUri
+                SalesforceSwiftSDKTests.testCredentials?.domain = SalesforceSwiftSDKTests.testConfig?.testLoginDomain
+                SalesforceSwiftSDKTests.testCredentials?.identityUrl = URL(string: (SalesforceSwiftSDKTests.testConfig?.identityUrl)!)
+                SFUserAccountManager.sharedInstance().loginHost = SalesforceSwiftSDKTests.testConfig?.testLoginDomain
+                return SalesforceSwiftSDKTests.refreshCredentials(credentials:(SalesforceSwiftSDKTests.testCredentials)!)
+            }
+            .then { userAccount -> Promise<Void> in
+                SFUserAccountManager.sharedInstance().currentUser = userAccount
+                return SFSmartStoreClient.removeAllGlobalStores()
+            }
+            .then { _  in
+                return SFSmartStoreClient.removeAllSharedStores()
+            }
+            .done { userAccount in
+                setupComplete = true
+            }.catch { error  in
+                setupComplete = true
+        }
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func setUp() {
+        super.setUp()
+        SalesforceSwiftSDKTests.waitForCompletion(maxWaitTime: 5) { () -> Bool in
+            if (SalesforceSwiftSDKTests.setupComplete) {
+                return true
+            }
+            return false
+        }
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    
+    override class func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        SalesforceSwiftSDKManager.shared().restoreState()
+        super.tearDown()
+    }
+    
+}

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SalesforceSwiftSDKBaseTest.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SalesforceSwiftSDKBaseTest.swift
@@ -67,7 +67,7 @@ class SalesforceSwiftSDKBaseTest: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        SalesforceSwiftSDKTests.waitForCompletion(maxWaitTime: 5) { () -> Bool in
+        SalesforceSwiftSDKTests.waitForCompletion(maxWaitTime: 10) { () -> Bool in
             if (SalesforceSwiftSDKTests.setupComplete) {
                 return true
             }

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SalesforceSwiftSDKTests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SalesforceSwiftSDKTests.swift
@@ -44,8 +44,7 @@ class SalesforceSwiftSDKTests: SalesforceSwiftSDKBaseTest {
     
     override class func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
-        SalesforceSDKManager.shared().restoreState()
-        super.tearDown()
+         super.tearDown()
     }
 
     func testConfiguration() {

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SalesforceSwiftSDKTests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SalesforceSwiftSDKTests.swift
@@ -27,51 +27,18 @@ import SalesforceSDKCore
 import PromiseKit
 @testable import SalesforceSwiftSDK
 
-class SalesforceSwiftSDKTests: XCTestCase {
-    static var testCredentials: SFOAuthCredentials?
-    static var testConfig: TestConfig?
-    static var setupComplete = false
+class SalesforceSwiftSDKTests: SalesforceSwiftSDKBaseTest {
     
     override class func setUp() {
         super.setUp()
-        
-        SalesforceSwiftSDKManager.initSDK().shared().saveState()
-        
-        _ = SalesforceSwiftSDKTests.readConfigFromFile(configFile: nil)
-            .then { testJsonConfig -> Promise<SFUserAccount> in
-                SalesforceSwiftSDKTests.testConfig = testJsonConfig
-                SalesforceSwiftSDKTests.testCredentials?.accessToken = nil
-                SalesforceSwiftSDKTests.testCredentials = SFOAuthCredentials(identifier: testJsonConfig.testClientId, clientId: testJsonConfig.testClientId, encrypted: true)
-                SalesforceSwiftSDKTests.testCredentials?.refreshToken = SalesforceSwiftSDKTests.testConfig?.refreshToken
-                SalesforceSwiftSDKTests.testCredentials?.redirectUri = SalesforceSwiftSDKTests.testConfig?.testRedirectUri
-                SalesforceSwiftSDKTests.testCredentials?.domain = SalesforceSwiftSDKTests.testConfig?.testLoginDomain
-                SalesforceSwiftSDKTests.testCredentials?.identityUrl = URL(string: (SalesforceSwiftSDKTests.testConfig?.identityUrl)!)
-                SFUserAccountManager.sharedInstance().loginHost = SalesforceSwiftSDKTests.testConfig?.testLoginDomain
-                return SalesforceSwiftSDKTests.refreshCredentials(credentials:(SalesforceSwiftSDKTests.testCredentials)!)
-            }.done { userAccount in
-                SFUserAccountManager.sharedInstance().currentUser = userAccount
-                setupComplete = true
-            }.catch { error  in
-                setupComplete = true
-            }
     }
     
     override func setUp() {
         super.setUp()
-        //let exp1 = expectation(description: "init")
-        SalesforceSwiftSDKTests.waitForCompletion(maxWaitTime: 5) { () -> Bool in
-            if (SalesforceSwiftSDKTests.setupComplete) {
-                return true
-            }
-            return false
-        }
-      //  waitForExpectations(timeout: 10)
-        
-    }
+     }
 
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
-      
         super.tearDown()
     }
     

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartStoreClientTests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartStoreClientTests.swift
@@ -1,0 +1,162 @@
+/*
+ SmartStoreClientTests
+ Created by Raj Rao on 01/19/18.
+ 
+ Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+import Foundation
+import XCTest
+import SalesforceSDKCore
+import PromiseKit
+import SmartStore
+@testable import SalesforceSwiftSDK
+
+class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
+    
+    override class func setUp() {
+        super.setUp()
+    }
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    override class func tearDown() {
+        super.tearDown()
+    }
+    
+    func testCreateGlobalStore() {
+        let glbStoreName = "SWIFTGLBLCOOKBOOK"
+        let soupName = "WONTONSOUP"
+        let expectation = XCTestExpectation(description: "CreateStore")
+        _ = SFSmartStoreClient
+            .globalStore(withName: glbStoreName)
+            .then { globalStore -> Promise<SFSmartStore> in
+                XCTAssertNotNil(globalStore)
+                return Promise(value: globalStore)
+            }
+            .then { store -> Promise<(Bool,SFSmartStore)>  in
+                let result  = store.soupExists(soupName)
+                return Promise(value:(result,store))
+            }
+            .then { (result,store) -> Promise<Void> in
+                XCTAssertFalse(result)
+                XCTAssertNotNil(store)
+                return SFSmartStoreClient.removeGlobalStore(withName: glbStoreName)
+            }
+            .done {
+                expectation.fulfill()
+            }
+        self.wait(for: [expectation], timeout: 10)
+    }
+    
+    
+    func testCreateSharedStore() {
+        let lclStoreName = "SWIFTLOCALCOOKBOOK"
+        let soupName = "WONTONSOUP"
+        let expectation = XCTestExpectation(description: "CreateUserStore")
+        _ = SFSmartStoreClient
+            .store(withName: lclStoreName)
+            .then { localStore -> Promise<SFSmartStore> in
+                XCTAssertNotNil(localStore)
+                return Promise(value: localStore)
+            }
+            .then { store -> Promise<(Bool,SFSmartStore)>  in
+                let result  = store.soupExists(soupName)
+                return Promise(value:(result,store))
+            }
+            .then { (result,store) -> Promise<Void> in
+                XCTAssertFalse(result)
+                XCTAssertNotNil(store)
+                return SFSmartStoreClient.removeSharedStore(withName: lclStoreName)
+            }
+            .done {
+                expectation.fulfill()
+        }
+        self.wait(for: [expectation], timeout: 10)
+    }
+    
+    
+    func testCreateSoup() {
+        let lclStoreName = "SWIFTLOCALCOOKBOOK"
+        let soupName = "WONTONSOUP"
+        let expectation = XCTestExpectation(description: "CreateSoup")
+        
+        _ =  SFSmartStoreClient
+            .store(withName: lclStoreName)
+            .then { localStore -> Promise<SFSmartStore> in
+                XCTAssertNotNil(localStore)
+                return Promise(value: localStore)
+            }
+            .then { store -> Promise<Bool>  in
+                let result  = store.soupExists(soupName)
+                XCTAssertFalse(result)
+                let indexSpecs = SFSoupIndex.asArraySoupIndexes([ ["path": "key"], ["type" : "string"] ])
+                return store.Promises.registerSoup(soupName: soupName, indexSpecs: indexSpecs)
+            }
+            .then { soupCreated -> Promise<Void> in
+                XCTAssertTrue(soupCreated)
+                return SFSmartStoreClient.removeSharedStore(withName: lclStoreName)
+            }
+            .done {
+                expectation.fulfill()
+            }
+            .catch { error in
+                XCTFail("testCreateSoup() Failed" + error.localizedDescription)
+                expectation.fulfill()
+            }
+        self.wait(for: [expectation], timeout: 10)
+    }
+    
+    func testFindAndRemoveSoup() {
+        let lclStoreName = "SWIFTLOCALCOOKBOOK"
+        let soupName = "WONTONSOUP"
+        let expectation = XCTestExpectation(description: "CreateAndRemoveSoup")
+        
+        let store: SFSmartStore  = SFSmartStore.sharedStore(withName: lclStoreName) as! SFSmartStore
+        let result  = store.soupExists(soupName)
+        XCTAssertFalse(result)
+        let indexSpecs = SFSoupIndex.asArraySoupIndexes([ ["path": "key"], ["type" : "string"]])
+            
+        store.Promises.registerSoup(soupName: soupName, indexSpecs: indexSpecs)
+        .then { soupCreated -> Promise<Void> in
+            XCTAssertTrue(soupCreated)
+            return store.Promises.removeSoup(soupName: soupName)
+        }
+        .then { _ in
+           return SFSmartStoreClient.removeSharedStore(withName: lclStoreName)
+        }
+        .done {
+            expectation.fulfill()
+        }
+        .catch { error in
+            XCTFail("testCreateSoup() Failed" + error.localizedDescription)
+            expectation.fulfill()
+        }
+        self.wait(for: [expectation], timeout: 10)
+    }
+    
+}
+

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -153,7 +153,7 @@ extern NSString *const EXPLAIN_ROWS;
  @param storeName The name of the store.  If in doubt, use kDefaultSmartStoreName.
  @return A shared instance of a store with the given name.
  */
-+ (id)sharedStoreWithName:(NSString*)storeName;
++ (nullable id)sharedStoreWithName:(NSString*)storeName;
 
 /**
  Use this method to obtain a shared store instance with the given name for the given user.


### PR DESCRIPTION
 Its missing docs and tests (next pr).  @wmathurin @bhariharan please review the api(s)

Summary 
-Added SmartStoreClient wrapper class  for all store creation and deletion. (Can start the promise chain from here)
-SmartStore extension has the Promises namespace with all supported api(s) wrapped in promises.(Can start or continue the promise chain here) 

