### PR TITLE
Refresh completion on the main thread

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -866,10 +866,14 @@ SFSDK_USE_DEPRECATED_BEGIN
     SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
     SFRestRequest *request = [[SFRestAPI sharedInstance] requestForResources];
     [[SFRestAPI sharedInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
-        failureBlock(authInfo, e);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            failureBlock(authInfo, e);
+        });
     } completeBlock:^(id response, NSURLResponse *rawResponse) {
         SFUserAccount *currentAccount = [SFUserAccountManager sharedInstance].currentUser;
-        completionBlock(authInfo, currentAccount);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completionBlock(authInfo, currentAccount);
+        });
     }];
 }
 


### PR DESCRIPTION
This might be some of what's being seen in https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/2466.  The switch to using `SFRestAPI` to refresh credentials caused what used to be exclusively main thread activities to get executed on a background thread through the underlying `NSURLSession` logic.  This puts completion back on the main thread.