### PR TITLE
Doc changes for swift

### DIFF
--- a/docs/jazzy.yaml
+++ b/docs/jazzy.yaml
@@ -6,30 +6,17 @@ exclude:
   - "**/*.h"
   - "**/*-ObjC.swift"
   - "**/*Deprecations.swift"
-  - "**/*SwiftExtensions.swift"
-
-copyright: 'Copyright (c) 2018-present, salesforce.com, inc. All rights reserved. Redistribution and
-use of this software in source and binary forms, with or without modification, are permitted provided
-that the following conditions are met:
- * Redistributions of source code must retain the above copyright notice, this list of conditions
- and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice, this list of
- conditions and the following disclaimer in the documentation and/or other materials provided
- with the distribution.
- * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
- endorse or promote products derived from this software without specific prior written
- permission of salesforce.com, inc.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
-WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.'
+  - "**/SwiftExtensions.swift"
+readme: 'libs/SalesforceSwiftSDK/readme.md'
+copyright: '© Copyright 2017–Current salesforce.com, inc. All rights reserved. Salesforce is a registered trademark of salesforce.com, inc.,
+as are other names and marks. Other marks appearing herein may be trademarks of their respective owners.'
 
 swift_version: 4.0
 
+skip_undocumented: true
+
 theme: fullwidth
