### PR TITLE
Add some loging around process pool getting, setting

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWebViewStateManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWebViewStateManager.m
@@ -51,6 +51,7 @@ static WKProcessPool *_processPool = nil;
 
 + (WKProcessPool *)sharedProcessPool {
     if (!_processPool) {
+        [SFSDKCoreLogger i:self format:@"[%@ %@]: No process pool exists.  Creating new instance.", NSStringFromClass(self), NSStringFromSelector(_cmd)];
         _processPool = [[WKProcessPool alloc] init];
     }
     return _processPool;
@@ -58,6 +59,7 @@ static WKProcessPool *_processPool = nil;
 
 + (void)setSharedProcessPool:(WKProcessPool *)sharedProcessPool {
     if (sharedProcessPool != _processPool) {
+        [SFSDKCoreLogger i:self format:@"[%@ %@]: changing from process pool %@ to %@", NSStringFromClass(self), NSStringFromSelector(_cmd), _processPool, sharedProcessPool];
         _processPool = sharedProcessPool;
     }
 }


### PR DESCRIPTION
We've been trying to track down some tricky issues with web state reset, and I'm thinking logging process pool changes might help that investigation.  For your consideration.