### PR TITLE
Cleanup CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,10 +255,11 @@ workflows:
       - test-SalesforceSwiftSDK
 
   # Cron is UTC timezone, which is 7 hours ahead of PST.
+  # Run tests at 1am.
   nightly-test-ios11:
     triggers:
       - schedule:
-          cron: "50 20 * * 2,3,4,5,6"
+          cron: "05 23 * * 2,3,4,5,6"
           filters:
             branches:
               only:
@@ -279,10 +280,11 @@ workflows:
       - test-SalesforceSwiftSDK:
             context: nightly-test
 
+  # Run tests at 1am.
   nightly-test-ios10:
     triggers:
       - schedule:
-          cron: "50 20 * * 2,3,4,5,6"
+          cron: "05 23 * * 2,3,4,5,6"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ workflows:
   nightly-test-ios11:
     triggers:
       - schedule:
-          cron: "35 18 * * 2,3,4,5,6"
+          cron: "50 20 * * 2,3,4,5,6"
           filters:
             branches:
               only:
@@ -282,7 +282,7 @@ workflows:
   nightly-test-ios10:
     triggers:
       - schedule:
-          cron: "35 18 * * 2,3,4,5,6"
+          cron: "50 20 * * 2,3,4,5,6"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ workflows:
   nightly-test-ios11:
     triggers:
       - schedule:
-          cron: "30 18 * * 2,3,4,5,6"
+          cron: "35 18 * * 2,3,4,5,6"
           filters:
             branches:
               only:
@@ -282,7 +282,7 @@ workflows:
   nightly-test-ios10:
     triggers:
       - schedule:
-          cron: "30 18 * * 2,3,4,5,6"
+          cron: "35 18 * * 2,3,4,5,6"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,11 +259,11 @@ workflows:
   nightly-test-ios11:
     triggers:
       - schedule:
-          cron: "05 23 * * 2,3,4,5,6"
+          cron: "07 23 * * 2,3,4,5,6"
           filters:
             branches:
               only:
-                - dev
+                - parallelNighlty
     jobs:
       - test-SalesforceAnalytics:
             context: nightly-test
@@ -284,11 +284,11 @@ workflows:
   nightly-test-ios10:
     triggers:
       - schedule:
-          cron: "05 23 * * 2,3,4,5,6"
+          cron: "07 23 * * 2,3,4,5,6"
           filters:
             branches:
               only:
-                - dev
+                - parallelNighlty
     jobs:
       - test-SalesforceAnalytics:
             context: nightly-test-ios10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ workflows:
       - test-SmartSync
       - test-SalesforceSwiftSDK
 
-  # Cron is UTC timezone
+  # Cron is UTC timezone, which is 7 hours ahead of PST.
   nightly-test-ios11:
     triggers:
       - schedule:
@@ -262,7 +262,7 @@ workflows:
           filters:
             branches:
               only:
-                - parallelNighlty
+                - dev
     jobs:
       - test-SalesforceAnalytics:
             context: nightly-test
@@ -286,7 +286,7 @@ workflows:
           filters:
             branches:
               only:
-                - parallelNighlty
+                - dev
     jobs:
       - test-SalesforceAnalytics:
             context: nightly-test-ios10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,52 +254,51 @@ workflows:
       - test-SmartSync
       - test-SalesforceSwiftSDK
 
-  # Cron are on a timezone 8 hours ahead of PST
-  # Nightly run is set for 3am Monday - Friday
+  # Cron is UTC timezone
   nightly-test-ios11:
     triggers:
       - schedule:
-          cron: "30 11 * * 2,3,4,5,6"
+          cron: "30 18 * * 2,3,4,5,6"
           filters:
             branches:
               only:
-                - dev
+                - parallelNighlty
     jobs:
-      - test-SalesforceAnalytics
+      - test-SalesforceAnalytics:
             context: nightly-test
-      - test-SalesforceHybridSDK
+      - test-SalesforceHybridSDK:
             context: nightly-test
-      - test-SalesforceReact
+      - test-SalesforceReact:
             context: nightly-test
-      - test-SalesforceSDKCore
+      - test-SalesforceSDKCore:
             context: nightly-test
-      - test-SmartStore
+      - test-SmartStore:
             context: nightly-test
