### PR TITLE
Validate plain text is not assumed to be null terminated

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
@@ -259,14 +259,13 @@
     
     SecKeyRef publicKeyRef = [SFSDKCryptoUtils getRSAPublicKeyRefWithName:@"test" keyLength:keySize];
     SecKeyRef privateKeyRef = [SFSDKCryptoUtils getRSAPrivateKeyRefWithName:@"test" keyLength:keySize];
+
+    NSUInteger byteDataInt = 123456;
+    NSData *testData = [NSData dataWithBytes:&byteDataInt length:sizeof(NSUInteger)];
+    NSData *encryptedData = [SFSDKCryptoUtils encryptUsingRSAforData:testData withKeyRef:publicKeyRef];
     
-    // Encrypt data
-    NSData *bigdata = [@"This is a test!FOOBARFOOBARFOOBAR" dataUsingEncoding:NSUTF8StringEncoding];
-    NSData *shortdata = [[NSData alloc] initWithBytesNoCopy:(void*)bigdata.bytes length:15 deallocator:nil];
-    NSData *encryptedData = [SFSDKCryptoUtils encryptUsingRSAforData:shortdata withKeyRef:publicKeyRef];
-    // Decrypt data
     NSData *decryptedData = [SFSDKCryptoUtils decryptUsingRSAforData:encryptedData withKeyRef:privateKeyRef];
-    XCTAssertTrue([shortdata isEqualToData:decryptedData]);
+    XCTAssertEqualObjects(testData, decryptedData, @"Data objects are not the same data.");
 }
 
 - (void)testRSAEncryptionAndDecryptionWrongKeys

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKCryptoUtilsTests.m
@@ -251,6 +251,24 @@
     XCTAssertTrue([testString isEqualToString:result]);
 }
 
+- (void)testRSAEncryptionAndDecryptionForData
+{
+    size_t keySize = 2048;
+    
+    [SFSDKCryptoUtils createRSAKeyPairWithName:@"test" keyLength:keySize accessibleAttribute:kSecAttrAccessibleAlways];
+    
+    SecKeyRef publicKeyRef = [SFSDKCryptoUtils getRSAPublicKeyRefWithName:@"test" keyLength:keySize];
+    SecKeyRef privateKeyRef = [SFSDKCryptoUtils getRSAPrivateKeyRefWithName:@"test" keyLength:keySize];
+    
+    // Encrypt data
+    NSData *bigdata = [@"This is a test!FOOBARFOOBARFOOBAR" dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *shortdata = [[NSData alloc] initWithBytesNoCopy:(void*)bigdata.bytes length:15 deallocator:nil];
+    NSData *encryptedData = [SFSDKCryptoUtils encryptUsingRSAforData:shortdata withKeyRef:publicKeyRef];
+    // Decrypt data
+    NSData *decryptedData = [SFSDKCryptoUtils decryptUsingRSAforData:encryptedData withKeyRef:privateKeyRef];
+    XCTAssertTrue([shortdata isEqualToData:decryptedData]);
+}
+
 - (void)testRSAEncryptionAndDecryptionWrongKeys
 {
     size_t keySize = 2048;


### PR DESCRIPTION
The previous encryptUsingRSAForData assumed the input data was null terminated, as it used strlen to determine length of input data. 

This was randomly picking up extraneous data depending what was in memory beyond the bytes of the NSData plain text.

