### PR TITLE
Fixing dismissal of safari view controller

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -141,9 +141,6 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelLoginPicker:)];
 
     SFSDKLoginViewControllerConfig *config = [SFUserAccountManager sharedInstance].loginViewControllerConfig;
-    [self.navigationController.navigationBar setBarTintColor:config.navBarColor];
-    self.navigationController.navigationBar.tintColor = config.navBarTextColor;
-    [self.navigationController.navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName: config.navBarTitleColor, NSFontAttributeName: config.navBarFont}];
     
     if (!config.navBarColor) {
         [self.navigationController.navigationBar setBarTintColor:config.navBarColor];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -145,6 +145,18 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
     self.navigationController.navigationBar.tintColor = config.navBarTextColor;
     [self.navigationController.navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName: config.navBarTitleColor, NSFontAttributeName: config.navBarFont}];
     
+    if (!config.navBarColor) {
+        [self.navigationController.navigationBar setBarTintColor:config.navBarColor];
+    }
+    
+    if (!config.navBarTextColor) {
+         self.navigationController.navigationBar.tintColor = config.navBarTextColor;
+    }
+    
+    if (!config.navBarFont && !config.navBarTitleColor) {
+        [self.navigationController.navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName: config.navBarTitleColor, NSFontAttributeName: config.navBarFont}];
+    }
+    
     // Make sure the current login host exists.
     NSUInteger index = [self indexOfCurrentLoginHost];
     if (NSNotFound == index) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -112,35 +112,27 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     if (!self.config.authViewHandler) {
         [readWriteLock lock];
         __weak typeof(self) weakSelf = self;
-        if (self.config.advancedAuthConfiguration == SFOAuthAdvancedAuthConfigurationRequire) {
-            self.config.authViewHandler = [[SFSDKAuthViewHandler alloc]
-                    initWithDisplayBlock:^(SFSDKAuthViewHolder *viewHandler) {
-                        __strong typeof(weakSelf) strongSelf = weakSelf;
-                        strongSelf.authWindow.viewController = viewHandler.safariViewController;
-                        [strongSelf.authWindow presentWindow];
-                    } dismissBlock:nil];
-        } else {
-            self.config.authViewHandler = [[SFSDKAuthViewHandler alloc]
-                    initWithDisplayBlock:^(SFSDKAuthViewHolder *viewHolder) {
-                        __strong typeof(weakSelf) strongSelf = weakSelf;
-                        
-                        if (!strongSelf.config.idpEnabled) {
-                            strongSelf.authWindow.viewController = strongSelf.config.authViewController;
-                            
-                        } else {
-                            if ([strongSelf.authWindow.window.rootViewController isViewLoaded]) {
-                                [strongSelf.authWindow.window.rootViewController  presentViewController:viewHolder.loginController   animated:NO completion:nil];
-                            }else {
-                                strongSelf.authWindow.viewController = viewHolder.loginController;
-                            }
-                        }
-                        [[SFSDKWindowManager sharedManager].authWindow presentWindow];
-                        
-                    } dismissBlock:^() {
-                        __strong typeof(weakSelf) strongSelf = weakSelf;
-                        [strongSelf dismissAuthViewControllerIfPresent];
-                    }];
-       }
+        self.config.authViewHandler = [[SFSDKAuthViewHandler alloc]
+                                       initWithDisplayBlock:^(SFSDKAuthViewHolder *viewHandler) {
+                                           __strong typeof(weakSelf) strongSelf = weakSelf;
+                                           [strongSelf.authWindow presentWindow];
+                                           UIViewController *controllerToPresent = nil;
+                                           if (viewHandler.isAdvancedAuthFlow) {
+                                               controllerToPresent = viewHandler.safariViewController;
+                                           } else {
+                                               controllerToPresent = viewHandler.loginController;
+                                           }
+                                           if ([strongSelf.authWindow.viewController presentedViewController]) {
+                                               [strongSelf.authWindow.viewController.presentedViewController dismissViewControllerAnimated:NO completion:^{
+                                                       [strongSelf.authWindow.viewController  presentViewController:controllerToPresent animated:YES completion:nil];
+                                               }];
+                                            }else {
+                                                [strongSelf.authWindow.viewController  presentViewController:controllerToPresent animated:YES completion:nil];
+                                            }
+                                       } dismissBlock:^() {
+                                           __strong typeof(weakSelf) strongSelf = weakSelf;
+                                           [strongSelf dismissAuthWindow];
+                                       }];
        [readWriteLock unlock];
     }
     return self.config.authViewHandler;
@@ -154,12 +146,22 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
         });
         return;
     }
-   [self dismissAuthWindow];
+    self.authViewHandler.authViewDismissBlock();
 
 }
 
 -(void)dismissAuthWindow {
-    [[SFSDKWindowManager sharedManager].authWindow dismissWindow];
+
+    UIViewController *presentedViewController = [SFSDKWindowManager sharedManager].authWindow.viewController.presentedViewController?:[SFSDKWindowManager sharedManager].authWindow.viewController;
+    
+    if (presentedViewController) {
+        [presentedViewController dismissViewControllerAnimated:YES completion:^{
+            [[SFSDKWindowManager sharedManager].authWindow dismissWindowAnimated:YES withCompletion:nil];
+        }];
+    } else {
+         //hide the window if no controllers were found.
+         [[SFSDKWindowManager sharedManager].authWindow dismissWindowAnimated:YES withCompletion:nil];
+    }
 }
 
 - (void)retrieveIdentityDataWithCompletion:(SFIdentitySuccessCallbackBlock)successBlock
@@ -442,7 +444,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     SFLoginViewController *loginViewController = [self createLoginViewControllerInstance];
     loginViewController.oauthView = view;
     SFSDKAuthViewHolder *viewHolder = [SFSDKAuthViewHolder new];
-    viewHolder.loginController = self.config.authViewController;
+    viewHolder.loginController = loginViewController;
     viewHolder.isAdvancedAuthFlow = NO;
     self.config.authViewController  = loginViewController;
     // Ensure this runs on the main thread.  Has to be sync, because the coordinator expects the auth view

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKAlertView.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKAlertView.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SFSDKAlertView : NSObject
 
 @property (nonatomic,readonly) UIAlertController *controller;
-@property (nonatomic,readonly) SFSDKWindowContainer *window;
+@property (nonatomic,readonly,weak) SFSDKWindowContainer *window;
 
 - (void)presentViewController:(BOOL)animated completion:(void (^ __nullable)(void))completion;
 


### PR DESCRIPTION
Fixing dismissal of safari view controller. Modally presented  view controllers & Safari View Controller  cannot be dismissed without a presenting view controller (uikit feature or a bug). All the special SDK windows have a placeholder SFSDKRootController. Use it to present and dismiss SafariViewController. 
