### PR TITLE
Updating CocoaLumberjack version

### DIFF
--- a/SalesforceAnalytics.podspec
+++ b/SalesforceAnalytics.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.subspec 'SalesforceAnalytics' do |sdkanalytics|
 
-      sdkanalytics.dependency 'CocoaLumberjack', '~> 2.4.0'
+      sdkanalytics.dependency 'CocoaLumberjack', '~> 3.4.0'
       sdkanalytics.source_files = 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/**/*.{h,m}', 'libs/SalesforceAnalytics/SalesforceAnalytics/SalesforceAnalytics.h'
       sdkanalytics.public_header_files = 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Util/NSUserDefaults+SFAdditions.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Transform/SFSDKAILTNTransform.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Util/SFSDKAnalyticsLogger.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Manager/SFSDKAnalyticsManager.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Util/SFSDKDatasharingHelper.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Model/SFSDKDeviceAppAttributes.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKFileLogger.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Model/SFSDKInstrumentationEvent.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Model/SFSDKInstrumentationEventBuilder.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Util/SFSDKReachability.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Transform/SFSDKTransform.h', 'libs/SalesforceAnalytics/SalesforceAnalytics/SalesforceAnalytics.h'
       sdkanalytics.prefix_header_contents = '#import "SFSDKAnalyticsLogger.h"'


### PR DESCRIPTION
Currently the project uses a CocoaLumberjack version that produces some warnings at build time. Those issues have been fixed in newer versions of CocoaLumberjack library.
I suggest updating the version to one that does not produce warnings.
![screen shot 2018-06-13 at 13 45 22](https://user-images.githubusercontent.com/24604564/41349834-6b93ed9e-6f11-11e8-9eea-7ce5476af99e.png)

