### PR TITLE
Add util methods for RSA keypair encryption/decryption

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
@@ -131,6 +131,38 @@ extern NSUInteger const kSFPBKDFDefaultSaltByteLength;
  */
 + (nullable NSData *)getRSAPrivateKeyDataWithName:(NSString *)keyName keyLength:(NSUInteger)length;
 
+/**
+ * Get RSA public SecKeyRef with given keyName and length
+ * @param keyName The name string used to generate the key.
+ * @param length The key length used for key
+ * @return The SecKeyRef, or `nil` if no matching key is found
+ */
++ (nullable SecKeyRef)getRSAPublicKeyRefWithName:(NSString *)keyName keyLength:(NSUInteger)length;
+
+/**
+ * Get RSA private SecKeyRef with given keyName and length
+ * @param keyName The name string used to generate the key.
+ * @param length The key length used for key
+ * @return The SecKeyRef, or `nil` if no matching key is found
+ */
++ (nullable SecKeyRef)getRSAPrivateKeyRefWithName:(NSString *)keyName keyLength:(NSUInteger)length;
+
+/**
+ * Encrypt data with givien SecKeyRef using RSA pkcs1 algorithm
+ * @param data The data to encrypt
+ * @param keyRef The keyref used in encryption
+ * @return The encrypted Dataa, or `nil` if encryption failed
+ */
++ (nullable NSData*)encryptUsingRSAforData:(NSData *)data withKeyRef:(SecKeyRef)keyRef;
+
+/**
+ * Decrypt data with givien SecKeyRef using RSA pkcs1 algorithm
+ * @param data The data to decypt
+ * @param keyRef The keyref used in decryption
+ * @return The decypted Data, or `nil` if decryption failed
+ */
++ (nullable NSData*)decryptUsingRSAforData:(NSData * )data withKeyRef:(SecKeyRef)keyRef;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
@@ -243,4 +243,40 @@
     XCTAssertFalse([privateKeyData3 isEqualToData:privateKeyData1], @"should get different private key strings with different sizes");
 
 }
+
+- (void)testRSAEncryptionAndDecryption
+{
+    size_t keySize = 2048;
+    
+    SecKeyRef publicKeyRef = [SFSDKCryptoUtils getRSAPublicKeyRefWithName:@"test" keyLength:keySize];
+    SecKeyRef privateKeyRef = [SFSDKCryptoUtils getRSAPrivateKeyRefWithName:@"test" keyLength:keySize];
+    
+    // Encrypt data
+    NSString *testString = @"This is a test";
+    NSData *testData = [testString dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *encryptedData = [SFSDKCryptoUtils encryptUsingRSAforData:testData withKeyRef:publicKeyRef];
+    
+    // Decrypt data
+    NSData *decryptedData = [SFSDKCryptoUtils decryptUsingRSAforData:encryptedData withKeyRef:privateKeyRef];
+    NSString *result = [[NSString alloc] initWithData:decryptedData encoding:NSUTF8StringEncoding];
+    XCTAssertTrue([testString isEqualToString:result]);
+}
+
+- (void)testRSAEncryptionAndDecryptionWrongKeys
+{
+    size_t keySize = 2048;
+    
+    SecKeyRef publicKeyRef = [SFSDKCryptoUtils getRSAPublicKeyRefWithName:@"test1" keyLength:keySize];
+    SecKeyRef privateKeyRef = [SFSDKCryptoUtils getRSAPrivateKeyRefWithName:@"test" keyLength:keySize];
+    
+    // Encrypt data
+    NSString *testString = @"This is a test";
+    NSData *testData = [testString dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *encryptedData = [SFSDKCryptoUtils encryptUsingRSAforData:testData withKeyRef:publicKeyRef];
+    
+    // Decrypt data
+    NSData *decryptedData = [SFSDKCryptoUtils decryptUsingRSAforData:encryptedData withKeyRef:privateKeyRef];
+    NSString *result = [[NSString alloc] initWithData:decryptedData encoding:NSUTF8StringEncoding];
+    XCTAssertFalse([testString isEqualToString:result]);
+}
 @end


### PR DESCRIPTION
@bhariharan @paultiarks
add unit test for rsa keypair encryption/decryption with PKCS1 padding.
I don't see issues when we do encryption/decryption. but we need to expose two methods to get seckeyref
related android pr:
https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/1603