### PR TITLE
Adding deprecations for old metadata manager and cache manager

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncCacheManager.h
@@ -24,7 +24,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef  enum {
+typedef enum {
     SFDataCachePolicyIgnoreCacheData = 0, // ignore cache and always load from server
     SFDataCachePolicyReloadAndReturnCacheOnFailure, // Always reload and return cache on failure
     SFDataCachePolicyReturnCacheDataDontReload, // Use cache and don't reload cache if cache exists
@@ -43,27 +43,27 @@ typedef  enum {
 /** Singleton method for accessing cache manager instance.
  @param user A user that will scope this manager instance data
  */
-+ (id)sharedInstance:(SFUserAccount *)user;
++ (id)sharedInstance:(SFUserAccount *)user SFSDK_DEPRECATED(6.2, 7.0, "Use SFSmartSyncSyncManager instead for synching data.");
 
 /** Removes the shared instance associated with the specified user
  @param user The user
  */
-+ (void)removeSharedInstance:(SFUserAccount*)user;
++ (void)removeSharedInstance:(SFUserAccount*)user SFSDK_DEPRECATED(6.2, 7.0, "Use SFSmartSyncSyncManager instead for synching data.");
 
 /** Enable in memory cache. Default value is YES
  @enableInMemoryCache YES to enable in memory cache
  */
-- (void)setEnableInMemoryCache:(BOOL)enableInMemoryCache;
+- (void)setEnableInMemoryCache:(BOOL)enableInMemoryCache SFSDK_DEPRECATED(6.2, 7.0, "Use SFSmartSyncSyncManager instead for synching data.");
 
 /** Clean cache
  */
-- (void)cleanCache;
+- (void)cleanCache SFSDK_DEPRECATED(6.2, 7.0, "Use SFSmartSyncSyncManager instead for synching data.");
 
 /** Remove data from cache
  @param cacheType Cache type
  @param cacheKey Key to use to retrieve cached data
  */
-- (void)removeCache:(NSString *)cacheType cacheKey:(NSString *)cacheKey;
+- (void)removeCache:(NSString *)cacheType cacheKey:(NSString *)cacheKey SFSDK_DEPRECATED(6.2, 7.0, "Use SFSmartSyncSyncManager instead for synching data.");
 
 /** Reurn YES if need to reload cache.
  Before calling this method, user should use `[SFSmartSyncCacheManager readDataWithCacheType:cacheKey:cachePolicy:encrypted:cachedTime]` to find out whether cache exists or not and what is the last time cache is updated
@@ -72,7 +72,7 @@ typedef  enum {
  @param cacheTime Last time cache is updated
  @param refreshIfOlderThan Number of secconds that has to pass in order to refresh cache. Pass any value that is <=0 if you don't want cache to be refrefreshed. This value is used together with `cachePolicy` to determine if cache needs reload or not
  */
-- (BOOL)needToReloadCache:(BOOL)cacheExists cachePolicy:(SFDataCachePolicy)cachePolicy lastCachedTime:(NSDate *)cacheTime refreshIfOlderThan:(NSTimeInterval)refreshIfOlderThan;
+- (BOOL)needToReloadCache:(BOOL)cacheExists cachePolicy:(SFDataCachePolicy)cachePolicy lastCachedTime:(NSDate *)cacheTime refreshIfOlderThan:(NSTimeInterval)refreshIfOlderThan SFSDK_DEPRECATED(6.2, 7.0, "Use SFSmartSyncSyncManager instead for synching data.");
 
 /** Read data from cache.
  @param cacheType Cache type
@@ -85,14 +85,14 @@ typedef  enum {
                           cacheKey:(NSString *)cacheKey
                        cachePolicy:(SFDataCachePolicy)cachePolicy
                         objectClass:(Class)objectClass
-                        cachedTime:(out NSDate *_Nullable*_Nullable)lastCachedTime;
+                        cachedTime:(out NSDate *_Nullable*_Nullable)lastCachedTime SFSDK_DEPRECATED(6.2, 7.0, "Use SFSmartSyncSyncManager instead for synching data.");
 
 /** Write data to cache.
  @param data Data to cache
  @param cacheType Cache type
  @param cacheKey Key to save cached data
  */
-- (void)writeDataToCache:(id)data cacheType:(NSString *)cacheType cacheKey:(NSString *)cacheKey;
+- (void)writeDataToCache:(id)data cacheType:(NSString *)cacheType cacheKey:(NSString *)cacheKey SFSDK_DEPRECATED(6.2, 7.0, "Use SFSmartSyncSyncManager instead for synching data.");
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncMetadataManager.h
@@ -50,27 +50,27 @@ extern NSString * const kSFAllObjectsCacheKey;
  This property is used internally to scope all the search
  queries toward the server.
  */
-@property (nullable, nonatomic, copy) NSString *communityId;
+@property (nullable, nonatomic, copy) NSString *communityId SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** API version being used.
  */
-@property (nonatomic, copy) NSString *apiVersion;
+@property (nonatomic, copy) NSString *apiVersion SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** Cache manager being used.
  */
-@property (nonatomic, strong) SFSmartSyncCacheManager *cacheManager;
+@property (nonatomic, strong) SFSmartSyncCacheManager *cacheManager SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** Singleton method for accessing metadata manager instance.
  @param user A user that will scope this manager instance data
  */
-+ (id)sharedInstance:(SFUserAccount *)user;
++ (id)sharedInstance:(SFUserAccount *)user SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** Removes the shared instance associated with the specified user
  @param user The user
  */
-+ (void)removeSharedInstance:(SFUserAccount*)user;
++ (void)removeSharedInstance:(SFUserAccount*)user SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
-+ (NSString *)globalMruCacheKey;
++ (NSString *)globalMruCacheKey SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** Get a list of smart scope object types
  
@@ -81,7 +81,7 @@ extern NSString * const kSFAllObjectsCacheKey;
  
  */
 - (void)loadSmartScopeObjectTypes:(SFDataCachePolicy)cachePolicy refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan
-                  completionBlock:(void(^)(NSArray *results, BOOL isDataFromCache))completionBlock error:(void(^)(NSError *error))errorBlock;
+                  completionBlock:(void(^)(NSArray *results, BOOL isDataFromCache))completionBlock error:(void(^)(NSError *error))errorBlock SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** Get a list of recently accessed objects by object type
  
@@ -98,7 +98,7 @@ extern NSString * const kSFAllObjectsCacheKey;
 - (void)loadMRUObjects:(nullable NSString *)objectTypeName limit:(NSInteger)limit cachePolicy:(SFDataCachePolicy)cachePolicy
             refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan networkFieldName:(nullable NSString *)networkFieldName
                 inRetry:(BOOL)inRetry completion:(void(^)(NSArray *results, BOOL isDataFromCache, BOOL needToReloadCache))completionBlock
-                    error:(void(^)(NSError *error))errorBlock;
+                    error:(void(^)(NSError *error))errorBlock SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** Load all object types
  
@@ -110,7 +110,7 @@ extern NSString * const kSFAllObjectsCacheKey;
  */
 - (void)loadAllObjectTypes:(SFDataCachePolicy)cachePolicy refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan
                 completion:(void(^)(NSArray * results, BOOL isDataFromCache))completionBlock
-                     error:(void(^)(NSError *error))errorBlock;
+                     error:(void(^)(NSError *error))errorBlock SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** Load a specific object type information
  
@@ -123,7 +123,7 @@ extern NSString * const kSFAllObjectsCacheKey;
  
  */
 - (void)loadObjectType:(NSString *)objectTypeName cachePolicy:(SFDataCachePolicy)cachePolicy refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan
-            completion:(void(^)(SFObjectType *result, BOOL isDataFromCache))completionBlock error:(void(^)(NSError *error))errorBlock;
+            completion:(void(^)(SFObjectType *result, BOOL isDataFromCache))completionBlock error:(void(^)(NSError *error))errorBlock SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** Load object layout information
  
@@ -135,19 +135,19 @@ extern NSString * const kSFAllObjectsCacheKey;
  
  */
 - (void)loadObjectTypesLayout:(NSArray *)objectTypesToLoad cachePolicy:(SFDataCachePolicy)cachePolicy refreshCacheIfOlderThan:(NSTimeInterval)refreshCacheIfOlderThan
-                   completion:(void(^)(NSArray *result, BOOL isDataFromCache))completionBlock error:(void(^)(NSError *error))errorBlock;
+                   completion:(void(^)(NSArray *result, BOOL isDataFromCache))completionBlock error:(void(^)(NSError *error))errorBlock SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** Color for the specific object type
  
  @param objectTypeName Object type name
  */
-- (UIColor *)colorForObjectType:(NSString *)objectTypeName;
+- (UIColor *)colorForObjectType:(NSString *)objectTypeName SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** Return YES if object type is searchable
  
  @param objectType Object type
  */
-- (BOOL)isObjectTypeSearchable:(SFObjectType *)objectType;
+- (BOOL)isObjectTypeSearchable:(SFObjectType *)objectType SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 /** Mark an object as viewed
  
@@ -159,7 +159,7 @@ extern NSString * const kSFAllObjectsCacheKey;
  
  */
 - (void)markObjectAsViewed:(NSString *)objectId objectType:(NSString *)objectType networkFieldName:(nullable NSString *)networkFieldName
-           completionBlock:(void(^)(void))completionBlock error:(void(^)(NSError *error))errorBlock;
+           completionBlock:(void(^)(void))completionBlock error:(void(^)(NSError *error))errorBlock SFSDK_DEPRECATED(6.2, 7.0, "Use SFMetadataSyncManager instead to fetch object metadata, SFLayoutSyncManager instead to fetch object layout data, and SFMruSyncDownTarget instead to fetch object MRU data.");
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Model/SFObjectType.h
+++ b/libs/SmartSync/SmartSync/Classes/Model/SFObjectType.h
@@ -30,28 +30,28 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SFObjectType : SFSmartSyncPersistableObject <NSCoding>
 
 /** Object type key prefix */
-@property (nonatomic, strong, readonly) NSString *keyPrefix;
+@property (nonatomic, strong, readonly) NSString *keyPrefix SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
 
 /** Object name */
-@property (nonatomic, strong, readonly) NSString *name;
+@property (nonatomic, strong, readonly) NSString *name SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
 
 /** Object label */
-@property (nonatomic, strong, readonly) NSString *label;
+@property (nonatomic, strong, readonly) NSString *label SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
 
 /** Object plural label */
-@property (nonatomic, strong, readonly) NSString *labelPlural;
+@property (nonatomic, strong, readonly) NSString *labelPlural SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
 
 /** Object name field */
-@property (nonatomic, strong, readonly, nullable) NSString *nameField;
+@property (nonatomic, strong, readonly, nullable) NSString *nameField SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
 
 /** Fields, array of NSDictionary objects */
-@property (nonatomic, strong, readonly) NSArray *fields;
+@property (nonatomic, strong, readonly) NSArray *fields SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
 
 /** Searchable */
-- (BOOL)isSearchable;
+- (BOOL)isSearchable SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
 
 /** Layoutable */
-- (BOOL)isLayoutable;
+- (BOOL)isLayoutable SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Model/SFObjectTypeLayout.h
+++ b/libs/SmartSync/SmartSync/Classes/Model/SFObjectTypeLayout.h
@@ -29,17 +29,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SFObjectTypeLayout : SFSmartSyncPersistableObject <NSCoding>
 
-@property (nonatomic, strong, readonly) NSNumber *limit;
-@property (nonatomic, strong, readonly) NSArray *columns;
+@property (nonatomic, strong, readonly) NSNumber *limit SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
+@property (nonatomic, strong, readonly) NSArray *columns SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
 
-+ (NSString *)parseColumnName:(NSString *)columnName;
++ (NSString *)parseColumnName:(NSString *)columnName SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
 
 /** Return YES if columns matches including # of columns and column name and order
  
  @columns sourceColumnNames NSArray of column names of NSString type
  @columns targetColumnNames NSArray of column names of NSString type
  */
-+ (BOOL)isMatchColumns:(NSArray *)sourceColumnNames target:(NSArray *)targetColumnNames;
++ (BOOL)isMatchColumns:(NSArray *)sourceColumnNames target:(NSArray *)targetColumnNames SFSDK_DEPRECATED(6.2, 7.0, "Will be removed in Mobile SDK 7.0.");
 
 @end
 


### PR DESCRIPTION
No code changes. Marked the old interfaces deprecated for removal in `Mobile SDK 7.0`.