-      - test-SmartSync
+      - test-SmartSync:
             context: nightly-test
-      - test-SalesforceSwiftSDK
+      - test-SalesforceSwiftSDK:
             context: nightly-test
 
   nightly-test-ios10:
     triggers:
       - schedule:
-          cron: "00 11 * * 2,3,4,5,6"
+          cron: "30 18 * * 2,3,4,5,6"
           filters:
             branches:
               only:
-                - dev
+                - parallelNighlty
     jobs:
-      - test-SalesforceAnalytics
+      - test-SalesforceAnalytics:
             context: nightly-test-ios10
-      - test-SalesforceHybridSDK
+      - test-SalesforceHybridSDK:
             context: nightly-test-ios10
-      - test-SalesforceReact
+      - test-SalesforceReact:
             context: nightly-test-ios10
-      - test-SalesforceSDKCore
+      - test-SalesforceSDKCore:
             context: nightly-test-ios10
-      - test-SmartStore
+      - test-SmartStore:
             context: nightly-test-ios10
-      - test-SmartSync
+      - test-SmartSync:
             context: nightly-test-ios10
-      - test-SalesforceSwiftSDK
+      - test-SalesforceSwiftSDK:
             context: nightly-test-ios10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,11 +259,11 @@ workflows:
   nightly-test-ios11:
     triggers:
       - schedule:
-          cron: "07 23 * * 2,3,4,5,6"
+          cron: "00 08 * * 2,3,4,5,6"
           filters:
             branches:
               only:
-                - parallelNighlty
+                - dev
     jobs:
       - test-SalesforceAnalytics:
             context: nightly-test
@@ -284,11 +284,11 @@ workflows:
   nightly-test-ios10:
     triggers:
       - schedule:
-          cron: "07 23 * * 2,3,4,5,6"
+          cron: "00 10 * * 2,3,4,5,6"
           filters:
             branches:
               only:
-                - parallelNighlty
+                - dev
     jobs:
       - test-SalesforceAnalytics:
             context: nightly-test-ios10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,11 @@ aliases:
 defaults: &defaults
   working_directory: ~/SalesforceMobileSDK-iOS
   macos:
-    xcode: "9.3.1"
+    xcode: "9.4.0"
   shell: /bin/bash --login -eo pipefail
   environment:
     BASH_ENV: ~/.bashrc
+    FASTLANE_SKIP_UPDATE_CHECK: true
     CHRUBY_VER: 2.5.1
 
 version: 2
@@ -240,152 +241,6 @@ jobs:
           destination: Static-Analysis
       - run: *codecov
 
