### PR TITLE
Enhancements to push notification registration and unregistration

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.h
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param completionBlock Completion block.
  * @return YES for successful unregistration call being made.
  */
-- (BOOL)unregisterSalesforceNotificationsWithCompletionBlock:(SFUserAccount*)user completionBlock:(void)completionBlock;
+- (BOOL)unregisterSalesforceNotificationsWithCompletionBlock:(SFUserAccount*)user completionBlock:(void (^)(void))completionBlock;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.h
@@ -67,14 +67,14 @@ NS_ASSUME_NONNULL_BEGIN
  * Unregister from notifications with Salesforce for all users. This method is called at logout.
  * @return YES for successful unregistration call being made.
  */
-- (BOOL)unregisterSalesforceNotifications;
+- (BOOL) SFSDK_DEPRECATED(6.1, 7.0, "Use 'unregisterSalesforceNotificationsWithCompletionBlock' instead.") unregisterSalesforceNotifications;
 
 /**
  * Unregister from notifications with Salesforce for a specific user. This method is called at logout.
  * @param user User account.
  * @return YES for successful unregistration call being made.
  */
-- (BOOL)unregisterSalesforceNotifications:(SFUserAccount*)user;
+- (BOOL) SFSDK_DEPRECATED(6.1, 7.0, "Use 'unregisterSalesforceNotificationsWithCompletionBlock' instead.") unregisterSalesforceNotifications:(SFUserAccount*)user;
 
 /**
  * Unregister from notifications with Salesforce for a specific user. This method is called at logout.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.h
@@ -76,6 +76,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)unregisterSalesforceNotifications:(SFUserAccount*)user;
 
+/**
+ * Unregister from notifications with Salesforce for a specific user. This method is called at logout.
+ * @param user User account.
+ * @param completionBlock Completion block.
+ * @return YES for successful unregistration call being made.
+ */
+- (BOOL)unregisterSalesforceNotificationsWithCompletionBlock:(SFUserAccount*)user completionBlock:(void)completionBlock;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.h
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param completionBlock Completion block.
  * @return YES for successful unregistration call being made.
  */
-- (BOOL)unregisterSalesforceNotificationsWithCompletionBlock:(SFUserAccount*)user completionBlock:(void (^)(void))completionBlock;
+- (BOOL)unregisterSalesforceNotificationsWithCompletionBlock:(SFUserAccount*)user completionBlock:(nullable void (^)(void))completionBlock;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -228,7 +228,7 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
     return [self unregisterSalesforceNotificationsWithCompletionBlock:[SFUserAccountManager sharedInstance].currentUser completionBlock:nil];
 }
 
