### PR TITLE
Misc fixes for SmartStore inspector

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -73,6 +73,11 @@ extern NSString *const ROWID_COL;
 extern NSString *const SOUP_INDEX_MAP_TABLE;
 
 /**
+ Soup attributes table
+ */
+extern NSString *const SOUP_ATTRS_TABLE;
+
+/**
  Table to keep track of status of long operations in flight
 */
 extern NSString *const LONG_OPERATIONS_STATUS_TABLE;

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -80,7 +80,7 @@ NSString *const kSFSmartStoreErrorLoadExternalSoup =  @"com.salesforce.smartstor
 NSString * const kSFSmartStoreEncryptionKeyLabel = @"com.salesforce.smartstore.encryption.keyLabel";
 
 // Table to keep track of soup attributes
-static NSString *const SOUP_ATTRS_TABLE = @"soup_attrs";
+NSString *const SOUP_ATTRS_TABLE = @"soup_attrs";
 static NSString *const SOUP_NAMES_TABLE = @"soup_names"; //legacy soup attrs, still around for backward compatibility. Do not use it.
 
 // Table to keep track of soup's index specs

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreInspectorViewController.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreInspectorViewController.m
@@ -220,7 +220,7 @@ static NSString * const kInspectorPickerDefault = @"default";
     [self stopEditing];
     NSString* smartSql = self.queryField.text;
     NSInteger pageSize = [self.pageSizeField.text integerValue];
-    pageSize = (pageSize <= 0 && ![self.pageSizeField.text isEqualToString:@"0"] ? 10 : pageSize);
+    pageSize = (pageSize <= 0 && ![self.pageSizeField.text isEqualToString:@"0"] ? 100 : pageSize);
     NSInteger pageIndex = [self.pageIndexField.text integerValue];
     NSError* error = nil;
     NSArray* results = [self.store queryWithQuerySpec:[SFQuerySpec newSmartQuerySpec:smartSql withPageSize:pageSize] pageIndex:pageIndex error:&error];
@@ -257,8 +257,8 @@ static NSString * const kInspectorPickerDefault = @"default";
         NSString* errorAlertTitle = [SFSDKResourceUtils localizedString:kInspectorQueryFailedKey];
         [self showAlert:[SFSDKResourceUtils localizedString:kInspectorNoSoupsFoundKey] title:errorAlertTitle];
     }
-    if ([names count] > 10) {
-        self.queryField.text = @"SELECT soupName from soup_names";
+    if ([names count] > 100) {
+        self.queryField.text = [NSString stringWithFormat:@"select %@ from %@", SOUP_NAME_COL, SOUP_ATTRS_TABLE];
     } else {
         NSMutableString* q = [NSMutableString string];
         BOOL first = YES;
@@ -275,7 +275,7 @@ static NSString * const kInspectorPickerDefault = @"default";
 
 - (void) indicesButtonClicked
 {
-    self.queryField.text = @"select soupName, path, columnType from soup_index_map";
+    self.queryField.text = [NSString stringWithFormat:@"select %@,%@,%@ from %@", SOUP_NAME_COL, PATH_COL, COLUMN_TYPE_COL, SOUP_INDEX_MAP_TABLE];
     [self runQuery];
 }
 

--- a/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
+++ b/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
@@ -91,7 +91,7 @@
 "inspectorTitle" = "Inspect SmartStore";
 "inspectorBackButtonTitle" = "Back";
 "inspectorRunButtonTitle" = "Run";
-"inspectorPageSizeHint" = "Page size (default: 10)";
+"inspectorPageSizeHint" = "Page size (default: 100)";
 "inspectorPageIndexHint" = "Page index (default: 0)";
 "inspectorClearButtonTitle" = "Clear";
 "inspectorSoupsButtonTitle" = "Soups";


### PR DESCRIPTION
SmartStore inspector was still referring soup_names
It has been renamed to soup_attrs a long time ago
Building the query using the constants from SFSmartStore

Also showing more rows by default (100 instead of 10)
Showing details soup info if there are 100 soups or less (instead of 10)