### PR TITLE
Allow file logger to be configurable

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.h
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.h
@@ -46,7 +46,7 @@
 /**
  * Instance of the underlying file logger being used.
  */
-@property (nonatomic, readonly, strong, nonnull) SFSDKFileLogger *fileLogger;
+@property (nonatomic, readwrite, strong, nonnull) SFSDKFileLogger *fileLogger;
 
 /**
  * Used to get and set the current log level associated with this logger.

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.m
@@ -41,7 +41,6 @@ static NSMutableDictionary<NSString *, SFSDKLogger *> *loggerList = nil;
 
 @property (nonatomic, readwrite, strong) NSString *componentName;
 @property (nonatomic, readwrite, strong) DDLog *logger;
-@property (nonatomic, readwrite, strong) SFSDKFileLogger *fileLogger;
 
 @end
 
@@ -98,6 +97,16 @@ static NSMutableDictionary<NSString *, SFSDKLogger *> *loggerList = nil;
         }
     }
     return self;
+}
+
+- (void)setFileLogger:(SFSDKFileLogger *)fileLogger {
+    if (fileLogger != _fileLogger) {
+        if (self.isFileLoggingEnabled) {
+            [_logger removeLogger:_fileLogger];
+            [_logger addLogger:fileLogger withLevel:self.logLevel];
+        }
+        _fileLogger = fileLogger;
+    }
 }
 
 - (void)setFileLoggingEnabled:(BOOL)loggingEnabled {


### PR DESCRIPTION
Probably a post-6.2 PR, but I figured I'd get it out there for review.  Making the file logger configurable allows for you to change the logging location, or even sharing a file logger between `SFSDKLogger`/`DDLog` instances.  We're hoping to consolidate our file logging into a single log file, for easier debugging/troubleshooting on a sequential timeline of events.