### PR TITLE
When duration is 0, EPT times are nil

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Transform/SFSDKAILTNTransform.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Transform/SFSDKAILTNTransform.m
@@ -95,7 +95,7 @@ static NSString* const kSFPerfEventType = @"defs";
     payload[kSFPageStartTimeKey] = [NSNumber numberWithInteger:event.sessionStartTime];
     NSInteger endTime = event.endTime;
     NSInteger duration = endTime - startTime;
-    if (duration > 0) {
+    if (duration >= 0) {
         if (schemaType == SchemaTypeInteraction || schemaType == SchemaTypePerf) {
             payload[kSFDurationKey] = [NSNumber numberWithInteger:duration];
         } else if (schemaType == SchemaTypePageView) {


### PR DESCRIPTION
The rare occurrence of duration being 0 causes the EPT times to be nil. We want the duration to be given as a value in this situation. 

@bhariharan I looked through the MSDK files and I think this is the only place where the EPT marker is calculated. Do you know of any other locations? Do you know of a way to test this on MSDK instead of having to cherry pick this to S1 and then testing there? 