### PR TITLE
Expose method for creating RSA Keys

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
@@ -116,6 +116,13 @@ extern NSUInteger const kSFPBKDFDefaultSaltByteLength;
 + (nullable NSData *)aes256DecryptData:(NSData *)data withKey:(NSData *)key iv:(NSData *)iv;
 
 /**
+ * Create asymmetric keys (public/private key pairs) using RSA algorithm with given keyName and length
+ * @param keyName The name string used to generate the key.
+ * @param length The key length used for key
+ */
++ (void)createRSAKeyPairWithName:(NSString *)keyName keyLength:(NSUInteger)length accessibleAttribute:(CFTypeRef)accessibleAttribute;
+
+/**
  * Get RSA public key as NSString with given keyName and length
  * @param keyName The name string used to generate the key.
  * @param length The key length used for key

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
@@ -340,12 +340,12 @@ static NSString * const kSFRSAPrivateKeyTagPrefix = @"com.salesforce.rsakey.priv
        (id)kSecPrivateKeyAttrs:
            @{ (id)kSecAttrIsPermanent:    @YES,
               (id)kSecAttrApplicationTag: privateTag,
-              (id)kSecAttrAccessible: (id)accessibleAttribute,
+              (id)kSecAttrAccessible: (__bridge id)accessibleAttribute,
               },
        (id)kSecPublicKeyAttrs:
            @{ (id)kSecAttrIsPermanent:    @YES,
               (id)kSecAttrApplicationTag: publicTag,
-              (id)kSecAttrAccessible: (id)accessibleAttribute,
+              (id)kSecAttrAccessible: (__bridge id)accessibleAttribute,
               },
 
        };

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
@@ -69,13 +69,6 @@ static NSString * const kSFRSAPrivateKeyTagPrefix = @"com.salesforce.rsakey.priv
 + (nullable NSData *)aesDecryptData:(NSData *)data withKey:(NSData *)key keyLength:(NSInteger)keyLength iv:(NSData *)iv;
 
 /**
- * Create asymmetric keys (public/private key pairs) using RSA algorithm with given keyName and length
- * @param keyName The name string used to generate the key.
- * @param length The key length used for key
- */
-+ (void)createRSAKeyPairWithName:(NSString *)keyName keyLength:(NSUInteger)length;
-
-/**
  * Get RSA key as NSString with given keyTagString and length
  * @param keyTagString The key tag string used to generate the key.
  * @param length The key length used for key
@@ -333,7 +326,7 @@ static NSString * const kSFRSAPrivateKeyTagPrefix = @"com.salesforce.rsakey.priv
     return (executeCryptSuccess ? resultData : nil);
 }
 
-+ (void)createRSAKeyPairWithName:(NSString *)keyName keyLength:(NSUInteger)length
++ (void)createRSAKeyPairWithName:(NSString *)keyName keyLength:(NSUInteger)length accessibleAttribute:(CFTypeRef)accessibleAttribute;
 {
     NSString *privateTagString = [NSString stringWithFormat:@"%@.%@", kSFRSAPrivateKeyTagPrefix, keyName];
     NSData *privateTag = [privateTagString dataUsingEncoding:NSUTF8StringEncoding];
@@ -347,10 +340,12 @@ static NSString * const kSFRSAPrivateKeyTagPrefix = @"com.salesforce.rsakey.priv
        (id)kSecPrivateKeyAttrs:
            @{ (id)kSecAttrIsPermanent:    @YES,
               (id)kSecAttrApplicationTag: privateTag,
+              (id)kSecAttrAccessible: (id)accessibleAttribute,
               },
        (id)kSecPublicKeyAttrs:
            @{ (id)kSecAttrIsPermanent:    @YES,
               (id)kSecAttrApplicationTag: publicTag,
+              (id)kSecAttrAccessible: (id)accessibleAttribute,
               },
 
        };
@@ -395,10 +390,7 @@ static NSString * const kSFRSAPrivateKeyTagPrefix = @"com.salesforce.rsakey.priv
                                           (CFTypeRef *)&result);
     if (status != errSecSuccess) {
         if (status == errSecItemNotFound) {
-            NSString *keyName = [[keyTagString componentsSeparatedByString:@"."] lastObject];
-            [self createRSAKeyPairWithName:keyName keyLength:length];
-            status = SecItemCopyMatching((__bridge CFDictionaryRef)getquery,
-                                         (CFTypeRef *)&result);
+            return nil;
         }
         if (status != errSecSuccess) {
             // Handle the error. . .
@@ -429,10 +421,7 @@ static NSString * const kSFRSAPrivateKeyTagPrefix = @"com.salesforce.rsakey.priv
                                           (CFTypeRef *)&keyRef);
     if (status != errSecSuccess) {
         if (status == errSecItemNotFound) {
-            NSString *keyName = [[keyTagString componentsSeparatedByString:@"."] lastObject];
-            [self createRSAKeyPairWithName:keyName keyLength:length];
-            status = SecItemCopyMatching((__bridge CFDictionaryRef)getquery,
-                                         (CFTypeRef *)&keyRef);
+            return nil;
         }
         if (status != errSecSuccess) {
             // Handle the error. . .

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
@@ -190,33 +190,18 @@
 
 - (void)testRSAKeyGeneration
 {
+    [SFSDKCryptoUtils createRSAKeyPairWithName:@"test" keyLength:2048 accessibleAttribute:kSecAttrAccessibleAlways];
     NSData *privateKeyData = [SFSDKCryptoUtils getRSAPrivateKeyDataWithName:@"test" keyLength:2048];
     XCTAssertNotNil(privateKeyData);
     NSString *publicKeyString = [SFSDKCryptoUtils getRSAPublicKeyStringWithName:@"test" keyLength:2048];
     XCTAssertNotNil(publicKeyString);
 }
 
-- (void)testRSAKeyGenerationSameKey
-{
-    NSData *privateKeyData1 = [SFSDKCryptoUtils getRSAPrivateKeyDataWithName:@"testSameKey" keyLength:2048];
-    XCTAssertNotNil(privateKeyData1);
-
-    NSData *privateKeyData2 = [SFSDKCryptoUtils getRSAPrivateKeyDataWithName:@"testSameKey" keyLength:2048];
-    XCTAssertNotNil(privateKeyData2);
-
-    XCTAssertTrue([privateKeyData1 isEqualToData:privateKeyData2], @"should get same private key data with same keyname and size");
-
-    NSString *public1KeyString = [SFSDKCryptoUtils getRSAPublicKeyStringWithName:@"testSameKey" keyLength:2048];
-    XCTAssertFalse([public1KeyString isEqualToString:@""]);
-
-    NSString *public2KeyString = [SFSDKCryptoUtils getRSAPublicKeyStringWithName:@"testSameKey" keyLength:2048];
-    XCTAssertFalse([public2KeyString isEqualToString:@""]);
-
-    XCTAssertTrue([public1KeyString isEqualToString:public2KeyString], @"should get same public key string with same keyname and size");
-}
-
 - (void)testRSAKeyGenerationDifferentKey
 {
+    [SFSDKCryptoUtils createRSAKeyPairWithName:@"test1" keyLength:2048 accessibleAttribute:kSecAttrAccessibleAlways];
+    [SFSDKCryptoUtils createRSAKeyPairWithName:@"test2" keyLength:2048 accessibleAttribute:kSecAttrAccessibleAlways];
+
     NSData *privateKeyData1 = [SFSDKCryptoUtils getRSAPrivateKeyDataWithName:@"test1" keyLength:2048];
     XCTAssertNotNil(privateKeyData1);
 
@@ -233,6 +218,8 @@
 
     XCTAssertFalse([public1KeyString isEqualToString:public2KeyString], @"should get different public key strings with different keynames");
 
+    [SFSDKCryptoUtils createRSAKeyPairWithName:@"test1" keyLength:1024 accessibleAttribute:kSecAttrAccessibleAlways];
+
     NSData *privateKeyData3 = [SFSDKCryptoUtils getRSAPrivateKeyDataWithName:@"test1" keyLength:1024];
     XCTAssertNotNil(privateKeyData3);
 
@@ -247,7 +234,9 @@
 - (void)testRSAEncryptionAndDecryption
 {
     size_t keySize = 2048;
-    
+
+    [SFSDKCryptoUtils createRSAKeyPairWithName:@"test" keyLength:keySize accessibleAttribute:kSecAttrAccessibleAlways];
+
     SecKeyRef publicKeyRef = [SFSDKCryptoUtils getRSAPublicKeyRefWithName:@"test" keyLength:keySize];
     SecKeyRef privateKeyRef = [SFSDKCryptoUtils getRSAPrivateKeyRefWithName:@"test" keyLength:keySize];
     
@@ -265,7 +254,10 @@
 - (void)testRSAEncryptionAndDecryptionWrongKeys
 {
     size_t keySize = 2048;
-    
+
+    [SFSDKCryptoUtils createRSAKeyPairWithName:@"test1" keyLength:keySize accessibleAttribute:kSecAttrAccessibleAlways];
+    [SFSDKCryptoUtils createRSAKeyPairWithName:@"test" keyLength:keySize accessibleAttribute:kSecAttrAccessibleAlways];
+
     SecKeyRef publicKeyRef = [SFSDKCryptoUtils getRSAPublicKeyRefWithName:@"test1" keyLength:keySize];
     SecKeyRef privateKeyRef = [SFSDKCryptoUtils getRSAPrivateKeyRefWithName:@"test" keyLength:keySize];
     


### PR DESCRIPTION
-  do not automatically create key pairs if not found, instead return nil
-  The caller can choose to create key pair if does not exist
-  Expose ability to specify accessible attribute for keypair when created