### PR TITLE
Use API permissions-agnostic endpoint to validate session

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -864,7 +864,7 @@ SFSDK_USE_DEPRECATED_BEGIN
      * instead of going through the entire OAuth dance all over again.
      */
     SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
-    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForResources];
+    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForUserInfo];
     [[SFRestAPI sharedInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         dispatch_async(dispatch_get_main_queue(), ^{
             failureBlock(authInfo, e);

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
@@ -190,6 +190,12 @@ extern NSString* const kSFRestIfUnmodifiedSince;
 ///---------------------------------------------------------------------------------------
 
 /**
+ * Returns an `SFRestRequest` which gets information aassociated with the current user.
+ * @see https://help.salesforce.com/articleView?id=remoteaccess_using_userinfo_endpoint.htm
+ */
+- (SFRestRequest *)requestForUserInfo;
+
+/**
  * Returns an `SFRestRequest` which lists summary information about each
  * Salesforce.com version currently available, including the version, 
  * label, and a link to each version's root.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -423,19 +423,13 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
     [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:user className:NSStringFromClass([self class]) attributes:attributes];
 }
 
-# pragma mark - helper method for conditional requests
-
-+ (NSString *)getHttpStringFomFromDate:(NSDate *)date {
-    if (date == nil) return nil;
-    return [httpDateFormatter stringFromDate:date];
-}
-
 #pragma mark - SFRestRequest factory methods
 
 - (SFRestRequest *)requestForUserInfo {
     NSString *path = @"/services/oauth2/userinfo";
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
     request.endpoint = @"";
+    request.baseURL = [[self class] loginHostBaseUrlForUser:self.user];
     return request;
 }
 
@@ -649,6 +643,20 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 
 + (BOOL) isStatusCodeNotFound:(NSUInteger) statusCode {
     return statusCode  == 404;
+}
+
+# pragma mark - Helper methods
+
++ (NSString *)getHttpStringFomFromDate:(NSDate *)date {
+    if (date == nil) return nil;
+    return [httpDateFormatter stringFromDate:date];
+}
+
++ (nullable NSString *)loginHostBaseUrlForUser:(nullable SFUserAccount *)user {
+    if (user.credentials.domain.length == 0 || user.credentials.protocol.length == 0) {
+        return nil;
+    }
+    return [NSString stringWithFormat:@"%@://%@", user.credentials.protocol, user.credentials.domain];
 }
 
 #pragma mark - SFAuthenticationManagerDelegate

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -432,6 +432,13 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 
 #pragma mark - SFRestRequest factory methods
 
+- (SFRestRequest *)requestForUserInfo {
+    NSString *path = @"/services/oauth2/userinfo";
+    SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
+    request.endpoint = @"";
+    return request;
+}
+
 - (SFRestRequest *)requestForVersions {
     NSString *path = @"/";
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -427,9 +427,8 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 
 - (SFRestRequest *)requestForUserInfo {
     NSString *path = @"/services/oauth2/userinfo";
-    SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
+    SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodGET serviceHostType:SFSDKRestServiceHostTypeLogin path:path queryParams:nil];
     request.endpoint = @"";
-    request.baseURL = [[self class] loginHostBaseUrlForUser:self.user];
     return request;
 }
 
@@ -650,13 +649,6 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 + (NSString *)getHttpStringFomFromDate:(NSDate *)date {
     if (date == nil) return nil;
     return [httpDateFormatter stringFromDate:date];
-}
-
-+ (nullable NSString *)loginHostBaseUrlForUser:(nullable SFUserAccount *)user {
-    if (user.credentials.domain.length == 0 || user.credentials.protocol.length == 0) {
-        return nil;
-    }
-    return [NSString stringWithFormat:@"%@://%@", user.credentials.protocol, user.credentials.domain];
 }
 
 #pragma mark - SFAuthenticationManagerDelegate

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest+Internal.h
@@ -31,4 +31,6 @@
 @property (nullable, nonatomic, copy) NSDictionary *requestBodyAsDictionary;
 @property (nullable, nonatomic, copy) NSString *requestContentType;
 
++ (nonnull NSString *)restUrlForBaseUrl:(nullable NSString *)baseUrl serviceHostType:(SFSDKRestServiceHostType)hostType credentials:(nonnull SFOAuthCredentials *)credentials;
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -38,6 +38,21 @@ typedef NS_ENUM(NSInteger, SFRestMethod) {
     SFRestMethodPATCH
 };
 
+/**
+ * The type of service host to use for Rest requests.
+ */
+typedef NS_ENUM(NSUInteger, SFSDKRestServiceHostType){
+    /**
+     *  Request uses the login endpoint.
+     */
+    SFSDKRestServiceHostTypeLogin,
+    
+    /**
+     *  Request uses the instance endpoint.
+     */
+    SFSDKRestServiceHostTypeInstance
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -123,6 +138,11 @@ extern NSString * const kSFDefaultRestEndpoint;
  * The HTTP method of the request. See SFRestMethod.
  */
 @property (nonatomic, assign, readwrite) SFRestMethod method;
+
+/**
+ * The type of service host for the request (e.g. login or instance).
+ */
+@property (nonatomic, assign, readwrite) SFSDKRestServiceHostType serviceHostType;
 
 /**
  * The NSURLSesssionDataTask instance associated with the request. This is set only
@@ -264,6 +284,15 @@ extern NSString * const kSFDefaultRestEndpoint;
  * @param queryParams the parameters of the request (could be nil)
  */
 + (instancetype)requestWithMethod:(SFRestMethod)method path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams;
+
+/**
+ * Creates an `SFRestRequest` object. See SFRestMethod. If you need to set body on the request, use one of the 'setCustomRequestBody...' methods to do so with the instance returned by this method.
+ * @param method the HTTP method
+ * @param hostType the type of service host for the request. 
+ * @param path the request path
+ * @param queryParams the parameters of the request (could be nil)
+ */
++ (instancetype)requestWithMethod:(SFRestMethod)method serviceHostType:(SFSDKRestServiceHostType)hostType path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams;
 
 /**
  * Creates an `SFRestRequest` object. See SFRestMethod. If you need to set body on the request, use one of the 'setCustomRequestBody...' methods to do so with the instance returned by this method.

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -175,6 +175,13 @@ static NSException *authException = nil;
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidFail, @"request should have failed");
 }
 
+// simple: just invoke requestForUserInfo
+- (void)testGetUserInfo {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForUserInfo];
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+}
+
 // simple: just invoke requestForResources
 - (void)testGetResources {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForResources];


### PR DESCRIPTION
`requestForResources` is an API endpoint that's dependent on the user having API access, which is unsuitable for testing sessions that don't have API access.  Replaced with the [user info endpoint](https://help.salesforce.com/articleView?id=remoteaccess_using_userinfo_endpoint.htm).