### PR TITLE
Add Nullable for SFPreference objectForKey

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFPreferences.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFPreferences.h
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** Returns the preferences object for the given key.
  @param key The key of the requested object.
  */
-- (id)objectForKey:(NSString*)key;
+- (nullable id)objectForKey:(NSString*)key;
 
 /** Sets the preference object for the given attribute key. Logs an SFLogLevelError if the key is not found.
  @param object Object to be set.


### PR DESCRIPTION
@bhariharan @trooper2013 
Add nullable to this property to fix crash/ unit tests in S1.