### PR TITLE
Allow application to manage rotations of windows

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -58,23 +58,23 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
 @interface UINavigationController(SFSDKOAuth)
 @end
 
-@implementation UINavigationController(SFSDKOAuth)
-
-- (BOOL)shouldAutorotate {
-    if (self.topViewController) {
-        return self.topViewController.shouldAutorotate;
-    }
-    return NO;
-}
-
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    if (self.topViewController) {
-        return self.topViewController.supportedInterfaceOrientations;
-    }
-    return UIInterfaceOrientationMaskPortrait;
-}
-
-@end
+//@implementation UINavigationController(SFSDKOAuth)
+//
+//- (BOOL)shouldAutorotate {
+//    if (self.topViewController) {
+//        return self.topViewController.shouldAutorotate;
+//    }
+//    return NO;
+//}
+//
+//- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+//    if (self.topViewController) {
+//        return self.topViewController.supportedInterfaceOrientations;
+//    }
+//    return UIInterfaceOrientationMaskPortrait;
+//}
+//
+//@end
 
 @interface SFSDKOAuthClient()<SFOAuthCoordinatorDelegate,SFIdentityCoordinatorDelegate,SFSDKLoginHostDelegate,SFLoginViewControllerDelegate>{
     NSRecursiveLock *readWriteLock;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -55,26 +55,6 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 static NSString * const kSFRevokePath = @"/services/oauth2/revoke";
 
 static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
-@interface UINavigationController(SFSDKOAuth)
-@end
-
-//@implementation UINavigationController(SFSDKOAuth)
-//
-//- (BOOL)shouldAutorotate {
-//    if (self.topViewController) {
-//        return self.topViewController.shouldAutorotate;
-//    }
-//    return NO;
-//}
-//
-//- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-//    if (self.topViewController) {
-//        return self.topViewController.supportedInterfaceOrientations;
-//    }
-//    return UIInterfaceOrientationMaskPortrait;
-//}
-//
-//@end
 
 @interface SFSDKOAuthClient()<SFOAuthCoordinatorDelegate,SFIdentityCoordinatorDelegate,SFSDKLoginHostDelegate,SFLoginViewControllerDelegate>{
     NSRecursiveLock *readWriteLock;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeViewController.m
@@ -326,11 +326,6 @@ static CGFloat      const kUseTouchIdButtonHeight           = 40.0f;
     [super viewWillLayoutSubviews];
 }
 
-- (void)viewDidUnload
-{
-    [super viewDidUnload];
-}
-
 - (void)layoutSubviews
 {
     [self layoutPasscodeField];
@@ -340,9 +335,12 @@ static CGFloat      const kUseTouchIdButtonHeight           = 40.0f;
     [self layoutUseTouchIdButton];
 }
 
-- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
-{
-    return YES;
+-(BOOL) shouldAutorotate {
+    return NO;
+}
+
+-(UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
 }
 
 - (void)layoutPasscodeField

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -432,7 +432,16 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
         });
         return;
     }
-    [SFSDKWindowManager.sharedManager.authWindow dismissWindow];
+    UIViewController *presentedViewController = [SFSDKWindowManager sharedManager].authWindow.viewController.presentedViewController?:[SFSDKWindowManager sharedManager].authWindow.viewController;
+    
+    if (presentedViewController) {
+        [presentedViewController dismissViewControllerAnimated:NO completion:^{
+            [[SFSDKWindowManager sharedManager].authWindow dismissWindow];
+        }];
+    } else {
+        //hide the window if no controllers were found.
+        [[SFSDKWindowManager sharedManager].authWindow dismissWindow];
+    }
 }
 
 + (BOOL)errorIsInvalidAuthCredentials:(NSError *)error {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKRootController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKRootController.m
@@ -67,7 +67,7 @@
     UIViewController *topViewController = [SFSDKRootController topViewController:self];
     if (topViewController!=nil && topViewController!=self)
         return [topViewController shouldAutorotate];
-    return YES;
+    return NO;
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
@@ -76,7 +76,7 @@
     if (topViewController!=nil && topViewController!=self)
         return [topViewController supportedInterfaceOrientations];
     
-    return UIInterfaceOrientationMaskAll;
+    return UIInterfaceOrientationMaskPortrait;
 }
 
 #pragma mark - Helper class methods

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowContainer.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowContainer.m
@@ -90,10 +90,8 @@
 }
 
 - (void)dismissWindowWithCompletion:(void (^ _Nullable)(void))completion {
-    if ([self isEnabled]) {
-        if ([self.windowDelegate respondsToSelector:@selector(dismissWindow:withCompletion:)]) {
-            [self.windowDelegate dismissWindow:self withCompletion:completion];
-        }
+    if ([self.windowDelegate respondsToSelector:@selector(dismissWindow:withCompletion:)]) {
+        [self.windowDelegate dismissWindow:self withCompletion:completion];
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.h
@@ -116,6 +116,14 @@
  */
 - (void)removeDelegate:(id<SFSDKWindowManagerDelegate>_Nonnull)delegate;
 
+/** Check if a given window is an SDK Window
+ */
+- (BOOL)isSDKWindow:(UIWindow *_Nonnull)window;
+
+/** Return the container given a UIWindow, or null if not found.
+ */
+- (SFSDKWindowContainer *_Nullable)lookup:(UIWindow *_Nonnull)window;
+
 + (instancetype _Nonnull )sharedManager;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
@@ -332,6 +332,15 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
     return foundWindow;
 }
 
+- (BOOL)isSDKWindow:(UIWindow *)window {
+    SFSDKWindowContainer *container = [self.reverseLookupTable objectForKey:window];
+    return (container != nil) && (!container.isMainWindow);
+}
+
+- (SFSDKWindowContainer *)lookup:(UIWindow *)window {
+    return [self.reverseLookupTable objectForKey:window];
+}
+
 + (instancetype)sharedManager {
     static dispatch_once_t token;
     static SFSDKWindowManager *sharedInstance = nil;


### PR DESCRIPTION
This PR allows for applications to control the rotational behavior of UIWindows. Applications could do the following in the app delegate or conversely call  [SFSDKWindowManager:lookup:] and then decide the orientation of the window.

```
-(UIInterfaceOrientationMask)application:(UIApplication *)application
  supportedInterfaceOrientationsForWindow:(UIWindow *)window {
   
    if (window && [[SFSDKWindowManager sharedManager] isSDKWindow:window])
        return UIInterfaceOrientationMaskPortrait;
    ...
    return UIInterfaceOrientationMaskAll;
}
```