### PR TITLE
Enable hideHostListView animation

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -310,12 +310,12 @@ SFSDK_USE_DEPRECATED_END
 #pragma mark - SFSDKLoginHostDelegate Methods
 
 - (void)hostListViewControllerDidAddLoginHost:(SFSDKLoginHostListViewController *)hostListViewController {
-    [self hideHostListView:NO];
+    [self hideHostListView:YES];
 }
 
 - (void)hostListViewControllerDidSelectLoginHost:(SFSDKLoginHostListViewController *)hostListViewController {
     // Hide the popover
-    [self hideHostListView:NO];
+    [self hideHostListView:YES];
 }
 
 - (void)hostListViewControllerDidCancelLoginHost:(SFSDKLoginHostListViewController *)hostListViewController {


### PR DESCRIPTION
@bhariharan @trooper2013 
Confirmed with PM and UX, dismissing page should always have animation enabled.
Instead of calling these delegate methods and customize on our end again, it makes more sense to me to change it here since we should always keep this behavior.