### PR TITLE
CI Cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,14 @@
 aliases:
   - &save-gem-cache
-    key: v4-gems-{{ checksum ".circleci/Gemfile.lock" }}
+    key: v5-gems-{{ checksum ".circleci/Gemfile.lock" }}
     paths:
-      - /Users/distiller/.gem/ruby/2.4.2
-      - /Users/distiller/.rubies/ruby-2.4.2/lib/ruby/gems/2.4.0
+      - /Users/distiller/.gem/ruby/2.5.1
+      - /Users/distiller/.rubies/ruby-2.4.2/lib/ruby/gems/2.5.1
 
   - &restore-gem-cache
     keys:
-      - v4-gems-{{ checksum ".circleci/Gemfile.lock" }}
-      - v4-gems-
+      - v5-gems-{{ checksum ".circleci/Gemfile.lock" }}
+      - v5-gems-
 
   - &install-dependecies
     name: Install Dependencies
@@ -32,7 +32,7 @@ aliases:
     name: Danger Lib
     command:  |
       chruby ${CHRUBY_VER}
-      DANGER_GITHUB_API_TOKEN="5d42eadf98c58c9c4f60""7fcfc72cee4c7ef1486b" danger --dangerfile=.circleci/Dangerfile-Lib.rb --danger_id="${LIB}" --verbose
+      DANGER_GITHUB_API_TOKEN="b676bc92bde5202b94d0""ec8dfecb2716044bf523" danger --dangerfile=.circleci/Dangerfile-Lib.rb --danger_id="${LIB}" --verbose
     background: true
     when: always
 
@@ -41,10 +41,16 @@ aliases:
     command: bash <(curl -s https://codecov.io/bash) -X gcov -X xcode
     when: always
 
+  - &pr-filter
+    filters:
+      branches:
+        only:
+        - /pull.*/
+
 defaults: &defaults
   working_directory: ~/SalesforceMobileSDK-iOS
   macos:
-    xcode: "9.4.0"
+    xcode: "9.4.1"
   shell: /bin/bash --login -eo pipefail
   environment:
     BASH_ENV: ~/.bashrc
@@ -66,7 +72,7 @@ jobs:
           name: Danger PR
           command:  |
             chruby ${CHRUBY_VER}
-            DANGER_GITHUB_API_TOKEN="5d42eadf98c58c9c4f60""7fcfc72cee4c7ef1486b" danger --dangerfile=.circleci/Dangerfile-PR.rb --danger_id=PR-Check --verbose
+            DANGER_GITHUB_API_TOKEN="b676bc92bde5202b94d0""ec8dfecb2716044bf523" danger --dangerfile=.circleci/Dangerfile-PR.rb --danger_id=PR-Check --verbose
           background: true
       - save_cache: *save-gem-cache
       - run: *run-tests
@@ -191,28 +197,6 @@ jobs:
           destination: Static-Analysis
       - run: *codecov
 
-  test-SmartSync:
-    <<: *defaults
-    environment:
-      - FASTLANE_LANE: "PR lib:SmartSync"
-      - LIB: "SmartSync"
-    steps:
-      - checkout
-      - restore_cache: *restore-gem-cache
-      - run: *install-dependecies
-      - save_cache: *save-gem-cache
-      - run: *run-tests
-      - run: *danger-lib
-      - store_test_results:
-          path: /Users/distiller/SalesforceMobileSDK-iOS/test_output/
-      - store_artifacts:
-          path: /Users/distiller/SalesforceMobileSDK-iOS/test_output/
-          destination: Test-Results
-      - store_artifacts:
-          path: /Users/distiller/SalesforceMobileSDK-iOS/clangReport
-          destination: Static-Analysis
-      - run: *codecov
-
   test-SalesforceSwiftSDK:
     <<: *defaults
     environment:
@@ -246,20 +230,27 @@ workflows:
 
   build-test-pr:
     jobs:
-      - test-SalesforceAnalytics
-      - test-SalesforceHybridSDK
-      - test-SalesforceReact
-      - test-SalesforceSDKCore
-      - test-SmartStore
-      - test-SmartSync
-      - test-SalesforceSwiftSDK
+      - test-SalesforceAnalytics:
+          *pr-filter
+      - test-SalesforceHybridSDK:
+          *pr-filter
+      - test-SalesforceReact:
+          *pr-filter
+      - test-SalesforceSDKCore:
+          *pr-filter
+      - test-SmartStore:
+          *pr-filter
+      - test-SmartSync:
+          *pr-filter
+      - test-SalesforceSwiftSDK:
+          *pr-filter
 
   # Cron is UTC timezone, which is 7 hours ahead of PST.
   # Run tests at 1am.
   nightly-test-ios11:
     triggers:
       - schedule:
-          cron: "00 08 * * 2,3,4,5,6"
+          cron: "00 08 * * 2,4,6"
           filters:
             branches:
               only:
@@ -279,28 +270,3 @@ workflows:
             context: nightly-test
       - test-SalesforceSwiftSDK:
             context: nightly-test
-
-  # Run tests at 1am.
-  nightly-test-ios10:
-    triggers:
-      - schedule:
-          cron: "00 10 * * 2,3,4,5,6"
-          filters:
-            branches:
-              only:
-                - dev
-    jobs:
-      - test-SalesforceAnalytics:
-            context: nightly-test-ios10
-      - test-SalesforceHybridSDK:
-            context: nightly-test-ios10
-      - test-SalesforceReact:
-            context: nightly-test-ios10
-      - test-SalesforceSDKCore:
-            context: nightly-test-ios10
-      - test-SmartStore:
-            context: nightly-test-ios10
-      - test-SmartSync:
-            context: nightly-test-ios10
-      - test-SalesforceSwiftSDK:
-            context: nightly-test-ios10

--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -24,6 +24,7 @@ lane :PR do |options|
       pull_files = `#{"curl %s" % [pr_files_api]}`
     else
       UI.error 'Not a PR on CircleCI, stopping stop execution now.'
+      `circleci step halt`
       next
     end
 
@@ -43,6 +44,7 @@ lane :PR do |options|
       test_scheme(lib_to_test)
     else
       UI.important "Lib #{lib_to_test} not modified by this PR, no need to test."
+      `circleci step halt`
     end
   end
 end


### PR DESCRIPTION
- Remove iOS 10 Nightly 
- Change iOS 11 Nightly to Mon/Wed/Fri 
- Update Danger token
- Fix ruby cache
- Bump Xcode to 9.4.1
- Don't waist cycles running on merge commit trigger + stop execution a little faster on unmodified libs where testing isn't necessary. 