-  test-ios-11:
-    <<: *defaults
-    environment:
-      - IOS_VERSION: " (11.3)"
-      - DEVICE: "iPhone X"
-    steps:
-      - checkout
-      - restore_cache: *restore-gem-cache
-      - run: *install-dependecies
-      - save_cache: *save-gem-cache
-      - run:
-          name: Test SalesforceAnalytics
-          command:  |
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SalesforceAnalytics | fastlane LCL
-          when: always
-      - run:
-          name: Test SalesforceHybridSDK
-          command:  |
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SalesforceHybridSDK | fastlane LCL
-          when: always
-      - run:
-          name: Test SalesforceReact
-          command:  |
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SalesforceReact | fastlane LCL
-          when: always
-      - run:
-          name: Test SalesforceSDKCore
-          command:  |
-            chruby${CHRUBY_VER}
-            cd .circleci
-            echo SalesforceSDKCore | fastlane LCL
-          when: always
-      - run:
-          name: Test SmartStore
-          command:  |
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SmartStore | fastlane LCL
-          when: always
-      - run:
-          name: Test SmartSync
-          command:  |
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SmartSync | fastlane LCL
-          when: always
-      - run:
-          name: Test SalesforceSwiftSDK
-          command:  |
-            xcrun swift -version
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SalesforceSwiftSDK | fastlane LCL
-          when: always
-      - store_test_results:
-          path: /Users/distiller/SalesforceMobileSDK-iOS/test_output/
-      - store_artifacts:
-          path: /Users/distiller/SalesforceMobileSDK-iOS/test_output/
-          destination: Test-Results
-      - store_artifacts:
-          path: /Users/distiller/SalesforceMobileSDK-iOS/clangReport
-          destination: Static-Analysis
-      - store_artifacts:
-          path: /Users/distiller/SalesforceMobileSDK-iOS/swiftlint.result.json
-          destination: Static-Analysis
-      - run: *codecov
-
-  test-ios-10:
-    <<: *defaults
-    environment:
-      - IOS_VERSION: " (10.3.1)"
-      - DEVICE: "iPhone 6 Plus"
-    steps:
-      - checkout
-      - restore_cache: *restore-gem-cache
-      - run: *install-dependecies
-      - save_cache: *save-gem-cache
-      - run:
-          name: Test SalesforceAnalytics
-          command:  |
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SalesforceAnalytics | fastlane LCL
-          when: always
-      - run:
-          name: Test SalesforceHybridSDK
-          command:  |
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SalesforceHybridSDK | fastlane LCL
-          when: always
-      - run:
-          name: Test SalesforceReact
-          command:  |
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SalesforceReact | fastlane LCL
-          when: always
-      - run:
-          name: Test SalesforceSDKCore
-          command:  |
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SalesforceSDKCore | fastlane LCL
-          when: always
-      - run:
-          name: Test SmartStore
-          command:  |
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SmartStore | fastlane LCL
-          when: always
-      - run:
-          name: Test SmartSync
-          command:  |
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SmartSync | fastlane LCL
-          when: always
-      - run:
-          name: Test SalesforceSwiftSDK
-          command:  |
-            xcrun swift -version
-            chruby ${CHRUBY_VER}
-            cd .circleci
-            echo SalesforceSwiftSDK | fastlane LCL
-          when: always
-      - store_test_results:
-          path: /Users/distiller/SalesforceMobileSDK-iOS/test_output/
-      - store_artifacts:
-          path: /Users/distiller/SalesforceMobileSDK-iOS/test_output/
-          destination: Test-Results
-      - store_artifacts:
-          path: /Users/distiller/SalesforceMobileSDK-iOS/clangReport
-          destination: Static-Analysis
-      - store_artifacts:
-          path: /Users/distiller/SalesforceMobileSDK-iOS/swiftlint.result.json
-          destination: Static-Analysis
-      - run: *codecov
-
 workflows:
   version: 2
 
@@ -400,15 +255,51 @@ workflows:
       - test-SalesforceSwiftSDK
 
   # Cron are on a timezone 8 hours ahead of PST
-  # Nightly run is set for midnight Monday - Friday
-  nightly-test-ios:
+  # Nightly run is set for 3am Monday - Friday
+  nightly-test-ios11:
     triggers:
       - schedule:
-          cron: "00 8 * * 2,3,4,5,6"
+          cron: "30 11 * * 2,3,4,5,6"
           filters:
             branches:
               only:
                 - dev
     jobs:
-      - test-ios-11
-      - test-ios-10
+      - test-SalesforceAnalytics
+            context: nightly-test
+      - test-SalesforceHybridSDK
+            context: nightly-test
+      - test-SalesforceReact
+            context: nightly-test
+      - test-SalesforceSDKCore
+            context: nightly-test
+      - test-SmartStore
+            context: nightly-test
+      - test-SmartSync
+            context: nightly-test
+      - test-SalesforceSwiftSDK
+            context: nightly-test
+
+  nightly-test-ios10:
+    triggers:
+      - schedule:
+          cron: "00 11 * * 2,3,4,5,6"
+          filters:
+            branches:
+              only:
+                - dev
+    jobs:
+      - test-SalesforceAnalytics
+            context: nightly-test-ios10
+      - test-SalesforceHybridSDK
+            context: nightly-test-ios10
+      - test-SalesforceReact
+            context: nightly-test-ios10
+      - test-SalesforceSDKCore
+            context: nightly-test-ios10
+      - test-SmartStore
+            context: nightly-test-ios10
+      - test-SmartSync
+            context: nightly-test-ios10
+      - test-SalesforceSwiftSDK
+            context: nightly-test-ios10

