### PR TITLE
Handling of navbar & statusbar with SFLoginViewController

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.h
@@ -113,7 +113,7 @@
 
 /** Factory Method to create the navigation title.
  */
-- (nonnull UINavigationItem *)createTitleItem;
+- (nonnull UIView *)createTitleItem;
 
 /** Logic to show back button.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -89,9 +89,7 @@ SFSDK_USE_DEPRECATED_END
 
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
-    if (self.navigationController == nil) {
-        [self layoutViews];
-    }
+    [self layoutWebView];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -159,13 +157,9 @@ SFSDK_USE_DEPRECATED_END
 #pragma mark - Setup Navigation bar
 
 - (void)setupNavigationBar {
-    if (self.navigationController != nil) {
-        self.navBar = self.navigationController.navigationBar;
-    } else {
-        self.navBar = [[UINavigationBar alloc] initWithFrame:CGRectZero];
-        self.navBar.items = @[[self createTitleItem]];
-    }
     
+    self.navBar = self.navigationController.navigationBar;
+    self.navBar.topItem.titleView = [self createTitleItem];
     // Hides the gear icon if there are no hosts to switch to.
     SFManagedPreferences *managedPreferences = [SFManagedPreferences sharedPreferences];
     if (managedPreferences.onlyShowAuthorizedHosts && managedPreferences.loginHosts.count == 0) {
@@ -226,13 +220,25 @@ SFSDK_USE_DEPRECATED_END
     return [[UIBarButtonItem alloc] initWithImage:image style:UIBarButtonItemStylePlain target:self action:@selector(showLoginHost:)];
 }
 
-- (UINavigationItem *)createTitleItem {
+- (UIView *)createTitleItem {
     NSString *title = [SFSDKResourceUtils localizedString:@"TITLE_LOGIN"];
     // Setup top item.
-    UINavigationItem *item = [[UINavigationItem alloc] initWithTitle:title];
+    UILabel *item = [[UILabel alloc] init];
+    if (self.config.navBarTitleColor) {
+        item.textColor = self.config.navBarTextColor;
+    }
+    if (self.config.navBarFont) {
+        item.font = self.config.navBarFont;
+    }
+    item.text = title;
     return item;
 }
 
+- (void)layoutWebView {
+    if (nil != _oauthView) {
+        [self.view addSubview:_oauthView];
+    }
+}
 
 #pragma mark - Action Methods
 
@@ -263,34 +269,12 @@ SFSDK_USE_DEPRECATED_END
     return _loginHostListViewController;
 }
 
-#pragma mark - Properties
+#pragma mark - Properties`
 
 - (void)setOauthView:(UIView *)oauthView {
     if (![oauthView isEqual:_oauthView]) {
         [_oauthView removeFromSuperview];
         _oauthView = oauthView;
-        if (nil != _oauthView) {
-            [self.view addSubview:_oauthView];
-            if (self.navigationController == nil) {
-                [self layoutViews];
-            }
-        }
-    }
-}
-
-#pragma mark - Layout Methods
-
-- (void)layoutViews {
-
-    // Let navBar tell us what height it would prefer at the current orientation
-    CGFloat navBarHeight = [self.navBar sizeThatFits:self.view.bounds.size].height;
-
-    // Resize navBar
-    self.navBar.frame = CGRectMake(0, self.topLayoutGuide.length, self.view.bounds.size.width, navBarHeight);
-
-    // resize oAuth view
-    if (_oauthView) {
-        _oauthView.frame = CGRectMake(0, CGRectGetMaxY(self.navBar.frame), self.view.bounds.size.width, self.view.bounds.size.height - CGRectGetMaxY(self.navBar.frame));
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFSDKLoginViewControllerConfig.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFSDKLoginViewControllerConfig.m
@@ -40,7 +40,7 @@
     self = [super init];
     if (self) {
         _navBarColor = [UIColor salesforceBlueColor];
-        _navBarTitleColor = [UIColor blackColor];
+        _navBarTitleColor = [UIColor whiteColor];
         _navBarFont = nil;
         _navBarTextColor = [UIColor whiteColor];
         _showNavbar = YES;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -971,7 +971,6 @@ static NSString * const kSFECParameter = @"ec";
     if (!self.initialRequestLoaded) {
         self.initialRequestLoaded = YES;
         [self.delegate oauthCoordinator:self didBeginAuthenticationWithView:self.view];
-        NSAssert((nil != [self.view superview]), @"No superview for oauth web view after didBeginAuthenticationWithView");
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -115,20 +115,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
         self.config.authViewHandler = [[SFSDKAuthViewHandler alloc]
                                        initWithDisplayBlock:^(SFSDKAuthViewHolder *viewHandler) {
                                            __strong typeof(weakSelf) strongSelf = weakSelf;
-                                           [strongSelf.authWindow presentWindow];
-                                           UIViewController *controllerToPresent = nil;
-                                           if (viewHandler.isAdvancedAuthFlow) {
-                                               controllerToPresent = viewHandler.safariViewController;
-                                           } else {
-                                               controllerToPresent = viewHandler.loginController;
-                                           }
-                                           if ([strongSelf.authWindow.viewController presentedViewController]) {
-                                               [strongSelf.authWindow.viewController.presentedViewController dismissViewControllerAnimated:NO completion:^{
-                                                       [strongSelf.authWindow.viewController  presentViewController:controllerToPresent animated:NO completion:nil];
-                                               }];
-                                            }else {
-                                                [strongSelf.authWindow.viewController  presentViewController:controllerToPresent animated:NO completion:nil];
-                                            }
+                                           [strongSelf presentLoginView:viewHandler];
                                        } dismissBlock:^() {
                                            __strong typeof(weakSelf) strongSelf = weakSelf;
                                            [strongSelf dismissAuthWindow];
@@ -155,12 +142,12 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     UIViewController *presentedViewController = [SFSDKWindowManager sharedManager].authWindow.viewController.presentedViewController?:[SFSDKWindowManager sharedManager].authWindow.viewController;
     
     if (presentedViewController) {
-        [presentedViewController dismissViewControllerAnimated:YES completion:^{
-            [[SFSDKWindowManager sharedManager].authWindow dismissWindowAnimated:YES withCompletion:nil];
+        [presentedViewController dismissViewControllerAnimated:NO completion:^{
+            [[SFSDKWindowManager sharedManager].authWindow dismissWindowAnimated:NO withCompletion:nil];
         }];
     } else {
          //hide the window if no controllers were found.
-         [[SFSDKWindowManager sharedManager].authWindow dismissWindowAnimated:YES withCompletion:nil];
+         [[SFSDKWindowManager sharedManager].authWindow dismissWindowAnimated:NO withCompletion:nil];
     }
 }
 
@@ -664,5 +651,35 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     instance.idCoordinator.delegate = instance;
     
     return instance;
+}
+
+- (void)presentLoginView:(SFSDKAuthViewHolder *)viewHandler {
+    [self.authWindow presentWindow];
+    UIViewController *controllerToPresent = nil;
+    
+    if (viewHandler.isAdvancedAuthFlow) {
+        controllerToPresent = viewHandler.safariViewController;
+    } else {
+        UINavigationController *navController = [[UINavigationController alloc]  initWithRootViewController:viewHandler.loginController];
+        controllerToPresent = navController;
+    }
+    
+    __weak typeof(self) weakSelf = self;
+    void (^presentViewBlock)(void) = ^void() {
+        [weakSelf.authWindow.viewController presentViewController:controllerToPresent animated:NO completion:^{
+            if (!viewHandler.isAdvancedAuthFlow) {
+                NSAssert((nil != [viewHandler.loginController.oauthView superview]), @"No superview for oauth web view invoke [super viewDidLayoutSubviews] in the SFLoginViewController subclass");
+            }
+        }];
+    };
+    
+    //dismiss if already presented and then present
+    if ([self.authWindow.viewController presentedViewController]) {
+        [self.authWindow.viewController.presentedViewController dismissViewControllerAnimated:NO completion:^{
+            presentViewBlock();
+        }];
+    }else {
+        presentViewBlock();
+    }
 }
 @end


### PR DESCRIPTION
Adding a navbar directly to a ViewController has its disadvantages when SFLoginViewController is subclassed and customized. Changed underlying code to present SFLoginViewController through a navigation controller. Also did a minor refactor of some code to present the login view in the oauth client.