### PR TITLE
This addresses a crash when the server returns a non JSON response but a 200 Status OK.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -202,9 +202,13 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
         [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeaturePushNotifications];
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) rawResponse;
         NSInteger statusCode = httpResponse.statusCode;
+
         if (statusCode < 200 || statusCode >= 300) {
             [SFSDKCoreLogger e:[strongSelf class] format:@"Registration for notifications with Salesforce failed with status %ld", statusCode];
             [SFSDKCoreLogger e:[strongSelf class] format:@"Response:%@", response];
+            [strongSelf postPushNotificationRegistration:failBlock];
+        } else if (![response isKindOfClass:[NSDictionary class]]) {
+            [SFSDKCoreLogger e:[strongSelf class] format:@"Registration for notifications with Salesforce failed due to unexpected response: %@", response];
             [strongSelf postPushNotificationRegistration:failBlock];
         } else {
             [SFSDKCoreLogger i:[strongSelf class] format:@"Registration for notifications with Salesforce succeeded"];


### PR DESCRIPTION
This can occur when the server attempts to use non HTTP Status Code redirects.