### PR TITLE
Call completion if the window is already presented.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -345,7 +345,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
         [self.config.safariViewDelegate authClient:self willBeginBrowserAuthentication:callbackBlock];
     }
     
-    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];;
+    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]?:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
     NSString *alertMessage = [NSString stringWithFormat:[SFSDKResourceUtils localizedString:@"authAlertBrowserFlowMessage"], coordinator.credentials.domain, appName];
     
      __weak typeof(self) weakSelf = self;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
@@ -303,7 +303,10 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
         });
         return;
     }
-    if (!window.isEnabled) return;
+    if (!window.isEnabled) {
+        if (completion)
+            completion();
+    }
     
     [self enumerateDelegates:^(id<SFSDKWindowManagerDelegate> delegate) {
         if ([delegate respondsToSelector:@selector(windowManager:willDismissWindow:)]){
@@ -355,15 +358,19 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
 }
 
 - (void)makeOpaqueWithCompletion:(SFSDKWindowContainer *)window completion:(void (^)(void))completion {
-    if ([window isEnabled]) return;
-    
     if (window.isSnapshotWindow) {
         SFSDKWindowContainer *activeWindow = [self activeWindow];
-       
         if (![activeWindow isSnapshotWindow]){
             _lastActiveWindow = activeWindow;
         }
     }
+    
+    if ([window isEnabled]) {
+        if (completion)
+            completion();
+        return;
+    }
+    
     [window.window makeKeyAndVisible];
     [self enumerateDelegates:^(id<SFSDKWindowManagerDelegate> delegate) {
         if ([delegate respondsToSelector:@selector(windowManager:didPresentWindow:)]){


### PR DESCRIPTION
@wmathurin The RestApiExplorer bug was caused because the window was already active and the completion block was not being invoked. It should not be a no-op.