### PR TITLE
Fixing session refresh bugs and UIWebView bugs in hybrid remote apps

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -62,7 +62,6 @@ static NSInteger  const kErrorCodeNoCredentials = 2;
 static NSString * const kErrorContextAppLoading = @"AppLoading";
 static NSString * const kErrorContextAuthExpiredSessionRefresh = @"AuthRefreshExpiredSession";
 static NSString * const kVFPingPageUrl = @"/apexpages/utils/ping.apexp";
-static NSString * const kVFSessionPrefix = @"%2Fvisualforce%2Fsession%3Furl%3D";
 
 // App feature constant.
 static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
@@ -428,7 +427,7 @@ SFSDK_USE_DEPRECATED_BEGIN
      * We need to use the absolute URL in some cases and relative URL in some
      * other cases, because of differences between instance URL and community URL.
      */
-    if (createAbsUrl && ![returnUrlString hasPrefix:@"http"]) {
+    if (createAbsUrl && ![returnUrlString containsString:@"http"]) {
         NSURLComponents *retUrlComponents = [NSURLComponents componentsWithURL:instUrl resolvingAgainstBaseURL:NO];
         retUrlComponents.path = [retUrlComponents.path stringByAppendingPathComponent:returnUrlString];
         fullReturnUrlString = retUrlComponents.string;
@@ -470,9 +469,6 @@ SFSDK_USE_DEPRECATED_BEGIN
         BOOL foundStartURL = (startUrlValue != nil);
         BOOL foundValidEcValue = ([ecValue isEqualToString:@"301"] || [ecValue isEqualToString:@"302"]);
         if (foundStartURL && foundValidEcValue) {
-            if ([startUrlValue containsString:kVFSessionPrefix]) {
-                startUrlValue = [startUrlValue stringByReplacingOccurrencesOfString:kVFSessionPrefix withString:@""];
-            }
             return startUrlValue;
         }
     }

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -427,7 +427,7 @@ SFSDK_USE_DEPRECATED_BEGIN
      * We need to use the absolute URL in some cases and relative URL in some
      * other cases, because of differences between instance URL and community URL.
      */
-    if (createAbsUrl && ![returnUrlString containsString:@"http"]) {
+    if (createAbsUrl && ![returnUrlString hasPrefix:@"http"]) {
         NSURLComponents *retUrlComponents = [NSURLComponents componentsWithURL:instUrl resolvingAgainstBaseURL:NO];
         retUrlComponents.path = [retUrlComponents.path stringByAppendingPathComponent:returnUrlString];
         fullReturnUrlString = retUrlComponents.string;

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -699,7 +699,7 @@ SFSDK_USE_DEPRECATED_BEGIN
              }];
             return NO;
         }
-        NSURL* url = [request URL];
+        NSURL* url = request.URL;
 
         /*
          * Execute any commands queued with cordova.exec() on the JS side.
@@ -709,33 +709,9 @@ SFSDK_USE_DEPRECATED_BEGIN
             [self.commandQueue fetchCommandsFromJs];
             [self.commandQueue executePending];
             return NO;
-        }
-
-        /*
-         * Give plugins the chance to handle the URL.
-         */
-        BOOL anyPluginsResponded = NO;
-        BOOL shouldAllowRequest = NO;
-        for (NSString* pluginName in self.pluginObjects) {
-            CDVPlugin* plugin = [self.pluginObjects objectForKey:pluginName];
-            SEL selector = NSSelectorFromString(@"shouldOverrideLoadWithRequest:navigationType:");
-            if ([plugin respondsToSelector:selector]) {
-                anyPluginsResponded = YES;
-                shouldAllowRequest = (((BOOL (*)(id, SEL, id, int)) objc_msgSend)(plugin, selector, request, navigationType));
-                if (!shouldAllowRequest) {
-                    break;
-                }
-            }
-        }
-        if (anyPluginsResponded) {
-            return shouldAllowRequest;
-        }
-        if ([url isFileURL]) {
-            return YES;
         } else {
             [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
         }
-        return NO;
     }
     return YES;
 }

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -649,7 +649,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (BOOL) webView:(UIWebView *) webView shouldStartLoadWithRequest:(NSURLRequest *) request navigationType:(UIWebViewNavigationType) navigationType
 {
-    [SFSDKHybridLogger d:[self class] format:@"webView:shouldStartLoadWithRequest:navigationType: Loading URL '%@'", [webView.request.URL redactedAbsoluteString:@[@"sid"]]];
+    [SFSDKHybridLogger d:[self class] format:@"webView:shouldStartLoadWithRequest:navigationType: Loading URL '%@'", [request.URL redactedAbsoluteString:@[@"sid"]]];
 
     // Hidden ping page load.
     if ([webView isEqual:self.vfPingPageHiddenUIWebView]) {
@@ -659,7 +659,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 
     // Local error page load.
     if ([webView isEqual:self.errorPageUIWebView]) {
-        [SFSDKHybridLogger d:[self class] format:@"Local error page ('%@') is loading.", webView.request.URL.absoluteString];
+        [SFSDKHybridLogger d:[self class] format:@"Local error page ('%@') is loading.", request.URL.absoluteString];
         return YES;
     }
 
@@ -670,7 +670,7 @@ SFSDK_USE_DEPRECATED_BEGIN
          * If the request is attempting to refresh an invalid session, take over
          * the refresh process via the OAuth refresh flow in the container.
          */
-        NSString *refreshUrl = [self isLoginRedirectUrl:webView.request.URL];
+        NSString *refreshUrl = [self isLoginRedirectUrl:request.URL];
         if (refreshUrl != nil) {
             [SFSDKHybridLogger w:[self class] message:@"Caught login redirect from session timeout. Reauthenticating."];
             


### PR DESCRIPTION
In some cases, the platform returns a `startURL` value with the additional prefix of `/visualforce/session?url=` (seems to be a new thing). This messes up our `frontdoor` computation during the token refresh flow.