### PR TITLE
Cleanup SFRestAPI instance on kSFNotificationUserDidLogout Notification

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -80,7 +80,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
             [SFSDKWebUtils configureUserAgent:[SFRestAPI userAgentString]];
         }
         [[SFAuthenticationManager sharedManager] addDelegate:self];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserDidLogout:)  name:kSFNotificationUserDidLogout object:nil];
     }
     return self;
 }
@@ -646,7 +646,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 
 #pragma mark - SFAuthenticationManagerDelegate
 
-- (void)handleUserWillLogout:(NSNotification *)notification {
+- (void)handleUserDidLogout:(NSNotification *)notification {
     SFUserAccount *user = notification.userInfo[kSFNotificationUserInfoAccountKey];
     [self handleLogoutForUser:user];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -342,6 +342,12 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
     }
 
     [SFSDKCoreLogger d:[self class] format:@"Logging out user '%@'.", user.userName];
+    
+    //save for use with didLogout notification
+    NSString *userId = user.credentials.userId;
+    NSString *orgId = user.credentials.organizationId;
+    NSString *communityId = user.credentials.communityId;
+    
     NSDictionary *userInfo = @{ kSFNotificationUserInfoAccountKey : user };
     [[NSNotificationCenter defaultCenter]  postNotificationName:kSFNotificationUserWillLogout
                                                          object:self
@@ -361,6 +367,12 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
         [SFSecurityLockout clearPasscodeState];
     }
     [SFSDKWebViewStateManager removeSession];
+    
+    //restore these id's inorder to enable post logout cleanup of components
+    user.credentials.userId = userId;
+    user.credentials.organizationId = orgId;
+    user.credentials.communityId = communityId;
+    
     NSNotification *logoutNotification = [NSNotification notificationWithName:kSFNotificationUserDidLogout object:self userInfo:userInfo];
     [[NSNotificationCenter defaultCenter] postNotification:logoutNotification];
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -59,27 +59,11 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 - (void)dealloc {
     [[SFUserAccountManager sharedInstance] removeDelegate:self];
 }
-- (void)userAccountManager:(SFUserAccountManager *)userAccountManager willLogin:(SFOAuthCredentials *)credentials {
-    self.willLoginCredentials = credentials;
-}
-
-- (void)userAccountManager:(SFUserAccountManager *)userAccountManager willLogout:(SFUserAccount *)userAccount {
-    
-}
-
-- (void)userAccountManager:(SFUserAccountManager *)userAccountManager didLogout:(SFUserAccount *)userAccount {
-
-}
-
-- (void)userAccountManager:(SFUserAccountManager *)userAccountManager didLogin:(SFUserAccount *)userAccount {
-    self.didLoginUserAccount = userAccount;
-}
 
 - (BOOL)userAccountManager:(SFUserAccountManager *)userAccountManager error:(NSError *)error info:(SFOAuthInfo *)info {
     self.error = error;
     return NO;
 }
-
 
 - (void)userAccountManager:(SFUserAccountManager *)userAccountManager
         willSwitchFromUser:(SFUserAccount *)fromUser


### PR DESCRIPTION
Moved the cleanup  of SFRestAPI instances  to kSFNotificationUserDidLogout. Had to hang on to some key attributes for the logout notification. Removed some unneeded code in test. 