### PR TITLE
SFQuerySpec swift builder using enum types instead of strings

### DIFF
--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
@@ -66,8 +66,8 @@ extension SFQuerySpec {
         /// Set the query type
         /// - Parameter value: type of query
         /// - Returns: SFQuerySpec.Builder instance
-        public func queryType(value: String) -> Self {
-            queryDict[kQuerySpecParamQueryType] = value
+        public func queryType(value: SFSoupQueryType) -> Self {
+            queryDict[kQuerySpecParamQueryType] = SFQuerySpec.queryType(fromEnum:value)
             return self
         }
         
@@ -75,6 +75,7 @@ extension SFQuerySpec {
         /// - Parameter value: smart sql string
         /// - Returns: SFQuerySpec.Builder instance
         public func smartSql(value: String) -> Self {
+            queryDict[kQuerySpecParamQueryType] = kQuerySpecTypeSmart
             queryDict[kQuerySpecParamSmartSql] = value
             return self
         }
@@ -147,10 +148,10 @@ extension SFQuerySpec {
         }
         
         /// Order by for the smart sql query
-        /// - Parameter value: string representing ascending/descending
+        /// - Parameter value: query sort order
         /// - Returns: SFQuerySpec.Builder instance
-        public func order(value: String) -> Self {
-            queryDict[kQuerySpecParamOrder] = value
+        public func order(value: SFSoupQuerySortOrder) -> Self {
+            queryDict[kQuerySpecParamOrder] = SFQuerySpec.sortOrder(fromEnum: value)
             return self
         }
         
@@ -328,7 +329,7 @@ extension SFSmartStore {
          - parameters:
             - querySpec: SFQuerySpec query specification
             - pageIndex: Page number for records.
-         - Returns: Integer wrapped in a promise indicating count.
+         - Returns: Array wrapped in a promise with query results.
          */
         public func query(querySpec: SFQuerySpec, pageIndex: UInt)  -> Promise<[Any]> {
             return Promise(.pending) {  resolver in

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartStoreClientTests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartStoreClientTests.swift
@@ -160,7 +160,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     
     func testCountQuerySpecBuilder() {
         let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
-            .queryType(value: "range")
+            .queryType(value: .range)
             .path(value: "wings")
             .beginKey(value: "1")
             .endKey(value: "2")
@@ -171,10 +171,10 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     
     func testSmartSqlWithSelectPathsQuerySpecBuilder() {
         let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
-            .queryType(value: "range")
+            .queryType(value: .range)
             .selectedPaths(value: ["wings", "legs", "qty"])
             .orderPath(value: "qty")
-            .order(value: "ascending")
+            .order(value: .ascending)
             .pageSize(value: 1)
             .build()
         XCTAssertEqual("SELECT {chickensoup:wings}, {chickensoup:legs}, {chickensoup:qty} FROM {chickensoup} ORDER BY {chickensoup:qty} ASC", spec.smartSql.trimmingCharacters(in: .whitespacesAndNewlines))
@@ -182,9 +182,9 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     
     func testAllQuerySmartSql() {
         let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
-            .queryType(value: "range")
+            .queryType(value: .range)
             .orderPath(value: "wings")
-            .order(value: "descending")
+            .order(value: .descending)
             .pageSize(value: 1)
             .build()
         
@@ -193,10 +193,10 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     
     func testAllQuerySmartSqlWithSelectPaths() {
         let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
-            .queryType(value: "range")
+            .queryType(value: .range)
             .selectedPaths(value: ["wings", "legs", "qty"])
             .orderPath(value: "qty")
-            .order(value: "descending")
+            .order(value: .descending)
             .pageSize(value: 1)
             .build()
         
@@ -205,10 +205,10 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     
     func testAllQueryCountSmartSql() {
         let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
-            .queryType(value: "range")
+            .queryType(value: .range)
             .path(value: "qty")
             .orderPath(value: "qty")
-            .order(value: "descending")
+            .order(value: .descending)
             .pageSize(value: 1)
             .build()
         XCTAssertEqual("SELECT count(*) FROM {chickensoup}", spec.countSmartSql.trimmingCharacters(in: .whitespacesAndNewlines))
@@ -216,10 +216,10 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     
     func testAllQueryIdsSmartSql() {
         let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
-            .queryType(value: "range")
+            .queryType(value: .range)
             .path(value: "qty")
             .orderPath(value: "qty")
-            .order(value: "descending")
+            .order(value: .descending)
             .pageSize(value: 1)
             .build()
         
@@ -229,7 +229,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     
     func testExactQueryIdsSmartSql() {
         let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
-            .queryType(value: "exact")
+            .queryType(value: .exact)
             .path(value: "wings")
             .beginKey(value: "1")
             .endKey(value: "2")
@@ -240,10 +240,10 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     
     func testMatchQuerySmartSql() {
         let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
-            .queryType(value: "match")
+            .queryType(value: .match)
             .path(value: "wings")
             .orderPath(value: "wings")
-            .order(value: "ascending")
+            .order(value: .ascending)
             .matchKey(value: "2")
             .pageSize(value: 1)
             .build()
@@ -252,11 +252,11 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     
     func testMatchQuerySmartSqlWithSelectPaths() {
         let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
-            .queryType(value: "match")
+            .queryType(value: .match)
             .selectedPaths(value: ["wings", "legs", "qty"])
             .path(value: "wings")
             .matchKey(value: "2")
-            .order(value: "ascending")
+            .order(value: .ascending)
             .orderPath(value: "legs")
             .pageSize(value: 1)
             .build()

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartSyncManagerTests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartSyncManagerTests.swift
@@ -80,7 +80,7 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
         .then { syncState -> Promise<UInt> in
             XCTAssertTrue(syncState.isDone())
             let querySpec =  SFQuerySpec.Builder(soupName: CONTACTS_SOUP)
-                                        .queryType(value: "range")
+                                        .queryType(value: .range)
                                         .build()
             return (self.store?.Promises.count(querySpec: querySpec))!
         }
@@ -144,7 +144,7 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
                 XCTAssertTrue(syncState.isDone())
                 syncId = UInt(syncState.syncId)
                 let querySpec =  SFQuerySpec.Builder(soupName: CONTACTS_SOUP)
-                    .queryType(value: "range")
+                    .queryType(value: .range)
                     .build()
                 return (self.store?.Promises.count(querySpec: querySpec))!
             }
@@ -185,7 +185,7 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
             XCTAssertTrue(syncState.isDone())
             syncId = UInt(syncState.syncId)
             let querySpec =  SFQuerySpec.Builder(soupName: CONTACTS_SOUP)
-                .queryType(value: "range")
+                .queryType(value: .range)
                 .build()
             return (self.store?.Promises.count(querySpec: querySpec))!
         }

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SyncManagerBaseTest.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SyncManagerBaseTest.swift
@@ -189,7 +189,7 @@ class SyncManagerBaseTest: SalesforceSwiftSDKBaseTest {
     func deleteAllTestContactsFromServer() -> Promise<Void> {
         
         let querySpec = SFQuerySpec.Builder(soupName: CONTACTS_SOUP)
-            .queryType(value: "range")
+            .queryType(value: .range)
             .selectedPaths(value: [ID])
             .pageSize(value: UInt.max)
             .build()

--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
@@ -246,6 +246,14 @@ typedef NS_ENUM(NSUInteger, SFSoupQuerySortOrder) {
  */
 - (nullable NSArray*) bindsForQuerySpec;
 
+
+/** Enum to/from string helper methods
+ */
++ (SFSoupQueryType) queryTypeFromString:(NSString*)queryType;
++ (NSString*) queryTypeFromEnum:(SFSoupQueryType)queryType;
++ (SFSoupQuerySortOrder) sortOrderFromString:(NSString*)sortOrder;
++ (NSString*) sortOrderFromEnum:(SFSoupQuerySortOrder)sortOrder;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Added helper methods to go from query type and sort order enum to string (and vice versa)