### PR TITLE
Capturing error during sync up on record

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -356,7 +356,7 @@ static NSMutableDictionary *syncMgrList = nil;
             NSArray* recordsToSave = idsToSkip && idsToSkip.count > 0 ? [strongSelf  removeWithIds:records idsToSkip:idsToSkip idField:target.idFieldName] : records;
 
             // Save to smartstore.
-            [target saveRecordsToLocalStore:strongSelf  soupName:soupName records:recordsToSave syncId:syncId];
+            [target cleanAndSaveRecordsToLocalStore:strongSelf soupName:soupName records:recordsToSave syncId:syncId];
             countFetched += [records count];
             progress = 100*countFetched / totalSize;
 

--- a/libs/SmartSync/SmartSync/Classes/Target/SFParentChildrenSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFParentChildrenSyncDownTarget.m
@@ -208,7 +208,7 @@
     return maxTimeStamp;
 }
 
-- (void)saveRecordsToLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString *)soupName records:(NSArray *)records syncId:(NSNumber *)syncId {
+- (void)cleanAndSaveRecordsToLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString *)soupName records:(NSArray *)records syncId:(NSNumber *)syncId {
     // NB: method is called during sync down so for this target records contain parent and children
 
     return [SFParentChildrenSyncHelper saveRecordTreesToLocalStore:syncManager target:self parentInfo:self.parentInfo childrenInfo:self.childrenInfo recordTrees:records syncId:syncId];

--- a/libs/SmartSync/SmartSync/Classes/Target/SFParentChildrenSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFParentChildrenSyncUpTarget.m
@@ -465,6 +465,10 @@ typedef void (^SFFetchLastModifiedDatesCompleteBlock)(NSDictionary<NSString *, N
 
             [self deleteFromLocalStore:syncManager soupName:soupName record:record];
         }
+        // Failure
+        else {
+            [self saveRecordToLocalStoreWithLastError:syncManager soupName:soupName record:record lastError:response.description];
+        }
     }
 
     // Create / update case
@@ -494,6 +498,11 @@ typedef void (^SFFetchLastModifiedDatesCompleteBlock)(NSDictionary<NSString *, N
                 needReRun = YES;
             }
         }
+        // Failure
+        else {
+            [self saveRecordToLocalStoreWithLastError:syncManager soupName:soupName record:record lastError:response.description];
+        }
+
     }
 
     return needReRun;
@@ -526,6 +535,10 @@ typedef void (^SFFetchLastModifiedDatesCompleteBlock)(NSDictionary<NSString *, N
                 || notFoundStatusCode) // or the record was already deleted on the server
         {
             [self deleteFromLocalStore:syncManager soupName:soupName record:record];
+        }
+        // Failure
+        else {
+            [self saveRecordToLocalStoreWithLastError:syncManager soupName:soupName record:record lastError:response.description];
         }
     }
 
@@ -567,6 +580,11 @@ typedef void (^SFFetchLastModifiedDatesCompleteBlock)(NSDictionary<NSString *, N
                 // We need a re-run
                 needReRun = YES;
             }
+        }
+
+        // Failure
+        else {
+            [self saveRecordToLocalStoreWithLastError:syncManager soupName:soupName record:record lastError:response.description];
         }
 
     }

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget+Internal.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget+Internal.h
@@ -32,7 +32,6 @@
 - (NSOrderedSet *)getIdsWithQuery:idsSql syncManager:(SFSmartSyncSyncManager *)syncManager;
 - (NSString*) getDirtyRecordIdsSql:(NSString*)soupName idField:(NSString*)idField;
 - (void) deleteRecordsFromLocalStore:(SFSmartSyncSyncManager*)syncManager soupName:(NSString*)soupName ids:(NSArray*)ids idField:(NSString*)idField;
-
-- (void)cleanAndSaveInSmartStore:(SFSmartStore *)smartStore soupName:(NSString *)soupName records:(NSArray *)record idFieldName:(NSString *)idFieldName syncId:(NSNumber *)syncId;
+- (void)saveInLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString *)soupName records:(NSArray *)records idFieldName:(NSString *)idFieldName syncId:(NSNumber *)syncId lastError:(NSString *)lastError cleanFirst:(BOOL)cleanFirst;
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.h
@@ -33,6 +33,7 @@ extern NSString * const kSyncTargetLocallyCreated;
 extern NSString * const kSyncTargetLocallyUpdated;
 extern NSString * const kSyncTargetLocallyDeleted;
 extern NSString * const kSyncTargetSyncId;
