### PR TITLE
setupGlobal/UserStore/SyncsFromConfig no longer calls getSmartStore if no configs

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.h
@@ -63,6 +63,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void) registerSoups:(SFSmartStore*) store;
 
+/**
+ * Return YES if soups are defined in config
+ * @return
+ */
+- (BOOL)hasSoups;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.m
@@ -75,4 +75,7 @@ static NSString *const kStoreConfigIndexes = @"indexes";
     }
 }
 
+- (BOOL)hasSoups {
+    return self.soupsConfig != nil && self.soupsConfig.count > 0;
+}
 @end

--- a/libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.m
+++ b/libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.m
@@ -57,18 +57,19 @@ SFSDK_USE_DEPRECATED_BEGIN
 - (void) setupGlobalStoreFromDefaultConfig {
     NSString *configPath = [self pathForGlobalStoreConfig];
     [SFSDKSmartStoreLogger d:[self class] format:@"Setting up global store using config found in %@", configPath];
-    [self setupStoreFromConfig:configPath store:[SFSmartStore sharedGlobalStoreWithName:kDefaultSmartStoreName]];
+    SFSDKStoreConfig* storeConfig = [[SFSDKStoreConfig alloc] initWithResourceAtPath:configPath];
+    if ([storeConfig hasSoups]) {
+        [storeConfig registerSoups:[SFSmartStore sharedGlobalStoreWithName:kDefaultSmartStoreName]];
+    }
 }
 
 - (void) setupUserStoreFromDefaultConfig {
     NSString *configPath = [self pathForUserStoreConfig];
     [SFSDKSmartStoreLogger d:[self class] format:@"Setting up user store using config found in %@", configPath];
-    [self setupStoreFromConfig:configPath store:[SFSmartStore sharedStoreWithName:kDefaultSmartStoreName]];
-}
-
-- (void) setupStoreFromConfig:(NSString*)path store:(SFSmartStore *)store {
-    SFSDKStoreConfig* storeConfig = [[SFSDKStoreConfig alloc] initWithResourceAtPath:path];
-    [storeConfig registerSoups:store];
+    SFSDKStoreConfig* storeConfig = [[SFSDKStoreConfig alloc] initWithResourceAtPath:configPath];
+    if ([storeConfig hasSoups]) {
+        [storeConfig registerSoups:[SFSmartStore sharedStoreWithName:kDefaultSmartStoreName]];
+    }
 }
 
 - (NSString*) pathForGlobalStoreConfig {

--- a/libs/SmartSync/SmartSync/Classes/Config/SFSDKSyncsConfig.h
+++ b/libs/SmartSync/SmartSync/Classes/Config/SFSDKSyncsConfig.h
@@ -62,6 +62,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void) createSyncs:(SFSmartStore*) store;
 
+/**
+ * Return YES if syncs are defined in config
+ * @return
+ */
+- (BOOL)hasSyncs;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SmartSync/SmartSync/Classes/Config/SFSDKSyncsConfig.m
+++ b/libs/SmartSync/SmartSync/Classes/Config/SFSDKSyncsConfig.m
@@ -85,4 +85,8 @@ static NSString *const kSyncsConfigTarget = @"target";
     }
 }
 
+- (BOOL)hasSyncs {
+    return self.syncConfigs != nil && self.syncConfigs.count > 0;
+}
+
 @end

--- a/libs/SmartSync/SmartSync/Classes/Manager/SmartSyncSDKManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SmartSyncSDKManager.m
@@ -31,18 +31,19 @@
 - (void) setupGlobalSyncsFromDefaultConfig {
     NSString *configPath = [self pathForGlobalSyncsConfig];
     [SFSDKSmartSyncLogger d:[self class] format:@"Setting up global syncs using config found in %@", configPath];
-    [self setupSyncsFromConfig:configPath store:[SFSmartStore sharedGlobalStoreWithName:kDefaultSmartStoreName]];
+    SFSDKSyncsConfig* syncsConfig = [[SFSDKSyncsConfig alloc] initWithResourceAtPath:configPath];
+    if ([syncsConfig hasSyncs]) {
+        [syncsConfig createSyncs:[SFSmartStore sharedGlobalStoreWithName:kDefaultSmartStoreName]];
+    }
 }
 
 - (void) setupUserSyncsFromDefaultConfig {
     NSString *configPath = [self pathForUserSyncsConfig];
     [SFSDKSmartSyncLogger d:[self class] format:@"Setting up user syncs using config found in %@", configPath];
-    [self setupSyncsFromConfig:configPath store:[SFSmartStore sharedStoreWithName:kDefaultSmartStoreName]];
-}
-
-- (void) setupSyncsFromConfig:(NSString*)path store:(SFSmartStore *)store {
-    SFSDKSyncsConfig* syncsConfig = [[SFSDKSyncsConfig alloc] initWithResourceAtPath:path];
-    [syncsConfig createSyncs:store];
+    SFSDKSyncsConfig* syncsConfig = [[SFSDKSyncsConfig alloc] initWithResourceAtPath:configPath];
+    if ([syncsConfig hasSyncs]) {
+        [syncsConfig createSyncs:[SFSmartStore sharedStoreWithName:kDefaultSmartStoreName]];
+    }
 }
 
 - (NSString*) pathForGlobalSyncsConfig {


### PR DESCRIPTION
setupGlobal/UserStore/SyncsFromConfig no longer calls getSmartStore or getGlobalSmartStore if there is no config (or if it's empty).