### PR TITLE
Clean up SFPreference instance during logout.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
@@ -179,6 +179,18 @@ typedef NS_ENUM(NSUInteger, SFUserAccountLoginState) {
  */
 NSString *_Nullable SFKeyForUserAndScope(SFUserAccount * _Nullable user, SFUserAccountScope scope);
 
+/** Function that returns a key that uniquely identifies this user,org & community for the
+ given scope. Note that if you use SFUserAccountScopeGlobal,
+ the same key will be returned regardless of the user account.
+ 
+ @param userId The user identifier
+ @param orgId The org identifier
+ @param communityId The community id identifier
+ @param scope The scope
+ @return a key identifying this user account for the specified scope
+ */
+NSString *_Nullable SFKeyForUserIdAndScope(NSString *userId,NSString *orgId, NSString *_Nullable communityId, SFUserAccountScope scope);
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
@@ -348,6 +348,10 @@ static NSString * const kGlobalScopingKey = @"-global-";
 }
 
 NSString *SFKeyForUserAndScope(SFUserAccount *user, SFUserAccountScope scope) {
+    return  SFKeyForUserIdAndScope(user.credentials.userId,user.credentials.organizationId,user.credentials.communityId,scope);
+}
+
+NSString *SFKeyForUserIdAndScope(NSString *userId,NSString *orgId, NSString *communityId, SFUserAccountScope scope) {
     NSString *key = nil;
     switch (scope) {
         case SFUserAccountScopeGlobal:
@@ -355,20 +359,20 @@ NSString *SFKeyForUserAndScope(SFUserAccount *user, SFUserAccountScope scope) {
             break;
             
         case SFUserAccountScopeOrg:
-            if (user.credentials.organizationId != nil) {
-                key = user.credentials.organizationId;
+            if (userId != nil) {
+                key = userId;
             }
             break;
             
         case SFUserAccountScopeUser:
-            if (user.credentials.organizationId != nil && user.credentials.userId != nil) {
-                key = [NSString stringWithFormat:@"%@-%@", user.credentials.organizationId, user.credentials.userId];
+            if (orgId != nil && userId != nil) {
+                key = [NSString stringWithFormat:@"%@-%@", orgId, userId];
             }
             break;
             
         case SFUserAccountScopeCommunity:
-            if (user.credentials.organizationId != nil && user.credentials.userId != nil) {
-                key = [NSString stringWithFormat:@"%@-%@-%@", user.credentials.organizationId, user.credentials.userId, user.communityId];
+            if (orgId != nil && userId != nil) {
+                key = [NSString stringWithFormat:@"%@-%@-%@", orgId, userId, communityId];
             }
             break;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
@@ -359,8 +359,8 @@ NSString *SFKeyForUserIdAndScope(NSString *userId,NSString *orgId, NSString *com
             break;
             
         case SFUserAccountScopeOrg:
-            if (userId != nil) {
-                key = userId;
+            if (orgId != nil) {
+                key = orgId;
             }
             break;
             

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
@@ -89,6 +89,13 @@
  */
 - (void)reload;
 
+/** Check if user accounts exist for a given org.
+ *
+ * @param orgId for org
+ * @return YES if accounts exist, otherwise NO.
+ */
+- (BOOL)orgHasLoggedInUsers:(nonnull NSString *)orgId;
+
 /** Get the Account Persister being used.
  * @return SFUserAccountPersister that is used.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -110,6 +110,10 @@ FOUNDATION_EXTERN NSString * const kSFNotificationUserWillLogout;
  */
 FOUNDATION_EXTERN NSString * const kSFNotificationUserDidLogout;
 
+/** Notification sent when all users of org have logged off.
+ */
+FOUNDATION_EXTERN NSString * const kSFNotificationOrgDidLogout;
+
 /** Notification sent prior to display of Auth View
  */
 FOUNDATION_EXTERN NSString * const kSFNotificationUserWillShowAuthView;
@@ -161,6 +165,10 @@ FOUNDATION_EXTERN NSString * const kSFNotificationUserInfoAuthTypeKey;
 /**  Key to use to lookup dictionary of nv-pairs type associated with NSNotification userInfo
  */
 FOUNDATION_EXTERN NSString * const kSFUserInfoAddlOptionsKey;
+
+/**  Key to use to lookup SFNotificationUserInfo object in Notitications dictionary
+ */
+FOUNDATION_EXTERN NSString * const kSFNotificationUserInfoKey;
 
 @protocol SFSDKOAuthClientDelegate;
 @protocol SFSDKOAuthClientSafariViewDelegate;
@@ -247,6 +255,13 @@ FOUNDATION_EXTERN NSString * const kSFUserInfoAddlOptionsKey;
 
 @end
 
+/** User Information for post logout notifications.
+ */
+@interface SFNotificationUserInfo : NSObject
+@property (nonatomic, readonly) NSString *userId;
+@property (nonatomic, readonly) NSString *orgId;
+@property (nonatomic, readonly, nullable) NSString *communityId;
+@end
 
 /** Class used to manage the accounts functions used across the app.
  It supports multiple accounts and their associated credentials.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -258,8 +258,7 @@ FOUNDATION_EXTERN NSString * const kSFNotificationUserInfoKey;
 /** User Information for post logout notifications.
  */
 @interface SFNotificationUserInfo : NSObject
-@property (nonatomic, readonly) NSString *userId;
-@property (nonatomic, readonly) NSString *orgId;
+@property (nonatomic,readonly) SFUserAccountIdentity *accountIdentity;
 @property (nonatomic, readonly, nullable) NSString *communityId;
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -121,8 +121,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 - (instancetype) initWithUser:(SFUserAccount *)user {
     self = [super init];
     if (self) {
-        _userId = user.credentials.userId;
-        _orgId = user.credentials.organizationId;
+        _accountIdentity = user.accountIdentity;
         _communityId = user.credentials.communityId;
     }
     return self;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -72,6 +72,7 @@ NSString * const kSFNotificationUserWillLogIn  = @"SFNotificationUserWillLogIn";
 NSString * const kSFNotificationUserDidLogIn   = @"SFNotificationUserDidLogIn";
 NSString * const kSFNotificationUserWillLogout = @"SFNotificationUserWillLogout";
 NSString * const kSFNotificationUserDidLogout  = @"SFNotificationUserDidLogout";
+NSString * const kSFNotificationOrgDidLogout   = @"SFNotificationOrgDidLogout";
 
 //Auth Display Notification
 NSString * const kSFNotificationUserWillShowAuthView = @"SFNotificationUserWillShowAuthView";
@@ -88,6 +89,7 @@ NSString * const kSFNotificationUserInfoAccountKey      = @"account";
 NSString * const kSFNotificationUserInfoCredentialsKey  = @"credentials";
 NSString * const kSFNotificationUserInfoAuthTypeKey     = @"authType";
 NSString * const kSFUserInfoAddlOptionsKey     = @"options";
+NSString * const kSFNotificationUserInfoKey    = @"sfuserInfo";
 
 NSString * const SFUserAccountManagerUserChangeKey      = @"change";
 NSString * const SFUserAccountManagerUserChangeUserKey      = @"user";
@@ -103,7 +105,6 @@ static NSString * const kAlertDismissButtonKey = @"authAlertDismissButton";
 static NSString * const kAlertConnectionErrorFormatStringKey = @"authAlertConnectionErrorFormatString";
 static NSString * const kAlertVersionMismatchErrorKey = @"authAlertVersionMismatchError";
 
-
 static NSString *const kSFIncompatibleAuthError = @"Cannot use SFUserAccountManager Auth functions with useLegacyAuthenticationManager enabled";
 
 static NSString *const kErroredClientKey = @"SFErroredOAuthClientKey";
@@ -111,6 +112,23 @@ static NSString * const kSFSPAppFeatureIDPLogin   = @"SP";
 static NSString * const kSFIDPAppFeatureIDPLogin   = @"IP";
 static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 
+@interface SFNotificationUserInfo()
+- (instancetype) initWithUser:(SFUserAccount *)user;
+@end
+
+@implementation SFNotificationUserInfo : NSObject
+
+- (instancetype) initWithUser:(SFUserAccount *)user {
+    self = [super init];
+    if (self) {
+        _userId = user.credentials.userId;
+        _orgId = user.credentials.organizationId;
+        _communityId = user.credentials.communityId;
+    }
+    return self;
+}
+
+@end
 
 @implementation SFUserAccountManager
 
@@ -379,6 +397,15 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
     NSNotification *logoutNotification = [NSNotification notificationWithName:kSFNotificationUserDidLogout object:self userInfo:userInfo];
     [[NSNotificationCenter defaultCenter] postNotification:logoutNotification];
 
+    //post a notification if all users of the given org have logged out.
+    if (![self orgHasLoggedInUsers:orgId]) {
+        SFNotificationUserInfo *sfUserInfo = [[SFNotificationUserInfo alloc] initWithUser:user];
+        
+        NSDictionary *notificationUserInfo = @{ kSFNotificationUserInfoKey : sfUserInfo };
+        NSNotification *orgLogoutNotification = [NSNotification notificationWithName:kSFNotificationOrgDidLogout object:self userInfo:notificationUserInfo];
+        [[NSNotificationCenter defaultCenter] postNotification:orgLogoutNotification];
+    }
+    
     // NB: There's no real action that can be taken if this login state transition fails.  At any rate,
     // it's an unlikely scenario.
     [user transitionToLoginState:SFUserAccountLoginStateNotLoggedIn];
@@ -847,6 +874,11 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
     }
     [_accountsLock unlock];
     return responseArray;
+}
+
+- (BOOL)orgHasLoggedInUsers:(NSString *)orgId {
+    NSArray *accounts = [self accountsForOrgId:orgId];
+    return accounts && (accounts.count > 0);
 }
 
 - (NSArray *)accountsForOrgId:(NSString *)orgId {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFPreferences.m
@@ -43,6 +43,8 @@ static NSMutableDictionary *instances = nil;
 + (void)initialize {
     if (self == [SFPreferences class]) {
         instances = [NSMutableDictionary dictionary];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserDidLogout:) name:kSFNotificationUserDidLogout object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleOrgDidLogout:) name:kSFNotificationOrgDidLogout object:nil];
     }
 }
 
@@ -198,4 +200,35 @@ static NSMutableDictionary *instances = nil;
     }
 }
 
++ (void)handleUserDidLogout:(NSNotification *)notification {
+    SFUserAccount *user = notification.userInfo[kSFNotificationUserInfoAccountKey];
+   
+    @synchronized (self) {
+        NSString *key;
+        if (user.credentials.communityId) {
+            key = SFKeyForUserAndScope(user, SFUserAccountScopeCommunity);
+            if (key) {
+                [instances removeObjectForKey:key];
+            }
+        }
+        key = SFKeyForUserAndScope(user, SFUserAccountScopeUser);
+        if (key) {
+            [instances removeObjectForKey:key];
+        }
+    }
+    
+}
+
++ (void)handleOrgDidLogout:(NSNotification *)notification {
+    SFNotificationUserInfo *userInfo = notification.userInfo[kSFNotificationUserInfoKey];
+   
+    @synchronized (self) {
+        if (userInfo) {
+            NSString *key = SFKeyForUserIdAndScope(userInfo.userId, userInfo.orgId, userInfo.communityId, SFUserAccountScopeOrg);
+            if (key) {
+                [instances removeObjectForKey:key];
+            }
+        }
+    }
+}
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFPreferences.m
@@ -224,7 +224,7 @@ static NSMutableDictionary *instances = nil;
    
     @synchronized (self) {
         if (userInfo) {
-            NSString *key = SFKeyForUserIdAndScope(userInfo.userId, userInfo.orgId, userInfo.communityId, SFUserAccountScopeOrg);
+            NSString *key = SFKeyForUserIdAndScope(userInfo.accountIdentity.userId, userInfo.accountIdentity.orgId, userInfo.communityId, SFUserAccountScopeOrg);
             if (key) {
                 [instances removeObjectForKey:key];
             }


### PR DESCRIPTION
Added a new Notification when all users of a given org have logged out. Also added SFNotificationUserInfo as a way to encapsulate post logout data for this new post logout Notification.