### PR TITLE
Fixing hybrid session refresh issues with passcode

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -38,6 +38,7 @@
 #import <SalesforceSDKCore/SFSDKEventBuilderHelper.h>
 #import <SalesforceSDKCore/NSString+SFAdditions.h>
 #import <SalesforceSDKCore/SFSDKWebViewStateManager.h>
+#import <SalesforceSDKCore/SFRestAPI+Blocks.h>
 #import <Cordova/NSDictionary+CordovaPreferences.h>
 #import <Cordova/CDVUserAgentUtil.h>
 #import <objc/message.h>
@@ -300,6 +301,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 
 - (void)authenticateWithCompletionBlock:(SFOAuthPluginAuthSuccessBlock)completionBlock failureBlock:(SFOAuthFlowFailureCallbackBlock)failureBlock
 {
+
     /*
      * Reconfigure user agent. Basically this ensures that Cordova whitelisting won't apply to the
      * WKWebView that hosts the login screen (important for SSO outside of Salesforce domains).
@@ -310,7 +312,6 @@ SFSDK_USE_DEPRECATED_BEGIN
         __strong typeof(weakSelf) strongSelf = weakSelf;
         [SFUserAccountManager sharedInstance].currentUser = userAccount;
         [strongSelf authenticationCompletion:nil authInfo:authInfo];
-        
         if (authInfo.authType == SFOAuthTypeRefresh) {
             [strongSelf loadVFPingPage];
         }
@@ -319,7 +320,6 @@ SFSDK_USE_DEPRECATED_BEGIN
             completionBlock(authInfo, authDict);
         }
     };
-
     SFOAuthFlowFailureCallbackBlock authFailureBlock = ^(SFOAuthInfo *authInfo, NSError *error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if ([strongSelf logoutOnInvalidCredentials:error]) {
@@ -487,8 +487,7 @@ SFSDK_USE_DEPRECATED_BEGIN
     if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
         return ([SFAuthenticationManager errorIsInvalidAuthCredentials:error]
                 && [[SFAuthenticationManager sharedManager].authErrorHandlerList authErrorHandlerInList:[SFAuthenticationManager sharedManager].invalidCredentialsAuthErrorHandler]);
-    }
-   else {
+    } else {
        return [SFUserAccountManager errorIsInvalidAuthCredentials:error];
    }
 }
@@ -859,11 +858,20 @@ SFSDK_USE_DEPRECATED_BEGIN
 - (void)refreshCredentials:(SFOAuthCredentials *)credentials
                  completion:(SFOAuthFlowSuccessCallbackBlock)completionBlock
                   failure:(SFOAuthFlowFailureCallbackBlock)failureBlock {
-    if ([SFUserAccountManager sharedInstance].useLegacyAuthenticationManager) {
-        [[SFAuthenticationManager sharedManager] refreshCredentials:credentials completion:completionBlock failure:failureBlock];
-    } else {
-        [[SFUserAccountManager sharedInstance] refreshCredentials:credentials completion:completionBlock failure:failureBlock];
-    }
+
+    /*
+     * Performs a cheap REST call to refresh the access token if needed
+     * instead of going through the entire OAuth dance all over again.
+     */
+    __weak __typeof(self) weakSelf = self;
+    SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
+    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForResources];
+    [[SFRestAPI sharedInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+        failureBlock(authInfo, e);
+    } completeBlock:^(id response, NSURLResponse *rawResponse) {
+        SFUserAccount *currentAccount = [SFUserAccountManager sharedInstance].currentUser;
+        completionBlock(authInfo, currentAccount);
+    }];
 }
 
 - (void)loginWithCompletion:(SFOAuthFlowSuccessCallbackBlock)completionBlock

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -863,7 +863,6 @@ SFSDK_USE_DEPRECATED_BEGIN
      * Performs a cheap REST call to refresh the access token if needed
      * instead of going through the entire OAuth dance all over again.
      */
-    __weak __typeof(self) weakSelf = self;
     SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
     SFRestRequest *request = [[SFRestAPI sharedInstance] requestForResources];
     [[SFRestAPI sharedInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {


### PR DESCRIPTION
We were going through `SFOAuthCoordinator` and the entire user agent flow to perform a hybrid refresh action (both `hybrid_remote` and `hybrid_local`). This is the only piece of code that triggers the entire user agent flow, including spinning up a dedicated `SFSDKOauthClient`, for a simple refresh call, instead of using `SFRestAPI` or `SFOAuthSessionRefresher` to perform a lightweight refresh by hitting the token endpoint directly and getting a new access token. The problem with this is that if passcode is enabled and the passcode screen is on display due to timeout, the `OAuth` flow stops in the `SFOAuthCoordinator` and the callbacks in the plugin are never triggered. This is by design based on the assumption that the user agent flow would be triggered only for the user agent flow, not for the refresh flow. I changed this to make a lightweight API call using `SFRestAPI` to perform refresh and return the new credentials. The new design is now inline with what we have always done on `Android` - see [here](https://github.com/forcedotcom/SalesforceMobileSDK-Android/blob/master/libs/SalesforceHybrid/src/com/salesforce/androidsdk/phonegap/ui/SalesforceDroidGapActivity.java#L315).