-- (BOOL)unregisterSalesforceNotificationsWithCompletionBlock:(SFUserAccount*)user completionBlock:(^void)completionBlock
+- (BOOL)unregisterSalesforceNotificationsWithCompletionBlock:(SFUserAccount*)user completionBlock:(void (^)(void))completionBlock
 {
     if (self.isSimulator) {
         [self postPushNotificationUnregistration:completionBlock];
@@ -273,7 +273,7 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
     return YES;
 }
 
-- (BOOL)postPushNotificationUnregistration:completionBlock
+- (void)postPushNotificationUnregistration:(void (^)(void))completionBlock
 {
     if (completionBlock != nil) {
         completionBlock();

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -273,7 +273,7 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
     return YES;
 }
 
-- (BOOL) postPushNotificationUnregistration:(^void)completionBlock
+- (BOOL)postPushNotificationUnregistration:completionBlock
 {
     if (completionBlock != nil) {
         completionBlock();

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -30,11 +30,11 @@
 #import "SFJsonUtils.h"
 #import "SFApplicationHelper.h"
 #import "SFSDKAppFeatureMarkers.h"
-#import "SFNetwork.h"
+#import "SFRestAPI+Blocks.h"
 
 static NSString* const kSFDeviceToken = @"deviceToken";
 static NSString* const kSFDeviceSalesforceId = @"deviceSalesforceId";
-static NSString* const kSFPushNotificationEndPoint = @"services/data/v42.0/sobjects/MobilePushServiceDevice";
+static NSString* const kSFPushNotificationEndPoint = @"sobjects/MobilePushServiceDevice";
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-const-variable"
@@ -52,7 +52,6 @@ static NSString* const kSFPushNotificationEndPoint = @"services/data/v42.0/sobje
 static NSUInteger const kiOS8UserNotificationTypes = ((1 << 0) | (1 << 1) | (1 << 2));
 
 static NSString * const kSFAppFeaturePushNotifications = @"PN";
-
 
 #pragma clang diagnostic pop
 
@@ -73,6 +72,7 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
 @synthesize deviceSalesforceId = _deviceSalesforceId;
 
 #pragma mark - Initialization
+
 - (id)init
 {
     self = [super init];
@@ -100,7 +100,6 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
     return self;
 }
 
-
 + (SFPushNotificationManager *) sharedInstance
 {
     static dispatch_once_t pred;
@@ -119,7 +118,7 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
         [SFSDKCoreLogger i:[self class] format:@"Skipping push notification registration with Apple because push isn't supported on the simulator"];
         return;
     }
-    
+
     // register with Apple for remote notifications
     [SFSDKCoreLogger i:[self class] format:@"Registering with Apple for remote push notifications"];
     [self registerNotifications];
@@ -131,7 +130,6 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
     // we switch to building libraries with Xcode 6, this can go away.
     NSSet *categories = nil;
     NSUInteger notificationTypes = kiOS8UserNotificationTypes;
-    
     Class userNotificationSettings = NSClassFromString(@"UIUserNotificationSettings");
     NSMethodSignature *settingsForTypesSig = [userNotificationSettings methodSignatureForSelector:@selector(settingsForTypes:categories:)];
     NSInvocation *settingsForTypesInv = [NSInvocation invocationWithMethodSignature:settingsForTypesSig];
@@ -140,12 +138,11 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
     [settingsForTypesInv setArgument:&notificationTypes atIndex:2];
     [settingsForTypesInv setArgument:&categories atIndex:3];
     [settingsForTypesInv invoke];
-    
     CFTypeRef settingsForTypesRetVal;
     [settingsForTypesInv getReturnValue:&settingsForTypesRetVal];
-    if (settingsForTypesRetVal)
+    if (settingsForTypesRetVal) {
         CFRetain(settingsForTypesRetVal);
-    
+    }
     [[SFApplicationHelper sharedApplication] performSelector:@selector(registerUserNotificationSettings:) withObject:(__bridge_transfer id)settingsForTypesRetVal];
     [[SFApplicationHelper sharedApplication] performSelector:@selector(registerForRemoteNotifications)];
 }
@@ -174,41 +171,31 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
         [SFSDKCoreLogger e:[self class] format:@"Cannot register for notifications with Salesforce: no deviceToken"];
         return NO;
     }
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
-    
-    // URL and method
-    [request setURL:[NSURL URLWithString:kSFPushNotificationEndPoint relativeToURL:credentials.instanceUrl]];
-    [request setHTTPMethod:@"POST"];
-    
-    // Headers
-    [request setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-    [request setValue:[NSString stringWithFormat:@"Bearer %@", credentials.accessToken] forHTTPHeaderField:@"Authorization"];
-    [request setHTTPShouldHandleCookies:NO];
-    
-    // Body
+    NSString *path = [NSString stringWithFormat:@"/%@/%@", [SFRestAPI sharedInstance].apiVersion, kSFPushNotificationEndPoint];
+    SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
     NSString *bundleId = [NSBundle mainBundle].bundleIdentifier;
     NSDictionary* bodyDict = @{@"ConnectionToken":_deviceToken, @"ServiceType":@"Apple", @"ApplicationBundle":bundleId};
-    [request setHTTPBody:[SFJsonUtils JSONDataRepresentation:bodyDict]];
-    
-    // Send
-    SFNetwork *network = [[SFNetwork alloc] init];
-    [network sendRequest:request dataResponseBlock:^(NSData *data, NSURLResponse *response, NSError *error) {
-        if (error != nil) {
-            [SFSDKCoreLogger e:[self class] format:@"Registration for notifications with Salesforce failed with error %@", error];
+    [request setCustomRequestBodyDictionary:bodyDict contentType:@"application/json"];
+    __weak typeof(self) weakSelf = self;
+    [[SFRestAPI sharedInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (e != nil) {
+            [SFSDKCoreLogger e:[strongSelf class] format:@"Registration for notifications with Salesforce failed with error %@", e];
+        }
+    } completeBlock:^(id response, NSURLResponse *rawResponse) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeaturePushNotifications];
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
+        NSInteger statusCode = httpResponse.statusCode;
+        if (statusCode < 200 || statusCode >= 300) {
+            [SFSDKCoreLogger e:[strongSelf class] format:@"Registration for notifications with Salesforce failed with status %ld", statusCode];
+            [SFSDKCoreLogger e:[strongSelf class] format:@"Response:%@", response];
         } else {
-            [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeaturePushNotifications];
-            NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) response;
-            NSInteger statusCode = httpResponse.statusCode;
-            if (statusCode < 200 || statusCode >= 300) {
-                [SFSDKCoreLogger e:[self class] format:@"Registration for notifications with Salesforce failed with status %ld", statusCode];
-                [SFSDKCoreLogger e:[self class] format:@"Response:%@", [SFJsonUtils objectFromJSONData:data]];
-            } else {
-                [SFSDKCoreLogger i:[self class] format:@"Registration for notifications with Salesforce succeeded"];
-                NSDictionary *responseAsJson = (NSDictionary*) [SFJsonUtils objectFromJSONData:data];
-                self->_deviceSalesforceId = (NSString*) responseAsJson[@"id"];
-                [[SFPreferences currentUserLevelPreferences] setObject:self->_deviceSalesforceId forKey:kSFDeviceSalesforceId];
-                [SFSDKCoreLogger i:[self class] format:@"Response:%@", responseAsJson];
-            }
+            [SFSDKCoreLogger i:[strongSelf class] format:@"Registration for notifications with Salesforce succeeded"];
+            NSDictionary *responseAsJson = (NSDictionary*) response;
+            strongSelf->_deviceSalesforceId = (NSString*) responseAsJson[@"id"];
+            [[SFPreferences currentUserLevelPreferences] setObject:strongSelf->_deviceSalesforceId forKey:kSFDeviceSalesforceId];
+            [SFSDKCoreLogger i:[strongSelf class] format:@"Response:%@", responseAsJson];
         }
     }];
     return YES;
@@ -252,20 +239,16 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
         return NO;
     }
     NSString *deviceSFID = [[NSString alloc] initWithString:[pref stringForKey:kSFDeviceSalesforceId]];
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
-
-    // URL and method
-    [request setURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@/%@", kSFPushNotificationEndPoint, deviceSFID] relativeToURL:credentials.instanceUrl]];
-    [request setHTTPMethod:@"DELETE"];
-
-    // Headers
-    [request setValue:[NSString stringWithFormat:@"Bearer %@", credentials.accessToken] forHTTPHeaderField:@"Authorization"];
-    [request setHTTPShouldHandleCookies:NO];
-
-    // Send
-    SFNetwork *network = [[SFNetwork alloc] init];
+    NSString *path = [NSString stringWithFormat:@"/%@/%@/%@", [SFRestAPI sharedInstance].apiVersion, kSFPushNotificationEndPoint, deviceSFID];
+    SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodDELETE path:path queryParams:nil];
     __weak typeof(self) weakSelf = self;
-    [network sendRequest:request dataResponseBlock:^(NSData *data, NSURLResponse *response, NSError *error) {
+    [[SFRestAPI sharedInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (e) {
+            [SFSDKCoreLogger e:[strongSelf class] format:@"Push notification unregistration failed %ld %@", (long)[e code], [e localizedDescription]];
+        }
+        [strongSelf postPushNotificationUnregistration:completionBlock];
+    } completeBlock:^(id response, NSURLResponse *rawResponse) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         [strongSelf postPushNotificationUnregistration:completionBlock];
     }];
@@ -289,7 +272,6 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
         [self registerForSalesforceNotifications];
     }
 }
-
 
 - (void)onAppWillEnterForeground:(NSNotification *)notification
 {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -297,7 +297,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 }
 
 - (BOOL)loginWithJwtToken:(NSString *)jwtToken completion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
-    NSAssert(self.useLegacyAuthenticationManager==false, kSFIncompatibleAuthError);
+    NSAssert(self.useLegacyAuthenticationManager == false, kSFIncompatibleAuthError);
     NSAssert(jwtToken.length > 0, @"JWT token value required.");
     SFOAuthCredentials *credentials = [self newClientCredentials];
     credentials.jwt = jwtToken;
@@ -328,22 +328,22 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
     [[NSNotificationCenter defaultCenter]  postNotificationName:kSFNotificationUserWillLogout
                                                         object:self
                                                       userInfo:userInfo];
-    SFSDKOAuthClient *client = [self fetchOAuthClient:user.credentials completion:nil failure:nil];
-    [self deleteAccountForUser:user error:nil];
-    [client cancelAuthentication:NO];
-    [client revokeCredentials];
     if ([SFPushNotificationManager sharedInstance].deviceSalesforceId) {
         __weak typeof(self) weakSelf = self;
         [[SFPushNotificationManager sharedInstance] unregisterSalesforceNotificationsWithCompletionBlock:user completionBlock:^void() {
             __strong typeof(weakSelf) strongSelf = weakSelf;
-            [strongSelf postPushUnregistration:userInfo user:user client:client];
+            [strongSelf postPushUnregistration:userInfo user:user];
         }];
     } else {
-        [self postPushUnregistration:userInfo user:user client:client];
+        [self postPushUnregistration:userInfo user:user];
     }
 }
 
