### PR TITLE
Dev info should show usernames not user emails

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -489,7 +489,7 @@ static NSString *const SFSDKShowDevDialogNotification = @"SFSDKShowDevDialogNoti
 }
 
 - (NSString*) userToString:(SFUserAccount*)user {
-    return user ? user.email : @"";
+    return user ? user.userName : @"";
 }
 
 - (NSString*) usersToString:(NSArray<SFUserAccount*>*)userAccounts {


### PR DESCRIPTION
To be consistent with Android and also because multiple users can have same email