### PR TITLE
Allow overriding of auto-refresh on HTTP 403

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -275,7 +275,8 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 
     // Checks if the access token has expired.
     NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
-    if (statusCode == 401 || statusCode == 403) {
+    BOOL shouldRefresh = request.shouldRefreshOn403 ? (statusCode == 401 || statusCode == 403) : (statusCode == 401);
+    if (shouldRefresh) {
         if (shouldRetry) {
             [SFSDKCoreLogger i:[self class] format:@"%@: REST request failed due to expired credentials. Attempting to refresh credentials.", NSStringFromSelector(_cmd)];
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -27,7 +27,7 @@
 #import "SFUserAccount.h"
 
 /**
- * HTTP methods for requests
+ * HTTP methods for requests.
  */
 typedef NS_ENUM(NSInteger, SFRestMethod) {
     SFRestMethodGET = 0,
@@ -41,7 +41,8 @@ typedef NS_ENUM(NSInteger, SFRestMethod) {
 /**
  * The type of service host to use for Rest requests.
  */
-typedef NS_ENUM(NSUInteger, SFSDKRestServiceHostType){
+typedef NS_ENUM(NSUInteger, SFSDKRestServiceHostType) {
+
     /**
      *  Request uses the login endpoint.
      */
@@ -60,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 extern NSString * const kSFDefaultRestEndpoint;
 
-//forward declaration
+// Forward declaration.
 @class SFRestRequest;
 
 /**
@@ -197,6 +198,12 @@ extern NSString * const kSFDefaultRestEndpoint;
  * the request headers before sending the request.  If NO, they will not.
  */
 @property (nonatomic, assign) BOOL requiresAuthentication;
+
+/**
+ * Used to specify if the SDK should attempt to refresh tokens on HTTP 403. If YES, the SDK will
+ * attempt to refresh on HTTP 403. If NO, refresh will not be attempted.
+ */
+@property (nonatomic, assign) BOOL shouldRefreshOn403;
 
 /**
  * Prepares the request before sending it out.


### PR DESCRIPTION
This PR allows the caller to override the default behavior of attempting to refresh on HTTP 403 for a given request.