### PR TITLE
Making pre-frontdoor cookie cleanup configurable

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.h
@@ -159,6 +159,16 @@ typedef void (^SFOAuthPluginAuthSuccessBlock)(SFOAuthInfo *_Nullable, NSDictiona
  */
 - (void)configureRemoteStartPage;
 
+/**
+ Initiates a web state cleanup strategy prior to staging the web-based auth context from an
+ OAuth authentication or refresh.
+ 
+ Default behavior is to remove all of the web view cookies from .salesforce.com and .force.com
+ domains.  Override this method if you wish to establish a different web state prior to the
+ web-based auth context setup.
+ */
+- (void)webStateCleanupStrategy;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -262,7 +262,8 @@ SFSDK_USE_DEPRECATED_BEGIN
 
     // Remote app. Device is online.
     if ([self userIsAuthenticated]) {
-        [SFSDKWebViewStateManager resetSessionCookie];
+        [SFSDKHybridLogger i:[self class] format:@"[%@ %@]: Initiating web state cleanup strategy before loading start page.", NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+        [self webStateCleanupStrategy];
     }
     [self configureRemoteStartPage];
     [super viewDidLoad];
@@ -543,6 +544,12 @@ SFSDK_USE_DEPRECATED_BEGIN
     startPageConfigured = YES;
 }
 
+- (void)webStateCleanupStrategy
+{
+    [SFSDKHybridLogger i:[self class] format:@"[%@ %@]: resetting session cookies.", NSStringFromClass([self class]), NSStringFromSelector(_cmd)];
+    [SFSDKWebViewStateManager resetSessionCookie];
+}
+
 - (BOOL)userIsAuthenticated
 {
     return ([SFUserAccountManager sharedInstance].currentUser.credentials.accessToken.length > 0);
@@ -813,7 +820,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 - (void)authenticationCompletion:(NSString *)originalUrl authInfo:(SFOAuthInfo *)authInfo
 {
     [SFSDKHybridLogger d:[self class] message:@"authenticationCompletion:authInfo: - Initiating post-auth configuration."];
-    [SFSDKWebViewStateManager resetSessionCookie];
+    [self webStateCleanupStrategy];
 
     // If there's an original URL, load it through frontdoor.
     if (originalUrl != nil) {


### PR DESCRIPTION
@bhariharan These are the changes we discussed.  Just pulling out the hybrid view's cookie cleanup to an overridable method.