### PR TITLE
Enforcing layout mode for auth Login view for iPhone devices

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -154,6 +154,14 @@ SFSDK_USE_DEPRECATED_END
     }
 }
 
+- (BOOL)shouldAutorotate {
+    return NO;
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+
 #pragma mark - Setup Navigation bar
 
 - (void)setupNavigationBar {
@@ -224,7 +232,7 @@ SFSDK_USE_DEPRECATED_END
     NSString *title = [SFSDKResourceUtils localizedString:@"TITLE_LOGIN"];
     // Setup top item.
     UILabel *item = [[UILabel alloc] init];
-    if (self.config.navBarTitleColor) {
+    if (self.config.navBarTextColor) {
         item.textColor = self.config.navBarTextColor;
     }
     if (self.config.navBarFont) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -351,6 +351,8 @@ static NSString * const kSFECParameter = @"ec";
         config.processPool = SFSDKWebViewStateManager.sharedProcessPool;
         _view = [[WKWebView alloc] initWithFrame:[[UIScreen mainScreen] bounds] configuration:config];
         _view.navigationDelegate = self;
+        _view.autoresizesSubviews = YES;
+        _view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
         _view.UIDelegate = self;
     }
     return _view;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -55,7 +55,26 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 static NSString * const kSFRevokePath = @"/services/oauth2/revoke";
 
 static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
+@interface UINavigationController(SFSDKOAuth)
+@end
 
+@implementation UINavigationController(SFSDKOAuth)
+
+- (BOOL)shouldAutorotate {
+    if (self.topViewController) {
+        return self.topViewController.shouldAutorotate;
+    }
+    return YES;
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    if (self.topViewController) {
+        return self.topViewController.supportedInterfaceOrientations;
+    }
+    return UIInterfaceOrientationMaskPortrait;
+}
+
+@end
 
 @interface SFSDKOAuthClient()<SFOAuthCoordinatorDelegate,SFIdentityCoordinatorDelegate,SFSDKLoginHostDelegate,SFLoginViewControllerDelegate>{
     NSRecursiveLock *readWriteLock;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKRootController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKRootController.m
@@ -27,6 +27,7 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #import "SFSDKRootController.h"
+#import "SFSDKWindowContainer.h"
 
 @interface SFSDKRootController ()
 
@@ -36,7 +37,7 @@
 
 -(UIStatusBarStyle)preferredStatusBarStyle
 {
-    UIViewController *topViewController = [SFSDKRootController topViewController:self];
+    UIViewController *topViewController = [SFSDKWindowContainer topViewControllerWithRootViewController:self];
     UIStatusBarStyle statusBarStyle = UIStatusBarStyleDefault;
     if (topViewController && topViewController!=self) {
         statusBarStyle = [topViewController preferredStatusBarStyle];
@@ -46,7 +47,7 @@
 
 -(UIViewController *)childViewControllerForStatusBarStyle
 {
-    UIViewController *topViewController = [SFSDKRootController topViewController:self];
+    UIViewController *topViewController = [SFSDKWindowContainer topViewControllerWithRootViewController:self];
     if (topViewController && topViewController!=self) {
         return [topViewController childViewControllerForStatusBarStyle];
     }
@@ -54,44 +55,27 @@
 }
 
 -(UIViewController *)childViewControllerForStatusBarHidden {
-    
-    UIViewController *topViewController = [SFSDKRootController topViewController:self];
-    if (topViewController && topViewController!=self) {
+    UIViewController *topViewController = [SFSDKWindowContainer topViewControllerWithRootViewController:self];
+    if (topViewController && (topViewController!=self)) {
         return [topViewController childViewControllerForStatusBarHidden];
     }
     return nil;
 }
 
--(BOOL)shouldAutorotate
-{
-    UIViewController *topViewController = [SFSDKRootController topViewController:self];
-    if (topViewController!=nil && topViewController!=self)
+-(BOOL)shouldAutorotate {
+    UIViewController *topViewController = [SFSDKWindowContainer topViewControllerWithRootViewController:self];
+    if (topViewController && (topViewController!=self)) {
         return [topViewController shouldAutorotate];
-    return YES;
-}
-
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations
-{
-    UIViewController *topViewController = [SFSDKRootController topViewController:self];
-    if (topViewController!=nil && topViewController!=self)
-        return [topViewController supportedInterfaceOrientations];
-    
-    return UIInterfaceOrientationMaskAll;
-}
-
-#pragma mark - Helper class methods
-+ (UIViewController *)topViewController:(SFSDKRootController *) controller
-{
-    UIViewController *topViewController = controller;
-    while (topViewController.presentedViewController != nil
-           && !topViewController.presentedViewController.isBeingDismissed) {
-        //stop if we find that an alert has been presented
-        if ([topViewController.presentedViewController isKindOfClass:[UIAlertController class]]) {
-            break;
-        }
-        topViewController = topViewController.presentedViewController;
     }
-    return topViewController;
+    return NO;
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    UIViewController *topViewController = [SFSDKWindowContainer topViewControllerWithRootViewController:self];
+    if (topViewController && (topViewController!=self)) {
+        return [topViewController supportedInterfaceOrientations];
+    }
+    return UIInterfaceOrientationMaskPortrait;
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowContainer.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowContainer.h
@@ -132,6 +132,11 @@ typedef NS_ENUM(NSInteger, SFSDKWindowType) {
  * Tries to return top view controller of this window
  */
 - (UIViewController*) topViewController;
+
+/**
+ * Tries to return top view controller given a root view Controller
+ */
++ (UIViewController*)topViewControllerWithRootViewController:(UIViewController*)viewController;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowContainer.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowContainer.m
@@ -106,10 +106,10 @@
 }
 
 - (UIViewController*)topViewController {
-    return [self topViewControllerWithRootViewController:self.window.rootViewController];
+    return [SFSDKWindowContainer  topViewControllerWithRootViewController:self.window.rootViewController];
 }
 
-- (UIViewController*)topViewControllerWithRootViewController:(UIViewController*)viewController {
++ (UIViewController*)topViewControllerWithRootViewController:(UIViewController*)viewController {
     if ([viewController isKindOfClass:[UITabBarController class]]) {
         UITabBarController* tabBarController = (UITabBarController*)viewController;
         return [self topViewControllerWithRootViewController:tabBarController.selectedViewController];


### PR DESCRIPTION
The enforcement will work on iPhone device. Autorotation cannot be controlled for iPad devices. But the view should size accordingly now.  There seems to be a few issues with the approach taken for adjusting transparency on windows and its impact on rotations(views and keyboard). Toggling the hide attribute on UIWindow seems to resolve most of these issues, but requires more testing. Once the alternative is tested we can enable rotations for auth views as well. Merged all use use of topViewController code to single method in SFSDKWindowContainer.