### PR TITLE
Using SFAuthenticationSession for advanced auth flows

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
@@ -242,17 +242,6 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
  */
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(WKWebView *)view;
 
-/** Sent after VC has been initialized with authentication URL.
- 
- The receiver should present the VC in the implementation of this method.
- 
- @param coordinator The SFOAuthCoordinator instance processing this message
- @param svc         The SFSafariViewController instance that will be used to conduct the authentication workflow
- 
- @see SFOAuthCoordinator
- */
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSafariViewController:(SFSafariViewController *)svc;
-
 /**
  Sent to notify the delegate that a browser authentication flow was cancelled out of by the user.
 
@@ -273,7 +262,7 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
  the Security framework and either the NSJSONSerialization iOS 5.0 SDK class 
  or the third party SBJsonParser class.
  */
-@interface SFOAuthCoordinator : NSObject <WKNavigationDelegate, WKUIDelegate, SFSafariViewControllerDelegate> {
+@interface SFOAuthCoordinator : NSObject <WKNavigationDelegate, WKUIDelegate> {
 }
 
 /** User credentials to use within the authentication process.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
@@ -329,6 +329,11 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
 @property (nonatomic, readonly, null_unspecified) WKWebView *view;
 
 /**
+ Auth session through which the user will input OAuth credentials for the user-agent flow OAuth process.
+ */
+@property (nonatomic, readonly, null_unspecified) SFAuthenticationSession *authSession;
+
+/**
  The user agent string that will be used for authentication.  While this property will persist throughout
  the lifetime of the coordinator object, the user agent configured for the system will be reset back to
  its original value in between authentication requests.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -435,10 +435,6 @@ static NSString * const kSFECParameter = @"ec";
     [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureSafariBrowserForLogin];
     __weak typeof(self) weakSelf = self;
     _authSession = [[SFAuthenticationSession alloc] initWithURL:nativeBrowserUrl callbackURLScheme:nil completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable error) {
-
-        NSLog(@"url-->%@", callbackURL);
-        NSLog(@"error-->%@", error);
-        
         if (error) {
             [weakSelf.delegate oauthCoordinatorDidCancelBrowserAuthentication:self];
         }
@@ -447,16 +443,12 @@ static NSString * const kSFECParameter = @"ec";
         }
 
     }];
-//    SFSafariViewController *svc = [[SFSafariViewController alloc] initWithURL:nativeBrowserUrl];
-//    svc.delegate = self;
     if (![_authSession start]) {
         [self.delegate oauthCoordinatorDidCancelBrowserAuthentication:self];
     }
     else {
         self.advancedAuthState = SFOAuthAdvancedAuthStateBrowserRequestInitiated;
     }
-    
-//    [self.delegate oauthCoordinator:self didBeginAuthenticationWithSafariViewController:svc];
 }
 
 - (void)beginUserAgentFlow {
@@ -999,11 +991,6 @@ static NSString * const kSFECParameter = @"ec";
     } else {
         [SFSDKCoreLogger w:[self class] format:@"WKWebView did want to display a confirmation alert but no delegate responded to it"];
     }
-}
-
-#pragma mark - SFSafariViewControllerDelegate
--(void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
-    [self.delegate oauthCoordinatorDidCancelBrowserAuthentication:self];
 }
 
 - (NSString *)brandedAuthorizeURL{

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -123,11 +123,6 @@
     [self finishForUnsupportedFlow:@"User Agent" coordinator:coordinator];
 }
 
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSafariViewController:(SFSafariViewController *)svc {
-    // Shouldn't happen (refreshSessionWithCompletion:error: is guarded by the presence of a refresh token), but....
-    [self finishForUnsupportedFlow:@"Web Server" coordinator:coordinator];
-}
-
 - (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator {
     // Shouldn't happen (refreshSessionWithCompletion:error: is guarded by the presence of a refresh token), but....
     [self finishForUnsupportedFlow:@"Web Server" coordinator:coordinator];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthViewHandler.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthViewHandler.h
@@ -28,7 +28,6 @@
  */
 #import <Foundation/Foundation.h>
 @class WKWebView;
-@class SFSafariViewController;
 @class SFSDKAuthViewHolder;
 @class SFLoginViewController;
 NS_ASSUME_NONNULL_BEGIN
@@ -47,10 +46,6 @@ typedef void (^SFSDKAuthViewDismissBlock)(void);
 @property (nonatomic,weak,nullable) WKWebView *wkWebView;
 
 @property (nonatomic,weak) SFLoginViewController *loginController;
-
-@property (nonatomic,weak,nullable) SFSafariViewController *safariViewController;
-
-@property (nonatomic,assign) BOOL isAdvancedAuthFlow;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.h
@@ -159,7 +159,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)authClient:(SFSDKOAuthClient *_Nonnull)client willDisplayAuthWebView:(WKWebView *_Nonnull)view;
 @end
 
-/** Delegate that will be used to notify of all the OAuth Client WebView Events.
+/** Delegate that will be used to notify of all the OAuth Client Browser Events.
  */
 @protocol SFSDKOAuthClientSafariViewDelegate <NSObject>
 
@@ -177,13 +177,6 @@ NS_ASSUME_NONNULL_BEGIN
  @param client The instance of SFSDKOAuthClient making the call.
  */
 - (BOOL)authClientDidCancelBrowserFlow:(SFSDKOAuthClient *)client;
