### PR TITLE
Made userId and orgId nonnull…

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity.h
@@ -36,12 +36,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The user ID associated with the account.
  */
-@property (nonatomic, copy, nullable) NSString *userId;
+@property (nonatomic, copy, nonnull) NSString *userId;
 
 /**
  The organization ID associated with the account.
  */
-@property (nonatomic, copy, nullable) NSString *orgId;
+@property (nonatomic, copy, nonnull) NSString *orgId;
 
 /**
  Convenience method to return a new account identity with the given User ID and Org ID.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity.h
@@ -49,14 +49,14 @@ NS_ASSUME_NONNULL_BEGIN
  @param orgId The org ID associated with the identity.
  @return An account identity representing the given User ID and Org ID.
  */
-+ (SFUserAccountIdentity *)identityWithUserId:(NSString *)userId orgId:(NSString *)orgId;
++ (nonnull SFUserAccountIdentity *)identityWithUserId:(nonnull NSString *)userId orgId:(nonnull NSString *)orgId;
 
 /**
  Creates a new account identity object with the given user ID and org ID.
  @param userId The user ID associated with the identity.
  @param orgId The org ID associated with the identity.
  */
-- (id)initWithUserId:(NSString *)userId orgId:(NSString *)orgId;
+- (nonnull id)initWithUserId:(nonnull NSString *)userId orgId:(nonnull NSString *)orgId;
 
 /**
  Compares this identity with another.  Useful for [NSArray sortedArrayUsingSelector:].

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity.m
@@ -101,8 +101,8 @@ static NSString * const kUserAccountIdentityOrgIdKey = @"orgIdKey";
     
     SFUserAccountIdentity *objectToCompare = (SFUserAccountIdentity *)object;
     
-    BOOL userIdsEqual = ((objectToCompare.userId == nil && self.userId == nil) || [objectToCompare.userId isEqualToEntityId:self.userId]);
-    BOOL orgIdsEqual = ((objectToCompare.orgId == nil && self.orgId == nil) || [objectToCompare.orgId isEqualToEntityId:self.orgId]);
+    BOOL userIdsEqual = [objectToCompare.userId isEqualToEntityId:self.userId];
+    BOOL orgIdsEqual = [objectToCompare.orgId isEqualToEntityId:self.orgId];
     return userIdsEqual && orgIdsEqual;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -147,22 +147,10 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 - (void)testAccountIdentityEquality {
     NSDictionary *accountIdentityMatrix = @{
                                             @"MatchGroup1": @[
-                                                    [[SFUserAccountIdentity alloc] initWithUserId:nil orgId:nil],
-                                                    [[SFUserAccountIdentity alloc] initWithUserId:nil orgId:nil]
-                                                    ],
-                                            @"MatchGroup2": @[
-                                                    [[SFUserAccountIdentity alloc] initWithUserId:nil orgId:@"OrgID1"],
-                                                    [[SFUserAccountIdentity alloc] initWithUserId:nil orgId:@"OrgID1"]
-                                                    ],
-                                            @"MatchGroup3": @[
-                                                    [[SFUserAccountIdentity alloc] initWithUserId:@"UserID1" orgId:nil],
-                                                    [[SFUserAccountIdentity alloc] initWithUserId:@"UserID1" orgId:nil]
-                                                    ],
-                                            @"MatchGroup4": @[
                                                     [[SFUserAccountIdentity alloc] initWithUserId:@"UserID1" orgId:@"OrgID1"],
                                                     [[SFUserAccountIdentity alloc] initWithUserId:@"UserID1" orgId:@"OrgID1"]
                                                     ],
-                                            @"MatchGroup5": @[
+                                            @"MatchGroup2": @[
                                                     [[SFUserAccountIdentity alloc] initWithUserId:@"UserID2" orgId:@"OrgID2"],
                                                     [[SFUserAccountIdentity alloc] initWithUserId:@"UserID2" orgId:@"OrgID2"]
                                                     ]


### PR DESCRIPTION
Since `userId` and `orgId` are being set in the initializer, they shouldn't be `nullable`

@trooper2013 @bhariharan 