### PR TITLE
Fixing corner case with auth timeout

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -864,7 +864,13 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
         if (authInfo.authType == SFOAuthTypeRefresh) {
             createAbsUrl = NO;
         }
-        NSURL *returnUrlAfterAuth = [self frontDoorUrlWithReturnUrl:originalUrl returnUrlIsEncoded:YES createAbsUrl:createAbsUrl];
+        BOOL encoded = YES;
+        if ([originalUrl containsString:@"frontdoor.jsp"]) {
+            if ([originalUrl rangeOfString:@"retURL=")].location != NSNotFound) {
+                encoded = NO;
+            }
+        }
+        NSURL *returnUrlAfterAuth = [self frontDoorUrlWithReturnUrl:originalUrl returnUrlIsEncoded:encoded createAbsUrl:createAbsUrl];
         NSURLRequest *newRequest = [NSURLRequest requestWithURL:returnUrlAfterAuth];
         if (self.useUIWebView) {
             [(UIWebView *)(self.webView) loadRequest:newRequest];

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/SFHybridViewController.m
@@ -866,7 +866,7 @@ static NSString * const kSFAppFeatureUsesUIWebView = @"WV";
         }
         BOOL encoded = YES;
         if ([originalUrl containsString:@"frontdoor.jsp"]) {
-            if ([originalUrl rangeOfString:@"retURL=")].location != NSNotFound) {
+            if ([originalUrl rangeOfString:@"retURL="].location != NSNotFound) {
                 encoded = NO;
             }
         }


### PR DESCRIPTION
The URL that comes back from the server is not always encoded (in some communities it's not encoded). This PR computes whether it's encoded or not dynamically to handle this situation and prevent a downstream crash while attempting to build `frontdoorUrl`.