### PR TITLE
Use of a safe mutable set for managing active requests 

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -125,6 +125,9 @@
 		B71129161F8A789F00436CFB /* SFSDKAlertMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = B711290C1F8A780800436CFB /* SFSDKAlertMessage.m */; };
 		B71129171F8A789F00436CFB /* SFSDKAlertMessageBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = B711290B1F8A780800436CFB /* SFSDKAlertMessageBuilder.m */; };
 		B71129181F8A789F00436CFB /* SFSDKAlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = B71129071F8A780700436CFB /* SFSDKAlertView.m */; };
+		B7245C7D206EFE1F003A5CD5 /* SFSDKSafeMutableSet.h in Headers */ = {isa = PBXBuildFile; fileRef = B7245C7B206EFE1F003A5CD5 /* SFSDKSafeMutableSet.h */; };
+		B7245C7E206EFE1F003A5CD5 /* SFSDKSafeMutableSet.m in Sources */ = {isa = PBXBuildFile; fileRef = B7245C7C206EFE1F003A5CD5 /* SFSDKSafeMutableSet.m */; };
+		B7245C9820701E7C003A5CD5 /* SFSDKSafeMutableSetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B7245C9720701E7C003A5CD5 /* SFSDKSafeMutableSetTests.m */; };
 		B75233C21F4D390B00040B6E /* SFSDKOAuthClientContext.h in Headers */ = {isa = PBXBuildFile; fileRef = B75233C01F4D390B00040B6E /* SFSDKOAuthClientContext.h */; };
 		B75233C31F4D390B00040B6E /* SFSDKOAuthClientContext.h in Headers */ = {isa = PBXBuildFile; fileRef = B75233C01F4D390B00040B6E /* SFSDKOAuthClientContext.h */; };
 		B75233C41F4D390B00040B6E /* SFSDKOAuthClientContext.m in Sources */ = {isa = PBXBuildFile; fileRef = B75233C11F4D390B00040B6E /* SFSDKOAuthClientContext.m */; };
@@ -1186,6 +1189,9 @@
 		B711290A1F8A780800436CFB /* SFSDKAlertMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKAlertMessage.h; sourceTree = "<group>"; };
 		B711290B1F8A780800436CFB /* SFSDKAlertMessageBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKAlertMessageBuilder.m; sourceTree = "<group>"; };
 		B711290C1F8A780800436CFB /* SFSDKAlertMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKAlertMessage.m; sourceTree = "<group>"; };
+		B7245C7B206EFE1F003A5CD5 /* SFSDKSafeMutableSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKSafeMutableSet.h; sourceTree = "<group>"; };
+		B7245C7C206EFE1F003A5CD5 /* SFSDKSafeMutableSet.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKSafeMutableSet.m; sourceTree = "<group>"; };
+		B7245C9720701E7C003A5CD5 /* SFSDKSafeMutableSetTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKSafeMutableSetTests.m; path = SalesforceSDKCoreTests/SFSDKSafeMutableSetTests.m; sourceTree = SOURCE_ROOT; };
 		B7282F3F1D8C70E700475F79 /* SalesforceSDKCoreTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SalesforceSDKCoreTestApp.entitlements; sourceTree = "<group>"; };
 		B75233C01F4D390B00040B6E /* SFSDKOAuthClientContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKOAuthClientContext.h; sourceTree = "<group>"; };
 		B75233C11F4D390B00040B6E /* SFSDKOAuthClientContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKOAuthClientContext.m; sourceTree = "<group>"; };
@@ -1444,6 +1450,7 @@
 				B7E1A50D1F43B0FE007AC36A /* SFSDKWindowManagerTests.m */,
 				B759CD881F8BDBAC0081AA87 /* SDSDKAlertMessageTest.m */,
 				B759CD8A1F8C10DC0081AA87 /* SFSDKErrorManagerTests.m */,
+				B7245C9720701E7C003A5CD5 /* SFSDKSafeMutableSetTests.m */,
 			);
 			name = SalesforceSDKCoreTests;
 			path = SalesforceSDKCore;
@@ -1514,6 +1521,8 @@
 				B791409B1EC11ADE0051492F /* SFSDKWebViewStateManager.m */,
 				44EFFA2F1EE8C63600B30267 /* SFSDKSafeMutableDictionary.h */,
 				44EFFA301EE8C63600B30267 /* SFSDKSafeMutableDictionary.m */,
