### PR TITLE
Removing use of Advanced Auth Options

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -470,7 +470,6 @@ static NSString *const SFSDKShowDevDialogNotification = @"SFSDKShowDevDialogNoti
             @"SDK Version", SALESFORCE_SDK_VERSION,
             @"App Type", [self getAppTypeAsString],
             @"User Agent", self.userAgentString(@""),
-            @"Browser Login Enabled", userAccountManager.advancedAuthConfiguration != SFOAuthAdvancedAuthConfigurationNone ? @"YES" : @"NO",
             @"IDP Enabled", [self idpEnabled] ? @"YES" : @"NO",
             @"Identity Provider", [self isIdentityProvider] ? @"YES" : @"NO",
             @"Current User", [self userToString:userAccountManager.currentUser],
@@ -558,7 +557,7 @@ static NSString *const SFSDKShowDevDialogNotification = @"SFSDKShowDevDialogNoti
 - (void)configureManagedSettings
 {
     if ([SFManagedPreferences sharedPreferences].requireCertificateAuthentication) {
-        [SFUserAccountManager sharedInstance].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        [SFUserAccountManager sharedInstance].requireCertificateAuthentication = YES;
     }
     
     if ([SFManagedPreferences sharedPreferences].connectedAppId.length > 0) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -470,6 +470,7 @@ static NSString *const SFSDKShowDevDialogNotification = @"SFSDKShowDevDialogNoti
             @"SDK Version", SALESFORCE_SDK_VERSION,
             @"App Type", [self getAppTypeAsString],
             @"User Agent", self.userAgentString(@""),
+             @"Browser Login Enabled", [SFUserAccountManager sharedInstance].requireBrowserAuthentication? @"YES" : @"NO",
             @"IDP Enabled", [self idpEnabled] ? @"YES" : @"NO",
             @"Identity Provider", [self isIdentityProvider] ? @"YES" : @"NO",
             @"Current User", [self userToString:userAccountManager.currentUser],
@@ -557,7 +558,7 @@ static NSString *const SFSDKShowDevDialogNotification = @"SFSDKShowDevDialogNoti
 - (void)configureManagedSettings
 {
     if ([SFManagedPreferences sharedPreferences].requireCertificateAuthentication) {
-        [SFUserAccountManager sharedInstance].requireCertificateAuthentication = YES;
+        [SFUserAccountManager sharedInstance].requireBrowserAuthentication = YES;
     }
     
     if ([SFManagedPreferences sharedPreferences].connectedAppId.length > 0) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -25,6 +25,7 @@
 #import <objc/runtime.h>
 #import "SalesforceSDKManager+Internal.h"
 #import "SFAuthenticationManager+Internal.h"
+#import "SFUserAccountManager+Internal.h"
 #import "SFSDKWindowManager.h"
 #import "SFManagedPreferences.h"
 #import "SFPasscodeManager.h"
@@ -470,7 +471,7 @@ static NSString *const SFSDKShowDevDialogNotification = @"SFSDKShowDevDialogNoti
             @"SDK Version", SALESFORCE_SDK_VERSION,
             @"App Type", [self getAppTypeAsString],
             @"User Agent", self.userAgentString(@""),
-             @"Browser Login Enabled", [SFUserAccountManager sharedInstance].requireBrowserAuthentication? @"YES" : @"NO",
+             @"Browser Login Enabled", [SFUserAccountManager sharedInstance].useBrowserAuth? @"YES" : @"NO",
             @"IDP Enabled", [self idpEnabled] ? @"YES" : @"NO",
             @"Identity Provider", [self isIdentityProvider] ? @"YES" : @"NO",
             @"Current User", [self userToString:userAccountManager.currentUser],
@@ -558,7 +559,7 @@ static NSString *const SFSDKShowDevDialogNotification = @"SFSDKShowDevDialogNoti
 - (void)configureManagedSettings
 {
     if ([SFManagedPreferences sharedPreferences].requireCertificateAuthentication) {
-        [SFUserAccountManager sharedInstance].requireBrowserAuthentication = YES;
+        [SFUserAccountManager sharedInstance].useBrowserAuth = YES;
     }
     
     if ([SFManagedPreferences sharedPreferences].connectedAppId.length > 0) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
@@ -382,7 +382,7 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
 
 /** Setup the coordinator to use SafariViewController for authentication.
  */
-@property (nonatomic, assign) BOOL requireBrowserAuthentication;
+@property (nonatomic, assign) BOOL useBrowserAuth;
 
 ///---------------------------------------------------------------------------------------
 /// @name Initialization

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
@@ -380,6 +380,10 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
  */
 @property (nonatomic, copy) NSString *brandLoginPath;
 
+/** Setup the coordinator to use SafariViewController for authenatication.
+ */
+@property (nonatomic, assign) BOOL requireCertificateAuthentication;
+
 ///---------------------------------------------------------------------------------------
 /// @name Initialization
 ///---------------------------------------------------------------------------------------

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
@@ -380,9 +380,9 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
  */
 @property (nonatomic, copy) NSString *brandLoginPath;
 
-/** Setup the coordinator to use SafariViewController for authenatication.
+/** Setup the coordinator to use SafariViewController for authentication.
  */
-@property (nonatomic, assign) BOOL requireCertificateAuthentication;
+@property (nonatomic, assign) BOOL requireBrowserAuthentication;
 
 ///---------------------------------------------------------------------------------------
 /// @name Initialization

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -219,7 +219,7 @@ static NSString * const kSFECParameter = @"ec";
         [self.oauthCoordinatorFlow beginJwtTokenExchangeFlow];
     } else {
          __weak typeof(self) weakSelf = self;
-        if (self.requireBrowserAuthentication) {
+        if (self.useBrowserAuth) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 strongSelf.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -229,22 +229,22 @@ static NSString * const kSFECParameter = @"ec";
         } else {
             [SFSDKAuthConfigUtil getMyDomainAuthConfig:^(SFOAuthOrgAuthConfiguration *authConfig, NSError *error) {
                 __strong typeof(weakSelf) strongSelf = weakSelf;
-                if (error) {
-                   dispatch_async(dispatch_get_main_queue(), ^{
-                       [weakSelf notifyDelegateOfFailure:error authInfo:weakSelf.authInfo];
-                   });
-                    return;
-                }
-                if (authConfig.useNativeBrowserForAuth) {
-                    strongSelf.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];
-                    [strongSelf notifyDelegateOfBeginAuthentication];
-                    [strongSelf.oauthCoordinatorFlow beginNativeBrowserFlow];
-                } else {
-                    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureSafariBrowserForLogin];
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf notifyDelegateOfBeginAuthentication];
-                    [strongSelf.oauthCoordinatorFlow beginUserAgentFlow];
-                }
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    if (error) {
+                       [strongSelf notifyDelegateOfFailure:error authInfo:strongSelf.authInfo];
+                        return;
+                    }
+                    if (authConfig.useNativeBrowserForAuth) {
+                         [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureSafariBrowserForLogin];
+                        strongSelf.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];
+                        [strongSelf notifyDelegateOfBeginAuthentication];
+                        [strongSelf.oauthCoordinatorFlow beginNativeBrowserFlow];
+                    } else {
+                        [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureSafariBrowserForLogin];
+                        [strongSelf notifyDelegateOfBeginAuthentication];
+                        [strongSelf.oauthCoordinatorFlow beginUserAgentFlow];
+                    }
+                });
             } oauthCredentials:self.credentials];
         }
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -220,6 +220,7 @@ static NSString * const kSFECParameter = @"ec";
     } else {
          __weak typeof(self) weakSelf = self;
         if (self.useBrowserAuth) {
+            [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureSafariBrowserForLogin];
             dispatch_async(dispatch_get_main_queue(), ^{
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 strongSelf.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -219,7 +219,7 @@ static NSString * const kSFECParameter = @"ec";
         [self.oauthCoordinatorFlow beginJwtTokenExchangeFlow];
     } else {
          __weak typeof(self) weakSelf = self;
-        if (self.requireCertificateAuthentication) {
+        if (self.requireBrowserAuthentication) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 strongSelf.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.h
@@ -106,5 +106,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic,copy) NSString *appDisplayName;
 
+/**
+ Whether the app is configured to require certificate-based authentication. (RequireCertAuth)
+ */
+@property (nonatomic, assign) BOOL requireCertificateAuthentication;
+
 @end
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.h
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
 /** Use this property to indicate the url scheme  for the Identity Provider app
  *
  */
-@property (nonatomic, copy) NSString *idpAppURIScheme;
+@property (nonatomic, copy,nullable) NSString *idpAppURIScheme;
 
 /** Use this property to indicate to provide a user-friendly name for your app. This name will be displayed
  *  in the user selection view of the identity provider app.
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Whether the app is configured to require certificate-based authentication. (RequireCertAuth)
  */
-@property (nonatomic, assign) BOOL requireCertificateAuthentication;
+@property (nonatomic, assign) BOOL requireBrowserAuthentication;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
@@ -223,6 +223,4 @@ NSString * const kSFLegacyAuthIndicatorKey = @"SFDCUseLegacyAuth";
     [defs setBool:enabled forKey:kSFLegacyAuthIndicatorKey];
     [defs synchronize];
 }
-
-
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -645,7 +645,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     SFSDKOAuthClient *instance = nil;
     if (config.idpEnabled || config.isIdentityProvider) {
         instance = [self idpAuthInstance:config];
-    } else if (config.requireCertificateAuthentication) {
+    } else if (config.requireBrowserAuthentication) {
         instance = [self nativeBrowserAuthInstance:config];
     } else if (credentials.refreshToken != nil) {
         instance = [self webviewAuthInstanceWithRefresh:config];
@@ -656,7 +656,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     context.credentials = credentials;
     instance.context = context;
     instance.coordinator  = [[SFOAuthCoordinator alloc] init];
-    instance.coordinator.requireCertificateAuthentication = config.requireCertificateAuthentication;
+    instance.coordinator.requireBrowserAuthentication = config.requireBrowserAuthentication;
     instance.coordinator.scopes = config.scopes;
     instance.coordinator.brandLoginPath = config.brandLoginPath;
     instance.coordinator.additionalOAuthParameterKeys = config.additionalOAuthParameterKeys;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -645,7 +645,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     SFSDKOAuthClient *instance = nil;
     if (config.idpEnabled || config.isIdentityProvider) {
         instance = [self idpAuthInstance:config];
-    } else if (config.requireBrowserAuthentication) {
+    } else if (config.useBrowserAuth) {
         instance = [self nativeBrowserAuthInstance:config];
     } else if (credentials.refreshToken != nil) {
         instance = [self webviewAuthInstanceWithRefresh:config];
@@ -656,7 +656,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     context.credentials = credentials;
     instance.context = context;
     instance.coordinator  = [[SFOAuthCoordinator alloc] init];
-    instance.coordinator.requireBrowserAuthentication = config.requireBrowserAuthentication;
+    instance.coordinator.useBrowserAuth = config.useBrowserAuth;
     instance.coordinator.scopes = config.scopes;
     instance.coordinator.brandLoginPath = config.brandLoginPath;
     instance.coordinator.additionalOAuthParameterKeys = config.additionalOAuthParameterKeys;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -645,7 +645,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     SFSDKOAuthClient *instance = nil;
     if (config.idpEnabled || config.isIdentityProvider) {
         instance = [self idpAuthInstance:config];
-    } else if (config.advancedAuthConfiguration == SFOAuthAdvancedAuthConfigurationRequire) {
+    } else if (config.requireCertificateAuthentication) {
         instance = [self nativeBrowserAuthInstance:config];
     } else if (credentials.refreshToken != nil) {
         instance = [self webviewAuthInstanceWithRefresh:config];
@@ -656,7 +656,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     context.credentials = credentials;
     instance.context = context;
     instance.coordinator  = [[SFOAuthCoordinator alloc] init];
-    instance.coordinator.advancedAuthConfiguration = config.advancedAuthConfiguration;
+    instance.coordinator.requireCertificateAuthentication = config.requireCertificateAuthentication;
     instance.coordinator.scopes = config.scopes;
     instance.coordinator.brandLoginPath = config.brandLoginPath;
     instance.coordinator.additionalOAuthParameterKeys = config.additionalOAuthParameterKeys;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientCache.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientCache.m
@@ -81,7 +81,7 @@ static NSString *const kSFAdvancedSuffix = @"ADVANCED";
     SFOAuthClientKeyType clientType =  SFOAuthClientKeyTypeBasic;
     if (preferences.isIdentityProvider || preferences.idpEnabled) {
         clientType = SFOAuthClientKeyTypeIDP;
-    } else if (preferences.requireCertificateAuthentication) {
+    } else if (preferences.requireBrowserAuthentication) {
         clientType = SFOAuthClientKeyTypeAdvanced;
     }
     return [self keyFromCredentials:credentials type:clientType];
@@ -102,7 +102,7 @@ static NSString *const kSFAdvancedSuffix = @"ADVANCED";
 
     if (client.config.idpEnabled)
         clientType = SFOAuthClientKeyTypeIDP;
-    else if (client.config.requireCertificateAuthentication)
+    else if (client.config.requireBrowserAuthentication)
         clientType = SFOAuthClientKeyTypeAdvanced;
     return [NSString stringWithFormat:@"%@-%lu", client.credentials.identifier, (unsigned long)clientType];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientCache.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientCache.m
@@ -81,12 +81,13 @@ static NSString *const kSFAdvancedSuffix = @"ADVANCED";
     SFOAuthClientKeyType clientType =  SFOAuthClientKeyTypeBasic;
     if (preferences.isIdentityProvider || preferences.idpEnabled) {
         clientType = SFOAuthClientKeyTypeIDP;
-    }else if (preferences.advancedAuthConfiguration == SFOAuthAdvancedAuthConfigurationRequire) {
+    } else if (preferences.requireCertificateAuthentication) {
         clientType = SFOAuthClientKeyTypeAdvanced;
     }
     return [self keyFromCredentials:credentials type:clientType];
     
 }
+
 + (NSString *)keyFromCredentials:(SFOAuthCredentials *)credentials type:(SFOAuthClientKeyType)clientType {
     return [NSString stringWithFormat:@"%@-%lu", credentials.identifier,(unsigned long)clientType];
 }
@@ -95,16 +96,14 @@ static NSString *const kSFAdvancedSuffix = @"ADVANCED";
     return [NSString stringWithFormat:@"%@-%lu", prefix,(unsigned long)clientType];
 }
 
-
 + (NSString *)keyFromClient:(SFSDKOAuthClient *)client{
 
     SFOAuthClientKeyType clientType = SFOAuthClientKeyTypeBasic;
 
     if (client.config.idpEnabled)
         clientType = SFOAuthClientKeyTypeIDP;
-    else if (client.config.advancedAuthConfiguration == SFOAuthAdvancedAuthConfigurationRequire)
+    else if (client.config.requireCertificateAuthentication)
         clientType = SFOAuthClientKeyTypeAdvanced;
-
     return [NSString stringWithFormat:@"%@-%lu", client.credentials.identifier, (unsigned long)clientType];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientCache.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientCache.m
@@ -102,7 +102,7 @@ static NSString *const kSFAdvancedSuffix = @"ADVANCED";
 
     if (client.config.idpEnabled)
         clientType = SFOAuthClientKeyTypeIDP;
-    else if (client.config.requireBrowserAuthentication)
+    else if (client.config.useBrowserAuth)
         clientType = SFOAuthClientKeyTypeAdvanced;
     return [NSString stringWithFormat:@"%@-%lu", client.credentials.identifier, (unsigned long)clientType];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientConfig.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientConfig.h
@@ -50,7 +50,7 @@
 @property (nonatomic, copy, nullable) NSString *brandLoginPath;
 @property (nonatomic, copy, nonnull) NSString *loginHost;
 @property (nonatomic, copy, nonnull) NSSet<NSString*> *scopes;
-@property (nonatomic, assign) SFOAuthAdvancedAuthConfiguration advancedAuthConfiguration;
+@property (nonatomic, assign) BOOL requireCertificateAuthentication;
 @property (nonatomic, strong, nullable) NSArray *additionalOAuthParameterKeys;
 @property (nonatomic, strong, nullable) NSDictionary *additionalTokenRefreshParams;
 @property (nonatomic, copy, nullable) NSString *appDisplayName;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientConfig.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientConfig.h
@@ -50,7 +50,7 @@
 @property (nonatomic, copy, nullable) NSString *brandLoginPath;
 @property (nonatomic, copy, nonnull) NSString *loginHost;
 @property (nonatomic, copy, nonnull) NSSet<NSString*> *scopes;
-@property (nonatomic, assign) BOOL requireBrowserAuthentication;
+@property (nonatomic, assign) BOOL useBrowserAuth;
 @property (nonatomic, strong, nullable) NSArray *additionalOAuthParameterKeys;
 @property (nonatomic, strong, nullable) NSDictionary *additionalTokenRefreshParams;
 @property (nonatomic, copy, nullable) NSString *appDisplayName;
@@ -70,8 +70,6 @@
 @property (nonatomic, copy,nullable) SFAuthenticationFailureCallbackBlock  failureCallbackBlock;
 @property (nonatomic, copy,nullable) SFIdentitySuccessCallbackBlock identitySuccessCallbackBlock;
 @property (nonatomic, copy,nullable) SFIdentityFailureCallbackBlock identityFailureCallbackBlock;
-
-
 @property (nonatomic, copy, nullable) SFIDPLoginFlowSelectionBlock idpLoginFlowSelectionBlock;
 @property (nonatomic, copy, nullable) SFIDPUserSelectionBlock idpUserSelectionBlock;
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientConfig.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClientConfig.h
@@ -50,7 +50,7 @@
 @property (nonatomic, copy, nullable) NSString *brandLoginPath;
 @property (nonatomic, copy, nonnull) NSString *loginHost;
 @property (nonatomic, copy, nonnull) NSSet<NSString*> *scopes;
-@property (nonatomic, assign) BOOL requireCertificateAuthentication;
+@property (nonatomic, assign) BOOL requireBrowserAuthentication;
 @property (nonatomic, strong, nullable) NSArray *additionalOAuthParameterKeys;
 @property (nonatomic, strong, nullable) NSDictionary *additionalTokenRefreshParams;
 @property (nonatomic, copy, nullable) NSString *appDisplayName;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFAuthenticationManager.m
@@ -494,12 +494,7 @@ static Class InstanceClass = nil;
 }
 
 - (SFOAuthAdvancedAuthConfiguration) advancedAuthConfiguration {
-    return [SFUserAccountManager sharedInstance].advancedAuthConfiguration;
-}
-
-- (void)setAdvancedAuthConfiguration:(SFOAuthAdvancedAuthConfiguration)advancedAuthConfiguration
-{
-    [SFUserAccountManager sharedInstance].advancedAuthConfiguration = advancedAuthConfiguration;
+    return SFOAuthAdvancedAuthConfigurationAllow;
 }
 
 - (BOOL)handleAdvancedAuthenticationResponse:(NSURL *)appUrlResponse
@@ -795,7 +790,6 @@ static Class InstanceClass = nil;
     self.coordinator.delegate = nil;
     self.coordinator = [[SFOAuthCoordinator alloc] initWithCredentials:credentials];
     self.coordinator.brandLoginPath = self.brandLoginPath;
-    self.coordinator.advancedAuthConfiguration = self.advancedAuthConfiguration;
     self.coordinator.delegate = self;
     self.coordinator.additionalOAuthParameterKeys = self.additionalOAuthParameterKeys;
     self.coordinator.additionalTokenRefreshParams = self.additionalTokenRefreshParams;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
@@ -66,7 +66,7 @@
 @property (nonatomic, strong, nullable) SFSDKAuthErrorManager *errorManager;
 
 /**
- Whether the app is configured to require certificate-based authentication. (RequireCertAuth)
+ Indicates if the app is configured to require browser based authentication.
  */
 @property (nonatomic, assign) BOOL useBrowserAuth;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
@@ -66,6 +66,11 @@
 @property (nonatomic, strong, nullable) SFSDKAuthErrorManager *errorManager;
 
 /**
+ Whether the app is configured to require certificate-based authentication. (RequireCertAuth)
+ */
+@property (nonatomic, assign) BOOL useBrowserAuth;
+
+/**
  Executes the given block for each configured delegate.
  @param block The block to execute for each delegate.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -282,12 +282,9 @@ FOUNDATION_EXTERN NSString * const kSFNotificationUserInfoKey;
 @property (nonatomic, readonly) BOOL logoutSettingEnabled;
 
 /**
- Advanced authentication configuration.  Default is SFOAuthAdvancedAuthConfigurationNone.  Leave the
- default value unless you need advanced authentication, as it requires an additional round trip to the
- service to retrieve org authentication configuration.
+ Whether the app is configured to require certificate-based authentication. (RequireCertAuth)
  */
-@property (nonatomic, assign) SFOAuthAdvancedAuthConfiguration advancedAuthConfiguration;
-
+@property (nonatomic, assign) BOOL requireCertificateAuthentication;
 /**
  An array of additional keys (NSString) to parse during OAuth
  */
@@ -363,7 +360,7 @@ FOUNDATION_EXTERN NSString * const kSFNotificationUserInfoKey;
 /** Use this property to indicate the url scheme  for the Identity Provider app
  *
  */
-@property (nonatomic, copy) NSString *idpAppURIScheme;
+@property (nonatomic, copy, nullable) NSString *idpAppURIScheme;
 
 /** Use this property to indicate to provide a user-friendly name for your app. This name will be displayed
  *  in the user selection view of the identity provider app.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -284,7 +284,7 @@ FOUNDATION_EXTERN NSString * const kSFNotificationUserInfoKey;
 /**
  Whether the app is configured to require certificate-based authentication. (RequireCertAuth)
  */
-@property (nonatomic, assign) BOOL requireCertificateAuthentication;
+@property (nonatomic, assign) BOOL requireBrowserAuthentication;
 /**
  An array of additional keys (NSString) to parse during OAuth
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -282,9 +282,9 @@ FOUNDATION_EXTERN NSString * const kSFNotificationUserInfoKey;
 @property (nonatomic, readonly) BOOL logoutSettingEnabled;
 
 /**
- Whether the app is configured to require certificate-based authentication. (RequireCertAuth)
+ Indicates if the app is configured to require browser based authentication.
  */
-@property (nonatomic, assign) BOOL requireBrowserAuthentication;
+@property (nonatomic, readonly) BOOL useBrowserAuth;
 /**
  An array of additional keys (NSString) to parse during OAuth
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -250,12 +250,12 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
     return self.authPreferences.idpAppURIScheme;
 }
 
-- (BOOL)requireCertificateAuthentication {
-     return self.authPreferences.requireCertificateAuthentication;
+- (BOOL)requireBrowserAuthentication {
+     return self.authPreferences.requireBrowserAuthentication;
 }
 
-- (void)setRequireCertificateAuthentication:(BOOL) requireCertificateAuth {
-     self.authPreferences.requireCertificateAuthentication = requireCertificateAuth;
+- (void)setRequireBrowserAuthentication:(BOOL) requireCertificateAuth {
+     self.authPreferences.requireBrowserAuthentication = requireCertificateAuth;
 }
 
 - (void)setIdpAppURIScheme:(NSString *)idpAppURIScheme {
@@ -530,7 +530,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
                                 kSFNotificationUserInfoAuthTypeKey: client.context.authInfo };
     //Rekey the client in cache. Need to do, since advanced auth
     //configuration was realized from org/domain setting.
-    if (!client.config.requireCertificateAuthentication) {
+    if (!client.config.requireBrowserAuthentication) {
         NSString *newKey = [SFSDKOAuthClientCache keyFromCredentials:client.credentials type:SFOAuthClientKeyTypeAdvanced];
         [[SFSDKOAuthClientCache sharedInstance] removeClient:client];
         [[SFSDKOAuthClientCache sharedInstance] addClient:client forKey:newKey];
@@ -1292,7 +1292,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
             config.oauthClientId = strongSelf.oauthClientId;
             config.idpAppURIScheme = strongSelf.idpAppURIScheme;
             config.appDisplayName = strongSelf.appDisplayName;
-            config.requireCertificateAuthentication = strongSelf.requireCertificateAuthentication;
+            config.requireBrowserAuthentication = strongSelf.requireBrowserAuthentication;
             config.delegate = strongSelf;
             config.webViewDelegate = strongSelf;
             config.safariViewDelegate = strongSelf;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -250,12 +250,12 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
     return self.authPreferences.idpAppURIScheme;
 }
 
-- (BOOL)requireBrowserAuthentication {
+- (BOOL)useBrowserAuth {
      return self.authPreferences.requireBrowserAuthentication;
 }
 
-- (void)setRequireBrowserAuthentication:(BOOL) requireCertificateAuth {
-     self.authPreferences.requireBrowserAuthentication = requireCertificateAuth;
+- (void)setUseBrowserAuth:(BOOL)useBrowserAuth {
+     self.authPreferences.requireBrowserAuthentication = useBrowserAuth;
 }
 
 - (void)setIdpAppURIScheme:(NSString *)idpAppURIScheme {
@@ -530,7 +530,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
                                 kSFNotificationUserInfoAuthTypeKey: client.context.authInfo };
     //Rekey the client in cache. Need to do, since advanced auth
     //configuration was realized from org/domain setting.
-    if (!client.config.requireBrowserAuthentication) {
+    if (!client.config.useBrowserAuth) {
         NSString *newKey = [SFSDKOAuthClientCache keyFromCredentials:client.credentials type:SFOAuthClientKeyTypeAdvanced];
         [[SFSDKOAuthClientCache sharedInstance] removeClient:client];
         [[SFSDKOAuthClientCache sharedInstance] addClient:client forKey:newKey];
@@ -1292,7 +1292,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
             config.oauthClientId = strongSelf.oauthClientId;
             config.idpAppURIScheme = strongSelf.idpAppURIScheme;
             config.appDisplayName = strongSelf.appDisplayName;
-            config.requireBrowserAuthentication = strongSelf.requireBrowserAuthentication;
+            config.useBrowserAuth = strongSelf.useBrowserAuth;
             config.delegate = strongSelf;
             config.webViewDelegate = strongSelf;
             config.safariViewDelegate = strongSelf;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -230,15 +230,6 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
     return self.authPreferences.idpEnabled;
 }
 
-- (SFOAuthAdvancedAuthConfiguration)advancedAuthConfiguration {
-   return self.authPreferences.advancedAuthConfiguration;
-}
-
-- (void)setAdvancedAuthConfiguration:(SFOAuthAdvancedAuthConfiguration)advancedAuthConfiguration {
-    self.authPreferences.advancedAuthConfiguration = advancedAuthConfiguration;
-}
-
-
 - (BOOL)useLegacyAuthenticationManager{
     return self.authPreferences.useLegacyAuthenticationManager;
 }
@@ -257,6 +248,14 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 
 - (NSString *)idpAppURIScheme{
     return self.authPreferences.idpAppURIScheme;
+}
+
+- (BOOL)requireCertificateAuthentication {
+     return self.authPreferences.requireCertificateAuthentication;
+}
+
+- (void)setRequireCertificateAuthentication:(BOOL) requireCertificateAuth {
+     self.authPreferences.requireCertificateAuthentication = requireCertificateAuth;
 }
 
 - (void)setIdpAppURIScheme:(NSString *)idpAppURIScheme {
@@ -529,9 +528,9 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 - (void)authClient:(SFSDKOAuthClient *)client willBeginBrowserAuthentication:(SFOAuthBrowserFlowCallbackBlock)callbackBlock {
     NSDictionary *userInfo = @{ kSFNotificationUserInfoCredentialsKey: client.credentials,
                                 kSFNotificationUserInfoAuthTypeKey: client.context.authInfo };
-    if (client.config.advancedAuthConfiguration == SFOAuthAdvancedAuthConfigurationAllow) {
-        //Rekey the client in cache. Need to do, since advanced auth configuration was realized
-        //from org/domain setting.
+    //Rekey the client in cache. Need to do, since advanced auth
+    //configuration was realized from org/domain setting.
+    if (!client.config.requireCertificateAuthentication) {
         NSString *newKey = [SFSDKOAuthClientCache keyFromCredentials:client.credentials type:SFOAuthClientKeyTypeAdvanced];
         [[SFSDKOAuthClientCache sharedInstance] removeClient:client];
         [[SFSDKOAuthClientCache sharedInstance] addClient:client forKey:newKey];
@@ -1293,7 +1292,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
             config.oauthClientId = strongSelf.oauthClientId;
             config.idpAppURIScheme = strongSelf.idpAppURIScheme;
             config.appDisplayName = strongSelf.appDisplayName;
-            config.advancedAuthConfiguration = strongSelf.advancedAuthConfiguration;
+            config.requireCertificateAuthentication = strongSelf.requireCertificateAuthentication;
             config.delegate = strongSelf;
             config.webViewDelegate = strongSelf;
             config.safariViewDelegate = strongSelf;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthClientCacheTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthClientCacheTests.m
@@ -50,7 +50,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        config.requireCertificateAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -66,7 +66,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        config.requireCertificateAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -74,7 +74,7 @@
     [[SFSDKOAuthClientCache sharedInstance] addClient:client];
     
     SFSDKOAuthClient *client2 = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        config.requireCertificateAuthentication = YES;
     }];
     
     NSString *key2 = [SFSDKOAuthClientCache keyFromClient:client2];
@@ -88,7 +88,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        config.requireCertificateAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -107,7 +107,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        config.requireCertificateAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -130,7 +130,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        config.requireCertificateAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -165,7 +165,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        config.requireCertificateAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -204,7 +204,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        config.requireCertificateAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -246,7 +246,7 @@
     SFOAuthCredentials *credentials2 = [[SFOAuthCredentials alloc] initWithIdentifier:@"test2Id" clientId:@"test2Id" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        config.requireCertificateAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -254,7 +254,7 @@
     [[SFSDKOAuthClientCache sharedInstance] addClient:client];
     
     SFSDKOAuthClient *client2 = [SFSDKOAuthClient clientWithCredentials:credentials2  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        config.requireCertificateAuthentication = YES;
     }];
     
     XCTAssertNotNil( [[SFSDKOAuthClientCache sharedInstance] clientForKey:key]);

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthClientCacheTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthClientCacheTests.m
@@ -50,7 +50,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireBrowserAuthentication = YES;
+        config.useBrowserAuth = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -66,7 +66,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireBrowserAuthentication = YES;
+        config.useBrowserAuth = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -74,7 +74,7 @@
     [[SFSDKOAuthClientCache sharedInstance] addClient:client];
     
     SFSDKOAuthClient *client2 = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireBrowserAuthentication = YES;
+        config.useBrowserAuth = YES;
     }];
     
     NSString *key2 = [SFSDKOAuthClientCache keyFromClient:client2];
@@ -88,7 +88,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireBrowserAuthentication = YES;
+        config.useBrowserAuth = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -107,7 +107,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireBrowserAuthentication = YES;
+        config.useBrowserAuth = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -130,7 +130,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireBrowserAuthentication = YES;
+        config.useBrowserAuth = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -165,7 +165,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireBrowserAuthentication = YES;
+        config.useBrowserAuth = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -204,7 +204,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireBrowserAuthentication = YES;
+        config.useBrowserAuth = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -246,7 +246,7 @@
     SFOAuthCredentials *credentials2 = [[SFOAuthCredentials alloc] initWithIdentifier:@"test2Id" clientId:@"test2Id" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireBrowserAuthentication = YES;
+        config.useBrowserAuth = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -254,7 +254,7 @@
     [[SFSDKOAuthClientCache sharedInstance] addClient:client];
     
     SFSDKOAuthClient *client2 = [SFSDKOAuthClient clientWithCredentials:credentials2  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireBrowserAuthentication = YES;
+        config.useBrowserAuth = YES;
     }];
     
     XCTAssertNotNil( [[SFSDKOAuthClientCache sharedInstance] clientForKey:key]);

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthClientCacheTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthClientCacheTests.m
@@ -50,7 +50,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireCertificateAuthentication = YES;
+        config.requireBrowserAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -66,7 +66,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireCertificateAuthentication = YES;
+        config.requireBrowserAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -74,7 +74,7 @@
     [[SFSDKOAuthClientCache sharedInstance] addClient:client];
     
     SFSDKOAuthClient *client2 = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireCertificateAuthentication = YES;
+        config.requireBrowserAuthentication = YES;
     }];
     
     NSString *key2 = [SFSDKOAuthClientCache keyFromClient:client2];
@@ -88,7 +88,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireCertificateAuthentication = YES;
+        config.requireBrowserAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -107,7 +107,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireCertificateAuthentication = YES;
+        config.requireBrowserAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -130,7 +130,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireCertificateAuthentication = YES;
+        config.requireBrowserAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -165,7 +165,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireCertificateAuthentication = YES;
+        config.requireBrowserAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -204,7 +204,7 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireCertificateAuthentication = YES;
+        config.requireBrowserAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -246,7 +246,7 @@
     SFOAuthCredentials *credentials2 = [[SFOAuthCredentials alloc] initWithIdentifier:@"test2Id" clientId:@"test2Id" encrypted:NO];
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireCertificateAuthentication = YES;
+        config.requireBrowserAuthentication = YES;
     }];
     
     NSString *key = [SFSDKOAuthClientCache keyFromClient:client];
@@ -254,7 +254,7 @@
     [[SFSDKOAuthClientCache sharedInstance] addClient:client];
     
     SFSDKOAuthClient *client2 = [SFSDKOAuthClient clientWithCredentials:credentials2  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireCertificateAuthentication = YES;
+        config.requireBrowserAuthentication = YES;
     }];
     
     XCTAssertNotNil( [[SFSDKOAuthClientCache sharedInstance] clientForKey:key]);

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorFlowTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorFlowTests.m
@@ -53,8 +53,7 @@
     SFSDKAsyncProcessListener *listener = [[SFSDKAsyncProcessListener alloc] initWithExpectedStatus:@YES
                                                                                   actualStatusBlock:^id{
                                                                                       return [NSNumber numberWithBool:self.testFlowDelegate.didAuthenticateCalled];
-                                                                                  }
-                                                                                            timeout:(self.oauthTestFlow.timeBeforeUserAgentCompletion + 0.5)];
+                                                                                  }  timeout:10];
     BOOL userAgentFlowSucceeded = [[listener waitForCompletion] boolValue];
     XCTAssertTrue(userAgentFlowSucceeded, @"User agent flow should have completed successfully.");
     XCTAssertTrue(self.oauthTestFlow.beginUserAgentFlowCalled, @"User agent flow should have been called in first authenticate.");
@@ -79,6 +78,13 @@
 
 - (void)testMultipleAuthenticationRequests {
     [self.coordinator authenticate];
+    SFSDKAsyncProcessListener *listener = [[SFSDKAsyncProcessListener alloc] initWithExpectedStatus:@YES
+                                                                                  actualStatusBlock:^id{
+                                                                                      return [NSNumber numberWithBool:self.oauthTestFlow.beginUserAgentFlowCalled];
+                                                                                  }
+                                                                                            timeout:10.0];
+    BOOL beginAuthFlowSucceeded = [[listener waitForCompletion] boolValue];
+    XCTAssertTrue(beginAuthFlowSucceeded, @"Oauth flow should have completed successfully.");
     XCTAssertTrue(self.oauthTestFlow.beginUserAgentFlowCalled, @"User agent flow should have been called in first authenticate.");
     XCTAssertFalse(self.oauthTestFlow.beginTokenEndpointFlowCalled, @"Token endpoint should not have been called in first authenticate.");
     XCTAssertEqual(self.oauthTestFlow.tokenEndpointFlowType, SFOAuthTokenEndpointFlowNone, @"Should be no token endpoint flow type configured.");

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
@@ -183,7 +183,7 @@
 
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireCertificateAuthentication = YES;
+        config.requireBrowserAuthentication = YES;
     }];
     
     XCTAssertNotNil(client);
@@ -452,11 +452,11 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-    [SFUserAccountManager sharedInstance].requireCertificateAuthentication = YES;
+    [SFUserAccountManager sharedInstance].requireBrowserAuthentication = YES;
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
         config.delegate = self;
         config.safariViewDelegate = self;
-        config.requireCertificateAuthentication = [SFUserAccountManager sharedInstance].requireCertificateAuthentication;
+        config.requireBrowserAuthentication = [SFUserAccountManager sharedInstance].requireBrowserAuthentication;
     }];
    
     XCTAssertNotNil(client);

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
@@ -152,7 +152,6 @@
     [SFSDKOAuthClient setClientProvider:_originalProvider];
     [SFUserAccountManager sharedInstance].idpAppURIScheme = nil;
     [SFUserAccountManager sharedInstance].isIdentityProvider = NO;
-    [SFUserAccountManager sharedInstance].advancedAuthConfiguration = SFOAuthTypeUserAgent;
     [super tearDown];
 }
 
@@ -184,7 +183,7 @@
 
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
+        config.requireCertificateAuthentication = YES;
     }];
     
     XCTAssertNotNil(client);
@@ -453,15 +452,11 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-
-    
-    [SFUserAccountManager sharedInstance].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
-    
-    
+    [SFUserAccountManager sharedInstance].requireCertificateAuthentication = YES;
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
         config.delegate = self;
         config.safariViewDelegate = self;
-        config.advancedAuthConfiguration = [SFUserAccountManager sharedInstance].advancedAuthConfiguration;
+        config.requireCertificateAuthentication = [SFUserAccountManager sharedInstance].requireCertificateAuthentication;
     }];
    
     XCTAssertNotNil(client);
@@ -511,27 +506,28 @@
 
 }
 
-#pragma mark - SFSDKOAuthClientSafariViewDelegate
-
-- (void)authClientDidProceedWithBrowserFlow:(SFSDKOAuthClient *)client {
- [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-}
-
-- (void)authClientDidCancelBrowserFlow:(SFSDKOAuthClient *)client {
- [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-}
-
-- (void)authClient:(SFSDKOAuthClient *)client willDisplayAuthSafariViewController:(SFSafariViewController *_Nonnull)svc {
- [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-}
-
-- (void)authClientDidCancelGenericFlow:(SFSDKOAuthClient *)client {
- [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-}
-
-- (void)authClient:(SFSDKOAuthClient * _Nonnull)client displayMessage:(nonnull SFSDKAlertMessage *)message { 
-    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-}
+//#pragma mark - SFSDKOAuthClientSafariViewDelegate
+//
+//- (void)authClientDidProceedWithBrowserFlow:(SFSDKOAuthClient *)client {
+//    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+//}
+//
+//- (BOOL)authClientDidCancelBrowserFlow:(SFSDKOAuthClient *)client {
+//    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+//    return NO;
+//}
+//
+//- (void)authClient:(SFSDKOAuthClient *)client willDisplayAuthSafariViewController:(SFSafariViewController *_Nonnull)svc {
+// [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+//}
+//
+//- (void)authClientDidCancelGenericFlow:(SFSDKOAuthClient *)client {
+//    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+//}
+//
+//- (void)authClient:(SFSDKOAuthClient * _Nonnull)client displayMessage:(nonnull SFSDKAlertMessage *)message { 
+//    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
+//}
 
 #pragma mark SFOAuthCoordinatorFlow
 - (void)beginUserAgentFlow {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
@@ -506,29 +506,6 @@
 
 }
 
-//#pragma mark - SFSDKOAuthClientSafariViewDelegate
-//
-//- (void)authClientDidProceedWithBrowserFlow:(SFSDKOAuthClient *)client {
-//    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-//}
-//
-//- (BOOL)authClientDidCancelBrowserFlow:(SFSDKOAuthClient *)client {
-//    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-//    return NO;
-//}
-//
-//- (void)authClient:(SFSDKOAuthClient *)client willDisplayAuthSafariViewController:(SFSafariViewController *_Nonnull)svc {
-// [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-//}
-//
-//- (void)authClientDidCancelGenericFlow:(SFSDKOAuthClient *)client {
-//    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-//}
-//
-//- (void)authClient:(SFSDKOAuthClient * _Nonnull)client displayMessage:(nonnull SFSDKAlertMessage *)message { 
-//    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-//}
-
 #pragma mark SFOAuthCoordinatorFlow
 - (void)beginUserAgentFlow {
     [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
@@ -33,6 +33,7 @@
 #import "SalesforceSDKCore.h"
 #import "SFOAuthCoordinator+Internal.h"
 #import "SFSDKOAuthClientCache.h"
+#import "SFUserAccountManager+Internal.h"
 @class SFSDKTestOAuthClient;
 
 @interface SFSDKTestOAuthClient : SFSDKOAuthClient
@@ -183,7 +184,7 @@
 
     
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.requireBrowserAuthentication = YES;
+        config.useBrowserAuth = YES;
     }];
     
     XCTAssertNotNil(client);
@@ -452,11 +453,11 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-    [SFUserAccountManager sharedInstance].requireBrowserAuthentication = YES;
+    [SFUserAccountManager sharedInstance].useBrowserAuth = YES;
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
         config.delegate = self;
         config.safariViewDelegate = self;
-        config.requireBrowserAuthentication = [SFUserAccountManager sharedInstance].requireBrowserAuthentication;
+        config.useBrowserAuth = [SFUserAccountManager sharedInstance].useBrowserAuth;
     }];
    
     XCTAssertNotNil(client);

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -323,13 +323,6 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 }
 
 - (void)testUserAccountManagerPersistentProperties {
-    
-    SFOAuthAdvancedAuthConfiguration oldAdvancedAuthConfiguration = [SFUserAccountManager sharedInstance].advancedAuthConfiguration;
-    [SFUserAccountManager sharedInstance].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
-    XCTAssertEqual([SFUserAccountManager sharedInstance].advancedAuthConfiguration, SFOAuthAdvancedAuthConfigurationRequire, @"SFUserAccountManager advancedAuthConfiguration should be set correctly");
-    [SFUserAccountManager sharedInstance].advancedAuthConfiguration = oldAdvancedAuthConfiguration;
-    XCTAssertEqual([SFUserAccountManager sharedInstance].advancedAuthConfiguration, oldAdvancedAuthConfiguration, @"SFUserAccountManager advancedAuthConfiguration should be set back correctly");
-    
     NSArray *oldAdditionalOAuthParameterKeys = [SFUserAccountManager sharedInstance].additionalOAuthParameterKeys;
     NSArray *addlKeys = @[@"A", @"__B", @"123", @""];
     [SFUserAccountManager sharedInstance].additionalOAuthParameterKeys = addlKeys;

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -46,11 +46,10 @@ class AppDelegate : UIResponder, UIApplicationDelegate
             .Builder.configure { (appconfig: SFSDKAppConfig) -> Void in
                 //set custom config if needed. By default this object should read from the bootconfig.plist
             }.postInit {
-                
                 //Uncomment following block to enable IDP Login flow.
+                // NOTE: If advanced authentication is configured for domain, it will launch Safari to handle authentication.
                 /*
                  // scheme of idpApp
-                 SFUserAccountManager.sharedInstance().advancedAuthConfiguration = .none
                  SalesforceSwiftSDKManager.shared().idpAppURIScheme = "sampleidpapp"
                  // user friendly display name
                  SalesforceSwiftSDKManager.shared().appDisplayName = "RestAPIExplorerSwift"

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -46,14 +46,6 @@ class AppDelegate : UIResponder, UIApplicationDelegate
             .Builder.configure { (appconfig: SFSDKAppConfig) -> Void in
                 //set custom config if needed. By default this object should read from the bootconfig.plist
             }.postInit {
-                //Uncomment the following line inorder to enable/force the use of advanced authentication flow.
-                SFUserAccountManager.sharedInstance().advancedAuthConfiguration = SFOAuthAdvancedAuthConfiguration.require;
-                // OR
-                // To  retrieve advanced auth configuration from the org, to determine whether to initiate advanced authentication.
-                // SFUserAccountManager.sharedInstance().advancedAuthConfiguration = SFOAuthAdvancedAuthConfiguration.allow;
-                
-                // NOTE: If advanced authentication is configured or forced,  it will launch Safari to handle authentication
-                // instead of a webview. You must implement application:openURL:options  to handle the callback.
                 
                 //Uncomment following block to enable IDP Login flow.
                 /*

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Info.plist
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>SFDCOAuthLoginHost</key>
+	<string>sdk.cs1.my.salesforce.com</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/shared/hybrid/AppDelegate+SalesforceHybridSDK.m
+++ b/shared/hybrid/AppDelegate+SalesforceHybridSDK.m
@@ -51,17 +51,7 @@
     // Need to use SalesforceHybridSDKManager in hybrid apps
     [SalesforceSDKManager setInstanceClass:[SalesforceHybridSDKManager class]];
     
-    //Uncomment the following line inorder to enable/force the use of advanced authentication flow.
-    //[SFUserAcountManager sharedInstance].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationRequire;
-    // OR
-    // To  retrieve advanced auth configuration from the org, to determine whether to initiate advanced authentication.
-    //[SFUserAcountManager sharedInstance].advancedAuthConfiguration = SFOAuthAdvancedAuthConfigurationAllow;
-    
-    // NOTE: If advanced authentication is configured or forced,  it will launch Safari to handle authentication
-    // instead of a webview. You must implement application:openURL:options: to handle the callback.
-    
-    
-    //Or uncomment following block to enable IDP Login flow.
+    //Uncomment following block to enable IDP Login flow.
     /*
      //scheme of idpAppp
      [SalesforceSDKManager sharedManager].idpAppURIScheme = @"sampleidpapp";


### PR DESCRIPTION
Removing the use of Advanced Auth Options as planned. I haven't removed the enum entirely from codebase. It will be removed with the SFAuthenticationManager in a subsequent PR. 