### PR TITLE
Fixing compilation of ReactNativeTests scheme

### DIFF
--- a/libs/SalesforceReact/SalesforceReact/SalesforceReact-Prefix.pch
+++ b/libs/SalesforceReact/SalesforceReact/SalesforceReact-Prefix.pch
@@ -7,5 +7,6 @@
 #ifdef __OBJC__
     #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>
+    #import <SalesforceSDKCore/SalesforceSDKConstants.h>
     #import "SFSDKReactLogger.h"
 #endif


### PR DESCRIPTION
We've fixed this in the past the same way for `SmartSync` and `SmartStore`.