### PR TITLE
Fix hybrid remote session refresh case for SAML/SSO login flows

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -459,20 +459,33 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
 
 - (NSString *)isLoginRedirectUrl:(NSURL *)url
 {
-    if (url == nil || [url absoluteString] == nil || [[url absoluteString] length] == 0) {
+    if (url == nil || url.absoluteString == nil || url.absoluteString.length == 0) {
         return nil;
     }
-    if ([[[url scheme] lowercaseString] hasPrefix:@"http"]
-        && [url query] != nil) {
-        NSString *startUrlValue = [url valueForParameterName:@"startURL"];
-        NSString *ecValue = [url valueForParameterName:@"ec"];
-        BOOL foundStartURL = (startUrlValue != nil);
-        BOOL foundValidEcValue = ([ecValue isEqualToString:@"301"] || [ecValue isEqualToString:@"302"]);
-        if (foundStartURL && foundValidEcValue) {
-            return startUrlValue;
+    if ([url.scheme.lowercaseString hasPrefix:@"http"]) {
+        if (url.query != nil) {
+            NSString *startUrlValue = [url valueForParameterName:@"startURL"];
+            NSString *ecValue = [url valueForParameterName:@"ec"];
+            BOOL foundStartURL = (startUrlValue != nil);
+            BOOL foundValidEcValue = ([ecValue isEqualToString:@"301"] || [ecValue isEqualToString:@"302"]);
+            if (foundValidEcValue) {
+                if (foundStartURL) {
+                    return startUrlValue;
+                } else {
+                    return _hybridViewConfig.startPage;
+                }
+            } else if ([self isSamlLoginRedirect:url.absoluteString]) {
+                return _hybridViewConfig.startPage;
+            }
+        } else if ([self isSamlLoginRedirect:url.absoluteString]) {
+            return _hybridViewConfig.startPage;
         }
     }
     return nil;
+}
+
+- (BOOL)isSamlLoginRedirect:(NSString *)url {
+    return NO;
 }
 
 - (BOOL)isOffline

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.h
@@ -24,8 +24,6 @@
 
 #import <Foundation/Foundation.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
 /**
  Data class representing the org authentication configuration.
  */
@@ -37,16 +35,19 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL useNativeBrowserForAuth;
 
 /**
+ List of configured SSO URLs.
+ */
+@property (nonatomic, strong, readonly, nullable) NSArray<NSString *> *ssoUrls;
+
+/**
  The raw dictionary data representing the org auth configuration.
  */
-@property (nonatomic, strong, readonly) NSDictionary *authConfigDict;
+@property (nonatomic, strong, readonly, nullable) NSDictionary *authConfigDict;
 
 /**
  Designated initializer.
  @param authConfigDict The NSDictionary containing the org auth configuration.
  */
-- (id)initWithConfigDict:(NSDictionary *)authConfigDict;
+- (nonnull id)initWithConfigDict:(nullable NSDictionary *)authConfigDict;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.m
@@ -26,6 +26,8 @@
 
 static NSString * const kAuthConfigMobileSDKKey        = @"MobileSDK";
 static NSString * const kAuthConfigUseNativeBrowserKey = @"UseiOSNativeBrowserForAuthentication";
+static NSString * const kAuthConfigSamlProvidersKey    = @"SamlProviders";
+static NSString * const kAuthConfigSSOUrlKey           = @"SsoUrl";
 
 @interface SFOAuthOrgAuthConfiguration ()
 
@@ -47,6 +49,20 @@ static NSString * const kAuthConfigUseNativeBrowserKey = @"UseiOSNativeBrowserFo
 
 - (BOOL)useNativeBrowserForAuth {
     return [self.authConfigDict[kAuthConfigMobileSDKKey][kAuthConfigUseNativeBrowserKey] boolValue];
+}
+
+- (NSArray<NSString *> *)ssoUrls {
+    NSMutableArray<NSString *> *ssoUrls = [[NSMutableArray alloc] init];
+    NSArray *samlProviders = self.authConfigDict[kAuthConfigSamlProvidersKey];
+    if (samlProviders && samlProviders.count > 0) {
+        for (int i = 0; i < samlProviders.count; i++) {
+            NSDictionary *provider = samlProviders[i];
+            if (provider) {
+                ssoUrls[i] = provider[kAuthConfigSSOUrlKey];
+            }
+        }
+    }
+    return ssoUrls;
 }
 
 - (NSString *) description {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthConfigUtilTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthConfigUtilTests.m
@@ -34,6 +34,7 @@
 static NSString * const kSFTestId = @"test_id";
 static NSString * const kSFTestClientId = @"test_client_id";
 static NSString * const kSFMyDomainEndpoint = @"images.cs4.my.salesforce.com";
+static NSString * const kSFAlternateMyDomainEndpoint = @"powerofus.force.com";
 static NSString * const kSFSandboxEndpoint = @"test.salesforce.com";
 
 @interface SFSDKAuthConfigUtilTests : XCTestCase
@@ -64,6 +65,35 @@ static NSString * const kSFSandboxEndpoint = @"test.salesforce.com";
         XCTAssertNotNil(authConfig, @"Auth config should not be nil");
         XCTAssertNotNil(authConfig.authConfigDict, @"Auth config dictionary should not be nil");
         XCTAssertTrue(authConfig.useNativeBrowserForAuth, @"Browser based login should be enabled");
+        [expect fulfill];
+    } oauthCredentials:credentials];
+    [self waitForExpectationsWithTimeout:20 handler:nil];
+}
+
+- (void)testGetSSOUrls {
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:kSFTestId clientId:kSFTestClientId encrypted:YES];
+    [credentials setDomain:kSFAlternateMyDomainEndpoint];
+    XCTestExpectation *expect = [self expectationWithDescription:@"testGetSSOUrls"];
+    [SFSDKAuthConfigUtil getMyDomainAuthConfig:^(SFOAuthOrgAuthConfiguration *authConfig, NSError *error) {
+        XCTAssertNil(error, @"Error should be nil");
+        XCTAssertNotNil(authConfig, @"Auth config should not be nil");
+        XCTAssertNotNil(authConfig.authConfigDict, @"Auth config dictionary should not be nil");
+        XCTAssertNotNil(authConfig.ssoUrls, @"SSO URLs should not be nil");
+        XCTAssertTrue(authConfig.ssoUrls.count >= 1, @"SSO URLs should have at least 1 valid entry");
+        [expect fulfill];
+    } oauthCredentials:credentials];
+    [self waitForExpectationsWithTimeout:20 handler:nil];
+}
+
+- (void)testGetNoSSOUrls {
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:kSFTestId clientId:kSFTestClientId encrypted:YES];
+    [credentials setDomain:kSFMyDomainEndpoint];
+    XCTestExpectation *expect = [self expectationWithDescription:@"testGetNoSSOUrls"];
+    [SFSDKAuthConfigUtil getMyDomainAuthConfig:^(SFOAuthOrgAuthConfiguration *authConfig, NSError *error) {
+        XCTAssertNil(error, @"Error should be nil");
+        XCTAssertNotNil(authConfig, @"Auth config should not be nil");
+        XCTAssertNotNil(authConfig.authConfigDict, @"Auth config dictionary should not be nil");
+        XCTAssertNil(authConfig.ssoUrls, @"SSO URLs should be nil");
         [expect fulfill];
     } oauthCredentials:credentials];
     [self waitForExpectationsWithTimeout:20 handler:nil];


### PR DESCRIPTION
If the org uses a SAML/SSO provider for login, it is possible to customize the SAML/SSO login URL to drop all arguments from the URL. Besides, the login redirect is beyond the control of the Salesforce IDP at this point and hence, the login redirect when a session timeout occurs will not contain `ec=301` or `startURL`. This leaves the user staring at a login page within the hybrid `WebView` that does nothing. Luckily, we can fetch the login URL in this case from `.well-known` and the container needs to do 2 things to solve this problem.
- We need to parse the SSO URLs from `.well-known` (which we already fetch) and check if these URLs are hit as part of the redirects that indicate session timeout.
- If this occurs, load the `startURL`.
This PR addresses these issues.

cc: @khawkins 

The equivalent `Android` PR is [here](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/1763).