--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -1,7 +1,7 @@
 $git_pr_api = "https://api.github.com/repos/%s/SalesforceMobileSDK-iOS/pulls/%s/files"
 $schemes = ['SalesforceAnalytics', 'SalesforceHybridSDK', 'SalesforceReact', 'SalesforceSDKCore', 'SmartStore', 'SmartSync', 'SalesforceSwiftSDK']
 ENV['DEVICE'] = 'iPhone 8' unless ENV.has_key?('DEVICE')
-ENV['IOS_VERSION'] = ' (11.4)' unless ENV.has_key?('IOS_VERSION')
+ENV['IOS_VERSION'] = '11.4' unless ENV.has_key?('IOS_VERSION')
 
 lane :PR do |options|
   lib_to_test = options[:lib]
@@ -14,7 +14,7 @@ lane :PR do |options|
   else
     # Check if this is a PR. 
     # Rebuilds of PR's don't have the CIRCLE_PULL_REQUEST key, so check the branch instead. 
-    if (ENV.has_key?('CIRCLE_BRANCH') && ENV['CIRCLE_BRANCH'].include?('pull/'))
+    if ENV.has_key?('CIRCLE_BRANCH') && ENV['CIRCLE_BRANCH'].include?('pull/')
       # No PR Number indicates that this PR is running in a CircleCI env linked to a fork, so force the url to forcedotcom project.
       if ENV.has_key?('CIRCLE_PR_NUMBER')
         pr_files_api = $git_pr_api % [ENV['CIRCLE_PROJECT_USERNAME'], ENV['CIRCLE_PR_NUMBER']]
@@ -80,7 +80,8 @@ def test_scheme(scheme)
     scan(
         workspace: 'SalesforceMobileSDK.xcworkspace',
         scheme: scheme,
-        device: ENV['DEVICE'] + ENV['IOS_VERSION'],
+        # (11.4)
+        device: ENV['DEVICE'] + ' (' + ENV['IOS_VERSION'] + ')',
         output_directory: 'test_output',
         output_types: 'html,junit',
         code_coverage: true,

--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -13,7 +13,7 @@ lane :PR do |options|
     UI.important "Nightly, skipping modified check."
     test_scheme(lib_to_test)
   else
-    if (ENV.has_key?('CIRCLE_PULL_REQUEST') || (ENV.has_key?('CIRCLE_BRANCH').contains?('pull/')))
+    if (ENV.has_key?('CIRCLE_PULL_REQUEST') || (ENV.has_key?('CIRCLE_BRANCH').include?('pull/')))
       # No PR Number indicates that this PR is running in a CircleCI env linked to a fork, so force the url to forcedotcom project.
       if ENV.has_key?('CIRCLE_PR_NUMBER')
         pr_files_api = $git_pr_api % [ENV['CIRCLE_PROJECT_USERNAME'], ENV['CIRCLE_PR_NUMBER']]

--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -1,7 +1,7 @@
 $git_pr_api = "https://api.github.com/repos/%s/SalesforceMobileSDK-iOS/pulls/%s/files"
 $schemes = ['SalesforceAnalytics', 'SalesforceHybridSDK', 'SalesforceReact', 'SalesforceSDKCore', 'SmartStore', 'SmartSync', 'SalesforceSwiftSDK']
 ENV['DEVICE'] = 'iPhone 8' unless ENV.has_key?('DEVICE')
-ENV['IOS_VERSION'] = ' (11.3)' unless ENV.has_key?('IOS_VERSION')
+ENV['IOS_VERSION'] = ' (11.4)' unless ENV.has_key?('IOS_VERSION')
 
 lane :PR do |options|
   lib_to_test = options[:lib]
@@ -9,35 +9,40 @@ lane :PR do |options|
   schemes = Set.new
 
   # Determine CI platform or exit
-  if ENV.has_key?('CIRCLE_PULL_REQUEST')
-    # No PR Number indicates that this PR is running in a CircleCI env linked to a fork, so force the url to forcedotcom project.
-    if ENV.has_key?('CIRCLE_PR_NUMBER')
-      pr_files_api = $git_pr_api % [ENV['CIRCLE_PROJECT_USERNAME'], ENV['CIRCLE_PR_NUMBER']]
-    else
-      pr_files_api = $git_pr_api % ['forcedotcom', ENV['CIRCLE_PULL_REQUEST'].split('/').last]
-    end
-    pull_files = `#{"curl %s" % [pr_files_api]}`
-  else
-    UI.error 'Not a PR on CircleCI, stopping stop execution now.'
-    next
-  end
-
-  # Determine which libs have been modified
-  pr_files = JSON.parse(pull_files)
-  for pr_file in pr_files
-    path = pr_file['filename']
-    for scheme in $schemes
-      if path.include? scheme
-        schemes.add(scheme)
-      end
-    end
-  end
-  UI.important "Schemes to test: " + schemes.to_a().join(',')
-
-  if schemes.include? lib_to_test
+  if (ENV.has_key?('NIGHTLY_TEST'))
+    UI.important "Nightly, skipping modified check."
     test_scheme(lib_to_test)
   else
-    UI.important "Lib #{lib_to_test} not modified by this PR, no need to test."
+    if (ENV.has_key?('CIRCLE_PULL_REQUEST') || (ENV.has_key?('CIRCLE_BRANCH').contains?('pull/')))
+      # No PR Number indicates that this PR is running in a CircleCI env linked to a fork, so force the url to forcedotcom project.
+      if ENV.has_key?('CIRCLE_PR_NUMBER')
+        pr_files_api = $git_pr_api % [ENV['CIRCLE_PROJECT_USERNAME'], ENV['CIRCLE_PR_NUMBER']]
+      else
+        pr_files_api = $git_pr_api % ['forcedotcom', ENV['CIRCLE_PULL_REQUEST'].split('/').last]
+      end
+      pull_files = `#{"curl %s" % [pr_files_api]}`
+    else
+      UI.error 'Not a PR on CircleCI, stopping stop execution now.'
+      next
+    end
+
+    # Determine which libs have been modified
+    pr_files = JSON.parse(pull_files)
+    for pr_file in pr_files
+      path = pr_file['filename']
+      for scheme in $schemes
+        if path.include? scheme
+          schemes.add(scheme)
+        end
+      end
+    end
+    UI.important "Schemes to test: " + schemes.to_a().join(',')
+
+    if schemes.include? lib_to_test
+      test_scheme(lib_to_test)
+    else
+      UI.important "Lib #{lib_to_test} not modified by this PR, no need to test."
+    end
   end
 end
 
@@ -76,7 +81,7 @@ def test_scheme(scheme)
         scheme: scheme,
         device: ENV['DEVICE'] + ENV['IOS_VERSION'],
         output_directory: 'test_output',
-        output_types: 'html',
+        output_types: 'html,junit',
         code_coverage: true,
         skip_build: true
     )

