### PR TITLE
Changed console logger to include timezones

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.h
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.h
@@ -309,3 +309,13 @@
 + (void)log:(nonnull Class)cls level:(DDLogLevel)level message:(nonnull NSString *)message;
 
 @end
+
+#pragma mark - Log formatter for console logs
+
+@interface SFSDKFormatter : NSObject <DDLogFormatter>
+
+@property (nonatomic, readwrite, strong) NSDateFormatter *dateFormatter;
+
+- (instancetype)init;
+
+@end

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.m
@@ -363,12 +363,14 @@ static inline DDLogFlag DDLogFlagForLogLevel(DDLogLevel level) {
 
 - (instancetype)initWithDateFormatter: (NSDateFormatter *)specialFormatter {
     self = [super init];
-    if (specialFormatter == nil) {
-        self.dateFormatter = [[NSDateFormatter alloc] init];
-        [self.dateFormatter setTimeZone:[NSTimeZone localTimeZone]];
-        [self.dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss.SSSZ"];
-    } else {
-        self.dateFormatter = specialFormatter;
+    if (self) {
+        if (specialFormatter == nil) {
+            self.dateFormatter = [[NSDateFormatter alloc] init];
+            [self.dateFormatter setTimeZone:[NSTimeZone localTimeZone]];
+            [self.dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss.SSSZ"];
+        } else {
+            self.dateFormatter = specialFormatter;
+        }
     }
     return self;
 }

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Logger/SFSDKLogger.m
@@ -90,6 +90,7 @@ static NSMutableDictionary<NSString *, SFSDKLogger *> *loggerList = nil;
         self.logger = [[DDLog alloc] init];
         self.fileLogger = [[SFSDKFileLogger alloc] initWithComponent:componentName];
         DDTTYLogger *consoleLogger = [DDTTYLogger sharedInstance];
+        consoleLogger.logFormatter = [[SFSDKFormatter alloc] init];
         consoleLogger.colorsEnabled = YES;
         [self.logger addLogger:consoleLogger withLevel:self.logLevel];
         if (self.fileLoggingEnabled) {
@@ -348,6 +349,34 @@ static inline DDLogFlag DDLogFlagForLogLevel(DDLogLevel level) {
 
 + (void)log:(Class)cls level:(DDLogLevel)level message:(NSString *)message {
     [[self sharedInstance] log:cls level:level message:message];
+}
+
+@end
+
+#pragma mark - Log formatter for console logs
+
+@implementation SFSDKFormatter
+
+- (instancetype)init {
+    return [self initWithDateFormatter:nil];
+}
+
+- (instancetype)initWithDateFormatter: (NSDateFormatter *)specialFormatter {
+    self = [super init];
+    if (specialFormatter == nil) {
+        self.dateFormatter = [[NSDateFormatter alloc] init];
+        [self.dateFormatter setTimeZone:[NSTimeZone localTimeZone]];
+        [self.dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss.SSSZ"];
+    } else {
+        self.dateFormatter = specialFormatter;
+    }
+    return self;
+}
+
+- (NSString *)formatLogMessage:(DDLogMessage *)logMessage {
+    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    NSString *date = [self.dateFormatter stringFromDate:logMessage.timestamp];
+    return [NSString stringWithFormat:@"%@ %@[%d:%@] %@", date, appName, (int)getpid(), [logMessage threadID], logMessage.message];
 }
 
 @end


### PR DESCRIPTION
This change is to add a formatter to the console logger and hopefully start adding timezones to all log lines without changing anything else in the current log lines for any app using the MSDK. 

@bhariharan 