### PR TITLE
Using Mobile SDK user agent for login and oauth requests

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -355,7 +355,7 @@ static NSString * const kSFECParameter = @"ec";
         _view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
          _view.clipsToBounds = YES;
         _view.translatesAutoresizingMaskIntoConstraints = NO;
-        
+        _view.customUserAgent = [SalesforceSDKManager sharedManager].userAgentString(@"");
         _view.UIDelegate = self;
     }
     return _view;
@@ -368,9 +368,6 @@ static NSString * const kSFECParameter = @"ec";
 {
     self.authenticating = NO;
     self.advancedAuthState = SFOAuthAdvancedAuthStateNotStarted;
-    if (info.authType == SFOAuthTypeUserAgent) {
-        [self resetWebUserAgent];
-    }
     if ([self.delegate respondsToSelector:@selector(oauthCoordinator:didFailWithError:authInfo:)]) {
         [self.delegate oauthCoordinator:self didFailWithError:error authInfo:info];
     } else if ([self.delegate respondsToSelector:@selector(oauthCoordinator:didFailWithError:)]) {
@@ -386,9 +383,6 @@ static NSString * const kSFECParameter = @"ec";
 {
     self.authenticating = NO;
     self.advancedAuthState = SFOAuthAdvancedAuthStateNotStarted;
-    if (authInfo.authType == SFOAuthTypeUserAgent) {
-        [self resetWebUserAgent];
-    }
     if ([self.delegate respondsToSelector:@selector(oauthCoordinatorDidAuthenticate:authInfo:)]) {
         [self.delegate oauthCoordinatorDidAuthenticate:self authInfo:authInfo];
     } else if ([self.delegate respondsToSelector:@selector(oauthCoordinatorDidAuthenticate:)]) {
@@ -472,8 +466,6 @@ static NSString * const kSFECParameter = @"ec";
         return;
     }
     
-    [self configureWebUserAgent];
-
     self.initialRequestLoaded = NO;
     
     // notify delegate will be begin authentication in our (web) vew
@@ -885,32 +877,6 @@ static NSString * const kSFECParameter = @"ec";
         self.credentials.additionalOAuthFields = parsedValues;
     }
 
-}
-
-- (void)configureWebUserAgent
-{
-    if (self.userAgentForAuth != nil) {
-        NSString *origWebUserAgent = [[NSUserDefaults msdkUserDefaults] objectForKey:kOAuthUserAgentUserDefaultsKey];
-        if (origWebUserAgent != nil) {
-            self.origWebUserAgent = origWebUserAgent;
-        }
-        
-        NSDictionary *userAgentDict = @{ kOAuthUserAgentUserDefaultsKey: self.userAgentForAuth };
-        [[NSUserDefaults msdkUserDefaults] registerDefaults:userAgentDict];
-    }
-}
-
-- (void)resetWebUserAgent
-{
-    if (self.userAgentForAuth != nil) {
-        // If the current web user agent has not changed from the one we set, reset it.  Otherwise, assume it's
-        // already been altered out of band, and we shouldn't touch it.
-        NSString *currentWebUserAgent = [[NSUserDefaults msdkUserDefaults] objectForKey:kOAuthUserAgentUserDefaultsKey];
-        if ([currentWebUserAgent isEqualToString:self.userAgentForAuth] && self.origWebUserAgent != nil) {
-            NSDictionary *userAgentDict = @{ kOAuthUserAgentUserDefaultsKey: self.origWebUserAgent };
-            [[NSUserDefaults msdkUserDefaults] registerDefaults:userAgentDict];
-        }
-    }
 }
 
 + (NSString *)advancedAuthStateDesc:(SFOAuthAdvancedAuthState)authState

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
@@ -28,6 +28,7 @@
  */
 
 #import "SFNetwork.h"
+#import "SalesforceSDKManager.h"
 
 @interface SFNetwork()
 
@@ -67,7 +68,12 @@ static NSURLSessionConfiguration *kSFSessionConfig;
     return self;
 }
 
-- (NSURLSessionDataTask *)sendRequest:(NSURLRequest *)urlRequest dataResponseBlock:(SFDataResponseBlock)dataResponseBlock {
+- (NSURLSessionDataTask *)sendRequest:(NSMutableURLRequest *)urlRequest dataResponseBlock:(SFDataResponseBlock)dataResponseBlock {
+    // Sets Mobile SDK user agent if it hasn't been set already elsewhere.
+    if (![urlRequest.allHTTPHeaderFields.allKeys containsObject:@"User-Agent"]) {
+        [urlRequest setValue:[SalesforceSDKManager sharedManager].userAgentString(@"") forHTTPHeaderField:@"User-Agent"];
+    }
+
     NSURLSessionDataTask *dataTask = [self.activeSession dataTaskWithRequest:urlRequest completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (dataResponseBlock) {
             dataResponseBlock(data, response, error);

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -76,9 +76,6 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
         self.apiVersion = kSFRestDefaultAPIVersion;
         self.sessionRefreshInProgress = NO;
         self.pendingRequestsBeingProcessed = NO;
-        if (!kIsTestRun) {
-            [SFSDKWebUtils configureUserAgent:[SFRestAPI userAgentString]];
-        }
         [[SFAuthenticationManager sharedManager] addDelegate:self];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserDidLogout:)  name:kSFNotificationUserDidLogout object:nil];
     }
@@ -192,11 +189,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 }
 
 + (NSString *)userAgentString:(NSString*)qualifier {
-    NSString *returnString = @"";
-    if ([SalesforceSDKManager sharedManager].userAgentString != NULL) {
-        returnString = [SalesforceSDKManager sharedManager].userAgentString(qualifier);
-    }
-    return returnString;
+    return [SalesforceSDKManager sharedManager].userAgentString(qualifier);
 }
 
 #pragma mark - send method

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -170,11 +170,6 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
             [self.request setValue:bearer forHTTPHeaderField:@"Authorization"];
         }
 
-        // Sets Mobile SDK user agent on REST API requests, if it hasn't been set already elsewhere.
-        if (![self.request.allHTTPHeaderFields.allKeys containsObject:@"User-Agent"]) {
-            [self.request setValue:[SFRestAPI userAgentString] forHTTPHeaderField:@"User-Agent"];
-        }
-
         // Adds custom headers to the request if any are set.
         if (self.customHeaders) {
             for (NSString *key in self.customHeaders.allKeys) {


### PR DESCRIPTION
iOS used to only set the Mobile SDK user agent in SFRestAPI and in SFHybridViewController.
On Android all network requests already use the Mobile SDK user agent.
With this PR, iOS will now behave like Android and use the Mobile SDK user agents for all network requests.