+
+clean: false
 
 xcodebuild_arguments: [-configuration, Release,-sdk, iphonesimulator,-scheme, SalesforceSwiftSDK, -workspace, SalesforceMobileSDK.xcworkspace]

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFRestAPIExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFRestAPIExtensions.swift
@@ -174,11 +174,13 @@ extension SFRestAPI {
         /**
          A factory method for describe object request.
          ```
-         restApi.Promises.describe()
+         restApi.Promises.describe(objectType:"Account")
          .then { (request) in
             restApi.send(request)
          }
          ```
+         - parameters :
+            - objectType: Type of object
          - Returns: SFRestRequest wrapped in a promise.
          */
         public func describe(objectType:String) -> Promise<SFRestRequest> {
@@ -206,11 +208,13 @@ extension SFRestAPI {
         /**
          A factory method for metadata object request.
          ```
-         restApi.Promises.metadata(objectType)
+         restApi.Promises.metadata(objectType: "Account")
          .then { (request) in
             restApi.send(request)
          }
          ```
+         - parameters:
+            - objectType: Type of object
          - Returns: SFRestRequest wrapped in a promise.
          */
         public func metadata(objectType: String) -> Promise<SFRestRequest> {
@@ -227,11 +231,30 @@ extension SFRestAPI {
              restApi.send(request)
          }
          ```
+         - parameters:
+            - objectType: Type of object
+            - objectId: Identifier of object
+            - fieldList: Varargs for field list as string
          - Returns: SFRestRequest wrapped in a promise.
          */
         public func retrieve(objectType: String,objectId: String, fieldList: String... ) -> Promise<SFRestRequest> {
             return  self.retrieve(objectType: objectType, objectId: objectId, fieldList: fieldList)
         }
+        
+        /**
+         A factory method for retrieve object request.
+         ```
+         restApi.Promises.retrieve(objectType: objectType,objectId: objectId, fieldList: ["Name","LastModifiedDate"])
+         .then { (request) in
+         restApi.send(request)
+         }
+         ```
+         - parameters:
+             - objectType: Type of object
+             - objectId: Identifier of object
+             - fieldList: Field list as a String array.
+         - Returns: SFRestRequest wrapped in a promise.
+         */
         
         public func retrieve(objectType: String,objectId: String, fieldList: [String] ) -> Promise<SFRestRequest> {
             return  Promise(.pending) {  resolver in
@@ -247,6 +270,9 @@ extension SFRestAPI {
             restApi.send(request)
          }
          ```
+         - parameters:
+             - objectType: Type of object
+             - fields: Field list as Dictionary.
          - Returns: SFRestRequest wrapped in a promise.
          */
         public func create(objectType: String, fields: [String:Any]) -> Promise<SFRestRequest> {
@@ -263,8 +289,11 @@ extension SFRestAPI {
          .then { (request) in
             restApi.send(request)
          }
-         
          ```
+         - parameters:
+             - objectType: Type of object.
+             - externalIdField: Identifier for field.
+             - fields: Field list as Dictionary.
          - Returns: SFRestRequest wrapped in a promise.
          */
         public func upsert(objectType: String,externalIdField: String, externalId: String, fieldList: Dictionary<String,Any>?) -> Promise<SFRestRequest> {
@@ -283,6 +312,11 @@ extension SFRestAPI {
          }
          
          ```
+         - parameters:
+             - objectType: Type of object.
+             - objectId: Identifier of the field.
+             - fields: Field list as Dictionary.
+             - ifUnmodifiedSince: update if unmodified since date.
          - Returns: SFRestRequest wrapped in a promise.
          */
         public func update(objectType: String,objectId: String,fieldList: [String: Any]?,ifUnmodifiedSince: Date?) -> Promise<SFRestRequest> {
@@ -299,6 +333,9 @@ extension SFRestAPI {
             ...
          }
          ```
+         - parameters:
+             - objectType: Type of object.
+             - objectId: Identifier of the field.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func delete(objectType: String, objectId: String) -> Promise<SFRestRequest> {
@@ -315,6 +352,8 @@ extension SFRestAPI {
             ...
          }
          ```
+         - parameters:
+             - soql: Soql string.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func query(soql: String) -> Promise<SFRestRequest> {
@@ -331,6 +370,8 @@ extension SFRestAPI {
             ...
          }
          ```
+         - parameters:
+            - soql: Soql string.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func queryAll(soql: String) -> Promise<SFRestRequest> {
@@ -347,6 +388,8 @@ extension SFRestAPI {
             ...
          }
          ```
+         - parameters:
+            - sosl: Sosl string.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func search(sosl: String) -> Promise<SFRestRequest> {
@@ -379,6 +422,8 @@ extension SFRestAPI {
             ...
          }
          ```
+         - parameters:
+            - objectList: Varargs of String objects.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func searchResultLayout(objectList: String...) -> Promise<SFRestRequest> {
@@ -393,6 +438,8 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+            - objectList: String array of objects.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func searchResultLayout(objectList: [String]) -> Promise<SFRestRequest> {
@@ -410,6 +457,9 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+            - requests: Varagrs of SFRestRequest
+            - haltOnError: Halt on error or not.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func batch(requests: SFRestRequest..., haltOnError: Bool = false) -> Promise<SFRestRequest> {
@@ -424,6 +474,9 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - requests: Varargs of SFRestRequest
+             - haltOnError: Halt on error or not.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func batch(requests: [SFRestRequest], haltOnError: Bool) -> Promise<SFRestRequest> {
@@ -441,6 +494,9 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - requests: Array of SFRestRequests.
+             - haltOnError: Halt on error or not.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func composite(requests: [SFRestRequest], refIds: [String], allOrNone: Bool) -> Promise<SFRestRequest> {
@@ -458,6 +514,9 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - requests: Array of SFRestRequests.
+             - objectTrees: Varagrs of SFSObjectTree
          - Returns:  SFRestRequest wrapped in a promise.
          */
         func sObjectTree(objectType: String, objectTrees: SFSObjectTree...) -> Promise<SFRestRequest> {
@@ -472,6 +531,9 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - requests: Array of SFRestRequests.
+             - objectTrees: Array of SFSObjectTree
          - Returns:  SFRestRequest wrapped in a promise.
          */
         func sObjectTree(objectType: String, objectTrees: [SFSObjectTree]) -> Promise<SFRestRequest> {
@@ -489,6 +551,9 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - userId: User Identifier
+             - page: A page number for results.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func filesOwned(userId: String?, page: UInt = 0) -> Promise<SFRestRequest> {
@@ -506,6 +571,9 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - userId: User Identifier
+             - page: A page number for results.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func filesInUsersGroups(userId: String?, page: UInt = 0) -> Promise<SFRestRequest> {
@@ -523,6 +591,9 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - userId: User Identifier
+             - page: A page number for results.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func filesShared(userId: String, page: UInt = 0) -> Promise<SFRestRequest> {
@@ -540,6 +611,9 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - sfdcFileId: File identifier.
+             - version: Version for file.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func fileDetails(sfdcFileId: String, version: String?) -> Promise<SFRestRequest> {
@@ -557,6 +631,8 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - sfdcFileIds: Array of File identifiers.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func batchDetails(sfdcFileIds: String...) -> Promise<SFRestRequest> {
@@ -571,6 +647,8 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - sfdcFileIds: Array of File identifiers.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func batchDetails(sfdcFileIds: [String] ) -> Promise<SFRestRequest> {
@@ -588,6 +666,11 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+            - sfdcFileId: File identifier.
+            - version: Version
+            - renditionType: type of file.
+            - page: Page number.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func fileRendition(sfdcFileId: String, version: String?, renditionType: String, page: UInt = 0) -> Promise<SFRestRequest> {
@@ -605,6 +688,9 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - sfdcId: File identifier.
+             - version: Version
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func fileContents(sfdcId: String, version: String?) -> Promise<SFRestRequest> {
@@ -622,6 +708,9 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - sfdcId: File identifier.
+             - page: Page number.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func fileShares(sfdcId: String, page: UInt? = 0) -> Promise<SFRestRequest> {
@@ -639,6 +728,10 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - fileId: File identifier.
+             - entityId: Identifier for entity.
+             - shareType: Type of Share
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func addFileShare(fileId: String, entityId: String, shareType: String) -> Promise<SFRestRequest> {
@@ -656,6 +749,8 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - shareId: Identifier for the shared file.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         public func deleteFileShare(shareId: String) -> Promise<SFRestRequest> {
@@ -673,6 +768,11 @@ extension SFRestAPI {
          ...
          }
          ```
+         - parameters:
+             - data: Content of file
+             - name: Name for the file.
+             - description: Upload file description.
+             - mimeType: Mime type.
          - Returns:  SFRestRequest wrapped in a promise.
          */
         
@@ -715,6 +815,8 @@ extension SFRestAPI {
          restError = error
          }
          ```
+         - parameters:
+            - request: SFRestRequest to send.
          - Returns: The instance of Promise<SFRestResponse>.
          */
         public func send(request :SFRestRequest) -> Promise<SFRestResponse> {

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
@@ -209,7 +209,7 @@ extension SFSmartStore {
          }
          ```
          - parameter soupName: The name of the soup
-         - Returns: [Any] of indices wrapped in a promise.
+         - Returns: Array of indices wrapped in a promise.
          */
         public func indices(soupName: String) -> Promise<[Any]> {
             return Promise(.pending) {  resolver in
@@ -300,7 +300,7 @@ extension SFSmartStore {
             ..
          }
          ```
-         - parameter soupSpec: SFSoupSpec Specification of the Soup
+         - parameter querySpec: SFQuerySpec query specification
          - Returns: Integer wrapped in a promise indicating count.
          */
         public func count(querySpec: SFQuerySpec) -> Promise<UInt> {
@@ -326,7 +326,7 @@ extension SFSmartStore {
          }
          ```
          - parameters:
-            - querySpec: SFSoupSpec Specification of the Soup
+            - querySpec: SFQuerySpec query specification
             - pageIndex: Page number for records.
          - Returns: Integer wrapped in a promise indicating count.
          */
@@ -358,7 +358,7 @@ extension SFSmartStore {
          ```
          - parameters:
              - entries: Entries to upsert in the soup
-             - soupName: Nameof Soup.
+             - soupName: Name of soup.
          - Returns: Upserted entries wrapped in a promise.
          */
         public func upsertEntries(entries: [Any],soupName: String) -> Promise<[[String:Any]]> {
@@ -380,7 +380,7 @@ extension SFSmartStore {
          ```
          - parameters:
              - entries: Entries to upsert in the soup
-             - soupName: Nameof Soup.
+             - soupName: Name of soup.
              - externalIdPath: External ID Path
          - Returns: Upserted entries wrapped in a promise.
          */
@@ -408,7 +408,7 @@ extension SFSmartStore {
          ```
          - parameters:
              - entries: Entries to upsert in the soup
-             - soupName: Nameof Soup.
+             - soupName: Name of soup.
              - fieldPath: Field Path
              - fieldValue: Value for the field.
          - Returns: EntryId wrapped in promise
@@ -558,7 +558,7 @@ public class SFSmartStoreClient {
      ..
      }
      ```
-     - parameter storeName: Name of Store.
+     - parameter withName: Name of Store.
      - Returns: SFSmartStore wrapped in a promise.
      */
     
@@ -582,8 +582,8 @@ public class SFSmartStoreClient {
      }
      ```
      - parameters:
-        -storeName: Name of Store.
-        -user: User associated with the store.
+        - withName: Name of Store.
+        - user: User associated with the store.
      - Returns: SFSmartStore wrapped in a promise.
      */
     public class func store(withName: String,user: SFUserAccount) -> Promise<SFSmartStore> {

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartSyncExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartSyncExtensions.swift
@@ -338,12 +338,12 @@ extension SFSmartSyncSyncManager {
          ..
          }
          ```
-         -parameters:
-            -target: The sync up target that will manage the sync up process.
-            -options: The options associated with this sync up.
-            -soupName: The soup name where the local entries are stored.
-            -syncName: The name for this sync.
-         -Returns: SFSyncState wrapped in a promise.
+         - parameters:
+            - target: The sync up target that will manage the sync up process.
+            - options: The options associated with this sync up.
+            - soupName: The soup name where the local entries are stored.
+            - syncName: The name for this sync.
+         - Returns: SFSyncState wrapped in a promise.
          */
         public func createSyncUp(target: SFSyncUpTarget, options: SFSyncOptions, soupName: String, syncName: String?) -> Promise<SFSyncState> {
             return Promise(.pending) {  resolver in
@@ -361,10 +361,10 @@ extension SFSmartSyncSyncManager {
          
          }
          ```
-         -parameters:
-             -options: The options associated with this sync up.
-             -soupName: The soup name where the local entries are stored.
-         -Returns: SFSyncState wrapped in a promise.
+         - parameters:
+             - options: The options associated with this sync up.
+             - soupName: The soup name where the local entries are stored.
+         - Returns: SFSyncState wrapped in a promise.
          */
         public func syncUp(options: SFSyncOptions, soupName: String) -> Promise<SFSyncState> {
             return Promise(.pending) {  resolver in
@@ -390,11 +390,11 @@ extension SFSmartSyncSyncManager {
          
          }
          ```
-         -parameters:
-             -target: The options associated with this sync up.
-             -options: The options associated with this sync up.
-             -soupName: The soup name where the local entries are stored.
-         -Returns: The sync state associated with this sync up.
+         - parameters:
+             - target: The options associated with this sync up.
+             - options: The options associated with this sync up.
+             - soupName: The soup name where the local entries are stored.
+         - Returns: The sync state associated with this sync up.
          */
         public func syncUp(target: SFSyncUpTarget, options: SFSyncOptions, soupName: String) -> Promise<SFSyncState> {
             return Promise(.pending) {  resolver in
@@ -418,12 +418,12 @@ extension SFSmartSyncSyncManager {
          
          }
          ```
-         -parameters:
-             -target: The options associated with this sync up.
-             -options: The options associated with this sync up.
-             -soupName: The soup name where the local entries are stored.
-             -syncName: The name for this sync.
-        -Returns: The SFSyncState wrapped in a promise
+         - parameters:
+             - target: The options associated with this sync up.
+             - options: The options associated with this sync up.
+             - soupName: The soup name where the local entries are stored.
+             - syncName: The name for this sync.
+        - Returns: The SFSyncState wrapped in a promise
          */
         public func syncUp(with target: SFSyncUpTarget, options: SFSyncOptions, soupName: String, syncName: String?) -> Promise<SFSyncState> {
             return Promise(.pending) {  resolver in
@@ -447,8 +447,8 @@ extension SFSmartSyncSyncManager {
          
          }
          ```
-         -parameter syncId: Sync ID.
-         -Returns: The SFSyncState wrapped in a promise
+         - parameter syncId: Sync ID.
+         - Returns: The SFSyncState wrapped in a promise
          */
         public func cleanResyncGhosts(syncId: UInt) -> Promise<SFSyncStateStatus> {
             return Promise(.pending) {  resolver in

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFUserAccountManagerExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFUserAccountManagerExtensions.swift
@@ -143,7 +143,7 @@ extension SFUserAccountManager {
          }
          
          ```
-         - Parameter user: The user to logout.
+         - Parameter userAccount: The user to logout.
          - Returns: A Promise in order to allow further chaining
          */
         public func logoutUser(userAccount: SFUserAccount) -> Promise<Void> {
@@ -163,7 +163,7 @@ extension SFUserAccountManager {
          }
          
          ```
-         - Parameter user: The user to logout.
+         - Parameter userAccount: The user to logout.
          - Returns: A Promise with the newly switched current user
          */
         public func switchToUser(userAccount: SFUserAccount) -> Promise<SFUserAccount> {
@@ -174,7 +174,7 @@ extension SFUserAccountManager {
         }
         
         /**
-         SwitchToNewUser API wrapped in a promise.
+         SwitchToNewUser API wrapped in a promise. Clears current user if the switch
          
          ```
          SFUserAccountManager.sharedInstance().Promises.switchToNewUser()
@@ -183,7 +183,6 @@ extension SFUserAccountManager {
          }
          
          ```
-         - Parameter user: The user to logout.
          - Returns: A Promise with the newly logged-in current user
          */
         public func switchToNewUser() -> Promise<SFUserAccount> {

--- a/libs/SalesforceSwiftSDK/readme.md
+++ b/libs/SalesforceSwiftSDK/readme.md
@@ -1,4 +1,4 @@
-Mobile SDK 6.1 enhances its Swift offering with PromiseKit adaptations. You can now use promises for these SDK components:
+Mobile SDK enhances its Swift offering with PromiseKit adaptations. You can now use promises for these SDK components:
 
 * [SalesforceSwiftSDKManager](Classes/SalesforceSwiftSDKManager.html)
 * [SFRestAPI](Extensions/SFRestAPI.html)

--- a/libs/SalesforceSwiftSDK/readme.md
+++ b/libs/SalesforceSwiftSDK/readme.md
@@ -1,0 +1,49 @@
+Mobile SDK 6.1 enhances its Swift offering with PromiseKit adaptations. You can now use promises for these SDK components:
+
+* [SalesforceSwiftSDKManager](Classes/SalesforceSwiftSDKManager.html)
+* [SFRestAPI](Extensions/SFRestAPI.html)
+* [SFSmartStoreClient](Classes/SFSmartStoreClient.html)
+* [SFSmartSyncSyncManager](Extensions/SFSmartSyncSyncManager.html)
+* [SFUserAccountManager](Extensions/SFUserAccountManager.html)
+
+Promises make coding asynchronous APIs simple and readable. Instead of jumping back into Objective-C to use nested block handlers, you simply define the callbacks as inline extensions of the main call. For example, to make a REST API call:
+
+```swift
+let restApi  = SFRestAPI.sharedInstance()
+ restApi.Promises.query(soql: "SELECT Id,FirstName,LastName FROM User")
+ .then { request in
+    restApi.Promises.send(request: request)
+ }
+ .done { sfRestResponse in
+    restResonse = sfRestResponse.asJsonDictionary()
+    ...
+ }
+ .catch { error in
+    //handle error
+ }
+```
+
+Or, to perform a SmartSync `syncDown()` operation:
+
+```swift
+firstly {
+     let syncDownTarget = SFSoqlSyncDownTarget.newSyncTarget(soqlQuery)
+     let syncOptions    = SFSyncOptions.newSyncOptions(forSyncDown: SFSyncStateMergeMode.overwrite)
+     return (self.syncManager.Promises.syncDown(target: syncDownTarget, options: syncOptions, soupName: CONTACTS_SOUP))
+}
+.then { syncState -> Promise<UInt> in
+     let querySpec =  SFQuerySpec.Builder(soupName: CONTACTS_SOUP)
+     .queryType(value: "range")
+     .build()
+     return (store.Promises.count(querySpec: querySpec))!
+}
+.then { count -> Promise<Void>  in
+     return new Promise(())
+}
+.done { syncStateStatus in
+}
+.catch { error in
+}
+```
+
+To learn more about promises and the PromiseKit SDK, see the [PromiseKit Readme](https://github.com/mxcl/PromiseKit/blob/master/README.md).


### PR DESCRIPTION
Fixed some spacing, missing params  and indentation issues impacting output of jazzy. Added a readme file for  the swift sdk, thats used by jazzy for the main page of docs. Generate docs using the following
```
jazzy --config ./docs/jazzy.yaml  --swift-version 4.0.3 --readme libs/SalesforceSwiftSDK/readme.md
``` 