### PR TITLE
Consistent indexing of booleans (between iOS and Android) in SmartStore

### DIFF
--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.h
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.h
@@ -40,6 +40,7 @@
 #define kName                 @"name"
 #define kEducation            @"education"
 #define kBuilding             @"building"
+#define kIsManager            @"isManager"
 
 @interface SFSmartSqlTests : SFSmartStoreTestCase
 - (SFUserAccount*) createUserAccount;

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.h
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.h
@@ -63,4 +63,5 @@
 - (void) testSmartQueryReturningSoupStringAndInteger;
 - (void) testSmartQueryWithPaging;
 - (void) testSmartQueryWithSpecialFields;
+- (void) testSmartQueryMatchingNullField;
 @end

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlWithExternalStorageTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlWithExternalStorageTests.m
@@ -149,4 +149,15 @@
 {
     [super testSmartQueryWithSpecialFields];
 }
+
+- (void) testSmartQueryMatchingNullField
+{
+    [super testSmartQueryMatchingNullField];
+}
+
+- (void) testSmartQueryMachingBooleanInJSON1Field
+{
+    // Doesn't apply to external storage case
+}
+
 @end


### PR DESCRIPTION
No code change.
Just a test demonstrating how to proceed:
- index the field as a JSON1 field
- in SmartSql look for 0 (false) or 1 (true) because SQLite does not have a separate Boolean storage class. Instead, Boolean values are stored as integers 0 (false) and 1 (true).