+				B7245C7B206EFE1F003A5CD5 /* SFSDKSafeMutableSet.h */,
+				B7245C7C206EFE1F003A5CD5 /* SFSDKSafeMutableSet.m */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -2157,6 +2166,7 @@
 				CE4CE33C1C0E5245009F6029 /* SFIdentityData.h in Headers */,
 				B7FB26C01F78094A00FB25A2 /* SFSDKIDPAuthClient.h in Headers */,
 				B711290E1F8A780800436CFB /* SFSDKAlertMessageBuilder.h in Headers */,
+				B7245C7D206EFE1F003A5CD5 /* SFSDKSafeMutableSet.h in Headers */,
 				CE4CE35D1C0E526A009F6029 /* SFAuthErrorHandler.h in Headers */,
 				CE4CE32C1C0E523B009F6029 /* SalesforceSDKManager.h in Headers */,
 				CE4CE3361C0E523B009F6029 /* SFUserActivityMonitor.h in Headers */,
@@ -2803,6 +2813,7 @@
 				CEB98EE21F86E7D70083AB9C /* SFSDKIDPAuthInitCommandTest.m in Sources */,
 				B7E1A50E1F43B0FE007AC36A /* SFSDKWindowManagerTests.m in Sources */,
 				4F06AF8A1C49A18E00F70798 /* SalesforceOAuthUnitTests.m in Sources */,
+				B7245C9820701E7C003A5CD5 /* SFSDKSafeMutableSetTests.m in Sources */,
 				010A9B5A1CC1A14C002AF4D3 /* SFEncryptDecryptStreamJSONTests.m in Sources */,
 				8214D955205316BA0007349E /* SFSDKSalesforceAnalyticsManagerTests.m in Sources */,
 				4F06AF891C49A18E00F70798 /* NSURL+SFStringUtilsTests.m in Sources */,
@@ -2981,6 +2992,7 @@
 				CE4CE3841C0E526A009F6029 /* SFPBKDF2PasscodeProvider.m in Sources */,
 				CEA8C9711F02F79F00448B51 /* SFSDKCoreLogger.m in Sources */,
 				B711290D1F8A780800436CFB /* SFSDKAlertView.m in Sources */,
+				B7245C7E206EFE1F003A5CD5 /* SFSDKSafeMutableSet.m in Sources */,
 				B7FB26DB1F78096300FB25A2 /* SFSDKIDPErrorHandler.m in Sources */,
 				CE4CE3641C0E526A009F6029 /* SFCommunityData.m in Sources */,
 				010A9AE91CC176DD002AF4D3 /* SFEncryptStream.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableSet.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableSet.h
@@ -25,35 +25,81 @@
 
 @interface SFSDKSafeMutableSet : NSObject
 
-- (NSArray *)allObjects;
-
+/**
+ * Adds a given object to the set, if it is not already a member.
+ */
 - (id)anyObject;
 
+/**
+ * Returns true if the object exists in the set.
+ */
 - (BOOL)containsObject:(id)anObject;
 
-- (BOOL)isEqualToSet:(SFSDKSafeMutableSet *)otherSet;
-
+/**
+ * Adds a given object to the set, if it is not already a member.
+ */
 - (void)addObject:(id)obj;
 
+/**
+ * Adds to the set each object contained in a given array that is not already a member.
+ */
 - (void)addObjectsFromArray:(NSArray *)array;
 
+/**
+ * Removes all objects from the set.
+ */
 - (void)removeAllObjects;
 
+/**
+ * Removes a given object from the set.
+ */
 - (void)removeObject:(id)object;
 
+/**
+ * Removes each object in another given set from the receiving set, if present.
+ */
 - (void)unionSet:(NSSet *)otherSet;
 
+/**
+ * Empties the receiving set, then adds each object contained in another given set.
+ */
 - (void)minusSet:(NSSet *)set;
 
+/**
+ * Empties the receiving set, then adds each object contained in another given set.
+ */
 - (void)intersectSet:(NSSet *)otherSet;
 
+/**
+ * Empties the receiving set, then adds each object contained in another given set.
+ */
 - (void)setSet:(NSSet *)otherSet;
 
+/**
+ * Filter the set using a predicate.
+ */
 - (void)filterUsingPredicate:(NSPredicate *)predicate;
 
+/**
+ * Enumerate objects in the set safely, using a block.
+ */
 - (void)enumerateObjectsUsingBlock:(void (^)(id obj, BOOL *stop))block;
 
+/**
+ * Get a NSSet from the mutable set
+ */
 - (NSSet *)asSet;
+
+/**
+ * Return an Array of all Objects
+ */
+- (NSArray *)allObjects;
+
+/**
+ * Returns true if the sets are equal.
+ */
+- (BOOL)isEqualToSet:(SFSDKSafeMutableSet *)otherSet;
+
 /**
  * The number of elements in this set.
  */
