### PR TITLE
Add SwiftSDK Tests to Nightly

### DIFF
--- a/.circleci/Dangerfile-Lib.rb
+++ b/.circleci/Dangerfile-Lib.rb
@@ -11,11 +11,12 @@ if File.file?(test_results)
   junit.report
 end
 
-if ENV.has_key?('JENKINS_URL')
+coverage_results = 'xcov_output/index.html'
+if ENV.has_key?('JENKINS_URL') && File.file?(coverage_results)
   xcov.report(
       scheme: 'UnitTests',
       workspace: '../SalesforceMobileSDK.xcworkspace',
-      exclude_targets:'CocoaLumberjack.framework,SalesforceSDKCoreTestApp.app,SmartStoreTestApp.app,SmartSyncTestApp.app,SalesforceHybridSDKTestApp.app,SalesforceAnalyticsTestApp.app,RestAPIExplorer.app,AccountEditor.app,NoteSync.app,SmartSyncExplorerHybrid.app,SmartSyncExplorer.app,SmartSyncExplorerCommon.framework,RecentContactsTodayExtension.appex,Cordova.framework,SalesforceReact.framework'
+      exclude_targets:'CocoaLumberjack.framework,SalesforceSDKCoreTestApp.app,SmartStoreTestApp.app,SmartSyncTestApp.app,SalesforceHybridSDKTestApp.app,SalesforceAnalyticsTestApp.app,RestAPIExplorer.app,AccountEditor.app,NoteSync.app,SmartSyncExplorerHybrid.app,SmartSyncExplorer.app,SmartSyncExplorerCommon.framework,RecentContactsTodayExtension.appex,Cordova.framework,SalesforceReact.framework,PromiseKit.framework,SalesforceSwiftSDKTestApp.app,SalesforceReactTestApp.app'
   )
 end
 

--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -4,13 +4,15 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "35...85"
+  range: "25...75"
 
 ignore:
   - "shared"
   - "hybrid"
   - "native"
   - "libs/**/*Test*/*"
+  - "libs/SalesforceReact/js"
+  - "libs/SalesforceReact/node_modules"
 
 comment:
   layout: "reach, diff"
@@ -41,3 +43,11 @@ coverage:
         target: auto
         paths: "libs/SmartSync/SmartSync/"
         flags: SmartSync
+      SalesforceReact:
+        target: auto
+        paths: "libs/SalesforceReact/SalesforceReact/"
+        flags: SalesforceReact
+      SalesforceSwiftSDK:
+        target: auto
+        paths: "libs/SalesforceSwiftSDK/SalesforceSwiftSDK/"
+        flags: SalesforceSwiftSDK

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ aliases:
 
   - &codecov
     name: Codecov Uplaod
