### PR TITLE
Added nullability markers for each property

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFCommunityData.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFCommunityData.h
@@ -24,35 +24,33 @@
 
 #import <Foundation/Foundation.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
 /** Class that groups the data describing a community
  */
 @interface SFCommunityData : NSObject <NSCoding>
 
 /** The community ID
  */
-@property (nonatomic, strong) NSString *entityId;
+@property (nonnull, nonatomic, strong) NSString *entityId;
 
 /** The community name
  */
-@property (nonatomic, strong) NSString *name;
+@property (nonnull, nonatomic, strong) NSString *name;
 
 /** The community description
  */
-@property (nonatomic, strong) NSString *descriptionText;
+@property (nullable, nonatomic, strong) NSString *descriptionText;
 
 /** The community siteUrl
  */
-@property (nonatomic, strong) NSURL *siteUrl;
+@property (nonnull, nonatomic, strong) NSURL *siteUrl;
 
 /** The community URL
  */
-@property (nonatomic, strong) NSURL *url;
+@property (nonnull, nonatomic, strong) NSURL *url;
 
 /** The community URL's path prefix
  */
-@property (nonatomic, strong) NSURL *urlPathPrefix;
+@property (nullable, nonatomic, strong) NSURL *urlPathPrefix;
 
 /** Flag indicating if the community is live or not
  */
@@ -68,4 +66,3 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Noticed that `/services/data/v38.0/connect/communities` end point can return properties with null values. So, added nullability marker for each property for us to be able to set an optional value. Below is the sample response for reference

`allowChatterAccessWithoutLogin: false
allowMembersToFlag: false
description: null
id: 0DBP00000004CAzOAM
invitationsEnabled: false
knowledgeableEnabled: false
loginUrl: https://sandbox-charliewutesting-developer-edition.cs4.force.com/login
name: mttTest
nicknameDisplayEnabled: false
privateMessagesEnabled: false
reputationEnabled: false
sendWelcomeEmail: true
siteUrl: https://sandbox-charliewutesting-developer-edition.cs4.force.com
status: Live
url: /services/data/v38.0/connect/communities/0DBP00000004CAzOAM
urlPathPrefix: null` 
