### PR TITLE
Unregistering from notifications before starting actual logout

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -217,6 +217,12 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
 
 - (BOOL)unregisterSalesforceNotificationsWithCompletionBlock:(SFUserAccount*)user completionBlock:(void (^)(void))completionBlock
 {
+    if (!_deviceSalesforceId) {
+        // Nothing to do - we have not registered for push notifications
+        [self postPushNotificationUnregistration:completionBlock];
+        return YES;
+    }
+    
     if (self.isSimulator) {
         [self postPushNotificationUnregistration:completionBlock];
         return YES;  // "Successful".  Simulator does not register/unregister for notifications.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.h
@@ -206,7 +206,7 @@ typedef void (^SFRestResponseBlock) (id _Nullable response, NSURLResponse * _Nul
  * @return the newly sent SFRestRequest
  */
 - (SFRestRequest *) performRequestForVersionsWithFailBlock:(SFRestFailBlock)failBlock 
-                                             completeBlock:(SFRestDictionaryResponseBlock)completeBlock;
+                                             completeBlock:(SFRestArrayResponseBlock)completeBlock;
 
 /**
  * Executes a request to get a file rendition

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
@@ -165,7 +165,7 @@ static char CompleteBlockKey;
     return request;
 }
 
-- (SFRestRequest *) performRequestForVersionsWithFailBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestDictionaryResponseBlock)completeBlock {
+- (SFRestRequest *) performRequestForVersionsWithFailBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestArrayResponseBlock)completeBlock {
     SFRestRequest *request = [self requestForVersions];
     [self sendRESTRequest:request
                 failBlock:failBlock

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPushNotificationManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPushNotificationManagerTests.m
@@ -50,6 +50,7 @@ static NSString* const kSFDeviceSalesforceId = @"deviceSalesforceId";
     [super setUp];
     self.manager = [[SFPushNotificationManager alloc] init];
     self.manager.isSimulator = NO;
+    self.manager.deviceSalesforceId = @"pretending-we-registered";
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"happy-user" clientId:[SFUserAccountManager sharedInstance].oauthClientId encrypted:YES];
     SFUserAccount *user =[[SFUserAccount alloc] initWithCredentials:credentials];
     user.credentials.identityUrl = [NSURL URLWithString:@"https://login.salesforce.com/id/00D000000000062EA0/005R0000000Dsl0"];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -1474,6 +1474,13 @@ static NSException *authException = nil;
         [self.currentExpectation fulfill];
     };
 
+    // An success block that we expected to succeed
+    SFRestArrayResponseBlock arraySuccessBlock = ^(NSArray *a, NSURLResponse *rawResponse) {
+        XCTAssertTrue([a isKindOfClass:[NSArray class]], @"Response should be an array");
+        [self.currentExpectation fulfill];
+    };
+
+    
     // Class helper function that creates an error.
     NSString *errorStr = @"Sample error.";
     XCTAssertTrue([errorStr isEqualToString:[[SFRestAPI errorWithDescription:errorStr] localizedDescription]],
@@ -1543,7 +1550,7 @@ static NSException *authException = nil;
 
     self.currentExpectation = [self expectationWithDescription:@"performRequestForVersionsWithFailBlock"];
     [api performRequestForVersionsWithFailBlock:failWithUnexpectedFail
-                                  completeBlock:dictSuccessBlock];
+                                  completeBlock:arraySuccessBlock];
     [self waitForExpectation];
 
     self.currentExpectation = [self expectationWithDescription:@"performDescribeGlobalWithFailBlock"];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -1421,25 +1421,6 @@ static NSException *authException = nil;
                              [self.currentExpectation fulfill];
                          }];
     [self waitForExpectation];
-    self.currentExpectation = [self expectationWithDescription:@"performUpsertWithObjectType-upserting contact"];
-    fields[LAST_NAME] = lastName;
-    [api performUpsertWithObjectType:CONTACT
-                     externalIdField:ID
-                          externalId:recordId
-                              fields:fields
-                           failBlock:failWithUnexpectedFail
-                       completeBlock:responseSuccessBlock];
-    [self waitForExpectation];
-    self.currentExpectation = [self expectationWithDescription:@"performRetrieveWithObjectType-retrieving contact"];
-    [api performRetrieveWithObjectType:CONTACT
-                              objectId:recordId
-                             fieldList:@[LAST_NAME]
-                             failBlock:failWithUnexpectedFail
-                         completeBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {
-                             XCTAssertEqualObjects(lastName, d[LAST_NAME]);
-                             [self.currentExpectation fulfill];
-                         }];
-    [self waitForExpectation];
     self.currentExpectation = [self expectationWithDescription:@"performDeleteWithObjectType-deleting contact"];
     [api performDeleteWithObjectType:CONTACT
                             objectId:recordId


### PR DESCRIPTION
If we unregister after sending out the will logout notification, then the SFRestAPI instance for the user will have been torn down already.
The unregister call will cause a new SFRestAPI to be built for the user. That user object credentials will be taken away during logout but the SFRestAPI will stay.
If you log back in as the same user, you will get that SFRestAPI for your network calls. Because it holds a user without credentials, the first network call will cause the app to go back to login!