+extern NSString * const kSyncTargetLastError;
 
 /**
  The field name of the ID field of the record.  Defaults to "Id".
@@ -67,13 +68,13 @@ extern NSString * const kSyncTargetSyncId;
 - (void) cleanAndSaveInLocalStore:(SFSmartSyncSyncManager*)syncManager soupName:(NSString*)soupName record:(NSDictionary*)record;
 
 /**
- * Save records in local store
+ * Save records in local store (marked as clean)
  * @param syncManager The sync manager
  * @param soupName The soup
  * @param records The records to save
  * @param syncId The sync id
  */
-- (void) saveRecordsToLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString *)soupName records:(NSArray *)records syncId:(NSNumber *)syncId;
+- (void)cleanAndSaveRecordsToLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString *)soupName records:(NSArray *)records syncId:(NSNumber *)syncId;
 
 /**
  * @param record The record

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.m
@@ -37,6 +37,7 @@ NSString * const kSyncTargetLocallyCreated = @"__locally_created__";
 NSString * const kSyncTargetLocallyUpdated = @"__locally_updated__";
 NSString * const kSyncTargetLocallyDeleted = @"__locally_deleted__";
 NSString * const kSyncTargetSyncId = @"__sync_id__";
+NSString * const kSyncTargetLastError = @"__last_error__";
 
 @implementation SFSyncTarget
 
@@ -76,11 +77,11 @@ NSString * const kSyncTargetSyncId = @"__sync_id__";
 
 - (void) cleanAndSaveInLocalStore:(SFSmartSyncSyncManager*)syncManager soupName:(NSString*)soupName record:(NSDictionary*)record {
     [SFSDKSmartSyncLogger d:[self class] format:@"cleanAndSaveInLocalStore:%@", record];
-    [self cleanAndSaveInSmartStore:syncManager.store soupName:soupName records:@[record] idFieldName:self.idFieldName syncId:nil /* method called from sync up - not setting syncId field then */];
+    [self saveInSmartStore:syncManager.store soupName:soupName records:@[record] idFieldName:self.idFieldName syncId:nil lastError:nil cleanFirst:YES /* method called from sync up - not setting syncId field then */];
 }
 
-- (void) saveRecordsToLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString *)soupName records:(NSArray *)records syncId:(NSNumber *)syncId {
-    [self cleanAndSaveInSmartStore:syncManager.store soupName:soupName records:records idFieldName:self.idFieldName syncId:syncId];
+- (void)cleanAndSaveRecordsToLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString *)soupName records:(NSArray *)records syncId:(NSNumber *)syncId {
+    [self saveInSmartStore:syncManager.store soupName:soupName records:records idFieldName:self.idFieldName syncId:syncId lastError:nil cleanFirst:YES];
 }
 
 - (void) deleteRecordsFromLocalStore:(SFSmartSyncSyncManager*)syncManager soupName:(NSString*)soupName ids:(NSArray*)ids idField:(NSString*)idField {
@@ -146,15 +147,22 @@ NSString * const kSyncTargetSyncId = @"__sync_id__";
     return ids;
 }
 
