### PR TITLE
Fixes advanced auth bug related to AdvancedAuthConfigurationAllow

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientCache.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientCache.h
@@ -67,6 +67,12 @@ typedef NS_ENUM(NSUInteger, SFOAuthClientKeyType) {
  */
 - (void)addClient:(SFSDKOAuthClient *)client;
 
+/** Add A Client to the cache given key
+ *
+ * @param client instance to add
+ */
+- (void)addClient:(SFSDKOAuthClient *)client forKey:(NSString *)key;
+
 /** Remove A Cached Client given key
  * @param key to use for looking up client
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientCache.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientCache.m
@@ -59,6 +59,10 @@ static NSString *const kSFAdvancedSuffix = @"ADVANCED";
     [self.oauthClientInstances setObject:client forKey:key];
 }
 
+- (void)addClient:(SFSDKOAuthClient *)client forKey:(NSString *)key {
+    [self.oauthClientInstances setObject:client forKey:key];
+}
+
 - (void)removeClient:(SFSDKOAuthClient *)client {
     NSString *key = [[self class] keyFromClient:client];
     [self.oauthClientInstances removeObject:key];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKAdvancedAuthURLHandler.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKAdvancedAuthURLHandler.m
@@ -48,10 +48,7 @@
 }
 
 - (BOOL)processRequest:(NSURL *)url options:(NSDictionary *)options {
-    [[SFUserAccountManager sharedInstance] handleNativeAuthResponse:url options:options];
-    // return NO so that another handler  interested in consuming this event cna also participate.
-    return NO;
-
+    return [[SFUserAccountManager sharedInstance] handleNativeAuthResponse:url options:options];
 }
 
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKURLHandlerManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKURLHandlerManager.h
@@ -33,10 +33,6 @@
 
 @interface SFSDKURLHandlerManager : NSObject
 
-- (void)addHandler:(id<SFSDKURLHandler>)handler;
-
-- (void)removeHandler:(id<SFSDKURLHandler>)handler;
-
 - (BOOL)canHandleRequest:(NSURL *)url options:(NSDictionary *)options;
 
 - (BOOL)processRequest:(NSURL *)url options:(NSDictionary *)options;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKURLHandlerManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKURLHandlerManager.m
@@ -56,18 +56,6 @@
     return self;
 }
 
-- (void)addHandler:(id <SFSDKURLHandler>)handler {
-    if (!handler) {
-        [handlerList addObject:handler];
-    }
-}
-
-- (void)removeHandler:(id <SFSDKURLHandler>)handler {
-    if (!handler) {
-        [handlerList removeObject:handler];
-    }
-}
-
 - (BOOL)canHandleRequest:(NSURL *)url options:(NSDictionary *)options {
 
      __block BOOL result = NO;


### PR DESCRIPTION
IF the sdk is configured to AdvancedAuthConfigurationAllow, the auth is not completed successfully. This happens due to the inability to reference the client from  cache.  The change in this PR makes it possible by simply re-keying the client in the cache. Removed some unused code.