### PR TITLE
 Add condition to ensure next active window isn't currently hidden

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
@@ -309,27 +309,32 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
    
     if ([self.snapshotWindow isEnabled])
         return;
-
-    BOOL windowFound = NO;
-    for (NSInteger i = [SFApplicationHelper sharedApplication].windows.count - 1; i >= 0; i--) {
-        UIWindow *win = ([SFApplicationHelper sharedApplication].windows)[i];
-        if (win.alpha == 0.0 || [self isKeyboard:win]) {
-            continue;
-        } else if (window!=nil && window.window!=win) {
-            continue; // in case the window is not the keywindow is not the enabled window (applies for enable only)
-        } else {
-            windowFound = YES;
-            [win makeKeyWindow];
-            break;
-        }
-    }
-    //Should not be the case but if we do find ourselves in this situation, we can make the mainWindow
-    //the key window as a fallback
-    if (!windowFound) {
-        [SFSDKCoreLogger e:[self class] format:@"SFSDKWindowManager could not make a window key: %@ will fallback to making mainWindow as Key Window", window.windowName];
-        [[self mainWindow].window makeKeyWindow];
+    
+    if (window != nil && [self isValidWindow:window]) {
+        [window.window makeKeyWindow];
+        return;
     }
     
+    UIWindow *activeWindow = [self findActiveWindow];
+    if (activeWindow != nil) {
+        [activeWindow makeKeyWindow];
+        return;
+    }
+    
+    //Should not be the case but if we do find ourselves in this situation, we can make the mainWindow
+    //the key window as a fallback
+    [SFSDKCoreLogger e:[self class] format:@"SFSDKWindowManager could not make a window key: %@ will fallback to making mainWindow as Key Window", window.windowName];
+    [[self mainWindow].window makeKeyWindow];
+    
+}
+
+- (BOOL)isValidWindow:(SFSDKWindowContainer *)container {
+    for (UIWindow *window in [SFApplicationHelper sharedApplication].windows) {
+        if (window == container.window) {
+            return YES;
+        }
+    }
+    return NO;
 }
 
 - (UIWindow *)findActiveWindow {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
@@ -342,7 +342,7 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
     UIWindow *foundWindow = nil;
     for (NSInteger i = [SFApplicationHelper sharedApplication].windows.count - 1; i >= 0; i--) {
         UIWindow *win = ([SFApplicationHelper sharedApplication].windows)[i];
-        if (win.alpha == 0.0 || [self isKeyboard:win]) {
+        if (win.alpha == 0.0 || win.hidden == YES || [self isKeyboard:win]) {
             continue;
         } else {
             foundWindow = win;


### PR DESCRIPTION
We ran into an issue where foregrounding the application incorrectly set the next key window to a `_UIInteractiveHighlightEffectWindow` presumably created by the OS and only present in iOS 11.1 builds. This window happens to be the last window in the list and passes the alpha and keyboard if conditions. To resolve this, I added an extra condition to ensure the next active window is not currently set to be hidden. 

I also took the time to do a bit of refactoring by reusing the `findActiveWindow` method.

@bhariharan @trooper2013 