-- (void)cleanAndSaveInSmartStore:(SFSmartStore *)smartStore soupName:(NSString *)soupName records:(NSArray *)records idFieldName:(NSString *)idFieldName syncId:(NSNumber *)syncId {
+- (void)saveInLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString *)soupName records:(NSArray *)records idFieldName:(NSString *)idFieldName syncId:(NSNumber *)syncId lastError:(NSString *)lastError cleanFirst:(BOOL)cleanFirst {
+    [self saveInSmartStore:syncManager.store soupName:soupName records:records idFieldName:idFieldName syncId:syncId lastError:lastError cleanFirst:cleanFirst];
+}
+
+- (void)saveInSmartStore:(SFSmartStore *)smartStore soupName:(NSString *)soupName records:(NSArray *)records idFieldName:(NSString *)idFieldName syncId:(NSNumber *)syncId lastError:(NSString *)lastError cleanFirst:(BOOL)cleanFirst  {
 
     NSMutableArray* recordsFromSmartStore = [NSMutableArray new];
     NSMutableArray* recordsFromServer = [NSMutableArray new];
 
     for (NSDictionary * record in records) {
         NSMutableDictionary *mutableRecord = [record mutableCopy];
+        if (cleanFirst) {
+            [self cleanRecord:mutableRecord];
+        }
         [self addSyncId:mutableRecord syncId:syncId];
-        [self cleanRecord:mutableRecord];
+        [self addLastError:mutableRecord lastError:lastError];
         if (mutableRecord[SOUP_ENTRY_ID]) {
             // Record came from smartstore
             [recordsFromSmartStore addObject:mutableRecord];
@@ -176,11 +184,18 @@ NSString * const kSyncTargetSyncId = @"__sync_id__";
     }
 }
 
+- (void) addLastError:(NSMutableDictionary*)record lastError:(NSString*)lastError {
+    if (lastError) {
+        record[kSyncTargetLastError] = lastError;
+    }
+}
+
 - (void) cleanRecord:(NSMutableDictionary*)record {
     record[kSyncTargetLocal] = @NO;
     record[kSyncTargetLocallyCreated] = @NO;
     record[kSyncTargetLocallyUpdated] = @NO;
     record[kSyncTargetLocallyDeleted] = @NO;
+    record[kSyncTargetLastError] = nil;
 }
 
 - (NSArray*) flatten:(NSArray*)results {

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget+Internal.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget+Internal.h
@@ -37,4 +37,9 @@
 - (BOOL)isNewerThanServer:(SFRecordModDate*)localModDate
             remoteModDate:(SFRecordModDate*)remoteModDate;
 
+- (void) saveRecordToLocalStoreWithLastError:(SFSmartSyncSyncManager*)syncManager
+                                    soupName:(NSString*) soupName
+                                      record:(NSDictionary*) record
+                                   lastError:(NSString*) lastError;
+
 @end

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
@@ -201,6 +201,16 @@ typedef void (^SFSyncUpTargetErrorBlock)(NSError *error);
  */
 - (NSArray *)getIdsOfRecordsToSyncUp:(SFSmartSyncSyncManager *)syncManager
                             soupName:(NSString *)soupName;
+/**
+ Save record with last error if any
+ @param syncManager The sync manager doing the sync
+ @param soupName the soup to save the record to
+ @param record The record being synced
+ */
+- (void) saveRecordToLocalStoreWithLastError:(SFSmartSyncSyncManager*)syncManager
+                                    soupName:(NSString*) soupName
+                                      record:(NSDictionary*) record;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.m
@@ -27,6 +27,7 @@
 #import "SFSmartSyncNetworkUtils.h"
 #import "SFSmartSyncSyncManager.h"
 #import "SFSmartSyncObjectUtils.h"
+#import "SFSyncTarget+Internal.h"
 #import <SalesforceSDKCore/SFJsonUtils.h>
 #import <SmartStore/SFSmartStore.h>
 
@@ -53,6 +54,7 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
 @interface  SFSyncUpTarget ()
 @property (nonatomic, strong) NSArray*  createFieldlist;
 @property (nonatomic, strong) NSArray*  updateFieldlist;
+@property (nonatomic, strong) NSString* lastError;
 @end
 
 @implementation SFSyncUpTarget
@@ -292,6 +294,31 @@ if ((localModDate.timestamp != nil && remoteModDate.timestamp != nil
         return true;
     }
     return false;
+}
+
+- (void) saveRecordToLocalStoreWithLastError:(SFSmartSyncSyncManager*)syncManager
+                                    soupName:(NSString*) soupName
+                                      record:(NSDictionary*) record {
+    [self saveRecordToLocalStoreWithLastError:syncManager
+                                     soupName:soupName
+                                       record:record
+                                    lastError:self.lastError];
+    self.lastError = nil;
+}
+
+- (void) saveRecordToLocalStoreWithLastError:(SFSmartSyncSyncManager*)syncManager
+                                    soupName:(NSString*) soupName
+                                      record:(NSDictionary*) record
+                                   lastError:(NSString*) lastError {
+    if (lastError) {
+        [self saveInLocalStore:syncManager
+                      soupName:soupName
+                       records:@[record]
+                   idFieldName:self.idFieldName
+                        syncId:nil
+                     lastError:lastError
+                    cleanFirst:NO];
+    }
 }
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.m
@@ -226,6 +226,7 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
 {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForCreateWithObjectType:objectType fields:fields];
     [SFSmartSyncNetworkUtils sendRequestWithSmartSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+        self.lastError = e.description;
         failBlock(e);
     } completeBlock:^(NSDictionary* d, NSURLResponse *rawResponse) {
         completionBlock(d);
@@ -240,6 +241,7 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
 {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForUpdateWithObjectType:objectType objectId:objectId fields:fields];
     [SFSmartSyncNetworkUtils sendRequestWithSmartSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+        self.lastError = e.description;
         failBlock(e);
     } completeBlock:^(NSDictionary* d, NSURLResponse *rawResponse) {
         completionBlock(d);
@@ -253,6 +255,7 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
 {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForDeleteWithObjectType:objectType objectId:objectId];
     [SFSmartSyncNetworkUtils sendRequestWithSmartSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+        self.lastError = e.description;
         failBlock(e);
     } completeBlock:^(NSDictionary* d, NSURLResponse *rawResponse) {
         completionBlock(d);

--- a/libs/SmartSync/SmartSync/Classes/Util/SFParentChildrenSyncHelper.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFParentChildrenSyncHelper.m
@@ -108,10 +108,10 @@ NSString * const kSFParentChildrenRelationshipLookup = @"LOOKUP";
     }
 
     // Saving parents
-    [target cleanAndSaveInSmartStore:syncManager.store soupName:parentInfo.soupName records:parentRecords idFieldName:parentInfo.idFieldName syncId:syncId];
-
+    [target saveInLocalStore:syncManager soupName:parentInfo.soupName records:parentRecords idFieldName:parentInfo.idFieldName syncId:syncId lastError:nil cleanFirst:YES];
+    
     // Saving children
-    [target cleanAndSaveInSmartStore:syncManager.store soupName:childrenInfo.soupName records:childrenRecords idFieldName:childrenInfo.idFieldName syncId:syncId];
+    [target saveInLocalStore:syncManager soupName:childrenInfo.soupName records:childrenRecords idFieldName:childrenInfo.idFieldName syncId:syncId lastError:nil cleanFirst:YES];
 }
 
 + (NSArray<NSMutableDictionary*> *)getMutableChildrenFromLocalStore:(SFSmartStore *)store parentInfo:(SFParentInfo *)parentInfo childrenInfo:(SFChildrenInfo *)childrenInfo parent:(NSDictionary *)parent {

--- a/libs/SmartSync/SmartSyncTests/ParentChildrenSyncTests.m
+++ b/libs/SmartSync/SmartSyncTests/ParentChildrenSyncTests.m
@@ -283,7 +283,7 @@ typedef NS_ENUM(NSInteger, SFSyncUpChange) {
 
     // Now calling saveRecordsToLocalStore
     SFParentChildrenSyncDownTarget * target = [self getAccountContactsSyncDownTarget];
-    [target saveRecordsToLocalStore:self.syncManager soupName:ACCOUNTS_SOUP records:records syncId:syncId];
+    [target cleanAndSaveRecordsToLocalStore:self.syncManager soupName:ACCOUNTS_SOUP records:records syncId:syncId];
 
     // Checking accounts and contacts soup
     // Making sure local fields are populated

--- a/libs/SmartSync/SmartSyncTests/ParentChildrenSyncTests.m
+++ b/libs/SmartSync/SmartSyncTests/ParentChildrenSyncTests.m
@@ -1189,6 +1189,93 @@ typedef NS_ENUM(NSInteger, SFSyncUpChange) {
     [self trySyncUpsWithVariousChangesWithNumberAccounts:2 numberContactsPerAccount:0 localChangeForAccount:DELETE remoteChangeForAccount:DELETE localChangeForContact:NONE remoteChangeForContact:NONE];
 }
 
+/**
+ * Create accounts and contacts on server, sync down
+ * Update some of the accounts and contacts - using bad names (too long) for some
+ * Sync up
+ * Check smartstore and server afterwards
+ */
+- (void) testSyncUpWithErrors
+{
+    // Creating test accounts and contacts on server
+    [self createAccountsAndContactsOnServer:3 numberContactsPerAccount:3];
+
+    // Sync down
+    SFParentChildrenSyncDownTarget * syncTarget = [self getAccountContactsSyncDownTargetWithParentSoqlFilter:
+            [NSString stringWithFormat:@"Id IN %@", [self buildInClause:[accountIdContactIdToFields allKeys]]]];
+    [self trySyncDown:SFSyncStateMergeModeOverwrite target:syncTarget soupName:ACCOUNTS_SOUP totalSize:3 numberFetches:1];
+
+    // Picking accounts / contacts
+    NSArray* accountIds = [accountIdToFields allKeys];
+    NSString* account1Id = accountIds[0];
+    NSArray* contactIdsOfAccount1 = [accountIdContactIdToFields[account1Id] allKeys];
+    NSString* contact11Id = contactIdsOfAccount1[0];
+    NSString* contact12Id = contactIdsOfAccount1[1];
+
+    NSString* account2Id = accountIds[1];
+    NSArray* contactIdsOfAccount2 = [accountIdContactIdToFields[account2Id] allKeys];
+    NSString* contact21Id = contactIdsOfAccount2[0];
+    NSString* contact22Id = contactIdsOfAccount2[1];
+
+    // Build long suffix
+    NSMutableString* suffixTooLong = [NSMutableString new];
+    for (int i = 0; i < 255; i++) [suffixTooLong appendString:@"x"];
+
+    // Updating with valid values
+    NSDictionary * updatedAccount1Fields = [self updateRecordLocally:accountIdToFields[account1Id] idToUpdate:account1Id soupName:ACCOUNTS_SOUP][account1Id];
+    NSDictionary * updatedContact11Fields = [self updateRecordLocally:accountIdContactIdToFields[account1Id][contact11Id] idToUpdate:contact11Id soupName:CONTACTS_SOUP][contact11Id];
+    NSDictionary * updatedContact21Fields = [self updateRecordLocally:accountIdContactIdToFields[account2Id][contact22Id] idToUpdate:contact21Id soupName:CONTACTS_SOUP][contact21Id];
+
+    // Updating with invalid values
+    [self updateRecordLocally:accountIdToFields[account2Id] idToUpdate:account2Id soupName:ACCOUNTS_SOUP suffix:suffixTooLong];
+    [self updateRecordLocally:accountIdContactIdToFields[account1Id][contact12Id] idToUpdate:contact12Id soupName:CONTACTS_SOUP suffix:suffixTooLong];
+    [self updateRecordLocally:accountIdContactIdToFields[account2Id][contact22Id] idToUpdate:contact22Id soupName:CONTACTS_SOUP suffix:suffixTooLong];
+
+    // Sync up
+    [self trySyncUp:2 target:[self getAccountContactsSyncUpTarget] mergeMode:SFSyncStateMergeModeOverwrite];
+
+    // Check valid records in db: should no longer be marked as dirty
+    [self checkDbStateFlags:@[account1Id] soupName:ACCOUNTS_SOUP expectedLocallyCreated:NO expectedLocallyUpdated:NO expectedLocallyDeleted:NO];
+    [self checkDbStateFlags:@[contact11Id, contact21Id] soupName:CONTACTS_SOUP expectedLocallyCreated:NO expectedLocallyUpdated:NO expectedLocallyDeleted:NO];
+
+    // Check invalid records in db
+    // Should still be marked as dirty
+    [self checkDbStateFlags:@[account2Id] soupName:ACCOUNTS_SOUP expectedLocallyCreated:NO expectedLocallyUpdated:YES expectedLocallyDeleted:NO];
+    [self checkDbStateFlags:@[contact12Id, contact22Id] soupName:CONTACTS_SOUP expectedLocallyCreated:NO expectedLocallyUpdated:YES expectedLocallyDeleted:NO];
+
+    // Should have populated last error fields
+    [self checkDbLastErrorField:@[ account2Id ] soupName:ACCOUNTS_SOUP lastErrorSubString:@"Account Name: data value too large"];
+    [self checkDbLastErrorField:@[ contact12Id, contact22Id ] soupName:CONTACTS_SOUP lastErrorSubString:@"Last Name: data value too large"];
+
+    // Check server
+    NSMutableDictionary * accountIdToFieldsExpectedOnServer = [NSMutableDictionary new];
+    for (NSString* id in accountIds) {
+        // Only update to account1 should have gone through
+        if ([id isEqualToString:account1Id]) {
+            accountIdToFieldsExpectedOnServer[id] = updatedAccount1Fields;
+        }
+        else {
+            accountIdToFieldsExpectedOnServer[id] = accountIdToFields[id];
+        }
+    }
+    [self checkServer:accountIdToFieldsExpectedOnServer objectType:ACCOUNT_TYPE];
+
+    NSMutableDictionary * contactIdToFieldsExpectedOnServer = [NSMutableDictionary new];
+    for (NSString* id in accountIds) {
+        NSDictionary * contactIdToFields = accountIdContactIdToFields[id];
+        for (NSString* cid in [contactIdToFields allKeys]) {
+            // Only update to contact11 and contact21 should have gone through
+            if ([cid isEqualToString:contact11Id]) {
+                contactIdToFieldsExpectedOnServer[cid] = updatedContact11Fields;
+            } else if ([cid isEqualToString:contact21Id]) {
+                contactIdToFieldsExpectedOnServer[cid] = updatedContact21Fields;
+            } else {
+                contactIdToFieldsExpectedOnServer[cid] = contactIdToFields[cid];
+            }
+        }
+    }
+    [self checkServer:contactIdToFieldsExpectedOnServer objectType:CONTACT_TYPE];
+}
 
 #pragma mark - Helper methods
 
@@ -1828,6 +1915,5 @@ typedef NS_ENUM(NSInteger, SFSyncUpChange) {
                        relationshipType:SFParentChildrenRelationpshipMasterDetail]; // account-contacts are master-detail
     return target;
 }
-
 
 @end

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.h
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.h
@@ -89,6 +89,8 @@
 
 - (void)checkDbSyncIdField:(NSArray *)ids soupName:(NSString *)soupName syncId:(NSNumber*)syncId;
 
+- (void)checkDbLastErrorField:(NSArray *)ids soupName:(NSString *)soupName lastErrorSubString:(NSString*)lastErrorSubString;
+
 - (NSDictionary *)makeSomeLocalChanges:(NSDictionary *)idToFields soupName:(NSString *)soupName;
 - (NSDictionary *)makeSomeLocalChanges:(NSDictionary *)idToFields soupName:(NSString *)soupName idsToUpdate:(NSArray *)idsToUpdate;
 - (NSDictionary *)prepareSomeChanges:(NSDictionary *)idToFields idsToUpdate:(NSArray *)idsToUpdate suffix:(NSString *)suffix;
@@ -111,6 +113,8 @@
 - (NSDictionary *)updateRecordOnServer:(NSDictionary *)fields idToUpdate:(NSString *)idToUpdate objectType:(NSString *)objectType;
 
 - (NSDictionary *)updateRecordLocally:(NSDictionary *)fields idToUpdate:(NSString *)idToUpdate soupName:(NSString *)soupName;
+
+- (NSDictionary *)updateRecordLocally:(NSDictionary *)fields idToUpdate:(NSString *)idToUpdate soupName:(NSString*)soupName suffix:(NSString*)suffix;
 
 - (void)deleteRecordsLocally:(NSArray *)ids soupName:(NSString *)soupName;
 

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.m
@@ -411,6 +411,8 @@ static NSException *authException = nil;
    expectedLocallyUpdated:(bool)expectedLocallyUpdated
    expectedLocallyDeleted:(bool)expectedLocallyDeleted {
 
+    BOOL expectedDirty = expectedLocallyCreated||expectedLocallyUpdated||expectedLocallyDeleted;
+
     // Ids clause
     NSString* idsClause = [self buildInClause:ids];
 
@@ -422,13 +424,18 @@ static NSException *authException = nil;
     XCTAssertEqual(ids.count, rows.count);
     for (NSArray* row in rows) {
         NSDictionary *recordFromDb = row[0];
-        XCTAssertEqualObjects(@(expectedLocallyCreated||expectedLocallyUpdated||expectedLocallyDeleted), recordFromDb[kSyncTargetLocal]);
+        XCTAssertEqualObjects(@(expectedDirty), recordFromDb[kSyncTargetLocal]);
         XCTAssertEqualObjects(@(expectedLocallyCreated), recordFromDb[kSyncTargetLocallyCreated]);
         XCTAssertEqualObjects(@(expectedLocallyUpdated), recordFromDb[kSyncTargetLocallyUpdated]);
         XCTAssertEqualObjects(@(expectedLocallyDeleted), recordFromDb[kSyncTargetLocallyDeleted]);
         NSString* id = recordFromDb[ID];
         bool hasLocalIdPrefix = [id hasPrefix:LOCAL_ID_PREFIX];
         XCTAssertEqual(expectedLocallyCreated, hasLocalIdPrefix);
+
+        // Last error field should be empty for a clean record
+        if (!expectedDirty) {
+            XCTAssertTrue([recordFromDb[kSyncTargetLastError] length] == 0, "Last error should be empty");
+        }
     }
 }
 

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.m
@@ -458,6 +458,26 @@ static NSException *authException = nil;
     }
 }
 
+- (void)checkDbLastErrorField:(NSArray *)ids
+                  soupName:(NSString *)soupName
+        lastErrorSubString:(NSString*)lastErrorSubString {
+
+    // Ids clause
+    NSString* idsClause = [self buildInClause:ids];
+
+    // Query
+    NSString* smartSql = [NSString stringWithFormat:@"SELECT {%@:_soup} FROM {%@} WHERE {%@:Id} IN %@", soupName, soupName, soupName, idsClause];
+
+    SFQuerySpec* query = [SFQuerySpec newSmartQuerySpec:smartSql withPageSize:ids.count];
+    NSArray* rows = [self.store queryWithQuerySpec:query pageIndex:0 error:nil];
+    XCTAssertEqual(ids.count, rows.count);
+    for (NSArray* row in rows) {
+        NSDictionary *recordFromDb = row[0];
+        NSString* lastErrorInDb = recordFromDb[kSyncTargetLastError];
+        XCTAssertTrue([lastErrorInDb containsString:lastErrorSubString]);
+    }
+}
+
 - (NSDictionary *)makeSomeLocalChanges:(NSDictionary *)idToFields soupName:(NSString *)soupName {
     NSArray* allIds = [[idToFields allKeys] sortedArrayUsingSelector:@selector(compare:)];
     return [self makeSomeLocalChanges:idToFields soupName:soupName idsToUpdate:@[allIds[0], allIds[2]]];
@@ -631,8 +651,12 @@ static NSException *authException = nil;
 }
 
 - (NSDictionary *)updateRecordLocally:(NSDictionary *)fields idToUpdate:(NSString *)idToUpdate soupName:(NSString*)soupName {
+    return [self updateRecordLocally:fields idToUpdate:idToUpdate soupName:soupName suffix:LOCALLY_UPDATED];
+}
+
+- (NSDictionary *)updateRecordLocally:(NSDictionary *)fields idToUpdate:(NSString *)idToUpdate soupName:(NSString*)soupName suffix:(NSString*)suffix {
     NSMutableDictionary * idToFieldsLocallyUpdated = [NSMutableDictionary new];
-    NSDictionary* updatedFields = [self updateFields:fields suffix:LOCALLY_UPDATED];
+    NSDictionary* updatedFields = [self updateFields:fields suffix:suffix];
     idToFieldsLocallyUpdated[idToUpdate] = updatedFields;
     [self updateRecordsLocally:idToFieldsLocallyUpdated soupName:soupName];
     return idToFieldsLocallyUpdated;

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -623,7 +623,7 @@
 }
 
 /**
- Test that error are captured on record during sync up
+ Test that errors are captured on record during sync up
  Create a few records - some with bad names (too long or empty)
  Sync up
  Make sure the records with bad names are still marked as locally created and have the last error field populated

--- a/libs/SmartSync/SmartSyncTests/Targets/TestSyncUpTarget.m
+++ b/libs/SmartSync/SmartSyncTests/Targets/TestSyncUpTarget.m
@@ -146,7 +146,7 @@ static NSString * const kTestSyncUpSendSyncUpErrorKey = @"sendSyncUpErrorKey";
         if (self.sendSyncUpError) {
             if (failBlock != NULL) {
                 NSError *syncUpError = [NSError errorWithDomain:kTestSyncUpTargetErrorDomain
-                                                           code:556
+                                                           code:kCFURLErrorCannotConnectToHost // only network error cause the sync to fail
                                                        userInfo:@{ NSLocalizedDescriptionKey: @"RemoteSyncUpError" }];
                 failBlock(syncUpError);
             }


### PR DESCRIPTION
If a record fails to sync up, the server response is saved in a __last_error__ field on the record.
NB: That field will be cleared in subsequent successful sync up

**Also, only network errors will cause a sync up to fail (which was already the behavior on Android but not on iOS).**