### PR TITLE
Avoid unnecessary creation of background NSURLSession configs

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator.m
@@ -136,7 +136,7 @@ static NSString * const kSFIdentityDataPropertyKey            = @"com.salesforce
     [request setHTTPShouldHandleCookies:NO];
     [SFSDKCoreLogger d:[self class] format:@"SFIdentityCoordinator:Starting identity request at %@", self.credentials.identityUrl.absoluteString];
     __weak __typeof(self) weakSelf = self;
-    SFNetwork *network = [[SFNetwork alloc] init];
+    SFNetwork *network = [[SFNetwork alloc] initWithEphemeralSession];
     self.session = network.activeSession;
     [network sendRequest:request dataResponseBlock:^(NSData *data, NSURLResponse *response, NSError *error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -931,7 +931,7 @@ static NSString * const kSFECParameter = @"ec";
 
 - (NSURLSession*)session {
     if (_session == nil) {
-        SFNetwork *network = [[SFNetwork alloc] init];
+        SFNetwork *network = [[SFNetwork alloc] initWithEphemeralSession];
         _session = network.activeSession;
     }
     return _session;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -525,7 +525,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
         NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
         [request setHTTPMethod:@"GET"];
         [request setHTTPShouldHandleCookies:NO];
-        SFNetwork *network = [[SFNetwork alloc] init];
+        SFNetwork *network = [[SFNetwork alloc] initWithEphemeralSession];
         [network sendRequest:request dataResponseBlock:nil];
     }
     [credentials revoke];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.h
@@ -28,12 +28,28 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "SalesforceSDKConstants.h"
 
 @interface SFNetwork : NSObject
 
 typedef void (^SFDataResponseBlock) (NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error);
 
-@property (nonatomic, readwrite, assign) BOOL useBackground;
+@property (nonatomic, readonly, assign) BOOL useBackground;
+@property (nonatomic, readonly, strong, nonnull) NSURLSession *activeSession;
+
+/**
+ * Initializes this class with an ephemeral session configuration.
+ *
+ * @return Instance of this class.
+ */
+- (nonnull instancetype)initWithEphemeralSession;
+
+/**
+ * Initializes this class with a background session configuration.
+ *
+ * @return Instance of this class.
+ */
+- (nonnull instancetype)initWithBackgroundSession;
 
 /**
  * Sends a REST request and calls the appropriate completion block.
@@ -45,18 +61,18 @@ typedef void (^SFDataResponseBlock) (NSData * _Nullable data, NSURLResponse * _N
 - (nonnull NSURLSessionDataTask *)sendRequest:(nonnull NSURLRequest *)urlRequest dataResponseBlock:(nullable SFDataResponseBlock)dataResponseBlock;
 
 /**
- * Returns the current NSURLSession instance being used.
- *
- * @return NSURLSession instance.
- */
-- (nonnull NSURLSession *)activeSession;
-
-/**
  * Sets a session configuration to be used for network requests in the Mobile SDK.
  *
  * @param sessionConfig Session configuration to be used.
  * @param isBackgroundSession YES - if it is a background session configuration, NO - otherwise.
  */
-+ (void)setSessionConfiguration:(nonnull NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession;
++ (void)setSessionConfiguration:(nonnull NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession SFSDK_DEPRECATED(6.2, 7.0, "Use 'setSessionConfiguration:' instead.");
+
+/**
+ * Sets a session configuration to be used for network requests in the Mobile SDK.
+ *
+ * @param sessionConfig Session configuration to be used.
+ */
++ (void)setSessionConfiguration:(nonnull NSURLSessionConfiguration *)sessionConfig;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
@@ -31,6 +31,7 @@
 
 @interface SFNetwork()
 
+@property (nonatomic, readwrite, assign) BOOL useBackground;
 @property (nonatomic, readwrite, strong) NSURLSession *activeSession;
 
 @end
@@ -49,6 +50,7 @@ static NSURLSessionConfiguration *kSFSessionConfig;
         self.activeSession = [NSURLSession sessionWithConfiguration:ephemeralSessionConfig];
         self.useBackground = NO;
     }
+    return self;
 }
 
 - (instancetype)initWithBackgroundSession {
@@ -59,9 +61,10 @@ static NSURLSessionConfiguration *kSFSessionConfig;
         if (kSFSessionConfig) {
             backgroundSessionConfig = kSFSessionConfig;
         }
-        self.backgroundSession = [NSURLSession sessionWithConfiguration:backgroundSessionConfig];
+        self.activeSession = [NSURLSession sessionWithConfiguration:backgroundSessionConfig];
         self.useBackground = YES;
     }
+    return self;
 }
 
 - (NSURLSessionDataTask *)sendRequest:(NSURLRequest *)urlRequest dataResponseBlock:(SFDataResponseBlock)dataResponseBlock {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
@@ -31,38 +31,41 @@
 
 @interface SFNetwork()
 
-@property (nonatomic, readwrite, strong, nonnull) NSURLSession *ephemeralSession;
-@property (nonatomic, readwrite, strong, nonnull) NSURLSession *backgroundSession;
+@property (nonatomic, readwrite, strong) NSURLSession *activeSession;
 
 @end
 
 @implementation SFNetwork
 
-static NSURLSessionConfiguration *kSFEphemeralSessionConfig;
-static NSURLSessionConfiguration *kSFBackgroundSessionConfig;
+static NSURLSessionConfiguration *kSFSessionConfig;
 
-- (instancetype)init {
+- (instancetype)initWithEphemeralSession {
     self = [super init];
     if (self) {
         NSURLSessionConfiguration *ephemeralSessionConfig = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-        if (kSFEphemeralSessionConfig) {
-            ephemeralSessionConfig = kSFEphemeralSessionConfig;
+        if (kSFSessionConfig) {
+            ephemeralSessionConfig = kSFSessionConfig;
         }
-        self.ephemeralSession = [NSURLSession sessionWithConfiguration:ephemeralSessionConfig];
-        
-        NSString *identifier = [NSString stringWithFormat:@"com.salesforce.network.%lu", (unsigned long)self.hash];
-        NSURLSessionConfiguration *backgroundSessionConfig = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:identifier];
-        if (kSFBackgroundSessionConfig) {
-            backgroundSessionConfig = kSFBackgroundSessionConfig;
-        }
-        self.backgroundSession = [NSURLSession sessionWithConfiguration:backgroundSessionConfig];
+        self.activeSession = [NSURLSession sessionWithConfiguration:ephemeralSessionConfig];
         self.useBackground = NO;
     }
-    return self;
 }
 
-- (NSURLSessionDataTask *)sendRequest:(nonnull NSURLRequest *)urlRequest dataResponseBlock:(nullable SFDataResponseBlock)dataResponseBlock {
-    NSURLSessionDataTask *dataTask = [[self activeSession] dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+- (instancetype)initWithBackgroundSession {
+    self = [super init];
+    if (self) {
+        NSString *identifier = [NSString stringWithFormat:@"com.salesforce.network.%lu", (unsigned long)self.hash];
+        NSURLSessionConfiguration *backgroundSessionConfig = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:identifier];
+        if (kSFSessionConfig) {
+            backgroundSessionConfig = kSFSessionConfig;
+        }
+        self.backgroundSession = [NSURLSession sessionWithConfiguration:backgroundSessionConfig];
+        self.useBackground = YES;
+    }
+}
+
+- (NSURLSessionDataTask *)sendRequest:(NSURLRequest *)urlRequest dataResponseBlock:(SFDataResponseBlock)dataResponseBlock {
+    NSURLSessionDataTask *dataTask = [self.activeSession dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (dataResponseBlock) {
             dataResponseBlock(data, response, error);
         }
@@ -71,16 +74,12 @@ static NSURLSessionConfiguration *kSFBackgroundSessionConfig;
     return dataTask;
 }
 
-- (NSURLSession *)activeSession {
-    return (self.useBackground ? self.backgroundSession : self.ephemeralSession);
++ (void)setSessionConfiguration:(NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession {
+    [SFNetwork setSessionConfiguration:sessionConfig];
 }
 
-+ (void)setSessionConfiguration:(NSURLSessionConfiguration *)sessionConfig isBackgroundSession:(BOOL)isBackgroundSession {
-    if (isBackgroundSession) {
-        kSFBackgroundSessionConfig = sessionConfig;
-    } else {
-        kSFEphemeralSessionConfig = sessionConfig;
-    }
++ (void)setSessionConfiguration:(NSURLSessionConfiguration *)sessionConfig {
+    kSFSessionConfig = sessionConfig;
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -248,7 +248,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
     __weak __typeof(self) weakSelf = self;
     NSURLRequest *finalRequest = [request prepareRequestForSend:self.user];
     if (finalRequest) {
-        SFNetwork *network = [[SFNetwork alloc] init];
+        SFNetwork *network = [[SFNetwork alloc] initWithEphemeralSession];
         NSURLSessionDataTask *dataTask = [network sendRequest:finalRequest dataResponseBlock:^(NSData *data, NSURLResponse *response, NSError *error) {
             __strong typeof(weakSelf) strongSelf = weakSelf;
             if (error) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -724,7 +724,7 @@ static Class InstanceClass = nil;
         NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
         [request setHTTPMethod:@"GET"];
         [request setHTTPShouldHandleCookies:NO];
-        SFNetwork *network = [[SFNetwork alloc] init];
+        SFNetwork *network = [[SFNetwork alloc] initWithEphemeralSession];
         [network sendRequest:request dataResponseBlock:nil];
     }
     [user.credentials revoke];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
@@ -37,7 +37,7 @@ static NSString * const kSFOAuthEndPointAuthConfiguration = @"/.well-known/auth-
     NSString *orgConfigUrl = [NSString stringWithFormat:@"%@://%@%@", oauthCredentials.protocol, oauthCredentials.domain, kSFOAuthEndPointAuthConfiguration];
     [SFSDKCoreLogger d:[self class] format:@"%@ Advanced authentication configured. Retrieving auth configuration from %@", NSStringFromSelector(_cmd), orgConfigUrl];
     NSMutableURLRequest *orgConfigRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:orgConfigUrl]];
-    SFNetwork *network = [[SFNetwork alloc] init];
+    SFNetwork *network = [[SFNetwork alloc] initWithEphemeralSession];
     __weak __typeof(self) weakSelf = self;
     [network sendRequest:orgConfigRequest dataResponseBlock:^(NSData *data, NSURLResponse *response, NSError *error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;


### PR DESCRIPTION
We were unnecessarily creating background sessions with unique identifiers. This decouples ephemeral sessions from background sessions and creates background sessions only if it has explicitly been asked for.