### PR TITLE
Adding guards to prevent creation of quasi singletons during logout

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -74,7 +74,7 @@ static NSMutableDictionary *analyticsManagerList = nil;
         id analyticsMgr = analyticsManagerList[key];
         if (!analyticsMgr) {
             if (userAccount.loginState != SFUserAccountLoginStateLoggedIn) {
-                [SFSDKCoreLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state inorder to create a SFSDKSalesforceAnalyticsManager instance for a user.", NSStringFromSelector(_cmd)];
+                [SFSDKCoreLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state in order to create a SFSDKSalesforceAnalyticsManager instance for a user.", NSStringFromSelector(_cmd)];
                 return nil;
             }
             analyticsMgr = [[self alloc] initWithUser:userAccount];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -73,6 +73,10 @@ static NSMutableDictionary *analyticsManagerList = nil;
         }
         id analyticsMgr = analyticsManagerList[key];
         if (!analyticsMgr) {
+            if (userAccount.loginState != SFUserAccountLoginStateLoggedIn) {
+                [SFSDKCoreLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state inorder to create a SFSDKSalesforceAnalyticsManager instance for a user.", NSStringFromSelector(_cmd)];
+                return nil;
+            }
             analyticsMgr = [[self alloc] initWithUser:userAccount];
             analyticsManagerList[key] = analyticsMgr;
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -130,6 +130,10 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
         }
         id sfRestApi = [sfRestApiList objectForKey:key];
         if (!sfRestApi) {
+            if (user.loginState != SFUserAccountLoginStateLoggedIn) {
+                [SFSDKCoreLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state inorder to create a SFRestAPI instance for a user.", NSStringFromSelector(_cmd)];
+                return nil;
+            }
             sfRestApi = [[SFRestAPI alloc] initWithUser:user];
             [sfRestApiList setObject:sfRestApi forKey:key];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -131,7 +131,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
         id sfRestApi = [sfRestApiList objectForKey:key];
         if (!sfRestApi) {
             if (user.loginState != SFUserAccountLoginStateLoggedIn) {
-                [SFSDKCoreLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state inorder to create a SFRestAPI instance for a user.", NSStringFromSelector(_cmd)];
+                [SFSDKCoreLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state in order to create a SFRestAPI instance for a user.", NSStringFromSelector(_cmd)];
                 return nil;
             }
             sfRestApi = [[SFRestAPI alloc] initWithUser:user];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -27,6 +27,7 @@
 #import "SFRestAPI+Internal.h"
 #import "SFRestRequest+Internal.h"
 #import "SFNativeRestRequestListener.h"
+#import "SFUserAccount+Internal.h"
  
  // Constants only used in the tests below
 #define ENTITY_PREFIX_NAME @"RestClientTestsiOS"
@@ -1243,6 +1244,7 @@ static NSException *authException = nil;
         origCreds.accessToken = origAccessToken;
         origCreds.refreshToken = origRefreshToken;
         _currentUser.credentials = origCreds;
+        [_currentUser transitionToLoginState:SFUserAccountLoginStateLoggedIn];
         [[SFUserAccountManager sharedInstance] saveAccountForUser:_currentUser error:nil];
         [SFUserAccountManager sharedInstance].currentUser = _currentUser;
     }
@@ -1365,6 +1367,7 @@ static NSException *authException = nil;
         origCreds.accessToken = origAccessToken;
         origCreds.refreshToken = origRefreshToken;
         _currentUser.credentials = origCreds;
+        [_currentUser transitionToLoginState:SFUserAccountLoginStateLoggedIn];
         [[SFUserAccountManager sharedInstance] saveAccountForUser:_currentUser error:nil];
         [SFUserAccountManager sharedInstance].currentUser = _currentUser;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
@@ -30,6 +30,7 @@
 #import "SFUserAccountManager+Internal.h"
 #import "SFSDKSalesforceAnalyticsManager.h"
 #import "SFSDKAppConfig.h"
+#import "SFUserAccount+Internal.h"
 
 static NSTimeInterval const kTimeDelaySecsBetweenLaunchSteps = 0.5;
 static NSString* const kTestAppName = @"OverridenAppName";

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
@@ -514,6 +514,7 @@ SFSDK_USE_DEPRECATED_END
     NSString *userId = [NSString stringWithFormat:@"user_%u", userIdentifier];
     NSString *orgId = [NSString stringWithFormat:@"org_%u", userIdentifier];
     user.credentials.identityUrl = [NSURL URLWithString:[NSString stringWithFormat:@"https://login.salesforce.com/id/%@/%@", orgId, userId]];
+    [user transitionToLoginState:SFUserAccountLoginStateLoggedIn];
     NSError *error = nil;
     [[SFUserAccountManager sharedInstance] saveAccountForUser:user error:&error];
     XCTAssertNil(error, @"Should be able to create user account");

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -323,7 +323,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
         SFSmartStore *store = _allSharedStores[userKey][storeName];
         if (nil == store) {
             if (user.loginState != SFUserAccountLoginStateLoggedIn) {
-                [SFSDKSmartStoreLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state inorder to create a store.", NSStringFromSelector(_cmd), storeName, NSStringFromClass(self)];
+                [SFSDKSmartStoreLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state in order to create a store.", NSStringFromSelector(_cmd), storeName, NSStringFromClass(self)];
                 return nil;
             }
             store = [[self alloc] initWithName:storeName user:user];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -322,6 +322,10 @@ NSString *const EXPLAIN_ROWS = @"rows";
         }
         SFSmartStore *store = _allSharedStores[userKey][storeName];
         if (nil == store) {
+            if (user.loginState != SFUserAccountLoginStateLoggedIn) {
+                [SFSDKSmartStoreLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state inorder to create a store.", NSStringFromSelector(_cmd), storeName, NSStringFromClass(self)];
+                return nil;
+            }
             store = [[self alloc] initWithName:storeName user:user];
             if (store)
                 _allSharedStores[userKey][storeName] = store;

--- a/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
@@ -101,6 +101,7 @@
     NSString *orgId = [NSString stringWithFormat:@"org_%u", userIdentifier];
     user.credentials.identityUrl = [NSURL URLWithString:[NSString stringWithFormat:@"https://login.salesforce.com/id/%@/%@", orgId, userId]];
     NSError *error = nil;
+    [user transitionToLoginState:SFUserAccountLoginStateLoggedIn];
     [[SFUserAccountManager sharedInstance] saveAccountForUser:user error:&error];
      XCTAssertNil(error);
     [SFUserAccountManager sharedInstance].currentUser = user;

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
@@ -84,7 +84,9 @@
     NSString *userId = [NSString stringWithFormat:@"user_%u", userIdentifier];
     NSString *orgId = [NSString stringWithFormat:@"org_%u", userIdentifier];
     user.credentials.identityUrl = [NSURL URLWithString:[NSString stringWithFormat:@"https://test.salesforce.com/id/%@/%@", orgId, userId]];
+    [user transitionToLoginState:SFUserAccountLoginStateLoggedIn];
     NSError *error = nil;
+    [user transitionToLoginState:SFUserAccountLoginStateLoggedIn];
     [[SFUserAccountManager sharedInstance] saveAccountForUser:user error:&error];
     XCTAssertNil(error);
    

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.h
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.h
@@ -27,6 +27,10 @@
 #import "FMResultSet.h"
 #import <SalesforceSDKCore/SFUserAccountManager.h>
 
+@interface SFUserAccount(SmartStoreTest)
+- (BOOL)transitionToLoginState:(SFUserAccountLoginState)newLoginState;
+@end
+
 @interface SFSmartStoreTestCase : XCTestCase
 
 - (void) assertSameJSONWithExpected:(id)expected actual:(id) actual message:(NSString*) message;

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
@@ -344,7 +344,7 @@
     NSString *userId = [NSString stringWithFormat:@"user_%u", userIdentifier];
     NSString *orgId = [NSString stringWithFormat:@"org_%u", userIdentifier];
     user.credentials.identityUrl = [NSURL URLWithString:[NSString stringWithFormat:@"https://login.salesforce.com/id/%@/%@", orgId, userId]];
-
+    [user transitionToLoginState:SFUserAccountLoginStateLoggedIn];
     NSError *error = nil;
     [[SFUserAccountManager sharedInstance] saveAccountForUser:user error:&error];
     XCTAssertNil(error);

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -85,6 +85,10 @@ static NSMutableDictionary *syncMgrList = nil;
         NSString *key = [SFSmartSyncSyncManager keyForStore:store];
         id syncMgr = [syncMgrList objectForKey:key];
         if (syncMgr == nil) {
+            if (store.user && store.user.loginState != SFUserAccountLoginStateLoggedIn) {
+                [SFSDKSmartSyncLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state inorder to create a sync for a user store.", NSStringFromSelector(_cmd), store.storeName, NSStringFromClass(self)];
+                return nil;
+            }
             syncMgr = [[self alloc] initWithStore:store];
             syncMgrList[key] = syncMgr;
         }
@@ -94,7 +98,12 @@ static NSMutableDictionary *syncMgrList = nil;
 }
 
 + (void)removeSharedInstance:(SFUserAccount*)user {
-    [self removeSharedInstanceForUser:user storeName:nil];
+     for (NSString *key in [syncMgrList allKeys]) {
+         // remove all user related sync managers
+         if ([self isUserRelatedSync:key user:user]) {
+             [self removeSharedInstanceForKey:key];
+         }
+     }
 }
 
 + (void)removeSharedInstanceForUser:(SFUserAccount *)user storeName:(NSString *)storeName {
@@ -131,7 +140,10 @@ static NSMutableDictionary *syncMgrList = nil;
     return [NSString  stringWithFormat:@"%@-%@", keyPrefix, storeName];
 }
 
-
++ (BOOL)isUserRelatedSync:(NSString*)key user:(SFUserAccount*)user {
+    NSString* userPrefix = SFKeyForUserAndScope(user, SFUserAccountScopeCommunity);
+    return ([key rangeOfString:userPrefix].location != NSNotFound );
+}
 
 #pragma mark - init / dealloc
 

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -86,7 +86,7 @@ static NSMutableDictionary *syncMgrList = nil;
         id syncMgr = [syncMgrList objectForKey:key];
         if (syncMgr == nil) {
             if (store.user && store.user.loginState != SFUserAccountLoginStateLoggedIn) {
-                [SFSDKSmartSyncLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state inorder to create a sync for a user store.", NSStringFromSelector(_cmd), store.storeName, NSStringFromClass(self)];
+                [SFSDKSmartSyncLogger w:[self class] format:@"%@ A user account must be in the  SFUserAccountLoginStateLoggedIn state in order to create a sync for a user store.", NSStringFromSelector(_cmd), store.storeName, NSStringFromClass(self)];
                 return nil;
             }
             syncMgr = [[self alloc] initWithStore:store];


### PR DESCRIPTION
@wmathurin  @bhariharan Please review. Some of the quasi-singleton objects that are keyed to the user, can get inadvertently recreated on-demand during the logout process. This will lead to some awkward behavior with stores and syncs. This PR simply adds a guard to allow creation of these object instances only when user is in a logged in state.