@@ -65,5 +111,12 @@
  * @return A new SFSDKSafeMutableSet instance.
  */
 + (id)set;
+
+/**
+ * A convenience method to allocate and initialize a new instance of a SFSDKSafeMutableSetWithCapacity.
+ *
+ * @return A new SFSDKSafeMutableSet instance.
+ */
++ (id)setWithCapacity:(NSUInteger)numItems;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableSet.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableSet.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011-present, salesforce.com, inc. All rights reserved.
+ Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -21,33 +21,49 @@
  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#import <Foundation/Foundation.h>
 
-#import "SFRestAPI.h"
-#import "SFUserAccountManager.h"
-#import "SFAuthenticationManager.h"
-#import "SFSDKSafeMutableSet.h"
+@interface SFSDKSafeMutableSet : NSObject
+
+- (NSArray *)allObjects;
+
+- (id)anyObject;
+
+- (BOOL)containsObject:(id)anObject;
+
+- (BOOL)isEqualToSet:(SFSDKSafeMutableSet *)otherSet;
+
+- (void)addObject:(id)obj;
+
+- (void)addObjectsFromArray:(NSArray *)array;
+
+- (void)removeAllObjects;
+
+- (void)removeObject:(id)object;
+
+- (void)unionSet:(NSSet *)otherSet;
+
+- (void)minusSet:(NSSet *)set;
+
+- (void)intersectSet:(NSSet *)otherSet;
+
+- (void)setSet:(NSSet *)otherSet;
+
+- (void)filterUsingPredicate:(NSPredicate *)predicate;
+
+- (void)enumerateObjectsUsingBlock:(void (^)(id obj, BOOL *stop))block;
+
+- (NSSet *)asSet;
 /**
- We declare here a set of interfaces that are meant to be used by code running internally
- to SFRestAPI or close "friend" classes such as unit test helpers. You SHOULD NOT access these interfaces
- from application code.  If you find yourself accessing properties or calling methods
- declared in this file from app code, you're probably doing something wrong.
+ * The number of elements in this set.
  */
-@interface SFRestAPI () <SFUserAccountManagerDelegate>
+@property (nonatomic,readonly) NSUInteger count;
 
 /**
- * Active requests property.
+ * A convenience method to allocate and initialize a new instance of a SFSDKSafeMutableSet.
+ *
+ * @return A new SFSDKSafeMutableSet instance.
  */
-@property (nonatomic, readonly, strong) SFSDKSafeMutableSet *activeRequests;
-
-- (void)removeActiveRequestObject:(SFRestRequest *)request;
-
-/**
- Force a request to timeout: for testing only!
- 
- @param req The request to force a timeout on, or nil to grab any active request and force it to timeout
- @return YES if we were able to find and timeout the request, NO if the request could not be found
- */
-- (BOOL)forceTimeoutRequest:(SFRestRequest*)req;
++ (id)set;
 
 @end