-
-/**
- Called when the auth client is going to present the safari view controller.
- @param client The instance of SFSDKOAuthClient making the call.
- @param svc The instance of the safari view controller to be presented.
- */
-- (void)authClient:(SFSDKOAuthClient *)client willDisplayAuthSafariViewController:(SFSafariViewController *_Nonnull)svc;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -434,7 +434,6 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     loginViewController.oauthView = view;
     SFSDKAuthViewHolder *viewHolder = [SFSDKAuthViewHolder new];
     viewHolder.loginController = loginViewController;
-    viewHolder.isAdvancedAuthFlow = NO;
     self.config.authViewController  = loginViewController;
     // Ensure this runs on the main thread.  Has to be sync, because the coordinator expects the auth view
     // to be added to a superview by the end of this method.
@@ -446,17 +445,6 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
         self.authViewHandler.authViewDisplayBlock(viewHolder);
     }
 
-}
-
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSafariViewController:(SFSafariViewController *)svc {
-    [SFSDKCoreLogger d:[self class] format:@"oauthCoordinator:didBeginAuthenticationWithSafariViewController"];
-    if ([self.config.safariViewDelegate respondsToSelector:@selector(authClient:willDisplayAuthSafariViewController:)]) {
-        [self.config.safariViewDelegate authClient:self willDisplayAuthSafariViewController:svc];
-    }
-    SFSDKAuthViewHolder *viewHolder = [SFSDKAuthViewHolder new];
-    viewHolder.safariViewController = svc;
-    viewHolder.isAdvancedAuthFlow = YES;
-    self.authViewHandler.authViewDisplayBlock(viewHolder);
 }
 
 - (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator {
@@ -669,21 +657,12 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
 
 - (void)presentLoginView:(SFSDKAuthViewHolder *)viewHandler {
     [self.authWindow presentWindow];
-    UIViewController *controllerToPresent = nil;
-    
-    if (viewHandler.isAdvancedAuthFlow) {
-        controllerToPresent = viewHandler.safariViewController;
-    } else {
-        SFSDKNavigationController *navController = [[SFSDKNavigationController  alloc]  initWithRootViewController:viewHandler.loginController];
-        controllerToPresent = navController;
-    }
+    UIViewController *controllerToPresent = [[SFSDKNavigationController  alloc]  initWithRootViewController:viewHandler.loginController];
     
     __weak typeof(self) weakSelf = self;
     void (^presentViewBlock)(void) = ^void() {
         [weakSelf.authWindow.viewController presentViewController:controllerToPresent animated:NO completion:^{
-            if (!viewHandler.isAdvancedAuthFlow) {
-                NSAssert((nil != [viewHandler.loginController.oauthView superview]), @"No superview for oauth web view invoke [super viewDidLayoutSubviews] in the SFLoginViewController subclass");
-            }
+            NSAssert((nil != [viewHandler.loginController.oauthView superview]), @"No superview for oauth web view invoke [super viewDidLayoutSubviews] in the SFLoginViewController subclass");
         }];
     };
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
@@ -114,10 +114,6 @@ NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
     NSAssert(NO, @"User Agent flow not supported in this class.");
 }
 
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSafariViewController:(SFSafariViewController *)svc {
-    NSAssert(NO, @"Web Server flow not supported in this class.");
-}
-
 - (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator {
     NSAssert(NO, @"Web Server flow not supported in this class.");
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlowCoordinatorDelegate.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlowCoordinatorDelegate.m
@@ -90,12 +90,6 @@ static NSString * const kSafariNotSupportedReasonFormat  = @"%@ SFSafariViewCont
     return self.isNetworkAvailable;
 }
 
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSafariViewController:(SFSafariViewController *)svc {
-    [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    NSString *reason = [NSString stringWithFormat:kSafariNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
-    @throw [NSException exceptionWithName:kSafariNotSupportedReasonFormat reason:reason userInfo:nil];
-}
-
 - (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator {
     [SFSDKLogger log:[self class] level:DDLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     NSString *reason = [NSString stringWithFormat:kSafariNotSupportedReasonFormat, NSStringFromSelector(_cmd)];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTestsCoordinatorDelegate.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTestsCoordinatorDelegate.m
@@ -51,12 +51,6 @@
     XCTFail(@"user agent authentication flow should not fail");
 }
 
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSafariViewController:(SFSafariViewController *)svc {
-
-    // Safari auth flow is not supported in unit test framework.
-    XCTFail(@"Safari auth flow is not supported in unit test framework");
-}
-
 - (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator {
 
     // Safari auth flow is not supported in unit test framework.

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -46,7 +46,6 @@ class AppDelegate : UIResponder, UIApplicationDelegate
                 //set custom config if needed. By default this object should read from the bootconfig.plist
             }.postInit {
                 //Uncomment following block to enable IDP Login flow.
-                // NOTE: If advanced authentication is configured for domain, it will launch Safari to handle authentication.
                 /*
                  // scheme of idpApp
                  SalesforceSwiftSDKManager.shared().idpAppURIScheme = "sampleidpapp"

--- a/shared/hybrid/AppDelegate+SalesforceHybridSDK.m
+++ b/shared/hybrid/AppDelegate+SalesforceHybridSDK.m
@@ -112,7 +112,7 @@
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
     
-    //Uncomment following block to enable IDP Login flow or If you're using advanced authentication:
+    //Uncomment following block to enable IDP Login flow
     // --Configure your app to handle incoming requests to your
     //   OAuth Redirect URI custom URL scheme.
     // --Uncomment the following line and delete the original return statement:


### PR DESCRIPTION
I don't think the work is quite done but I wanted to get some feedback.

Basically, the new class is super easy to use. I took out the code that is no longer used at all, but I feel like we could go further e.g. SFSDKOAuthClientSafariViewDelegate could be further simplified. Also, maybe more renaming should take place: should we use "safari" or "browser" in the method or property names.