### PR TITLE
Fixing Password policy check for multiple users

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.h
@@ -128,7 +128,7 @@ typedef void (^SFPasscodeViewControllerPresentationBlock)(UIViewController*);
 @end
 
 @class SFOAuthCredentials;
-
+@class SFUserAccount;
 /**
  This class interacts with the inactivity timer.
  It is responsible for locking and unlocking the device by presenting the passcode modal controller when the timer expires.
@@ -174,6 +174,13 @@ typedef void (^SFPasscodeViewControllerPresentationBlock)(UIViewController*);
  be subject to that policy.
  */
 + (void)clearPasscodeState;
+
+/**
+ Resets the passcode state of the app, *if* there aren't other users with an overriding passcode
+ policy.  I.e. passcode state can only be cleared if the  user is the only user who would
+ be subject to that policy.
+ */
++ (void)clearPasscodeState:(SFUserAccount *)userLoggingOut;
 
 /** Initialize the timer
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -264,14 +264,18 @@ static BOOL _showPasscode = YES;
 + (BOOL)nonCurrentUsersHavePasscodePolicy
 {
     SFUserAccount *currentAccount = [SFUserAccountManager sharedInstance].currentUser;
+    return [self otherUsersHavePasscodePolicy:currentAccount];
+}
+
++ (BOOL)otherUsersHavePasscodePolicy:(SFUserAccount *)thisUser
+{
     for (SFUserAccount *account in [SFUserAccountManager sharedInstance].allUserAccounts) {
-        if (![account isEqual:currentAccount]) {
+        if (![account isEqual:thisUser]) {
             if (account.idData.mobileAppScreenLockTimeout > 0) {
                 return YES;
             }
         }
     }
-    
     return NO;
 }
 
@@ -281,8 +285,12 @@ static BOOL _showPasscode = YES;
     // on passcode policies across users.  So for instance, if another configured user in the app still has
     // passcode policies which apply to that account, this method will effectively do nothing.  On the other hand,
     // if the current user is the only user of the app, this will remove passcode policies for the app.
-    
-    if (![SFSecurityLockout nonCurrentUsersHavePasscodePolicy]) {
+    return [self clearPasscodeState:[SFUserAccountManager sharedInstance].currentUser];
+}
+
++ (void)clearPasscodeState:(SFUserAccount *)userLoggingOut {
+   
+    if (![SFSecurityLockout otherUsersHavePasscodePolicy:userLoggingOut]) {
         [SFSecurityLockout clearAllPasscodeState];
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -374,15 +374,12 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
     [self deleteAccountForUser:user error:nil];
     [client cancelAuthentication:NO];
     [client revokeCredentials];
+    [SFSecurityLockout clearPasscodeState:user];
     BOOL isCurrentUser = [user isEqual:self.currentUser];
     if (isCurrentUser) {
         self.currentUser = nil;
     }
 
-    // Need to reset Passcode if no other users are around.
-    if ([[self allUserAccounts] count] < 1 ) {
-        [SFSecurityLockout clearPasscodeState];
-    }
     [SFSDKWebViewStateManager removeSession];
     
     //restore these id's inorder to enable post logout cleanup of components


### PR DESCRIPTION
Fixed Password policy check for multiple users. No need to check for number of users in the SFUserAccountManager. Refactored  the SFSecurityLockout to handle a user logging out vs. current user logging out.