--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -8,17 +8,18 @@ lane :PR do |options|
   Dir.chdir('../')
   schemes = Set.new
 
-  # Determine CI platform or exit
-  if (ENV.has_key?('NIGHTLY_TEST'))
+  if ENV.has_key?('NIGHTLY_TEST')
     UI.important "Nightly, skipping modified check."
     test_scheme(lib_to_test)
   else
-    if (ENV.has_key?('CIRCLE_PULL_REQUEST') || (ENV.has_key?('CIRCLE_BRANCH').include?('pull/')))
+    # Check if this is a PR. 
+    # Rebuilds of PR's don't have the CIRCLE_PULL_REQUEST key, so check the branch instead. 
+    if (ENV.has_key?('CIRCLE_BRANCH') && ENV['CIRCLE_BRANCH'].include?('pull/'))
       # No PR Number indicates that this PR is running in a CircleCI env linked to a fork, so force the url to forcedotcom project.
       if ENV.has_key?('CIRCLE_PR_NUMBER')
         pr_files_api = $git_pr_api % [ENV['CIRCLE_PROJECT_USERNAME'], ENV['CIRCLE_PR_NUMBER']]
       else
-        pr_files_api = $git_pr_api % ['forcedotcom', ENV['CIRCLE_PULL_REQUEST'].split('/').last]
+        pr_files_api = $git_pr_api % ['forcedotcom', ENV['CIRCLE_BRANCH'].split('/').last]
       end
       pull_files = `#{"curl %s" % [pr_files_api]}`
     else


### PR DESCRIPTION
- Paralyze nightly builds for stability and readability.
- Update to Xcode 9.4/iOS 11.4 - thought I had done this already.
- Fix test reporting
- Fix test not running on rebuild
- yaml/fastlane cleanup