-

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableSet.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableSet.m
@@ -1,0 +1,164 @@
+/*
+ Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#import "SFSDKSafeMutableSet.h"
+
+@interface SFSDKSafeMutableSet()
+@property (nonatomic,strong) NSMutableSet *backingSet;
+@property (nonatomic,strong) dispatch_queue_t queue;
+@end
+
+@implementation SFSDKSafeMutableSet
+
+- (id)init {
+    if ((self = [super init]))
+    {
+        self.backingSet = [NSMutableSet set];
+        self.queue = dispatch_queue_create([NSString stringWithFormat:@"com.salesforce.mobilesdk.readWriteSetQ%u", arc4random_uniform(UINT32_MAX)].UTF8String, DISPATCH_QUEUE_CONCURRENT);
+    }
+    return self;
+}
+
+- (NSUInteger)count {
+    __block NSUInteger size;
+    dispatch_sync(self.queue, ^{
+        size = self.backingSet.count;
+    });
+    
+    return size;
+}
+
+- (id)anyObject {
+    __block id object;
+    dispatch_sync(self.queue, ^{
+        object = [self.backingSet anyObject];
+    });
+    return object;
+}
+
+- (BOOL)containsObject:(id)anObject {
+    __block BOOL exists;
+    dispatch_sync(self.queue, ^{
+        exists = [self.backingSet containsObject:anObject];
+    });
+    return exists;
+}
+
+- (NSArray *)allObjects {
+    __block NSArray *array;
+    dispatch_sync(self.queue, ^{
+        array = [self.backingSet allObjects];
+    });
+    return array;
+}
+
+- (NSSet *)asSet {
+    __block NSSet *set;
+    dispatch_sync(self.queue, ^{
+        set = [NSSet setWithSet:self.backingSet];
+    });
+    return set;
+}
+
+- (BOOL)isEqualToSet:(SFSDKSafeMutableSet *)that {
+    BOOL isEqual = [self isEqual:that];
+    if (!isEqual) {
+         NSSet *thisSet = [self asSet];
+         NSSet *thatSet = [that asSet];
+         isEqual = [thisSet isEqualToSet:thatSet];
+    }
+    return isEqual;
+}
+
+- (void)addObject:(id)obj {
+    dispatch_barrier_async(self.queue, ^{
+        [self.backingSet addObject:obj];
+    });
+}
+
+- (void)addObjectsFromArray:(NSArray *)array {
+    dispatch_barrier_async(self.queue, ^{
+         [self.backingSet addObjectsFromArray:array];
+    });
+}
+
+- (void)removeAllObjects {
+    dispatch_barrier_async(self.queue, ^{
+        [self.backingSet removeAllObjects];
+    });
+}
+
+- (void)removeObject:(id)object {
+    dispatch_barrier_async(self.queue, ^{
+        [self.backingSet removeObject:object];
+    });
+}
+
+- (void)unionSet:(NSSet *)set {
+    dispatch_barrier_async(self.queue, ^{
+        [self.backingSet unionSet:set];
+    });
+}
+
+- (void)minusSet:(NSSet *)set {
+    dispatch_barrier_async(self.queue, ^{
+        [self.backingSet unionSet:set];
+    });
+}
+
+- (void)intersectSet:(NSSet *)set {
+    dispatch_barrier_async(self.queue, ^{
+        [self.backingSet intersectSet:set];
+    });
+}
+
+- (void)setSet:(NSSet *)set {
+    dispatch_barrier_async(self.queue, ^{
+        [self.backingSet intersectSet:set];
+    });
+}
+
+- (void)filterUsingPredicate:(NSPredicate *)predicate {
+    dispatch_barrier_async(self.queue, ^{
+        [self.backingSet filterUsingPredicate:predicate];
+    });
+}
+
+- (void)enumerateObjectsUsingBlock:(void (^)(id obj, BOOL *stop))block {
+    __block NSArray *array = [self allObjects];
+    dispatch_barrier_sync(self.queue, ^{
+        [array enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+            block(obj, stop);
+        }];
+    });
+}
+
+#pragma mark - Class Level
+
++ (id)set {
+    id retVal = [[self alloc] init];
+    return retVal;
+}
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableSet.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableSet.m
@@ -132,7 +132,7 @@
 
 - (void)minusSet:(NSSet *)set {
     dispatch_barrier_async(self.queue, ^{
-        [self.backingSet unionSet:set];
+        [self.backingSet minusSet:set];
     });
 }
 
@@ -144,7 +144,7 @@
 
 - (void)setSet:(NSSet *)set {
     dispatch_barrier_async(self.queue, ^{
-        [self.backingSet intersectSet:set];
+        [self.backingSet setSet:set];
     });
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableSet.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableSet.m
@@ -35,7 +35,16 @@
     if ((self = [super init]))
     {
         self.backingSet = [NSMutableSet set];
-        self.queue = dispatch_queue_create([NSString stringWithFormat:@"com.salesforce.mobilesdk.readWriteSetQ%u", arc4random_uniform(UINT32_MAX)].UTF8String, DISPATCH_QUEUE_CONCURRENT);
+        [self initQueue];
+    }
+    return self;
+}
+
+- (id)initWithCapacity:(NSUInteger)numItems {
+    if ((self = [super init]))
+    {
+        self.backingSet = [NSMutableSet setWithCapacity:numItems];
+        [self initQueue];
     }
     return self;
 }
@@ -159,6 +168,16 @@
 + (id)set {
     id retVal = [[self alloc] init];
     return retVal;
+}
+
++ (id)setWithCapacity:(NSUInteger)numItems {
+    id retVal = [[self alloc] initWithCapacity:numItems];
+    return retVal;
+}
+
+#pragma private methods
+- (void)initQueue {
+     self.queue = dispatch_queue_create([NSString stringWithFormat:@"com.salesforce.mobilesdk.readWriteSetQ%u", arc4random_uniform(UINT32_MAX)].UTF8String, DISPATCH_QUEUE_CONCURRENT);
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -72,7 +72,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
     self = [super init];
     if (self) {
         self.user = user;
-        _activeRequests = [SFSDKSafeMutableSet set];
+        _activeRequests = [SFSDKSafeMutableSet setWithCapacity:10];
         self.apiVersion = kSFRestDefaultAPIVersion;
         self.sessionRefreshInProgress = NO;
         self.pendingRequestsBeingProcessed = NO;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKSafeMutableSetTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKSafeMutableSetTests.m
@@ -1,0 +1,170 @@
+/*
+ Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#import <XCTest/XCTest.h>
+#import "SFSDKSafeMutableSet.h"
+@interface SFSDKSafeMutableSetTests : XCTestCase
+@end
+
+@implementation SFSDKSafeMutableSetTests
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testReadWrites {
+    
+    SFSDKSafeMutableSet *set = [SFSDKSafeMutableSet set];
+    [set addObject:@"Test1"];
+    [set addObject:@"Test2"];
+    
+    [set addObject:[NSNumber numberWithInt:10]];
+    
+    XCTAssertTrue([set containsObject:@"Test1"]);
+    XCTAssertTrue([set containsObject:@"Test2"]);
+    XCTAssertTrue([set containsObject:[NSNumber numberWithInt:10]]);
+}
+
+
+- (void)testReadWriteDelete {
+    
+    SFSDKSafeMutableSet *set = [SFSDKSafeMutableSet set];
+    [set addObject:@"Test1"];
+    [set addObject:@"Test2"];
+    XCTAssertTrue([set containsObject:@"Test1"]);
+    XCTAssertTrue([set containsObject:@"Test2"]);
+    [set removeObject:@"Test1"];
+    XCTAssertFalse([set containsObject:@"Test1"]);
+    [set removeAllObjects];
+    XCTAssertTrue([set count]==0);
+}
+
+- (void)testConcurrentWrites {
+    NSArray *inputs = @[@"Test1", @"Test2", @"Test3", @"Test4", @"Test5"];
+    
+    SFSDKSafeMutableSet *set = [SFSDKSafeMutableSet set];
+    dispatch_group_t group = dispatch_group_create();
+   
+    [inputs enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [set addObject:inputs[idx]];
+        });
+    }];
+    
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+        
+    //Does the set have the right number of items?
+    XCTAssertTrue(set.count == inputs.count);
+    //Does the set have each of our items?
+    [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+       XCTAssertTrue([set containsObject:inputs[idx]]);
+    }];
+}
+
+- (void)testConcurrentReadWrites {
+    NSArray *inputs = @[@"Test1", @"Test2", @"Test3", @"Test4", @"Test5"];
+    
+    SFSDKSafeMutableSet *set = [SFSDKSafeMutableSet set];
+    dispatch_group_t group = dispatch_group_create();
+    
+    [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [set addObject:inputs[idx]];
+        });
+    }];
+    
+   [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [set anyObject];
+        });
+    }];
+    
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+    //Does the set have the right number of items?
+    XCTAssertTrue(set.count == inputs.count);
+     //Does the set have each of our items?
+    [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        XCTAssertTrue([set containsObject:inputs[idx]]);
+    }];
+}
+
+- (void)testConcurrentReadsAndRemove {
+    NSArray *inputs = @[@"Test1", @"Test2", @"Test3", @"Test4", @"Test5"];
+    
+    SFSDKSafeMutableSet *set = [SFSDKSafeMutableSet set];
+    dispatch_group_t group = dispatch_group_create();
+    
+    [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        [set addObject:inputs[idx]];
+    }];
+    
+    XCTAssertEqual(set.count,inputs.count);
+    [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [set removeObject:inputs[idx]];
+        });
+    }];
+    
+    [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [set anyObject];
+        });
+    }];
+    
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+    //Have all items been removed
+    XCTAssertTrue(set.count == 0);
+    
+}
+
+- (void)testConcurrentReadsAndRemoveAll {
+    NSArray *inputs = @[@"Test1", @"Test2", @"Test3", @"Test4", @"Test5"];
+    
+    SFSDKSafeMutableSet *set = [SFSDKSafeMutableSet set];
+    dispatch_group_t group = dispatch_group_create();
+    
+    [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        [set addObject:inputs[idx]];
+    }];
+    
+    XCTAssertEqual(set.count,inputs.count);
+    [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
+            [set anyObject];
+        });
+    }];
+    
+    dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [set removeAllObjects];
+    });
+    
+    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+    //Have all items been removed
+    XCTAssertTrue(set.count == 0);
+    
+}
+@end


### PR DESCRIPTION
@sgoldberg-sfdc @bhariharan Please Review. Small change to add some guard rails around the management of active requests in SFRestAPI.  Added a SFSDKSafeMutableSet to the core. We can certainly reuse this class.