### PR TITLE
Fixing linker errors with pod specs in some cases

### DIFF
--- a/SalesforceSwiftSDK.podspec
+++ b/SalesforceSwiftSDK.podspec
@@ -20,6 +20,9 @@ Pod::Spec.new do |s|
   s.subspec 'SalesforceSwiftSDK' do |salesforceswift|
 
       salesforceswift.dependency 'SmartSync'
+      salesforceswift.dependency 'SmartStore'
+      salesforceswift.dependency 'SalesforceSDKCore'
+      salesforceswift.dependency 'SalesforceAnalytics'
       salesforceswift.dependency 'PromiseKit', '~> 5.0'
       salesforceswift.source_files = 'libs/SalesforceSwiftSDK/SalesforceSwiftSDK/**/*.{h,m,swift}'
       salesforceswift.requires_arc = true


### PR DESCRIPTION
Transitive dependencies don't work with pod specs + `Xcode 9.2` while using `Swift Extensions` from those libraries.