### PR TITLE
Add methods for updating accessibility of RSA Keys

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
@@ -148,6 +148,20 @@ extern NSUInteger const kSFPBKDFDefaultSaltByteLength;
 + (nullable SecKeyRef)getRSAPrivateKeyRefWithName:(NSString *)keyName keyLength:(NSUInteger)length;
 
 /**
+ * Updates a private key's accessibility to given attribute
+ * @param keyName The name string used to generate the key.
+ * @param accessibleAttribute The accessibility attributed to use for keys
+ */
++ (void)updateRSAPrivateKeyStringWithName:(NSString *)keyName keyLength:(NSUInteger)length withAccessiblity:(CFTypeRef)accessibleAttribute;
+
+/**
+ * Updates a public key's accessibility to given attribute
+ * @param keyName The name string used to generate the key.
+ * @param accessibleAttribute The accessibility attributed to use for keys
+ */
++ (void)updateRSAPublicKeyStringWithName:(NSString *)keyName keyLength:(NSUInteger)length withAccessiblity:(CFTypeRef)accessibleAttribute;
+
+/**
  * Encrypt data with givien SecKeyRef using RSA pkcs1 algorithm
  * @param data The data to encrypt
  * @param keyRef The keyref used in encryption

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
@@ -379,6 +379,51 @@ static NSString * const kSFRSAPrivateKeyTagPrefix = @"com.salesforce.rsakey.priv
     }
 }
 
++ (void)updateRSAPublicKeyStringWithName:(NSString *)keyName keyLength:(NSUInteger)length withAccessiblity:(CFTypeRef)accessibleAttribute {
+    NSString *keyTagString = [NSString stringWithFormat:@"%@.%@", kSFRSAPublicKeyTagPrefix, keyName];
+    [SFSDKCryptoUtils updateRSAKeyWithTag:keyTagString keyLength:length withAccessiblity:accessibleAttribute];
+    
+}
+
++ (void)updateRSAPrivateKeyStringWithName:(NSString *)keyName keyLength:(NSUInteger)length withAccessiblity:(CFTypeRef)accessibleAttribute {
+    NSString *keyTagString = [NSString stringWithFormat:@"%@.%@", kSFRSAPrivateKeyTagPrefix, keyName];
+    [SFSDKCryptoUtils updateRSAKeyWithTag:keyTagString keyLength:length withAccessiblity:accessibleAttribute];
+}
+
++ (void)updateRSAKeyWithTag:(NSString *)keyTagString keyLength:(NSUInteger)length withAccessiblity:(CFTypeRef)accessibleAttribute {
+    NSData *tag = [keyTagString dataUsingEncoding:NSUTF8StringEncoding];
+    
+    NSDictionary *getquery = @{ (id)kSecClass: (id)kSecClassKey,
+                                (id)kSecAttrApplicationTag: tag,
+                                (id)kSecAttrKeyType: (id)kSecAttrKeyTypeRSA,
+                                (id)kSecReturnData: @YES,
+                                (id)kSecAttrKeySizeInBits: [NSNumber numberWithUnsignedInteger:length],
+                                };
+    
+    CFTypeRef result = NULL;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)getquery,
+                                          (CFTypeRef *)&result);
+    if (status != errSecSuccess) {
+        NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:status userInfo:nil];
+        [SFSDKCoreLogger e:[self class] format:@"Error getting RSA key with tag %@ and length %d. Error code: %@", keyTagString, length, error.localizedDescription];
+        return;
+    }
+
+    NSDictionary *updatedAttributes = @{ (id)kSecAttrAccessible: (__bridge id)accessibleAttribute,
+                                         (id)kSecValueData: (__bridge id)result,};
+
+    NSDictionary *updateQuery = @{(id)kSecClass: (id)kSecClassKey,
+                                  (id)kSecAttrApplicationTag: tag,
+                                  (id)kSecAttrKeyType: (id)kSecAttrKeyTypeRSA,
+                                  (id)kSecAttrKeySizeInBits: [NSNumber numberWithUnsignedInteger:length],};
+    OSStatus updateItemStatus = SecItemUpdate((CFDictionaryRef)updateQuery,
+                                                  (CFDictionaryRef)updatedAttributes);
+    if (updateItemStatus != errSecSuccess) {
+        NSError *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:status userInfo:nil];
+        [SFSDKCoreLogger e:[self class] format:@"Error updating RSA key with tag %@ and length %d. Error code: %@", keyTagString, length, error.localizedDescription];
+    }
+}
+
 +(nullable NSData *)getRSAKeyDataWithTag:(NSString *)keyTagString keyLength:(NSUInteger)length {
     NSData *tag = [keyTagString dataUsingEncoding:NSUTF8StringEncoding];
     


### PR DESCRIPTION
Notification extensions require access to the key pair when device is locked in order to support decrypting encrypted push notifications. These methods allow a client app to change the accessibility of a key pair.