-- (void)postPushUnregistration:(NSDictionary *)userInfo user:(SFUserAccount *)user client:(SFSDKOAuthClient *)client {
+- (void)postPushUnregistration:(NSDictionary *)userInfo user:(SFUserAccount *)user {
+    SFSDKOAuthClient *client = [self fetchOAuthClient:user.credentials completion:nil failure:nil];
+    [self deleteAccountForUser:user error:nil];
+    [client cancelAuthentication:NO];
+    [client revokeCredentials];
     BOOL isCurrentUser = [user isEqual:self.currentUser];
     if (isCurrentUser) {
         self.currentUser = nil;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -334,7 +334,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
     [client revokeCredentials];
     if ([SFPushNotificationManager sharedInstance].deviceSalesforceId) {
         __weak typeof(self) weakSelf = self;
-        [[SFPushNotificationManager sharedInstance] unregisterSalesforceNotificationsWithCompletionBlock:user completionBlock:^(void) {
+        [[SFPushNotificationManager sharedInstance] unregisterSalesforceNotificationsWithCompletionBlock:user completionBlock:^void() {
             __strong typeof(weakSelf) strongSelf = weakSelf;
             [strongSelf postPushUnregistration:userInfo user:user client:client];
         }];


### PR DESCRIPTION
Work done in this PR:
- Replaced usage of `SFNetwork` with `SFRestAPI` for both registration and unregistration. This gives us session refresh on an expired token.
- Added a new API that takes a completion block for the unregistration call.
- Marked the fire-and-forget API deprecated for removal in `Mobile SDK 7.0`.
- Replaced the existing fire-and-forget call in `SFUserAccountManager` for unregistration with the new API. Logout processing resumes once the unregistration call returns.
- Did NOT replace the call in `SFAuthenticationManager` since that's deprecated and will be removed in `Mobile SDK 7.0`.