-    command: bash <(curl -s https://codecov.io/bash) -f slather_output/cobertura.xml -X gcov -X xcode
+    command: bash <(curl -s https://codecov.io/bash) -X gcov -X xcode
     when: always
 
 defaults: &defaults
@@ -205,6 +205,56 @@ jobs:
           destination: Code-Coverage
       - run: *codecov
 
+  test-SmartSync:
+    <<: *defaults
+    environment:
+      - FASTLANE_LANE: "PR lib:SmartSync"
+      - LIB: "SmartSync"
+    steps:
+      - checkout
+      - restore_cache: *restore-gem-cache
+      - run: *install-dependecies
+      - save_cache: *save-gem-cache
+      - run: *run-tests
+      - run: *danger-lib
+      - store_test_results:
+          path: /Users/distiller/SalesforceMobileSDK-iOS/test_output/
+      - store_artifacts:
+          path: /Users/distiller/SalesforceMobileSDK-iOS/test_output/
+          destination: Test-Results
+      - store_artifacts:
+          path: /Users/distiller/SalesforceMobileSDK-iOS/clangReport
+          destination: Static-Analysis
+      - store_artifacts:
+          path: /Users/distiller/SalesforceMobileSDK-iOS/slather_output/
+          destination: Code-Coverage
+      - run: *codecov
+
+  test-SalesforceReact:
+    <<: *defaults
+    environment:
+      - FASTLANE_LANE: "PR lib:SalesforceReact"
+      - LIB: "SalesforceReact"
+    steps:
+      - checkout
+      - restore_cache: *restore-gem-cache
+      - run: *install-dependecies
+      - save_cache: *save-gem-cache
+      - run: *run-tests
+      - run: *danger-lib
+      - store_test_results:
+          path: /Users/distiller/SalesforceMobileSDK-iOS/test_output/
+      - store_artifacts:
+          path: /Users/distiller/SalesforceMobileSDK-iOS/test_output/
+          destination: Test-Results
+      - store_artifacts:
+          path: /Users/distiller/SalesforceMobileSDK-iOS/clangReport
+          destination: Static-Analysis
+      - store_artifacts:
+          path: /Users/distiller/SalesforceMobileSDK-iOS/slather_output/
+          destination: Code-Coverage
+      - run: *codecov
+
 
   test-ios-11:
     <<: *defaults
@@ -225,6 +275,9 @@ jobs:
         destination: Test-Results
     - store_artifacts:
         path: /Users/distiller/SalesforceMobileSDK-iOS/clangReport
+        destination: Static-Analysis
+    - store_artifacts:
+        path: /Users/distiller/SalesforceMobileSDK-iOS/swiftlint.result.json
         destination: Static-Analysis
     - store_artifacts:
         path: /Users/distiller/SalesforceMobileSDK-iOS/slather_output/
@@ -250,6 +303,9 @@ jobs:
         destination: Test-Results
     - store_artifacts:
         path: /Users/distiller/SalesforceMobileSDK-iOS/clangReport
+        destination: Static-Analysis
+    - store_artifacts:
+        path: /Users/distiller/SalesforceMobileSDK-iOS/swiftlint.result.json
         destination: Static-Analysis
     - store_artifacts:
         path: /Users/distiller/SalesforceMobileSDK-iOS/slather_output/

--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -68,7 +68,7 @@ def testScheme(scheme)
           workspace: "SalesforceMobileSDK.xcworkspace",
           scheme: scheme,
           output_directory: "xcov_output",
-          exclude_targets: "CocoaLumberjack.framework,SalesforceSDKCoreTestApp.app,SmartStoreTestApp.app,SmartSyncTestApp.app,SalesforceHybridSDKTestApp.app,SalesforceAnalyticsTestApp.app,RestAPIExplorer.app,AccountEditor.app,NoteSync.app,SmartSyncExplorerHybrid.app,SmartSyncExplorer.app,SmartSyncExplorerCommon.framework,RecentContactsTodayExtension.appex,Cordova.framework,SalesforceReact.framework"
+          exclude_targets: 'CocoaLumberjack.framework,SalesforceSDKCoreTestApp.app,SmartStoreTestApp.app,SmartSyncTestApp.app,SalesforceHybridSDKTestApp.app,SalesforceAnalyticsTestApp.app,RestAPIExplorer.app,AccountEditor.app,NoteSync.app,SmartSyncExplorerHybrid.app,SmartSyncExplorer.app,SmartSyncExplorerCommon.framework,RecentContactsTodayExtension.appex,Cordova.framework,SalesforceReact.framework,PromiseKit.framework,SalesforceSwiftSDKTestApp.app,SalesforceReactTestApp.app'
       )
 
       schemes = [scheme]
@@ -107,6 +107,16 @@ def testScheme(scheme)
         end
       end
       combinePackagesOfXML(desFile, mergeFiles)
+
+      if scheme == 'SalesforceSwiftSDK' || scheme == 'UnitTests'
+        system('brew install swiftlint')
+        swiftlint(
+            mode: :lint,
+            output_file: "swiftlint.result.json",
+            reporter: "json",
+            ignore_exit_status: true
+        )
+      end
     end
   end
 end

--- a/SalesforceMobileSDK.xcworkspace/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/SalesforceMobileSDK.xcworkspace/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -468,6 +468,16 @@
                ReferencedContainer = "container:native/SampleApps/SmartSyncExplorer/SmartSyncExplorer.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B7DA7AC31FCDE08F0098C1EA"
+               BuildableName = "SalesforceSwiftSDKTests.xctest"
+               BlueprintName = "SalesforceSwiftSDKTests"
+               ReferencedContainer = "container:libs/SalesforceSwiftSDK/SalesforceSwiftSDK.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/libs/SalesforceReact/SalesforceReact.xcodeproj/xcshareddata/xcschemes/SalesforceReact.xcscheme
+++ b/libs/SalesforceReact/SalesforceReact.xcodeproj/xcshareddata/xcschemes/SalesforceReact.xcscheme
@@ -27,8 +27,18 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4FA796AA2020E6D500CA9759"
+               BuildableName = "SalesforceReactTests.xctest"
+               BlueprintName = "SalesforceReactTests"
+               ReferencedContainer = "container:SalesforceReact.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -39,6 +49,13 @@
             ReferencedContainer = "container:SalesforceReact.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "CI_USE_PACKAGER"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>


### PR DESCRIPTION
- Add Swiftlint
- Tweak coverage range and exclude more targets
- Add SwiftSDK CirlceCI Nightlys
- Add SwiftSDK and React Native to CirlceCI PRs

For an unknown reason React Native tests don't work on Jenkins and I don't think it's worth the effort to figure out why with CircleCI on the horizon.  