### PR TITLE
Turning of parallel builds in SwiftSDK

### DIFF
--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK.xcodeproj/xcshareddata/xcschemes/SalesforceSwiftSDK.xcscheme
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK.xcodeproj/xcshareddata/xcschemes/SalesforceSwiftSDK.xcscheme
@@ -3,8 +3,8 @@
    LastUpgradeVersion = "0910"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"


### PR DESCRIPTION
Since Carthage tries to build all framework targets in the workspace, parallel builds tend to sporadically error out on race conditions, as dependency project builds (CocoaLumberjack is the one I see the most) end up getting yanked out from under other upstream targets being built.