### PR TITLE
Swift friendly APIs in SmartStore and SmartSync

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,9 @@
 [submodule "external/fmdb"]
 	path = external/fmdb
 	url = https://github.com/forcedotcom/fmdb
+[submodule "external/wypopovercontroller"]
+	path = external/wypopovercontroller
+	url = https://github.com/sammcewan/WYPopoverController
 [submodule "external/CocoaLumberjack"]
 	path = external/CocoaLumberjack
 	url=https://github.com/forcedotcom/CocoaLumberjack.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "external/fmdb"]
 	path = external/fmdb
 	url = https://github.com/forcedotcom/fmdb
-[submodule "external/wypopovercontroller"]
-	path = external/wypopovercontroller
-	url = https://github.com/sammcewan/WYPopoverController
 [submodule "external/CocoaLumberjack"]
 	path = external/CocoaLumberjack
 	url=https://github.com/forcedotcom/CocoaLumberjack.git

--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
@@ -186,7 +186,7 @@ NSString * const kStoreName           = @"storeName";
         // XXX we could populate error
         return nil;
     }
-    NSUInteger totalEntries = [[self getStoreInst:argsDict] countWithQuerySpec:querySpec error:error];
+    NSUInteger totalEntries = [[[self getStoreInst:argsDict] countWithQuerySpec:querySpec error:error] unsignedIntegerValue];
     if (*error) {
         return nil;
     }

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
@@ -400,7 +400,7 @@ RCT_EXPORT_METHOD(removeAllStores:(NSDictionary *)argsDict callback:(RCTResponse
         // XXX we could populate error
         return nil;
     }
-    NSUInteger totalEntries = [[self getStoreInst:argsDict] countWithQuerySpec:querySpec error:error];
+    NSUInteger totalEntries = [[[self getStoreInst:argsDict] countWithQuerySpec:querySpec error:error] unsignedIntegerValue];
     if (*error) {
         return nil;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFCrypto.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFCrypto.h
@@ -69,7 +69,7 @@ typedef NS_ENUM(NSUInteger, SFCryptoOperation) {
  @param iv Initialization vector. If set to nil, uses the default initialization vector.
  @param mode Mode which determines whether to perform operation in memory at once or in chunks writing to the disk.
  */
-- (nullable id)initWithOperation:(SFCryptoOperation)operation key:(nullable NSData *)key iv:(nullable NSData*)iv mode:(SFCryptoMode)mode;
+- (nullable instancetype)initWithOperation:(SFCryptoOperation)operation key:(nullable NSData *)key iv:(nullable NSData*)iv mode:(SFCryptoMode)mode;
 
 /**
  Encrypts or decrypts the passed in data. The input data is assumed to be passed in as a chunk.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+QueryBuilder.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+QueryBuilder.h
@@ -58,7 +58,6 @@ extern NSString * const kSOSLEscapeCharacter;
 // Maximum number of records returned via SOSL search
 extern NSInteger const kMaxSOSLSearchLimit;
 
-NS_SWIFT_NAME(QueryBuilder)
 @interface SFRestAPI (QueryBuilder)
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFSObjectTree.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFSObjectTree.h
@@ -40,7 +40,7 @@ NS_SWIFT_NAME(SObjectTree)
  * @param fields             Fields for the root sobject
  * @param childrenTrees      Array of SFSObjectTree for the children sobject's
  */
-- (nullable id)initWithObjectType:(NSString*)objectType
+- (nullable instancetype)initWithObjectType:(NSString*)objectType
         objectTypePlural:(nullable NSString*)objectTypePlural
         referenceId:(NSString *)referenceId
              fields:(NSDictionary<NSString *, id> *)fields

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
@@ -23,7 +23,6 @@
  */
 
 #import <SalesforceSDKCore/SFUserAccountManager.h>
-#import <SalesforceSDKCore/SFJsonUtils.h>
 #import "TestSetupUtils.h"
 #import "SFJsonUtils.h"
 #import "SFUserAccountManager+Internal.h"

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.m
@@ -23,7 +23,7 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <SalesforceSDKCore/SFJsonUtils.h>
+#import "SFJsonUtils.h"
 #import "SFSDKResourceUtils.h"
 
 @implementation SFSDKResourceUtils

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
@@ -156,7 +156,7 @@ extension QuerySpec {
         }
         
         public func build() -> QuerySpec {
-            return QuerySpec(dictionary: self.queryDict,withSoupName: soupName)
+            return QuerySpec(querySpec: self.queryDict,targetSoupName: soupName)
         }
     }
 }

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
@@ -440,8 +440,13 @@ extension SmartStore {
          */
         public func removeEntries(entryIds: [Any], soupName: String) -> Promise<Void> {
             return Promise {  resolver in
-                self.api!.remove(entryIds: entryIds, soupName: soupName)
-                resolver.fulfill(())
+                do {
+                    try self.api!.remove(entryIds: entryIds, soupName: soupName)
+                    resolver.fulfill(())
+                }
+                catch let error {
+                    resolver.reject(error)
+                }
             }
         }
         
@@ -460,8 +465,13 @@ extension SmartStore {
          */
         public func removeEntries(querySpec: QuerySpec, soupName: String) -> Promise<Void> {
             return Promise {  resolver in
-                self.api!.removeByQuery(querySpec: querySpec, soupName: soupName)
-                resolver.fulfill(())
+                do {
+                    try self.api!.removeByQuery(querySpec: querySpec, soupName: soupName)
+                    resolver.fulfill(())
+                }
+                catch let error {
+                    resolver.reject(error)
+                }
             }
         }
         

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
@@ -50,7 +50,7 @@ enum SmartStoreError : Error {
      .build()
  ```
  */
-extension SFQuerySpec {
+extension QuerySpec {
     
     /// Builder class
     public class Builder {
@@ -66,8 +66,8 @@ extension SFQuerySpec {
         /// Set the query type
         /// - Parameter value: type of query
         /// - Returns: SFQuerySpec.Builder instance
-        public func queryType(value: SFSoupQueryType) -> Self {
-            queryDict[kQuerySpecParamQueryType] = SFQuerySpec.queryType(fromEnum:value)
+        public func queryType(value: QueryType) -> Self {
+            queryDict[kQuerySpecParamQueryType] = QuerySpec.queryType(fromEnum:value)
             return self
         }
         
@@ -150,19 +150,19 @@ extension SFQuerySpec {
         /// Order by for the smart sql query
         /// - Parameter value: query sort order
         /// - Returns: SFQuerySpec.Builder instance
-        public func order(value: SFSoupQuerySortOrder) -> Self {
-            queryDict[kQuerySpecParamOrder] = SFQuerySpec.sortOrder(fromEnum: value)
+        public func order(value: SortOrder) -> Self {
+            queryDict[kQuerySpecParamOrder] = QuerySpec.sortOrder(fromEnum: value)
             return self
         }
         
-        public func build() -> SFQuerySpec {
-            return SFQuerySpec(dictionary: self.queryDict,withSoupName: soupName)
+        public func build() -> QuerySpec {
+            return QuerySpec(dictionary: self.queryDict,withSoupName: soupName)
         }
     }
 }
 
 /// Extension of SFSmartStore.
-extension SFSmartStore {
+extension SmartStore {
     
     public var Promises : SFSmartStorePromises {
         return SFSmartStorePromises(api: self)
@@ -171,9 +171,9 @@ extension SFSmartStore {
     /// Smart Store api(s) wrapped in promises.
     public class SFSmartStorePromises {
         
-        weak var api: SFSmartStore?
+        weak var api: SmartStore?
         
-        init(api: SFSmartStore) {
+        init(api: SmartStore) {
             self.api = api
         }
         
@@ -189,9 +189,9 @@ extension SFSmartStore {
          - parameter soupName: The Name of the soup
          - Returns: SFSoupSpec wrapped in a promise.
          */
-        public func attributes(soupName: String) -> Promise<SFSoupSpec> {
+        public func attributes(soupName: String) -> Promise<SoupSpec> {
             return Promise {  resolver in
-                let soupSpec : SFSoupSpec?  = self.api!.attributes(forSoup: soupName)
+                let soupSpec : SoupSpec?  = self.api!.attributes(forSoup: soupName)
                 if let spec = soupSpec {
                      resolver.fulfill(spec)
                 } else {
@@ -281,7 +281,7 @@ extension SFSmartStore {
              - indexSpecs: Array of Index specs
          - Returns: Boolean wrapped in a promise indicating success.
          */
-        public func registerSoup(soupSpec: SFSoupSpec,indexSpecs: [Any]) -> Promise<Bool> {
+        public func registerSoup(soupSpec: SoupSpec,indexSpecs: [Any]) -> Promise<Bool> {
             return Promise {  resolver in
                 do {
                     try self.api!.registerSoup(with: soupSpec, withIndexSpecs: indexSpecs)
@@ -304,7 +304,7 @@ extension SFSmartStore {
          - parameter querySpec: SFQuerySpec query specification
          - Returns: Integer wrapped in a promise indicating count.
          */
-        public func count(querySpec: SFQuerySpec) -> Promise<UInt> {
+        public func count(querySpec: QuerySpec) -> Promise<UInt> {
             return Promise {  resolver in
                 var count: UInt = 0
                 var error: NSError?
@@ -331,7 +331,7 @@ extension SFSmartStore {
             - pageIndex: Page number for records.
          - Returns: Array wrapped in a promise with query results.
          */
-        public func query(querySpec: SFQuerySpec, pageIndex: UInt)  -> Promise<[Any]> {
+        public func query(querySpec: QuerySpec, pageIndex: UInt)  -> Promise<[Any]> {
             return Promise {  resolver in
                 var result: [Any]?
                 var error: NSError?
@@ -460,7 +460,7 @@ extension SFSmartStore {
              - querySpec: SFQuerySoupSpec for the soup
              - soupName: Name of soup.
          */
-        public func removeEntries(querySpec: SFQuerySpec, soupName: String) -> Promise<Void> {
+        public func removeEntries(querySpec: QuerySpec, soupName: String) -> Promise<Void> {
             return Promise {  resolver in
                 self.api!.removeEntries(byQuery: querySpec, fromSoup: soupName)
                 resolver.fulfill(())
@@ -563,13 +563,13 @@ public class SFSmartStoreClient {
      - Returns: SFSmartStore wrapped in a promise.
      */
     
-    public class func store(withName: String) -> Promise<SFSmartStore> {
+    public class func store(withName: String) -> Promise<SmartStore> {
         return Promise { resolver in
-            let smartStore = SFSmartStore.sharedStore(withName : withName)
+            let smartStore = SmartStore.sharedStore(withName : withName)
             guard let _ = smartStore else {
                 return resolver.reject(SmartStoreError.StoreNotFoundError)
             }
-            resolver.fulfill(smartStore as! SFSmartStore)
+            resolver.fulfill(smartStore as! SmartStore)
         }
     }
     
@@ -587,13 +587,13 @@ public class SFSmartStoreClient {
         - user: User associated with the store.
      - Returns: SFSmartStore wrapped in a promise.
      */
-    public class func store(withName: String,user: UserAccount) -> Promise<SFSmartStore> {
+    public class func store(withName: String,user: UserAccount) -> Promise<SmartStore> {
         return Promise { resolver in
-            let smartStore = SFSmartStore.sharedStore(withName : withName,user: user)
+            let smartStore = SmartStore.sharedStore(withName : withName,user: user)
             guard let _ = smartStore else {
                 return resolver.reject(SmartStoreError.StoreNotFoundError)
             }
-            resolver.fulfill(smartStore as! SFSmartStore)
+            resolver.fulfill(smartStore as! SmartStore)
         }
     }
     
@@ -609,10 +609,10 @@ public class SFSmartStoreClient {
      - parameter withName: Name of Store.
      - Returns: SFSmartStore wrapped in a promise.
      */
-    public class func globalStore(withName: String) -> Promise<SFSmartStore> {
+    public class func globalStore(withName: String) -> Promise<SmartStore> {
         return Promise { resolver in
-            let smartStore = SFSmartStore.sharedGlobalStore(withName : withName)
-            resolver.fulfill(smartStore as! SFSmartStore)
+            let smartStore = SmartStore.sharedGlobalStore(withName : withName)
+            resolver.fulfill(smartStore as! SmartStore)
         }
     }
     
@@ -630,7 +630,7 @@ public class SFSmartStoreClient {
      */
     public class func removeGlobalStore(withName: String) -> Promise<Void> {
         return Promise { resolver in
-            SFSmartStore.removeSharedGlobalStore(withName:  withName)
+            SmartStore.removeSharedGlobalStore(withName:  withName)
             resolver.fulfill(())
         }
     }
@@ -649,7 +649,7 @@ public class SFSmartStoreClient {
      */
     public class func removeSharedStore(withName: String) -> Promise<Void> {
         return Promise { resolver in
-            SFSmartStore.removeSharedStore(withName:  withName)
+            SmartStore.removeSharedStore(withName:  withName)
             resolver.fulfill(())
         }
     }
@@ -667,7 +667,7 @@ public class SFSmartStoreClient {
      */
     public class func removeAllSharedStores() -> Promise<Void> {
         return Promise { resolver in
-            SFSmartStore.removeAllStores()
+            SmartStore.removeAllStores()
             resolver.fulfill(())
         }
     }
@@ -685,7 +685,7 @@ public class SFSmartStoreClient {
      */
     public class func removeAllGlobalStores() -> Promise<Void> {
         return Promise { resolver in
-            SFSmartStore.removeAllGlobalStores()
+            SmartStore.removeAllGlobalStores()
             resolver.fulfill(())
         }
     }

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartStoreExtensions.swift
@@ -259,7 +259,7 @@ extension SmartStore {
         public func registerSoup(soupName: String, indexSpecs: [Any]) -> Promise<Bool> {
             return Promise {  resolver in
                 do {
-                    try self.api!.registerSoup(soupName: soupName, indexSpecs: indexSpecs)
+                    try self.api!.registerSoup(soupName: soupName, indexSpecs: indexSpecs as! [SoupIndex])
                     resolver.fulfill(true)
                 } catch let error {
                     resolver.reject(error)
@@ -284,7 +284,7 @@ extension SmartStore {
         public func registerSoup(soupSpec: SoupSpec,indexSpecs: [Any]) -> Promise<Bool> {
             return Promise {  resolver in
                 do {
-                    try self.api!.registerSoup(soupSpec: soupSpec, indexSpecs: indexSpecs)
+                    try self.api!.registerSoup(soupSpec: soupSpec, indexSpecs: indexSpecs as! [SoupIndex])
                     resolver.fulfill(true)
                 } catch  let error {
                     resolver.reject(error)
@@ -363,7 +363,7 @@ extension SmartStore {
         public func upsertEntries(entries: [Any],soupName: String) -> Promise<[[String:Any]]> {
             return Promise {  resolver in
                 var result: [Any] = []
-                result = self.api!.upsert(entries: entries, soupName: soupName)
+                result = self.api!.upsert(entries: entries as! [[AnyHashable : Any]], soupName: soupName)
                 resolver.fulfill(result as! [[String:Any]])
             }
         }
@@ -441,7 +441,7 @@ extension SmartStore {
         public func removeEntries(entryIds: [Any], soupName: String) -> Promise<Void> {
             return Promise {  resolver in
                 do {
-                    try self.api!.remove(entryIds: entryIds, soupName: soupName)
+                    try self.api!.remove(entryIds: entryIds as! [NSNumber], soupName: soupName)
                     resolver.fulfill(())
                 }
                 catch let error {
@@ -573,11 +573,11 @@ public class SFSmartStoreClient {
     
     public class func store(withName: String) -> Promise<SmartStore> {
         return Promise { resolver in
-            let smartStore = SmartStore.sharedStore(storeName : withName)
-            guard let _ = smartStore else {
+            if let smartStore = SmartStore.sharedStore(name : withName) {
+                resolver.fulfill(smartStore)
+            } else {
                 return resolver.reject(SmartStoreError.StoreNotFoundError)
             }
-            resolver.fulfill(smartStore as! SmartStore)
         }
     }
     
@@ -597,11 +597,11 @@ public class SFSmartStoreClient {
      */
     public class func store(withName: String,user: UserAccount) -> Promise<SmartStore> {
         return Promise { resolver in
-            let smartStore = SmartStore.sharedStore(storeName : withName,user: user)
-            guard let _ = smartStore else {
+            if let smartStore = SmartStore.sharedStore(name : withName,user: user) {
+                resolver.fulfill(smartStore)
+            } else {
                 return resolver.reject(SmartStoreError.StoreNotFoundError)
             }
-            resolver.fulfill(smartStore as! SmartStore)
         }
     }
     
@@ -619,8 +619,8 @@ public class SFSmartStoreClient {
      */
     public class func globalStore(withName: String) -> Promise<SmartStore> {
         return Promise { resolver in
-            let smartStore = SmartStore.sharedGlobalStore(storeName : withName)
-            resolver.fulfill(smartStore as! SmartStore)
+            let smartStore = SmartStore.sharedGlobalStore(name : withName)
+            resolver.fulfill(smartStore)
         }
     }
     
@@ -638,7 +638,7 @@ public class SFSmartStoreClient {
      */
     public class func removeGlobalStore(withName: String) -> Promise<Void> {
         return Promise { resolver in
-            SmartStore.removeSharedGlobalStore(storeName:  withName)
+            SmartStore.removeSharedGlobalStore(name:  withName)
             resolver.fulfill(())
         }
     }
@@ -657,7 +657,7 @@ public class SFSmartStoreClient {
      */
     public class func removeSharedStore(withName: String) -> Promise<Void> {
         return Promise { resolver in
-            SmartStore.removeSharedStore(storeName:  withName)
+            SmartStore.removeSharedStore(name:  withName)
             resolver.fulfill(())
         }
     }

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartSyncExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartSyncExtensions.swift
@@ -33,9 +33,9 @@ import PromiseKit
 /// - ReSyncFailed: Thrown when the resync fails.
 /// - CleanResyncGhostsFailed: Thrown when the cleanresyncghosts fails.
 enum SFSmartSyncError : Error {
-    case SyncDownFailed(syncState: SFSyncState)
-    case SyncUpFailed(syncState: SFSyncState)
-    case ReSyncFailed(syncState: SFSyncState)
+    case SyncDownFailed(syncState: SyncState)
+    case SyncUpFailed(syncState: SyncState)
+    case ReSyncFailed(syncState: SyncState)
     case CleanResyncGhostsFailed
 }
 
@@ -61,7 +61,7 @@ firstly {
 }
 ```
  */
-extension SFSmartSyncSyncManager {
+extension SyncManager {
     
     public var Promises : SFSmartSyncSyncManagerPromises {
         return SFSmartSyncSyncManagerPromises(api: self)
@@ -70,9 +70,9 @@ extension SFSmartSyncSyncManager {
     /// SF SmartSyncSyncManager api(s) wrapped in promises.
     public class SFSmartSyncSyncManagerPromises {
 
-        weak var api: SFSmartSyncSyncManager?
+        weak var api: SyncManager?
 
-        init(api: SFSmartSyncSyncManager) {
+        init(api: SyncManager) {
             self.api = api
         }
 
@@ -88,7 +88,7 @@ extension SFSmartSyncSyncManager {
          - parameter syncId: Id for sync.
          - Returns: SFSyncState wrapped in a promise.
          */
-        public func getSyncStatus(syncId: UInt) -> Promise<SFSyncState?> {
+        public func getSyncStatus(syncId: UInt) -> Promise<SyncState?> {
             return Promise {  resolver in
                 resolver.fulfill(self.api!.getSyncStatus(NSNumber(value: syncId)))
             }
@@ -106,7 +106,7 @@ extension SFSmartSyncSyncManager {
          - parameter name: Name of sync.
          - Returns: SFSyncState wrapped in a promise.
          */
-        public func getSyncStatus(name: String) -> Promise<SFSyncState?> {
+        public func getSyncStatus(name: String) -> Promise<SyncState?> {
             return Promise {  resolver in
                 resolver.fulfill(self.api!.getSyncStatus(byName: name))
             }
@@ -180,7 +180,7 @@ extension SFSmartSyncSyncManager {
              - syncName: Sync Name
          - Returns: SFSyncState wrapped in a promise.
          */
-        public func createSyncDown(target: SFSyncDownTarget, options: SFSyncOptions, soupName: String, syncName: String?) -> Promise<SFSyncState> {
+        public func createSyncDown(target: SyncDownTarget, options: SyncOptions, soupName: String, syncName: String?) -> Promise<SyncState> {
             return Promise {  resolver in
                 resolver.fulfill( self.api!.createSyncDown(target, options: options, soupName: soupName, syncName: syncName))
             }
@@ -203,7 +203,7 @@ extension SFSmartSyncSyncManager {
              - soupName: Soup Name
          - Returns: SFSmartStore wrapped in a promise.
          */
-        public func syncDown(target: SFSyncDownTarget, soupName: String) -> Promise<SFSyncState> {
+        public func syncDown(target: SyncDownTarget, soupName: String) -> Promise<SyncState> {
             return Promise {  resolver in
                 self.api!.syncDown(with: target, soupName: soupName, update: { (syncState) in
                     if syncState.status == .done  {
@@ -232,7 +232,7 @@ extension SFSmartSyncSyncManager {
          - soupName: Soup Name
          - Returns: SFSmartStore wrapped in a promise.
          */
-        public func syncDown(target: SFSyncDownTarget, options: SFSyncOptions, soupName: String) -> Promise<SFSyncState> {
+        public func syncDown(target: SyncDownTarget, options: SyncOptions, soupName: String) -> Promise<SyncState> {
             return Promise {  resolver in
                 self.api!.syncDown(with: target, options: options, soupName: soupName, update: { (syncState) in
                     if syncState.status == .done  {
@@ -261,7 +261,7 @@ extension SFSmartSyncSyncManager {
          - soupName: Soup Name
          - Returns: SFSmartStore wrapped in a promise.
          */
-        public func syncDown(target: SFSyncDownTarget, options: SFSyncOptions, soupName: String, syncName: String?) -> Promise<SFSyncState> {
+        public func syncDown(target: SyncDownTarget, options: SyncOptions, soupName: String, syncName: String?) -> Promise<SyncState> {
             return Promise {  resolver in
                 self.api!.syncDown(with: target, options: options, soupName: soupName, syncName: syncName, update: { (syncState) in
                     if syncState.status == .done  {
@@ -290,7 +290,7 @@ extension SFSmartSyncSyncManager {
          - Returns: SFSyncState wrapped in a promise.
          */
 
-        public func reSync(syncId: UInt) -> Promise<SFSyncState> {
+        public func reSync(syncId: UInt) -> Promise<SyncState> {
             return Promise {  resolver in
                 self.api!.reSync(NSNumber(value: syncId), update: { (syncState) in
                     if syncState.status == .done  {
@@ -318,7 +318,7 @@ extension SFSmartSyncSyncManager {
              - syncName: Soup Name
          - Returns: SFSyncState wrapped in a promise.
          */
-        public func reSync(syncName: String) -> Promise<SFSyncState> {
+        public func reSync(syncName: String) -> Promise<SyncState> {
             return Promise {  resolver in
                 self.api!.reSync(byName: syncName, update: { (syncState) in
                     if syncState.status == .done  {
@@ -345,7 +345,7 @@ extension SFSmartSyncSyncManager {
             - syncName: The name for this sync.
          - Returns: SFSyncState wrapped in a promise.
          */
-        public func createSyncUp(target: SFSyncUpTarget, options: SFSyncOptions, soupName: String, syncName: String?) -> Promise<SFSyncState> {
+        public func createSyncUp(target: SyncUpTarget, options: SyncOptions, soupName: String, syncName: String?) -> Promise<SyncState> {
             return Promise {  resolver in
                 resolver.fulfill(self.api!.createSyncUp(target, options: options, soupName: soupName, syncName: syncName))
             }
@@ -366,7 +366,7 @@ extension SFSmartSyncSyncManager {
              - soupName: The soup name where the local entries are stored.
          - Returns: SFSyncState wrapped in a promise.
          */
-        public func syncUp(options: SFSyncOptions, soupName: String) -> Promise<SFSyncState> {
+        public func syncUp(options: SyncOptions, soupName: String) -> Promise<SyncState> {
             return Promise {  resolver in
                 self.api!.syncUp(with: options, soupName: soupName) { (syncState) in
                     if syncState.status == .done  {
@@ -396,7 +396,7 @@ extension SFSmartSyncSyncManager {
              - soupName: The soup name where the local entries are stored.
          - Returns: The sync state associated with this sync up.
          */
-        public func syncUp(target: SFSyncUpTarget, options: SFSyncOptions, soupName: String) -> Promise<SFSyncState> {
+        public func syncUp(target: SyncUpTarget, options: SyncOptions, soupName: String) -> Promise<SyncState> {
             return Promise {  resolver in
                 self.api!.syncUp(with: target, options: options, soupName: soupName, update: { (syncState) in
                     if syncState.status == .done  {
@@ -425,7 +425,7 @@ extension SFSmartSyncSyncManager {
              - syncName: The name for this sync.
         - Returns: The SFSyncState wrapped in a promise
          */
-        public func syncUp(with target: SFSyncUpTarget, options: SFSyncOptions, soupName: String, syncName: String?) -> Promise<SFSyncState> {
+        public func syncUp(with target: SyncUpTarget, options: SyncOptions, soupName: String, syncName: String?) -> Promise<SyncState> {
             return Promise {  resolver in
                 self.api!.syncUp(with: target, options: options, soupName: soupName,syncName: syncName, update: { (syncState) in
                     if syncState.status == .done  {
@@ -450,7 +450,7 @@ extension SFSmartSyncSyncManager {
          - parameter syncId: Sync ID.
          - Returns: The SFSyncStateStatus and number of records cleaned wrapped in a promise
          */
-        public func cleanResyncGhosts(syncId: UInt) -> Promise<(SFSyncStateStatus, UInt)> {
+        public func cleanResyncGhosts(syncId: UInt) -> Promise<(SyncStatus, UInt)> {
             return Promise {  resolver in
                 self.api!.cleanResyncGhosts(NSNumber(value: syncId), completionStatusBlock: { (syncStatus, numRecords) in
                     if syncStatus == .done  {

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartSyncExtensions.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDK/Extensions/SFSmartSyncExtensions.swift
@@ -108,7 +108,7 @@ extension SyncManager {
          */
         public func getSyncStatus(name: String) -> Promise<SyncState?> {
             return Promise {  resolver in
-                resolver.fulfill(self.api!.getSyncStatus(byName: name))
+                resolver.fulfill(self.api!.getSyncStatus(syncName: name))
             }
         }
 
@@ -126,7 +126,7 @@ extension SyncManager {
          */
         public func hasSync(name: String) -> Promise<Bool> {
             return Promise {  resolver in
-                resolver.fulfill(self.api!.hasSync(withName: name))
+                resolver.fulfill(self.api!.hasSync(syncName: name))
             }
         }
         
@@ -143,7 +143,7 @@ extension SyncManager {
          */
         public func deleteSync(syncId: UInt) -> Promise<Void>  {
             return Promise {  resolver in
-                resolver.fulfill(self.api!.deleteSync(byId: NSNumber(value: syncId)))
+                resolver.fulfill(self.api!.deleteSync(syncId: NSNumber(value: syncId)))
             }
         }
 
@@ -160,7 +160,7 @@ extension SyncManager {
          */
         public func deleteSync(name: String) -> Promise<Void>  {
             return Promise {  resolver in
-                resolver.fulfill(self.api!.deleteSync(byName:name))
+                resolver.fulfill(self.api!.deleteSync(syncName:name))
             }
         }
 
@@ -205,13 +205,13 @@ extension SyncManager {
          */
         public func syncDown(target: SyncDownTarget, soupName: String) -> Promise<SyncState> {
             return Promise {  resolver in
-                self.api!.syncDown(with: target, soupName: soupName, update: { (syncState) in
+                self.api!.syncDown(target: target, soupName: soupName) { (syncState) in
                     if syncState.status == .done  {
                         resolver.fulfill(syncState)
                     } else if syncState.status == .failed {
                         resolver.reject(SFSmartSyncError.SyncDownFailed(syncState: syncState))
                     }
-                })
+                }
             }
         }
         
@@ -234,13 +234,13 @@ extension SyncManager {
          */
         public func syncDown(target: SyncDownTarget, options: SyncOptions, soupName: String) -> Promise<SyncState> {
             return Promise {  resolver in
-                self.api!.syncDown(with: target, options: options, soupName: soupName, update: { (syncState) in
+                self.api!.syncDown(target: target, options: options, soupName: soupName) { (syncState) in
                     if syncState.status == .done  {
                         resolver.fulfill(syncState)
                     } else if syncState.status == .failed {
                         resolver.reject(SFSmartSyncError.SyncDownFailed(syncState: syncState))
                     }
-                })
+                }
             }
         }
 
@@ -263,13 +263,13 @@ extension SyncManager {
          */
         public func syncDown(target: SyncDownTarget, options: SyncOptions, soupName: String, syncName: String?) -> Promise<SyncState> {
             return Promise {  resolver in
-                self.api!.syncDown(with: target, options: options, soupName: soupName, syncName: syncName, update: { (syncState) in
+                self.api!.syncDown(target: target, options: options, soupName: soupName, syncName: syncName) { (syncState) in
                     if syncState.status == .done  {
                         resolver.fulfill(syncState)
                     } else if syncState.status == .failed {
                         resolver.reject(SFSmartSyncError.SyncDownFailed(syncState: syncState))
                     }
-                })
+                }
             }
         }
 
@@ -292,13 +292,13 @@ extension SyncManager {
 
         public func reSync(syncId: UInt) -> Promise<SyncState> {
             return Promise {  resolver in
-                self.api!.reSync(NSNumber(value: syncId), update: { (syncState) in
+                self.api!.reSync(syncId: NSNumber(value: syncId)) { (syncState) in
                     if syncState.status == .done  {
                         resolver.fulfill(syncState)
                     } else if syncState.status == .failed {
                         resolver.reject(SFSmartSyncError.ReSyncFailed(syncState: syncState))
                     }
-                })
+                }
             }
         }
 
@@ -320,13 +320,13 @@ extension SyncManager {
          */
         public func reSync(syncName: String) -> Promise<SyncState> {
             return Promise {  resolver in
-                self.api!.reSync(byName: syncName, update: { (syncState) in
+                self.api!.reSync(syncName: syncName) { (syncState) in
                     if syncState.status == .done  {
                         resolver.fulfill(syncState)
                     } else if syncState.status == .failed {
                          resolver.reject(SFSmartSyncError.ReSyncFailed(syncState: syncState))
                     }
-                })
+                }
             }
         }
        
@@ -368,7 +368,7 @@ extension SyncManager {
          */
         public func syncUp(options: SyncOptions, soupName: String) -> Promise<SyncState> {
             return Promise {  resolver in
-                self.api!.syncUp(with: options, soupName: soupName) { (syncState) in
+                self.api!.syncUp(options: options, soupName: soupName) { (syncState) in
                     if syncState.status == .done  {
                         resolver.fulfill(syncState)
                     } else if syncState.status == .failed {
@@ -398,13 +398,13 @@ extension SyncManager {
          */
         public func syncUp(target: SyncUpTarget, options: SyncOptions, soupName: String) -> Promise<SyncState> {
             return Promise {  resolver in
-                self.api!.syncUp(with: target, options: options, soupName: soupName, update: { (syncState) in
+                self.api!.syncUp(target: target, options: options, soupName: soupName) { (syncState) in
                     if syncState.status == .done  {
                         resolver.fulfill(syncState)
                     } else if syncState.status == .failed {
                         resolver.reject(SFSmartSyncError.SyncUpFailed(syncState: syncState))
                     }
-                })
+                }
             }
         }
         
@@ -427,13 +427,13 @@ extension SyncManager {
          */
         public func syncUp(with target: SyncUpTarget, options: SyncOptions, soupName: String, syncName: String?) -> Promise<SyncState> {
             return Promise {  resolver in
-                self.api!.syncUp(with: target, options: options, soupName: soupName,syncName: syncName, update: { (syncState) in
+                self.api!.syncUp(target: target, options: options, soupName: soupName,syncName: syncName) { (syncState) in
                     if syncState.status == .done  {
                         resolver.fulfill(syncState)
                     } else if syncState.status == .failed {
                         resolver.reject(SFSmartSyncError.SyncUpFailed(syncState: syncState))
                     }
-                })
+                }
             }
         }
         
@@ -452,13 +452,13 @@ extension SyncManager {
          */
         public func cleanResyncGhosts(syncId: UInt) -> Promise<(SyncStatus, UInt)> {
             return Promise {  resolver in
-                self.api!.cleanResyncGhosts(NSNumber(value: syncId), completionStatusBlock: { (syncStatus, numRecords) in
+                self.api!.cleanResyncGhosts(syncId: NSNumber(value: syncId)) { (syncStatus, numRecords) in
                     if syncStatus == .done  {
                         resolver.fulfill((syncStatus, numRecords))
                     } else if syncStatus == .failed {
                         resolver.reject(SFSmartSyncError.CleanResyncGhostsFailed)
                     }
-                })
+                }
             }
         }
     }

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartStoreClientTests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartStoreClientTests.swift
@@ -135,7 +135,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
         let soupName = "WONTONSOUP"
         let expectation = XCTestExpectation(description: "CreateAndRemoveSoup")
         
-        let store: SmartStore  = SmartStore.sharedStore(withName: lclStoreName) as! SmartStore
+        let store: SmartStore  = SmartStore.sharedStore(storeName: lclStoreName) as! SmartStore
         let result  = store.soupExists(soupName)
         XCTAssertFalse(result)
         let indexSpecs = SoupIndex.asArraySoupIndexes([ ["path": "key"], ["type" : "string"]])

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartStoreClientTests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartStoreClientTests.swift
@@ -135,7 +135,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
         let soupName = "WONTONSOUP"
         let expectation = XCTestExpectation(description: "CreateAndRemoveSoup")
         
-        let store: SmartStore  = SmartStore.sharedStore(storeName: lclStoreName) as! SmartStore
+        let store: SmartStore  = SmartStore.sharedStore(name: lclStoreName)!
         let result  = store.soupExists(soupName)
         XCTAssertFalse(result)
         let indexSpecs = SoupIndex.asArraySoupIndexes([ ["path": "key"], ["type" : "string"]])

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartStoreClientTests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartStoreClientTests.swift
@@ -53,11 +53,11 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
         let expectation = XCTestExpectation(description: "CreateStore")
         _ = SFSmartStoreClient
             .globalStore(withName: glbStoreName)
-            .then { globalStore -> Promise<SFSmartStore> in
+            .then { globalStore -> Promise<SmartStore> in
                 XCTAssertNotNil(globalStore)
                 return .value(globalStore)
             }
-            .then { store -> Promise<(Bool,SFSmartStore)>  in
+            .then { store -> Promise<(Bool,SmartStore)>  in
                 let result  = store.soupExists(soupName)
                 return .value((result,store))
             }
@@ -79,11 +79,11 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
         let expectation = XCTestExpectation(description: "CreateUserStore")
         _ = SFSmartStoreClient
             .store(withName: lclStoreName)
-            .then { localStore -> Promise<SFSmartStore> in
+            .then { localStore -> Promise<SmartStore> in
                 XCTAssertNotNil(localStore)
                 return .value(localStore)
             }
-            .then { store -> Promise<(Bool,SFSmartStore)>  in
+            .then { store -> Promise<(Bool,SmartStore)>  in
                 let result  = store.soupExists(soupName)
                 return .value((result,store))
             }
@@ -106,14 +106,14 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
         
         _ =  SFSmartStoreClient
             .store(withName: lclStoreName)
-            .then { localStore -> Promise<SFSmartStore> in
+            .then { localStore -> Promise<SmartStore> in
                 XCTAssertNotNil(localStore)
                 return .value(localStore)
             }
             .then { store -> Promise<Bool>  in
                 let result  = store.soupExists(soupName)
                 XCTAssertFalse(result)
-                let indexSpecs = SFSoupIndex.asArraySoupIndexes([ ["path": "key"], ["type" : "string"] ])
+                let indexSpecs = SoupIndex.asArraySoupIndexes([ ["path": "key"], ["type" : "string"] ])
                 return store.Promises.registerSoup(soupName: soupName, indexSpecs: indexSpecs)
             }
             .then { soupCreated -> Promise<Void> in
@@ -135,10 +135,10 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
         let soupName = "WONTONSOUP"
         let expectation = XCTestExpectation(description: "CreateAndRemoveSoup")
         
-        let store: SFSmartStore  = SFSmartStore.sharedStore(withName: lclStoreName) as! SFSmartStore
+        let store: SmartStore  = SmartStore.sharedStore(withName: lclStoreName) as! SmartStore
         let result  = store.soupExists(soupName)
         XCTAssertFalse(result)
-        let indexSpecs = SFSoupIndex.asArraySoupIndexes([ ["path": "key"], ["type" : "string"]])
+        let indexSpecs = SoupIndex.asArraySoupIndexes([ ["path": "key"], ["type" : "string"]])
             
         store.Promises.registerSoup(soupName: soupName, indexSpecs: indexSpecs)
         .then { soupCreated -> Promise<Void> in
@@ -159,7 +159,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     }
     
     func testCountQuerySpecBuilder() {
-        let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
+        let spec =  QuerySpec.Builder(soupName: "chickensoup")
             .queryType(value: .range)
             .path(value: "wings")
             .beginKey(value: "1")
@@ -170,7 +170,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     }
     
     func testSmartSqlWithSelectPathsQuerySpecBuilder() {
-        let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
+        let spec =  QuerySpec.Builder(soupName: "chickensoup")
             .queryType(value: .range)
             .selectedPaths(value: ["wings", "legs", "qty"])
             .orderPath(value: "qty")
@@ -181,7 +181,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     }
     
     func testAllQuerySmartSql() {
-        let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
+        let spec =  QuerySpec.Builder(soupName: "chickensoup")
             .queryType(value: .range)
             .orderPath(value: "wings")
             .order(value: .descending)
@@ -192,7 +192,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     }
     
     func testAllQuerySmartSqlWithSelectPaths() {
-        let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
+        let spec =  QuerySpec.Builder(soupName: "chickensoup")
             .queryType(value: .range)
             .selectedPaths(value: ["wings", "legs", "qty"])
             .orderPath(value: "qty")
@@ -204,7 +204,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     }
     
     func testAllQueryCountSmartSql() {
-        let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
+        let spec =  QuerySpec.Builder(soupName: "chickensoup")
             .queryType(value: .range)
             .path(value: "qty")
             .orderPath(value: "qty")
@@ -215,7 +215,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     }
     
     func testAllQueryIdsSmartSql() {
-        let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
+        let spec =  QuerySpec.Builder(soupName: "chickensoup")
             .queryType(value: .range)
             .path(value: "qty")
             .orderPath(value: "qty")
@@ -228,7 +228,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     
     
     func testExactQueryIdsSmartSql() {
-        let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
+        let spec =  QuerySpec.Builder(soupName: "chickensoup")
             .queryType(value: .exact)
             .path(value: "wings")
             .beginKey(value: "1")
@@ -239,7 +239,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     }
     
     func testMatchQuerySmartSql() {
-        let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
+        let spec =  QuerySpec.Builder(soupName: "chickensoup")
             .queryType(value: .match)
             .path(value: "wings")
             .orderPath(value: "wings")
@@ -251,7 +251,7 @@ class SmartStoreClientTests: SalesforceSwiftSDKBaseTest {
     }
     
     func testMatchQuerySmartSqlWithSelectPaths() {
-        let spec =  SFQuerySpec.Builder(soupName: "chickensoup")
+        let spec =  QuerySpec.Builder(soupName: "chickensoup")
             .queryType(value: .match)
             .selectedPaths(value: ["wings", "legs", "qty"])
             .path(value: "wings")

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartSyncManagerTests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartSyncManagerTests.swift
@@ -71,15 +71,15 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
         firstly {
             try super.createContactsOnServer(noOfRecords: numberOfRecords)
         }
-        .then { ids -> Promise<SFSyncState> in
+        .then { ids -> Promise<SyncState> in
             contactIds = ids
             let syncDownTarget = super.createSyncDownTargetFor(contactIds: contactIds)
-            let syncOptions    = SFSyncOptions.newSyncOptions(forSyncDown: SFSyncStateMergeMode.overwrite)
+            let syncOptions    = SyncOptions.newSyncOptions(forSyncDown: MergeMode.overwrite)
             return (self.syncManager?.Promises.syncDown(target: syncDownTarget, options: syncOptions, soupName: CONTACTS_SOUP))!
         }
         .then { syncState -> Promise<UInt> in
             XCTAssertTrue(syncState.isDone())
-            let querySpec =  SFQuerySpec.Builder(soupName: CONTACTS_SOUP)
+            let querySpec =  QuerySpec.Builder(soupName: CONTACTS_SOUP)
                                         .queryType(value: .range)
                                         .build()
             return (self.store?.Promises.count(querySpec: querySpec))!
@@ -104,12 +104,12 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
         firstly {
             super.createContactsLocally(count: 1)
         }
-        .then { result -> Promise<SFSyncState> in
+            .then { result -> Promise<SyncState> in
             XCTAssert(result.count == numberOfRecords)
             result.forEach { value in
                 XCTAssertTrue(value [kSyncTargetLocallyCreated] as! Bool == true)
             }
-            let syncOptions = SFSyncOptions.newSyncOptions(forSyncUp: contactSyncFieldList, mergeMode: SFSyncStateMergeMode.overwrite)
+                let syncOptions = SyncOptions.newSyncOptions(forSyncUp: contactSyncFieldList, mergeMode: MergeMode.overwrite)
             return (self.syncManager?.Promises.syncUp(options: syncOptions, soupName: CONTACTS_SOUP))!
         }
         .then { syncState -> Promise<Void> in
@@ -134,16 +134,16 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
         firstly {
             try super.createContactsOnServer(noOfRecords: numberOfRecords)
             }
-            .then { ids -> Promise<SFSyncState> in
+            .then { ids -> Promise<SyncState> in
                 contactIds = ids
                 let syncDownTarget = super.createSyncDownTargetFor(contactIds: contactIds)
-                let syncOptions    = SFSyncOptions.newSyncOptions(forSyncDown: SFSyncStateMergeMode.overwrite)
+                let syncOptions    = SyncOptions.newSyncOptions(forSyncDown: MergeMode.overwrite)
                 return (self.syncManager?.Promises.syncDown(target: syncDownTarget, options: syncOptions, soupName: CONTACTS_SOUP))!
             }
             .then { syncState -> Promise<UInt> in
                 XCTAssertTrue(syncState.isDone())
                 syncId = UInt(syncState.syncId)
-                let querySpec =  SFQuerySpec.Builder(soupName: CONTACTS_SOUP)
+                let querySpec =  QuerySpec.Builder(soupName: CONTACTS_SOUP)
                     .queryType(value: .range)
                     .build()
                 return (self.store?.Promises.count(querySpec: querySpec))!
@@ -152,12 +152,12 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
                 XCTAssertTrue(count==numberOfRecords)
                 return try super.deleteContactsFromServer(contactIds: contactIds)
             }
-            .then { _ -> Promise<(SFSyncStateStatus, UInt)> in
+            .then { _ -> Promise<(SyncStatus, UInt)> in
                 XCTAssertTrue(syncId > 0)
                 return (self.syncManager?.Promises.cleanResyncGhosts(syncId: syncId))!
             }
             .done { (syncStateStatus, numRecords) in
-                XCTAssertTrue(syncStateStatus==SFSyncStateStatus.done)
+                XCTAssertTrue(syncStateStatus==SyncStatus.done)
                 expectation.fulfill()
             }
             .catch { error in
@@ -175,16 +175,16 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
         firstly {
             try super.createContactsOnServer(noOfRecords: numberOfRecords)
         }
-        .then { ids -> Promise<SFSyncState> in
+            .then { ids -> Promise<SyncState> in
             contactIds = ids
             let syncDownTarget = super.createSyncDownTargetFor(contactIds: contactIds)
-            let syncOptions    = SFSyncOptions.newSyncOptions(forSyncDown: SFSyncStateMergeMode.overwrite)
+                let syncOptions    = SyncOptions.newSyncOptions(forSyncDown: MergeMode.overwrite)
             return (self.syncManager?.Promises.syncDown(target: syncDownTarget, options: syncOptions, soupName: CONTACTS_SOUP))!
         }
         .then { syncState -> Promise<UInt> in
             XCTAssertTrue(syncState.isDone())
             syncId = UInt(syncState.syncId)
-            let querySpec =  SFQuerySpec.Builder(soupName: CONTACTS_SOUP)
+            let querySpec =  QuerySpec.Builder(soupName: CONTACTS_SOUP)
                 .queryType(value: .range)
                 .build()
             return (self.store?.Promises.count(querySpec: querySpec))!
@@ -193,7 +193,7 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
             XCTAssertTrue(count==numberOfRecords)
             return try super.deleteContactsFromServer(contactIds: contactIds)
         }
-        .then { _ -> Promise<SFSyncState> in
+            .then { _ -> Promise<SyncState> in
             XCTAssertTrue(syncId > 0)
             return (self.syncManager?.Promises.reSync(syncId: syncId))!
         }

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartSyncManagerTests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartSyncManagerTests.swift
@@ -74,7 +74,7 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
         .then { ids -> Promise<SyncState> in
             contactIds = ids
             let syncDownTarget = super.createSyncDownTargetFor(contactIds: contactIds)
-            let syncOptions    = SyncOptions.newSyncOptions(forSyncDown: MergeMode.overwrite)
+            let syncOptions    = SyncOptions.newSyncOptions(forSyncDown: SyncMergeMode.overwrite)
             return (self.syncManager?.Promises.syncDown(target: syncDownTarget, options: syncOptions, soupName: CONTACTS_SOUP))!
         }
         .then { syncState -> Promise<UInt> in
@@ -109,7 +109,7 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
             result.forEach { value in
                 XCTAssertTrue(value [kSyncTargetLocallyCreated] as! Bool == true)
             }
-                let syncOptions = SyncOptions.newSyncOptions(forSyncUp: contactSyncFieldList, mergeMode: MergeMode.overwrite)
+                let syncOptions = SyncOptions.newSyncOptions(forSyncUp: contactSyncFieldList, mergeMode: SyncMergeMode.overwrite)
             return (self.syncManager?.Promises.syncUp(options: syncOptions, soupName: CONTACTS_SOUP))!
         }
         .then { syncState -> Promise<Void> in
@@ -137,7 +137,7 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
             .then { ids -> Promise<SyncState> in
                 contactIds = ids
                 let syncDownTarget = super.createSyncDownTargetFor(contactIds: contactIds)
-                let syncOptions    = SyncOptions.newSyncOptions(forSyncDown: MergeMode.overwrite)
+                let syncOptions    = SyncOptions.newSyncOptions(forSyncDown: SyncMergeMode.overwrite)
                 return (self.syncManager?.Promises.syncDown(target: syncDownTarget, options: syncOptions, soupName: CONTACTS_SOUP))!
             }
             .then { syncState -> Promise<UInt> in
@@ -178,7 +178,7 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
             .then { ids -> Promise<SyncState> in
             contactIds = ids
             let syncDownTarget = super.createSyncDownTargetFor(contactIds: contactIds)
-                let syncOptions    = SyncOptions.newSyncOptions(forSyncDown: MergeMode.overwrite)
+                let syncOptions    = SyncOptions.newSyncOptions(forSyncDown: SyncMergeMode.overwrite)
             return (self.syncManager?.Promises.syncDown(target: syncDownTarget, options: syncOptions, soupName: CONTACTS_SOUP))!
         }
         .then { syncState -> Promise<UInt> in

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartSyncManagerTests.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SmartSyncManagerTests.swift
@@ -175,10 +175,10 @@ class SmartSyncManagerTests: SyncManagerBaseTest {
         firstly {
             try super.createContactsOnServer(noOfRecords: numberOfRecords)
         }
-            .then { ids -> Promise<SyncState> in
+        .then { ids -> Promise<SyncState> in
             contactIds = ids
             let syncDownTarget = super.createSyncDownTargetFor(contactIds: contactIds)
-                let syncOptions    = SyncOptions.newSyncOptions(forSyncDown: SyncMergeMode.overwrite)
+            let syncOptions    = SyncOptions.newSyncOptions(forSyncDown: SyncMergeMode.overwrite)
             return (self.syncManager?.Promises.syncDown(target: syncDownTarget, options: syncOptions, soupName: CONTACTS_SOUP))!
         }
         .then { syncState -> Promise<UInt> in

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SyncManagerBaseTest.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SyncManagerBaseTest.swift
@@ -73,10 +73,10 @@ class SyncManagerBaseTest: SalesforceSwiftSDKBaseTest {
         super.setUp()
         currentUser = UserAccountManager.sharedInstance().currentUser
         store = SmartStore.sharedStore(storeName: SmartStore.defaultStoreName, user: currentUser!) as?  SmartStore
-        syncManager = SyncManager.sharedInstance(for:store!)
+        syncManager = SyncManager.sharedInstance(store:store!)
         
         globalStore = SmartStore.sharedGlobalStore(storeName: SmartStore.defaultStoreName) as? SmartStore
-        globalSyncManager = SyncManager.sharedInstance(for: globalStore!)
+        globalSyncManager = SyncManager.sharedInstance(store: globalStore!)
     }
     
     override func tearDown() {

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SyncManagerBaseTest.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SyncManagerBaseTest.swift
@@ -58,11 +58,11 @@ enum TestError : Error {
 class SyncManagerBaseTest: SalesforceSwiftSDKBaseTest {
     
     var currentUser: UserAccount?
-    var syncManager: SFSmartSyncSyncManager?
-    var store: SFSmartStore?
+    var syncManager: SyncManager?
+    var store: SmartStore?
     var storeClient: SFSmartStoreClient?
-    var globalSyncManager: SFSmartSyncSyncManager?
-    var globalStore: SFSmartStore?
+    var globalSyncManager: SyncManager?
+    var globalStore: SmartStore?
     
     override class func setUp() {
         super.setUp()
@@ -72,11 +72,11 @@ class SyncManagerBaseTest: SalesforceSwiftSDKBaseTest {
     override func setUp() {
         super.setUp()
         currentUser = UserAccountManager.sharedInstance().currentUser
-        store = SFSmartStore.sharedStore(withName: kDefaultSmartStoreName, user: currentUser!) as?  SFSmartStore
-        syncManager = SFSmartSyncSyncManager.sharedInstance(for:store!)
+        store = SmartStore.sharedStore(withName: kDefaultSmartStoreName, user: currentUser!) as?  SmartStore
+        syncManager = SyncManager.sharedInstance(for:store!)
         
-        globalStore = SFSmartStore.sharedGlobalStore(withName: kDefaultSmartStoreName) as? SFSmartStore
-        globalSyncManager = SFSmartSyncSyncManager.sharedInstance(for: globalStore!)
+        globalStore = SmartStore.sharedGlobalStore(withName: kDefaultSmartStoreName) as? SmartStore
+        globalSyncManager = SyncManager.sharedInstance(for: globalStore!)
     }
     
     override func tearDown() {
@@ -133,16 +133,16 @@ class SyncManagerBaseTest: SalesforceSwiftSDKBaseTest {
     
    func createContactsSoup() -> Promise<Bool> {
         let indexSpecs:[AnyObject]! = [
-            SFSoupIndex(path: ID, indexType: kSoupIndexTypeString, columnName: nil)!,
-            SFSoupIndex(path:FIRST_NAME, indexType:kSoupIndexTypeString, columnName:nil)!,
-            SFSoupIndex(path:LAST_NAME, indexType:kSoupIndexTypeString, columnName:nil)!,
-            SFSoupIndex(path:TITLE, indexType:kSoupIndexTypeString, columnName:nil)!,
-            SFSoupIndex(path:MOBILE_PHONE, indexType:kSoupIndexTypeString, columnName:nil)!,
-            SFSoupIndex(path:HOME_PHONE, indexType:kSoupIndexTypeString, columnName:nil)!,
-            SFSoupIndex(path:EMAIL, indexType:kSoupIndexTypeString, columnName:nil)!,
-            SFSoupIndex(path:DESCRIPTION, indexType:kSoupIndexTypeFullText, columnName:nil)!,
-            SFSoupIndex(path:kSyncTargetLocal, indexType:kSoupIndexTypeString, columnName:nil)!,
-            SFSoupIndex(path:kSyncTargetSyncId, indexType:kSoupIndexTypeInteger, columnName:nil)!
+            SoupIndex(path: ID, indexType: kSoupIndexTypeString, columnName: nil)!,
+            SoupIndex(path:FIRST_NAME, indexType: kSoupIndexTypeString, columnName:nil)!,
+            SoupIndex(path:LAST_NAME, indexType:kSoupIndexTypeString, columnName:nil)!,
+            SoupIndex(path:TITLE, indexType:kSoupIndexTypeString, columnName:nil)!,
+            SoupIndex(path:MOBILE_PHONE, indexType:kSoupIndexTypeString, columnName:nil)!,
+            SoupIndex(path:HOME_PHONE, indexType:kSoupIndexTypeString, columnName:nil)!,
+            SoupIndex(path:EMAIL, indexType:kSoupIndexTypeString, columnName:nil)!,
+            SoupIndex(path:DESCRIPTION, indexType:kSoupIndexTypeFullText, columnName:nil)!,
+            SoupIndex(path:kSyncTargetLocal, indexType:kSoupIndexTypeString, columnName:nil)!,
+            SoupIndex(path:kSyncTargetSyncId, indexType:kSoupIndexTypeInteger, columnName:nil)!
         ]
         return (self.store?.Promises.registerSoup(soupName: CONTACTS_SOUP, indexSpecs: indexSpecs))!
     }
@@ -174,10 +174,10 @@ class SyncManagerBaseTest: SalesforceSwiftSDKBaseTest {
         }
     }
     
-    func createSyncDownTargetFor(contactIds: [String]) -> SFSoqlSyncDownTarget {
+    func createSyncDownTargetFor(contactIds: [String]) -> SoqlSyncDownTarget {
         let inString = contactIds.joined(separator: "','")
         let soqlQuery = "Select \(contactFieldList.joined(separator: ",")) from Contact where Id in ('\(inString)')"
-        let syncTarget = SFSoqlSyncDownTarget.newSyncTarget(soqlQuery)
+        let syncTarget = SoqlSyncDownTarget.newSyncTarget(soqlQuery)
         return syncTarget
     }
     
@@ -203,7 +203,7 @@ class SyncManagerBaseTest: SalesforceSwiftSDKBaseTest {
     
     func deleteAllTestContactsFromServer() throws -> Promise<Void> {
         
-        let querySpec = SFQuerySpec.Builder(soupName: CONTACTS_SOUP)
+        let querySpec = QuerySpec.Builder(soupName: CONTACTS_SOUP)
             .queryType(value: .range)
             .selectedPaths(value: [ID])
             .pageSize(value: UInt.max)

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SyncManagerBaseTest.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SyncManagerBaseTest.swift
@@ -72,10 +72,10 @@ class SyncManagerBaseTest: SalesforceSwiftSDKBaseTest {
     override func setUp() {
         super.setUp()
         currentUser = UserAccountManager.sharedInstance().currentUser
-        store = SmartStore.sharedStore(storeName: SmartStore.defaultStoreName, user: currentUser!) as?  SmartStore
+        store = SmartStore.sharedStore(name: SmartStore.defaultStoreName, user: currentUser!)
         syncManager = SyncManager.sharedInstance(store:store!)
         
-        globalStore = SmartStore.sharedGlobalStore(storeName: SmartStore.defaultStoreName) as? SmartStore
+        globalStore = SmartStore.sharedGlobalStore(name: SmartStore.defaultStoreName)
         globalSyncManager = SyncManager.sharedInstance(store: globalStore!)
     }
     

--- a/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SyncManagerBaseTest.swift
+++ b/libs/SalesforceSwiftSDK/SalesforceSwiftSDKTests/SyncManagerBaseTest.swift
@@ -72,10 +72,10 @@ class SyncManagerBaseTest: SalesforceSwiftSDKBaseTest {
     override func setUp() {
         super.setUp()
         currentUser = UserAccountManager.sharedInstance().currentUser
-        store = SmartStore.sharedStore(withName: kDefaultSmartStoreName, user: currentUser!) as?  SmartStore
+        store = SmartStore.sharedStore(storeName: SmartStore.defaultStoreName, user: currentUser!) as?  SmartStore
         syncManager = SyncManager.sharedInstance(for:store!)
         
-        globalStore = SmartStore.sharedGlobalStore(withName: kDefaultSmartStoreName) as? SmartStore
+        globalStore = SmartStore.sharedGlobalStore(storeName: SmartStore.defaultStoreName) as? SmartStore
         globalSyncManager = SyncManager.sharedInstance(for: globalStore!)
     }
     

--- a/libs/SmartStore/SmartStore/Classes/SFAlterSoupLongOperation.h
+++ b/libs/SmartStore/SmartStore/Classes/SFAlterSoupLongOperation.h
@@ -40,7 +40,7 @@ typedef NS_ENUM(NSUInteger, SFAlterSoupStep) {
     SFAlterSoupStepReIndexSoup,
     SFAlterSoupStepDropOldTable,
     SFAlterSoupStepCleanup
-};
+} NS_SWIFT_NAME(AlterSoup.Step);
 
 
 // Fields of details for alter soup long operation row in long_operations_status table
@@ -56,7 +56,7 @@ static NSInteger  const kLastStep = SFAlterSoupStepCleanup;
 /**
  Use this class to configure and run alter soup "long" operations. Note that these operations can take a long time to complete.
  */
-
+NS_SWIFT_NAME(AlterSoupLongOperation)
 @interface SFAlterSoupLongOperation : NSObject {
 
 }

--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
@@ -30,26 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString * const kQuerySpecSortOrderAscending;
 extern NSString * const kQuerySpecSortOrderDescending;
 
-// TODO Following could be better
-//typedef NSString * const SFQuerySpecSortOrder NS_TYPED_ENUM NS_SWIFT_NAME(QuerySpec.SortOrder);
-//FOUNDATION_EXTERN SFQuerySpecSortOrder kQuerySpecSortOrderAscending  NS_SWIFT_NAME(ascending);
-//FOUNDATION_EXTERN SFQuerySpecSortOrder kQuerySpecSortOrderDescending NS_SWIFT_NAME(descending);
-
-
 //kQuerySpecTypeFoo constants are used when translating to SFSoupQueryType from JS (dictionary) values
 extern NSString * const kQuerySpecTypeExact;
 extern NSString * const kQuerySpecTypeRange;
 extern NSString * const kQuerySpecTypeLike;
 extern NSString * const kQuerySpecTypeSmart;
 extern NSString * const kQuerySpecTypeMatch;
-
-// TODO Following could be better
-//typedef NSString * const SFQuerySpecType NS_TYPED_ENUM NS_SWIFT_NAME(QuerySpec.Type);
-//FOUNDATION_EXTERN SFQuerySpecType kQuerySpecTypeExact NS_SWIFT_NAME(exact);
-//FOUNDATION_EXTERN SFQuerySpecType kQuerySpecTypeRange NS_SWIFT_NAME(range);
-//FOUNDATION_EXTERN SFQuerySpecType kQuerySpecTypeLike  NS_SWIFT_NAME(like);
-//FOUNDATION_EXTERN SFQuerySpecType kQuerySpecTypeSmart NS_SWIFT_NAME(smart);
-//FOUNDATION_EXTERN SFQuerySpecType kQuerySpecTypeMatch NS_SWIFT_NAME(match);
 
 //kQuerySpecParamFoo constants are used when build SFQuerySpec from JS (dictionary) values
 extern NSString * const kQuerySpecParamQueryType;
@@ -63,20 +49,6 @@ extern NSString * const kQuerySpecParamBeginKey;
 extern NSString * const kQuerySpecParamEndKey;
 extern NSString * const kQuerySpecParamLikeKey;
 extern NSString * const kQuerySpecParamSmartSql;
-
-// TODO Following could be better
-//typedef NSString * const SFQuerySpecParam NS_TYPED_ENUM NS_SWIFT_NAME(QuerySpec.Param);
-//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamQueryType     NS_SWIFT_NAME(queryType);
-//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamSelectPaths   NS_SWIFT_NAME(selectPaths);
-//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamIndexPath     NS_SWIFT_NAME(indexPath);
-//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamOrder         NS_SWIFT_NAME(paramOrder);
-//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamPageSize      NS_SWIFT_NAME(pageSize);
-//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamOrderPath     NS_SWIFT_NAME(orderPath);
-//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamMatchKey      NS_SWIFT_NAME(matchKey);
-//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamBeginKey      NS_SWIFT_NAME(beginKey);
-//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamEndKey        NS_SWIFT_NAME(endKey);
-//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamLikeKey       NS_SWIFT_NAME(likeKey);
-//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamSmartSql      NS_SWIFT_NAME(smartSql);
 
 extern NSUInteger const kQuerySpecDefaultPageSize;
 
@@ -187,8 +159,9 @@ NS_SWIFT_NAME(QuerySpec)
  * @param pageSize The page size.
  * @return A query spec object.
  */
-+ (nullable SFQuerySpec*) newExactQuerySpec:(NSString*)soupName withSelectPaths:(nullable NSArray*)selectPaths withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
-+ (SFQuerySpec*) newExactQuerySpec:(NSString*)soupName withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
++ (nullable SFQuerySpec*) newExactQuerySpec:(NSString*)soupName withSelectPaths:(nullable NSArray*)selectPaths withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize NS_SWIFT_NAME(buildExactQuerySpec(soupName:selectPaths:path:matchKey:orderPath:order:pageSize:));
++ (SFQuerySpec*) newExactQuerySpec:(NSString*)soupName withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize NS_SWIFT_NAME(buildExactQuerySpec(soupName:path:matchKey:orderPath:order:pageSize:));
+
 
 /**
  * Factory method to build an like query spec
@@ -202,8 +175,8 @@ NS_SWIFT_NAME(QuerySpec)
  * @param pageSize The page size.
  * @return A query spec object.
  */
-+ (nullable SFQuerySpec*) newLikeQuerySpec:(NSString*)soupName withSelectPaths:(nullable NSArray*)selectPaths withPath:(NSString*)path withLikeKey:(NSString*)likeKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
-+ (SFQuerySpec*) newLikeQuerySpec:(NSString*)soupName withPath:(NSString*)path withLikeKey:(NSString*)likeKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
++ (nullable SFQuerySpec*) newLikeQuerySpec:(NSString*)soupName withSelectPaths:(nullable NSArray*)selectPaths withPath:(NSString*)path withLikeKey:(NSString*)likeKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize NS_SWIFT_NAME(buildLikeQuerySpec(soupName:selectPaths:path:likeKey:orderPath:order:pageSize:));
++ (SFQuerySpec*) newLikeQuerySpec:(NSString*)soupName withPath:(NSString*)path withLikeKey:(NSString*)likeKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize NS_SWIFT_NAME(buildLikeQuerySpec(soupName:path:likeKey:orderPath:order:pageSize:));
 
 /**
  * Factory method to build an range query spec
@@ -218,8 +191,8 @@ NS_SWIFT_NAME(QuerySpec)
  * @param pageSize The page size.
  * @return A query spec object.
  */
-+ (nullable SFQuerySpec*) newRangeQuerySpec:(NSString*)soupName withSelectPaths:(nullable NSArray*)selectPaths withPath:(nullable NSString*)path withBeginKey:(nullable NSString*)beginKey withEndKey:(nullable NSString*)endKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
-+ (SFQuerySpec*) newRangeQuerySpec:(NSString*)soupName withPath:(NSString*)path withBeginKey:(NSString*)beginKey withEndKey:(NSString*)endKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
++ (nullable SFQuerySpec*) newRangeQuerySpec:(NSString*)soupName withSelectPaths:(nullable NSArray*)selectPaths withPath:(nullable NSString*)path withBeginKey:(nullable NSString*)beginKey withEndKey:(nullable NSString*)endKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize NS_SWIFT_NAME(buildRangeQuerySpec(soupName:selectPaths:path:beginKey:endKey:orderPath:order:pageSize:));
++ (SFQuerySpec*) newRangeQuerySpec:(NSString*)soupName withPath:(NSString*)path withBeginKey:(NSString*)beginKey withEndKey:(NSString*)endKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize NS_SWIFT_NAME(buildRangeQuerySpec(soupName:path:beginKey:endKey:orderPath:order:pageSize:));
 
 /**
  * Factory method to build a query spec to return all data from a soup.
@@ -229,8 +202,8 @@ NS_SWIFT_NAME(QuerySpec)
  * @param order The sort order.
  * @param pageSize The page size.
  */
-+ (SFQuerySpec*) newAllQuerySpec:(NSString*)soupName withSelectPaths:(nullable NSArray*)selectPaths withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
-+ (SFQuerySpec*) newAllQuerySpec:(NSString*)soupName withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
++ (SFQuerySpec*) newAllQuerySpec:(NSString*)soupName withSelectPaths:(nullable NSArray*)selectPaths withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize NS_SWIFT_NAME(buildAllQuerySpec(soupName:selectPaths:orderPath:order:pageSize:));
++ (SFQuerySpec*) newAllQuerySpec:(NSString*)soupName withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize NS_SWIFT_NAME(buildAllQuerySpec(soupName:orderPath:order:pageSize:));
 
 /**
  * Factory method to build a match query spec (full-text search)
@@ -244,8 +217,8 @@ NS_SWIFT_NAME(QuerySpec)
  * @param pageSize The page size.
  * @return A query spec object.
  */
-+ (nullable SFQuerySpec*) newMatchQuerySpec:(NSString*)soupName withSelectPaths:(nullable NSArray*)selectPaths withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
-+ (SFQuerySpec*) newMatchQuerySpec:(NSString*)soupName withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize;
++ (nullable SFQuerySpec*) newMatchQuerySpec:(NSString*)soupName withSelectPaths:(nullable NSArray*)selectPaths withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize NS_SWIFT_NAME(buildMatchQuerySpec(soupName:selectPaths:path:matchKey:orderPath:order:pageSize:));
++ (SFQuerySpec*) newMatchQuerySpec:(NSString*)soupName withPath:(NSString*)path withMatchKey:(NSString*)matchKey withOrderPath:(NSString*)orderPath withOrder:(SFSoupQuerySortOrder)order withPageSize:(NSUInteger)pageSize NS_SWIFT_NAME(buildMatchQuerySpec(soupName:path:matchKey:orderPath:order:pageSize:));
 
 /**
  * Factory method to build a smart query spec
@@ -254,7 +227,7 @@ NS_SWIFT_NAME(QuerySpec)
  * @param pageSize The page size.
  * @return A query spec object.
  */
-+ (nullable SFQuerySpec*) newSmartQuerySpec:(NSString*)smartSql withPageSize:(NSUInteger)pageSize;
++ (nullable SFQuerySpec*) newSmartQuerySpec:(NSString*)smartSql withPageSize:(NSUInteger)pageSize NS_SWIFT_NAME(buildSmartQuerySpec(smartSql:pageSize:));
 
 /**
  * Initializes the object with the given query spec.
@@ -262,7 +235,7 @@ NS_SWIFT_NAME(QuerySpec)
  * @param targetSoupName the soup name targeted (not nil for exact/like/range queries)
  * @return A new instance of the object.
  */
-- (id)initWithDictionary:(NSDictionary*)querySpec withSoupName:(NSString*) targetSoupName;
+- (id)initWithDictionary:(NSDictionary*)querySpec withSoupName:(NSString*) targetSoupName NS_SWIFT_NAME(init(querySpec:targetSoupName:));
 
 /**
  * The NSDictionary representation of the query spec.

--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
@@ -86,12 +86,12 @@ typedef NS_ENUM(NSInteger, SFSoupQueryType) {
     kSFSoupQueryTypeLike  NS_SWIFT_NAME(like) = 8,
     kSFSoupQueryTypeSmart NS_SWIFT_NAME(smart) = 16,
     kSFSoupQueryTypeMatch NS_SWIFT_NAME(match) = 32
-} NS_SWIFT_NAME(QueryType);
+} NS_SWIFT_NAME(QuerySpec.QueryType);
 
 typedef NS_ENUM(NSUInteger, SFSoupQuerySortOrder) {
     kSFSoupQuerySortOrderAscending  NS_SWIFT_NAME(ascending),
     kSFSoupQuerySortOrderDescending NS_SWIFT_NAME(descending)
-} NS_SWIFT_NAME(SortOrder);
+} NS_SWIFT_NAME(QuerySpec.SortOrder);
 
 /**
  * Object containing the query specification for queries against a soup.

--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
@@ -53,9 +53,9 @@ extern NSString * const kQuerySpecParamSmartSql;
 extern NSUInteger const kQuerySpecDefaultPageSize;
 
 typedef NS_ENUM(NSInteger, SFSoupQueryType) {
-    kSFSoupQueryTypeExact NS_SWIFT_NAME(exact) = 2 ,
+    kSFSoupQueryTypeExact NS_SWIFT_NAME(exact) = 2,
     kSFSoupQueryTypeRange NS_SWIFT_NAME(range) = 4,
-    kSFSoupQueryTypeLike  NS_SWIFT_NAME(like) = 8,
+    kSFSoupQueryTypeLike  NS_SWIFT_NAME(like)  = 8,
     kSFSoupQueryTypeSmart NS_SWIFT_NAME(smart) = 16,
     kSFSoupQueryTypeMatch NS_SWIFT_NAME(match) = 32
 } NS_SWIFT_NAME(QuerySpec.QueryType);

--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.h
@@ -30,7 +30,11 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString * const kQuerySpecSortOrderAscending;
 extern NSString * const kQuerySpecSortOrderDescending;
 
-extern NSString * const kQuerySpecParamQueryType;
+// TODO Following could be better
+//typedef NSString * const SFQuerySpecSortOrder NS_TYPED_ENUM NS_SWIFT_NAME(QuerySpec.SortOrder);
+//FOUNDATION_EXTERN SFQuerySpecSortOrder kQuerySpecSortOrderAscending  NS_SWIFT_NAME(ascending);
+//FOUNDATION_EXTERN SFQuerySpecSortOrder kQuerySpecSortOrderDescending NS_SWIFT_NAME(descending);
+
 
 //kQuerySpecTypeFoo constants are used when translating to SFSoupQueryType from JS (dictionary) values
 extern NSString * const kQuerySpecTypeExact;
@@ -39,35 +43,60 @@ extern NSString * const kQuerySpecTypeLike;
 extern NSString * const kQuerySpecTypeSmart;
 extern NSString * const kQuerySpecTypeMatch;
 
+// TODO Following could be better
+//typedef NSString * const SFQuerySpecType NS_TYPED_ENUM NS_SWIFT_NAME(QuerySpec.Type);
+//FOUNDATION_EXTERN SFQuerySpecType kQuerySpecTypeExact NS_SWIFT_NAME(exact);
+//FOUNDATION_EXTERN SFQuerySpecType kQuerySpecTypeRange NS_SWIFT_NAME(range);
+//FOUNDATION_EXTERN SFQuerySpecType kQuerySpecTypeLike  NS_SWIFT_NAME(like);
+//FOUNDATION_EXTERN SFQuerySpecType kQuerySpecTypeSmart NS_SWIFT_NAME(smart);
+//FOUNDATION_EXTERN SFQuerySpecType kQuerySpecTypeMatch NS_SWIFT_NAME(match);
+
+//kQuerySpecParamFoo constants are used when build SFQuerySpec from JS (dictionary) values
+extern NSString * const kQuerySpecParamQueryType;
 extern NSString * const kQuerySpecParamSelectPaths;
 extern NSString * const kQuerySpecParamIndexPath;
 extern NSString * const kQuerySpecParamOrder;
 extern NSString * const kQuerySpecParamPageSize;
-extern NSUInteger const kQuerySpecDefaultPageSize;
 extern NSString * const kQuerySpecParamOrderPath;
-
 extern NSString * const kQuerySpecParamMatchKey;
 extern NSString * const kQuerySpecParamBeginKey;
 extern NSString * const kQuerySpecParamEndKey;
 extern NSString * const kQuerySpecParamLikeKey;
 extern NSString * const kQuerySpecParamSmartSql;
 
+// TODO Following could be better
+//typedef NSString * const SFQuerySpecParam NS_TYPED_ENUM NS_SWIFT_NAME(QuerySpec.Param);
+//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamQueryType     NS_SWIFT_NAME(queryType);
+//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamSelectPaths   NS_SWIFT_NAME(selectPaths);
+//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamIndexPath     NS_SWIFT_NAME(indexPath);
+//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamOrder         NS_SWIFT_NAME(paramOrder);
+//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamPageSize      NS_SWIFT_NAME(pageSize);
+//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamOrderPath     NS_SWIFT_NAME(orderPath);
+//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamMatchKey      NS_SWIFT_NAME(matchKey);
+//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamBeginKey      NS_SWIFT_NAME(beginKey);
+//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamEndKey        NS_SWIFT_NAME(endKey);
+//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamLikeKey       NS_SWIFT_NAME(likeKey);
+//FOUNDATION_EXTERN SFQuerySpecParam kQuerySpecParamSmartSql      NS_SWIFT_NAME(smartSql);
+
+extern NSUInteger const kQuerySpecDefaultPageSize;
+
 typedef NS_ENUM(NSInteger, SFSoupQueryType) {
-    kSFSoupQueryTypeExact = 2,
-    kSFSoupQueryTypeRange = 4,
-    kSFSoupQueryTypeLike = 8,
-    kSFSoupQueryTypeSmart = 16,
-    kSFSoupQueryTypeMatch = 32
-};
+    kSFSoupQueryTypeExact NS_SWIFT_NAME(exact) = 2 ,
+    kSFSoupQueryTypeRange NS_SWIFT_NAME(range) = 4,
+    kSFSoupQueryTypeLike  NS_SWIFT_NAME(like) = 8,
+    kSFSoupQueryTypeSmart NS_SWIFT_NAME(smart) = 16,
+    kSFSoupQueryTypeMatch NS_SWIFT_NAME(match) = 32
+} NS_SWIFT_NAME(QueryType);
 
 typedef NS_ENUM(NSUInteger, SFSoupQuerySortOrder) {
-    kSFSoupQuerySortOrderAscending,
-    kSFSoupQuerySortOrderDescending
-};
+    kSFSoupQuerySortOrderAscending  NS_SWIFT_NAME(ascending),
+    kSFSoupQuerySortOrderDescending NS_SWIFT_NAME(descending)
+} NS_SWIFT_NAME(SortOrder);
 
 /**
  * Object containing the query specification for queries against a soup.
  */
+NS_SWIFT_NAME(QuerySpec)
 @interface SFQuerySpec : NSObject
 
 /**

--- a/libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.h
@@ -54,7 +54,7 @@ NS_SWIFT_NAME(StoreConfig)
  * @param path to the config file
  * @return instance of SFSDKStoreConfig
  */
-- (nullable id)initWithResourceAtPath:(NSString*)path;
+- (nullable instancetype)initWithResourceAtPath:(NSString*)path;
 
 /**
  * Register the soup from the config in the given store

--- a/libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.h
@@ -46,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  *     ]
  * }
  */
+NS_SWIFT_NAME(StoreConfig)
 @interface SFSDKStoreConfig : NSObject
 
 /**

--- a/libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Utility helper functions for Smart SQL.
  */
-
+NS_SWIFT_NAME(SmartSqlHelper)
 @interface SFSmartSqlHelper : NSObject
 
 /**

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -115,7 +115,7 @@ extern NSString *const EXPLAIN_ROWS;
 @class SFSoupSpec;
 @class SFUserAccount;
 
-
+NS_SWIFT_NAME(SmartStore)
 @interface SFSmartStore : NSObject {
 
     //used for monitoring the status of file data protection

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -372,8 +372,9 @@ NS_SWIFT_NAME(SmartStore)
  @param entryIds An array of opaque soup entry IDs from _soupEntryId.
  @param soupName The name of the soup from which to remove the soup entries.
  @param error Sets/returns any error generated as part of the process.
+ @return YES if no error occurs
  */
-- (void) removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName error:(NSError **)error NS_SWIFT_NAME(remove(entryIds:soupName:));
+- (BOOL) removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName error:(NSError **)error NS_SWIFT_NAME(remove(entryIds:soupName:));
 
 /**
  Remove soup entries exactly matching the soup entry IDs.
@@ -381,7 +382,7 @@ NS_SWIFT_NAME(SmartStore)
  @param entryIds An array of opaque soup entry IDs from _soupEntryId.
  @param soupName The name of the soup from which to remove the soup entries.
  */
-- (void)removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName NS_SWIFT_NAME(remove(entryIds:soupName:));
+- (void)removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName NS_SWIFT_UNAVAILABLE("Use removeEntries");
 
 /**
  Remove soup entries returned by the given query spec.
@@ -390,8 +391,9 @@ NS_SWIFT_NAME(SmartStore)
  @param querySpec Query returning entries to delete (if querySpec uses smartSQL, it must select soup entry ids).
  @param soupName The name of the soup from which to remove the soup entries.
  @param error Sets/returns any error generated as part of the process.
+ @return YES if no error occurs
  */
-- (void)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName  error:(NSError **)error NS_SWIFT_NAME(removeByQuery(querySpec:soupName:));
+- (BOOL)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName  error:(NSError **)error NS_SWIFT_NAME(removeByQuery(querySpec:soupName:));
 
 /**
  Remove soup entries returned by the given query spec.
@@ -400,7 +402,7 @@ NS_SWIFT_NAME(SmartStore)
  @param querySpec Query returning entries to delete (if querySpec uses smartSQL, it must select soup entry ids).
  @param soupName The name of the soup from which to remove the soup entries.
  */
-- (void)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName NS_SWIFT_NAME(removeByQuery(querySpec:soupName:));
+- (void)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName NS_SWIFT_UNAVAILABLE("Use removeEntriesByQuery");
 
 /**
  Remove all elements from soup.

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -373,7 +373,7 @@ NS_SWIFT_NAME(SmartStore)
  @param soupName The name of the soup from which to remove the soup entries.
  @param error Sets/returns any error generated as part of the process.
  */
-- (void) removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName error:(NSError **)error /* TODO NS_SWIFT_NAME(remove(entryIds:soupName:))*/;
+- (void) removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName error:(NSError **)error NS_SWIFT_NAME(remove(entryIds:soupName:));
 
 /**
  Remove soup entries exactly matching the soup entry IDs.
@@ -391,7 +391,7 @@ NS_SWIFT_NAME(SmartStore)
  @param soupName The name of the soup from which to remove the soup entries.
  @param error Sets/returns any error generated as part of the process.
  */
-- (void)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName  error:(NSError **)error /* TODO NS_SWIFT_NAME(removeByQuery(querySpec:soupName:))*/;
+- (void)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName  error:(NSError **)error NS_SWIFT_NAME(removeByQuery(querySpec:soupName:));
 
 /**
  Remove soup entries returned by the given query spec.

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -52,7 +52,7 @@ extern NSString * const kSFSmartStoreEncryptionKeyLabel;
 /**
  Block typedef for generating an encryption key.
  */
-typedef SFEncryptionKey*  _Nullable (^SFSmartStoreEncryptionKeyBlock)(void);
+typedef SFEncryptionKey*  _Nullable (^SFSmartStoreEncryptionKeyBlock)(void) NS_SWIFT_NAME(EncryptionKeyBlock);
 
 /**
  The columns of a soup table

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  The default store name used by the SFSmartStorePlugin: native code may choose
  to use separate stores.
  */
-extern NSString *const kDefaultSmartStoreName;
+extern NSString *const kDefaultSmartStoreName NS_SWIFT_NAME(SmartStore.defaultStoreName);
 
 /**
  The NSError domain for SmartStore errors.
@@ -163,21 +163,21 @@ NS_SWIFT_NAME(SmartStore)
  @param storeName The name of the store.  If in doubt, use kDefaultSmartStoreName.
  @return A shared instance of a store with the given name.
  */
-+ (nullable id)sharedStoreWithName:(NSString*)storeName;
++ (nullable id)sharedStoreWithName:(NSString*)storeName NS_SWIFT_NAME(sharedStore(storeName:));
 
 /**
  Use this method to obtain a shared store instance with the given name for the given user.
  @param storeName The name of the store.  If in doubt, use kDefaultSmartStoreName.
  @param user The user associated with the store.
  */
-+ (nullable id)sharedStoreWithName:(NSString*)storeName user:(SFUserAccount *)user;
++ (nullable id)sharedStoreWithName:(NSString*)storeName user:(SFUserAccount *)user NS_SWIFT_NAME(sharedStore(storeName:user:));
 
 /**
  Use this method to obtain a shared global store instance with the given name.  This store will
  not be specific to a particular user.
  @param storeName The name of the global store to retrieve.
  */
-+ (id)sharedGlobalStoreWithName:(NSString *)storeName;
++ (id)sharedGlobalStoreWithName:(NSString *)storeName NS_SWIFT_NAME(sharedGlobalStore(storeName:));
 
 /**
  You may use this method to completely remove a persistent shared store with
@@ -185,7 +185,7 @@ NS_SWIFT_NAME(SmartStore)
  
  @param storeName The name of the store. 
  */
-+ (void)removeSharedStoreWithName:(NSString *)storeName;
++ (void)removeSharedStoreWithName:(NSString *)storeName NS_SWIFT_NAME(removeSharedStore(storeName:));
 
 /**
  You may use this method to completely remove a persisted shared store with the given name
@@ -193,13 +193,13 @@ NS_SWIFT_NAME(SmartStore)
  @param storeName The name of the store to remove.
  @param user The user associated with the store.
  */
-+ (void)removeSharedStoreWithName:(NSString *)storeName forUser:(SFUserAccount *)user;
++ (void)removeSharedStoreWithName:(NSString *)storeName forUser:(SFUserAccount *)user NS_SWIFT_NAME(removeSharedStore(storeName:user:));
 
 /**
  You may use this method to completely remove a persisted global store with the given name.
  @param storeName The name of the global store to remove.
  */
-+ (void)removeSharedGlobalStoreWithName:(NSString *)storeName;
++ (void)removeSharedGlobalStoreWithName:(NSString *)storeName NS_SWIFT_NAME(removeSharedGlobalStore(storeName:));
 
 /**
  Removes all of the stores for the current user from this app.
@@ -210,7 +210,7 @@ NS_SWIFT_NAME(SmartStore)
  Removes all of the store for the given user from this app.
  @param user The user associated with the stores to remove.
  */
-+ (void)removeAllStoresForUser:(SFUserAccount *)user;
++ (void)removeAllStoresForUser:(SFUserAccount *)user NS_SWIFT_NAME(removeAllStores(user:));
 
 /**
  Removes all of the global stores from this app.
@@ -253,13 +253,13 @@ NS_SWIFT_NAME(SmartStore)
  *  @param soupName Name of the soup.
  *  @return Specs of the soup if it exists.
  */
-- (SFSoupSpec*)attributesForSoup:(NSString*)soupName;
+- (SFSoupSpec*)attributesForSoup:(NSString*)soupName NS_SWIFT_NAME(attributes(soupName:));
 
 /**
  @param soupName Name of the soup.
  @return NSArray of SFSoupIndex for the given soup.
  */
-- (NSArray*)indicesForSoup:(NSString*)soupName;
+- (NSArray*)indicesForSoup:(NSString*)soupName NS_SWIFT_NAME(indices(soupName:));
 
 /**
  @param soupName Name of the soup.
@@ -274,7 +274,7 @@ NS_SWIFT_NAME(SmartStore)
  @param error Sets/returns any error generated as part of the process.
  @return YES if the soup is registered or already exists.
  */
-- (BOOL)registerSoup:(NSString*)soupName withIndexSpecs:(NSArray*)indexSpecs error:(NSError**)error;
+- (BOOL)registerSoup:(NSString*)soupName withIndexSpecs:(NSArray*)indexSpecs error:(NSError**)error NS_SWIFT_NAME(registerSoup(soupName:indexSpecs:));
 
 /**
  Creates a new soup or confirms the existence of an existing soup.
@@ -284,7 +284,8 @@ NS_SWIFT_NAME(SmartStore)
  @param indexSpecs Array of one or more SFSoupIndex objects.
  @return YES if the soup is registered or already exists.
  */
-- (BOOL)registerSoup:(NSString*)soupName withIndexSpecs:(NSArray*)indexSpecs __attribute__((deprecated("Use -registerSoup:withIndexSpecs:error:")));
+- (BOOL)registerSoup:(NSString*)soupName withIndexSpecs:(NSArray*)indexSpecs
+    __attribute__((deprecated("Use -registerSoup:withIndexSpecs:error:")));
 
 /**
  Creates a new soup or confirms the existence of an existing soup.
@@ -295,7 +296,7 @@ NS_SWIFT_NAME(SmartStore)
  @return YES if the soup is registered or already exists.
 
  */
-- (BOOL)registerSoupWithSpec:(SFSoupSpec*)soupSpec withIndexSpecs:(NSArray*)indexSpecs error:(NSError**)error;
+- (BOOL)registerSoupWithSpec:(SFSoupSpec*)soupSpec withIndexSpecs:(NSArray*)indexSpecs error:(NSError**)error NS_SWIFT_NAME(registerSoup(soupSpec:indexSpecs:));
 
 /**
  Get the number of entries that would be returned with the given query spec
@@ -303,7 +304,7 @@ NS_SWIFT_NAME(SmartStore)
  @param querySpec A native query spec.
  @param error Sets/returns any error generated as part of the process.
  */
-- (NSUInteger)countWithQuerySpec:(SFQuerySpec*)querySpec error:(NSError **)error;
+- (NSNumber* __nullable) countWithQuerySpec:(SFQuerySpec*)querySpec error:(NSError **)error NS_SWIFT_NAME(count(querySpec:));
 
 /**
  Search for entries matching the given query spec.
@@ -314,7 +315,7 @@ NS_SWIFT_NAME(SmartStore)
  
  @return A set of entries given the pageSize provided in the querySpec.
  */
-- (NSArray *)queryWithQuerySpec:(SFQuerySpec *)querySpec pageIndex:(NSUInteger)pageIndex error:(NSError **)error;
+- (NSArray * __nullable)queryWithQuerySpec:(SFQuerySpec *)querySpec pageIndex:(NSUInteger)pageIndex error:(NSError **)error NS_SWIFT_NAME(query(querySpec:pageIndex:));
 
 /**
  Search soup for entries exactly matching the soup entry IDs.
@@ -324,7 +325,7 @@ NS_SWIFT_NAME(SmartStore)
  
  @return An array with zero or more entries matching the input IDs. Order is not guaranteed.
  */
-- (NSArray*)retrieveEntries:(NSArray*)soupEntryIds fromSoup:(NSString*)soupName;
+- (NSArray*)retrieveEntries:(NSArray*)soupEntryIds fromSoup:(NSString*)soupName NS_SWIFT_NAME(retrieve(soupEntryIds:soupName:));
 
 /**
  Insert/update entries to the soup.  Insert vs. update will be determined by the internal
@@ -336,7 +337,7 @@ NS_SWIFT_NAME(SmartStore)
  
  @return The array of updated entries in the soup.
  */
-- (NSArray*)upsertEntries:(NSArray*)entries toSoup:(NSString*)soupName;
+- (NSArray*)upsertEntries:(NSArray*)entries toSoup:(NSString*)soupName NS_SWIFT_NAME(upsert(entries:soupName:));
 
 /**
  Insert/update entries to the soup.  Insert vs. update will be determined by the specified
@@ -349,7 +350,7 @@ NS_SWIFT_NAME(SmartStore)
  
  @return The array of updated entries in the soup.
  */
-- (NSArray *)upsertEntries:(NSArray *)entries toSoup:(NSString *)soupName withExternalIdPath:(NSString *)externalIdPath error:(NSError **)error;
+- (NSArray * _Nullable)upsertEntries:(NSArray *)entries toSoup:(NSString *)soupName withExternalIdPath:(NSString *)externalIdPath error:(NSError **)error  NS_SWIFT_NAME(upsert(entries:soupName:externalIdPath:));
 
 /**
  Look up the ID for an entry in a soup.
@@ -360,10 +361,10 @@ NS_SWIFT_NAME(SmartStore)
  @param error Sets/returns any error generated as part of the process.
  @return The ID of the specified soup entry.
  */
-- (NSNumber *)lookupSoupEntryIdForSoupName:(NSString *)soupName
+- (NSNumber * __nullable)lookupSoupEntryIdForSoupName:(NSString *)soupName
                               forFieldPath:(NSString *)fieldPath
                                 fieldValue:(NSString *)fieldValue
-                                     error:(NSError **)error;
+                                                error:(NSError **)error NS_SWIFT_NAME(lookupSoupEntryId(soupName:fieldPath:fieldValue:));
 
 /**
  Remove soup entries exactly matching the soup entry IDs.
@@ -372,7 +373,7 @@ NS_SWIFT_NAME(SmartStore)
  @param soupName The name of the soup from which to remove the soup entries.
  @param error Sets/returns any error generated as part of the process.
  */
-- (void)removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName error:(NSError **)error;
+- (void) removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName error:(NSError **)error /* TODO NS_SWIFT_NAME(remove(entryIds:soupName:))*/;
 
 /**
  Remove soup entries exactly matching the soup entry IDs.
@@ -380,7 +381,7 @@ NS_SWIFT_NAME(SmartStore)
  @param entryIds An array of opaque soup entry IDs from _soupEntryId.
  @param soupName The name of the soup from which to remove the soup entries.
  */
-- (void)removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName;
+- (void)removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName NS_SWIFT_NAME(remove(entryIds:soupName:));
 
 /**
  Remove soup entries returned by the given query spec.
@@ -390,7 +391,7 @@ NS_SWIFT_NAME(SmartStore)
  @param soupName The name of the soup from which to remove the soup entries.
  @param error Sets/returns any error generated as part of the process.
  */
-- (void)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName  error:(NSError **)error;
+- (void)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName  error:(NSError **)error /* TODO NS_SWIFT_NAME(removeByQuery(querySpec:soupName:))*/;
 
 /**
  Remove soup entries returned by the given query spec.
@@ -399,7 +400,7 @@ NS_SWIFT_NAME(SmartStore)
  @param querySpec Query returning entries to delete (if querySpec uses smartSQL, it must select soup entry ids).
  @param soupName The name of the soup from which to remove the soup entries.
  */
-- (void)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName;
+- (void)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName NS_SWIFT_NAME(removeByQuery(querySpec:soupName:));
 
 /**
  Remove all elements from soup.
@@ -432,7 +433,7 @@ NS_SWIFT_NAME(SmartStore)
  @param soupName Name of the soup.
  @return External file storage size, in bytes.
  */
-- (unsigned long long)getExternalFileStorageSizeForSoup:(NSString*)soupName;
+- (unsigned long long)getExternalFileStorageSizeForSoup:(NSString*)soupName NS_SWIFT_NAME(getExternalFileStorageSize(soupName:));
 
 /**
  Return the number of external storage files for a given soup.
@@ -440,7 +441,7 @@ NS_SWIFT_NAME(SmartStore)
  @param soupName The name of the soup.
  @return Number of external files.
  */
-- (NSUInteger)getExternalFilesCountForSoup:(NSString*)soupName;
+- (NSUInteger)getExternalFilesCountForSoup:(NSString*)soupName NS_SWIFT_NAME(getExternalFilesCount(soupName:));
 
 /**
  Alter soup indexes.
@@ -450,7 +451,7 @@ NS_SWIFT_NAME(SmartStore)
  @param reIndexData pass true if you want existing records to be re-indexed for new index specs.
  @return YES if the soup was altered successfully.
  */
-- (BOOL) alterSoup:(NSString*)soupName withIndexSpecs:(NSArray*)indexSpecs reIndexData:(BOOL)reIndexData;
+- (BOOL) alterSoup:(NSString*)soupName withIndexSpecs:(NSArray*)indexSpecs reIndexData:(BOOL)reIndexData NS_SWIFT_NAME(alterSoup(soupName:indexSpecs:reIndexData:));
 
 /**
  Alter soup indexes.
@@ -461,7 +462,7 @@ NS_SWIFT_NAME(SmartStore)
  @param reIndexData Pass YES if you want existing records to be re-indexed for new index specs.
  @return YES if the soup was altered successfully.
  */
-- (BOOL) alterSoup:(NSString*)soupName withSoupSpec:(SFSoupSpec*)soupSpec withIndexSpecs:(NSArray*)indexSpecs reIndexData:(BOOL)reIndexData;
+- (BOOL) alterSoup:(NSString*)soupName withSoupSpec:(SFSoupSpec*)soupSpec withIndexSpecs:(NSArray*)indexSpecs reIndexData:(BOOL)reIndexData NS_SWIFT_NAME(alterSoup(soupName:soupSpec:indexSpecs:reIndexData:));
 
 
 /**
@@ -471,7 +472,7 @@ NS_SWIFT_NAME(SmartStore)
  @param indexPaths Array of on ore more paths to be reindexed.
  @return YES if soup reindexing succeeded.
  */
-- (BOOL) reIndexSoup:(NSString*)soupName withIndexPaths:(NSArray*)indexPaths;
+- (BOOL) reIndexSoup:(NSString*)soupName withIndexPaths:(NSArray*)indexPaths NS_SWIFT_NAME(reIndexSoup(soupName:indexPaths:));
 
 /**
  * Return compile options
@@ -516,7 +517,7 @@ NS_SWIFT_NAME(SmartStore)
  @param lastModifiedValue The numeric value of the date stored in the soup entry.
  @return The NSDate representation of the last modified date.
  */
-+ (NSDate *)dateFromLastModifiedValue:(NSNumber *)lastModifiedValue;
++ (NSDate *)dateFromLastModifiedValue:(NSNumber *)lastModifiedValue NS_SWIFT_NAME(date(lastModifiedValue:));
 
 @end
 

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -27,6 +27,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SFEncryptionKey;
+@class SFSoupIndex;
 
 /**
  The default store name used by the SFSmartStorePlugin: native code may choose
@@ -163,21 +164,21 @@ NS_SWIFT_NAME(SmartStore)
  @param storeName The name of the store.  If in doubt, use kDefaultSmartStoreName.
  @return A shared instance of a store with the given name.
  */
-+ (nullable id)sharedStoreWithName:(NSString*)storeName NS_SWIFT_NAME(sharedStore(storeName:));
++ (nullable instancetype)sharedStoreWithName:(NSString*)storeName NS_SWIFT_NAME(sharedStore(name:));
 
 /**
  Use this method to obtain a shared store instance with the given name for the given user.
  @param storeName The name of the store.  If in doubt, use kDefaultSmartStoreName.
  @param user The user associated with the store.
  */
-+ (nullable id)sharedStoreWithName:(NSString*)storeName user:(SFUserAccount *)user NS_SWIFT_NAME(sharedStore(storeName:user:));
++ (nullable instancetype)sharedStoreWithName:(NSString*)storeName user:(SFUserAccount *)user NS_SWIFT_NAME(sharedStore(name:user:));
 
 /**
  Use this method to obtain a shared global store instance with the given name.  This store will
  not be specific to a particular user.
  @param storeName The name of the global store to retrieve.
  */
-+ (id)sharedGlobalStoreWithName:(NSString *)storeName NS_SWIFT_NAME(sharedGlobalStore(storeName:));
++ (instancetype)sharedGlobalStoreWithName:(NSString *)storeName NS_SWIFT_NAME(sharedGlobalStore(name:));
 
 /**
  You may use this method to completely remove a persistent shared store with
@@ -185,7 +186,7 @@ NS_SWIFT_NAME(SmartStore)
  
  @param storeName The name of the store. 
  */
-+ (void)removeSharedStoreWithName:(NSString *)storeName NS_SWIFT_NAME(removeSharedStore(storeName:));
++ (void)removeSharedStoreWithName:(NSString *)storeName NS_SWIFT_NAME(removeSharedStore(name:));
 
 /**
  You may use this method to completely remove a persisted shared store with the given name
@@ -193,13 +194,13 @@ NS_SWIFT_NAME(SmartStore)
  @param storeName The name of the store to remove.
  @param user The user associated with the store.
  */
-+ (void)removeSharedStoreWithName:(NSString *)storeName forUser:(SFUserAccount *)user NS_SWIFT_NAME(removeSharedStore(storeName:user:));
++ (void)removeSharedStoreWithName:(NSString *)storeName forUser:(SFUserAccount *)user NS_SWIFT_NAME(removeSharedStore(name:user:));
 
 /**
  You may use this method to completely remove a persisted global store with the given name.
  @param storeName The name of the global store to remove.
  */
-+ (void)removeSharedGlobalStoreWithName:(NSString *)storeName NS_SWIFT_NAME(removeSharedGlobalStore(storeName:));
++ (void)removeSharedGlobalStoreWithName:(NSString *)storeName NS_SWIFT_NAME(removeSharedGlobalStore(name:));
 
 /**
  Removes all of the stores for the current user from this app.
@@ -259,7 +260,7 @@ NS_SWIFT_NAME(SmartStore)
  @param soupName Name of the soup.
  @return NSArray of SFSoupIndex for the given soup.
  */
-- (NSArray*)indicesForSoup:(NSString*)soupName NS_SWIFT_NAME(indices(soupName:));
+- (NSArray<SFSoupIndex*>*)indicesForSoup:(NSString*)soupName NS_SWIFT_NAME(indices(soupName:));
 
 /**
  @param soupName Name of the soup.
@@ -274,7 +275,7 @@ NS_SWIFT_NAME(SmartStore)
  @param error Sets/returns any error generated as part of the process.
  @return YES if the soup is registered or already exists.
  */
-- (BOOL)registerSoup:(NSString*)soupName withIndexSpecs:(NSArray*)indexSpecs error:(NSError**)error NS_SWIFT_NAME(registerSoup(soupName:indexSpecs:));
+- (BOOL)registerSoup:(NSString*)soupName withIndexSpecs:(NSArray<SFSoupIndex*>*)indexSpecs error:(NSError**)error NS_SWIFT_NAME(registerSoup(soupName:indexSpecs:));
 
 /**
  Creates a new soup or confirms the existence of an existing soup.
@@ -284,7 +285,7 @@ NS_SWIFT_NAME(SmartStore)
  @param indexSpecs Array of one or more SFSoupIndex objects.
  @return YES if the soup is registered or already exists.
  */
-- (BOOL)registerSoup:(NSString*)soupName withIndexSpecs:(NSArray*)indexSpecs
+- (BOOL)registerSoup:(NSString*)soupName withIndexSpecs:(NSArray<SFSoupIndex*>*)indexSpecs
     __attribute__((deprecated("Use -registerSoup:withIndexSpecs:error:")));
 
 /**
@@ -296,7 +297,7 @@ NS_SWIFT_NAME(SmartStore)
  @return YES if the soup is registered or already exists.
 
  */
-- (BOOL)registerSoupWithSpec:(SFSoupSpec*)soupSpec withIndexSpecs:(NSArray*)indexSpecs error:(NSError**)error NS_SWIFT_NAME(registerSoup(soupSpec:indexSpecs:));
+- (BOOL)registerSoupWithSpec:(SFSoupSpec*)soupSpec withIndexSpecs:(NSArray<SFSoupIndex*>*)indexSpecs error:(NSError**)error NS_SWIFT_NAME(registerSoup(soupSpec:indexSpecs:));
 
 /**
  Get the number of entries that would be returned with the given query spec
@@ -325,7 +326,7 @@ NS_SWIFT_NAME(SmartStore)
  
  @return An array with zero or more entries matching the input IDs. Order is not guaranteed.
  */
-- (NSArray*)retrieveEntries:(NSArray*)soupEntryIds fromSoup:(NSString*)soupName NS_SWIFT_NAME(retrieve(soupEntryIds:soupName:));
+- (NSArray<NSDictionary*>*)retrieveEntries:(NSArray<NSNumber*>*)soupEntryIds fromSoup:(NSString*)soupName NS_SWIFT_NAME(retrieve(soupEntryIds:soupName:));
 
 /**
  Insert/update entries to the soup.  Insert vs. update will be determined by the internal
@@ -337,7 +338,7 @@ NS_SWIFT_NAME(SmartStore)
  
  @return The array of updated entries in the soup.
  */
-- (NSArray*)upsertEntries:(NSArray*)entries toSoup:(NSString*)soupName NS_SWIFT_NAME(upsert(entries:soupName:));
+- (NSArray<NSDictionary*>*)upsertEntries:(NSArray<NSDictionary*>*)entries toSoup:(NSString*)soupName NS_SWIFT_NAME(upsert(entries:soupName:));
 
 /**
  Insert/update entries to the soup.  Insert vs. update will be determined by the specified
@@ -374,7 +375,7 @@ NS_SWIFT_NAME(SmartStore)
  @param error Sets/returns any error generated as part of the process.
  @return YES if no error occurs
  */
-- (BOOL) removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName error:(NSError **)error NS_SWIFT_NAME(remove(entryIds:soupName:));
+- (BOOL) removeEntries:(NSArray<NSNumber*>*)entryIds fromSoup:(NSString*)soupName error:(NSError **)error NS_SWIFT_NAME(remove(entryIds:soupName:));
 
 /**
  Remove soup entries exactly matching the soup entry IDs.
@@ -382,7 +383,7 @@ NS_SWIFT_NAME(SmartStore)
  @param entryIds An array of opaque soup entry IDs from _soupEntryId.
  @param soupName The name of the soup from which to remove the soup entries.
  */
-- (void)removeEntries:(NSArray*)entryIds fromSoup:(NSString*)soupName NS_SWIFT_UNAVAILABLE("Use removeEntries");
+- (void)removeEntries:(NSArray<NSNumber*>*)entryIds fromSoup:(NSString*)soupName NS_SWIFT_UNAVAILABLE("Use removeEntries");
 
 /**
  Remove soup entries returned by the given query spec.
@@ -453,7 +454,7 @@ NS_SWIFT_NAME(SmartStore)
  @param reIndexData pass true if you want existing records to be re-indexed for new index specs.
  @return YES if the soup was altered successfully.
  */
-- (BOOL) alterSoup:(NSString*)soupName withIndexSpecs:(NSArray*)indexSpecs reIndexData:(BOOL)reIndexData NS_SWIFT_NAME(alterSoup(soupName:indexSpecs:reIndexData:));
+- (BOOL) alterSoup:(NSString*)soupName withIndexSpecs:(NSArray<SFSoupIndex*>*)indexSpecs reIndexData:(BOOL)reIndexData NS_SWIFT_NAME(alterSoup(soupName:indexSpecs:reIndexData:));
 
 /**
  Alter soup indexes.
@@ -464,7 +465,7 @@ NS_SWIFT_NAME(SmartStore)
  @param reIndexData Pass YES if you want existing records to be re-indexed for new index specs.
  @return YES if the soup was altered successfully.
  */
-- (BOOL) alterSoup:(NSString*)soupName withSoupSpec:(SFSoupSpec*)soupSpec withIndexSpecs:(NSArray*)indexSpecs reIndexData:(BOOL)reIndexData NS_SWIFT_NAME(alterSoup(soupName:soupSpec:indexSpecs:reIndexData:));
+- (BOOL) alterSoup:(NSString*)soupName withSoupSpec:(SFSoupSpec*)soupSpec withIndexSpecs:(NSArray<SFSoupIndex*>*)indexSpecs reIndexData:(BOOL)reIndexData NS_SWIFT_NAME(alterSoup(soupName:soupSpec:indexSpecs:reIndexData:));
 
 
 /**
@@ -474,7 +475,7 @@ NS_SWIFT_NAME(SmartStore)
  @param indexPaths Array of on ore more paths to be reindexed.
  @return YES if soup reindexing succeeded.
  */
-- (BOOL) reIndexSoup:(NSString*)soupName withIndexPaths:(NSArray*)indexPaths NS_SWIFT_NAME(reIndexSoup(soupName:indexPaths:));
+- (BOOL) reIndexSoup:(NSString*)soupName withIndexPaths:(NSArray<NSString*>*)indexPaths NS_SWIFT_NAME(reIndexSoup(soupName:indexPaths:));
 
 /**
  * Return compile options
@@ -512,7 +513,7 @@ NS_SWIFT_NAME(SmartStore)
  Return all soup names.
  @return Array containing all soup names.
  */
-- (NSArray*) allSoupNames;
+- (NSArray<NSString*>*) allSoupNames;
 
 /**
  Creates a date object from the last modified date column value, which is numeric.

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -1525,13 +1525,13 @@ NSString *const EXPLAIN_ROWS = @"rows";
     return returnId;
 }
 
-- (NSUInteger)countWithQuerySpec:(SFQuerySpec*)querySpec error:(NSError **)error;
+- (NSNumber*)countWithQuerySpec:(SFQuerySpec*)querySpec error:(NSError **)error;
 {
     __block NSInteger result;
     [self inDatabase:^(FMDatabase* db) {
         result = [self countWithQuerySpec:querySpec withDb:db];
     } error:error];
-    return result;
+    return [NSNumber numberWithUnsignedInteger:result];
 }
 
 - (NSUInteger)countWithQuerySpec:(SFQuerySpec*)querySpec withDb:(FMDatabase*)db

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -649,7 +649,8 @@ NSString *const EXPLAIN_ROWS = @"rows";
     }];
 }
 
-- (void)inTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block error:(NSError* __autoreleasing *)error {
+- (BOOL)inTransaction:(void (^)(FMDatabase *db, BOOL *rollback))block error:(NSError* __autoreleasing *)error {
+    __block BOOL success = YES;
     [self.storeQueue inTransaction:^(FMDatabase* db, BOOL *rollback) {
         @try {
             block(db, rollback);
@@ -661,9 +662,10 @@ NSString *const EXPLAIN_ROWS = @"rows";
             if (error != nil) {
                 *error = [self errorForException:exception];
             }
+            success = FALSE;
         }
     }];
-    
+    return success;
 }
 
 - (NSError*) errorForException:(NSException*)exception
@@ -1961,9 +1963,9 @@ NSString *const EXPLAIN_ROWS = @"rows";
     [self removeEntries:soupEntryIds fromSoup:soupName error:nil];
 }
 
-- (void)removeEntries:(NSArray*)soupEntryIds fromSoup:(NSString*)soupName error:(NSError**)error
+- (BOOL)removeEntries:(NSArray*)soupEntryIds fromSoup:(NSString*)soupName error:(NSError**)error
 {
-    [self inTransaction:^(FMDatabase* db, BOOL* rollback) {
+    return [self inTransaction:^(FMDatabase* db, BOOL* rollback) {
         [self removeEntries:soupEntryIds fromSoup:soupName withDb:db];
     } error:error];
 }
@@ -1997,9 +1999,9 @@ NSString *const EXPLAIN_ROWS = @"rows";
     [self removeEntriesByQuery:querySpec fromSoup:soupName error:nil];
 }
 
-- (void)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName error:(NSError**)error
+- (BOOL)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName error:(NSError**)error
 {
-    [self inTransaction:^(FMDatabase* db, BOOL* rollback) {
+    return [self inTransaction:^(FMDatabase* db, BOOL* rollback) {
         [self removeEntriesByQuery:querySpec fromSoup:soupName withDb:db];
     } error:error];
 }

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -2001,7 +2001,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
 {
     [self inTransaction:^(FMDatabase* db, BOOL* rollback) {
         [self removeEntriesByQuery:querySpec fromSoup:soupName withDb:db];
-    } error:nil];
+    } error:error];
 }
 
 - (void)removeEntriesByQuery:(SFQuerySpec*)querySpec fromSoup:(NSString*)soupName withDb:(FMDatabase*) db

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
  The NSError domain for SmartStore database errors.
  */
 extern NSString * const kSFSmartStoreDbErrorDomain;
-
+NS_SWIFT_NAME(DatabaseManager)
 @interface SFSmartStoreDatabaseManager : NSObject
 
 /**

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreInspectorViewController.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreInspectorViewController.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The view controller for managing the SmartStore inspector screen.
  */
+NS_SWIFT_NAME(InspectorViewController)
 @interface SFSmartStoreInspectorViewController : UIViewController <UICollectionViewDataSource, UICollectionViewDelegateFlowLayout, UITextViewDelegate>
 
 /**

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreUtils.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreUtils.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**Utility methods used by SmartStore.
  */
+NS_SWIFT_NAME(Utils)
 @interface SFSmartStoreUtils : NSObject
 
 /** Returns a unique key for the given user, or a "global" key if no proper

--- a/libs/SmartStore/SmartStore/Classes/SFSoupIndex.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSoupIndex.h
@@ -47,6 +47,7 @@ extern SFIndexSpecTypeFilterBlock const kValueIndexedWithJSONExtract;
 /**
  * Definition of an index on a given soup.
  */
+NS_SWIFT_NAME(SoupIndex)
 @interface SFSoupIndex : NSObject {
     NSString *_path;
     NSString *_indexType;

--- a/libs/SmartStore/SmartStore/Classes/SFSoupIndex.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSoupIndex.h
@@ -81,7 +81,7 @@ NS_SWIFT_NAME(SoupIndex)
  * @param type An index type, e.g. kSoupIndexTypeString.
  * @param columnName The SQL column name, or nil.
  */
-- (nullable id)initWithPath:(NSString*)path indexType:(NSString*)type columnName:(nullable NSString*)columnName;
+- (nullable instancetype)initWithPath:(NSString*)path indexType:(NSString*)type columnName:(nullable NSString*)columnName;
 
 /**
  * Creates an SFSoupIndex based on the given NSDictionary index spec.

--- a/libs/SmartStore/SmartStore/Classes/SFSoupSpec.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSoupSpec.h
@@ -40,6 +40,7 @@ extern NSString * const kSoupFeatureExternalStorage;
 /**
  * Object containing soup specifications, such as soup name and features.
  */
+NS_SWIFT_NAME(SoupSpec)
 @interface SFSoupSpec : NSObject
 
 /**

--- a/libs/SmartStore/SmartStore/Classes/SFStoreCursor.h
+++ b/libs/SmartStore/SmartStore/Classes/SFStoreCursor.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Defines a cursor into data stored in a soup.
  */
+NS_SWIFT_NAME(StoreCursor)
 @interface SFStoreCursor : NSObject {
     SFSmartStore *_store;
     NSString *_cursorId;

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
@@ -259,7 +259,7 @@
 {
     [self loadData];
     SFQuerySpec* querySpec = [SFQuerySpec newSmartQuerySpec:@"select {employees:firstName} from {employees} order by {employees:firstName}" withPageSize:1];
-    XCTAssertTrue(7 ==[self.store countWithQuerySpec:querySpec  error:nil], @"Expected 7 employees");
+    XCTAssertTrue(7 ==[[self.store countWithQuerySpec:querySpec  error:nil] unsignedIntegerValue], @"Expected 7 employees");
     NSArray* expectedResults = @[@"Christine", @"Eileen", @"Eva", @"Irving", @"John", @"Michael", @"Sally"];
     for (int i=0; i<7; i++) {
         NSArray* result = [self.store queryWithQuerySpec:querySpec pageIndex:i  error:nil];

--- a/libs/SmartSync/SmartSync/Classes/Config/SFSDKSyncsConfig.h
+++ b/libs/SmartSync/SmartSync/Classes/Config/SFSDKSyncsConfig.h
@@ -45,6 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
  * }
  */
 
+NS_SWIFT_NAME(SyncsConfig)
 @interface SFSDKSyncsConfig : NSObject
 
 /**

--- a/libs/SmartSync/SmartSync/Classes/Config/SFSDKSyncsConfig.h
+++ b/libs/SmartSync/SmartSync/Classes/Config/SFSDKSyncsConfig.h
@@ -53,7 +53,7 @@ NS_SWIFT_NAME(SyncsConfig)
  * @param path to the config file
  * @return instance of SFSDKSyncsConfig
  */
-- (nullable id)initWithResourceAtPath:(NSString*)path;
+- (nullable instancetype)initWithResourceAtPath:(NSString*)path;
 
 /**
  * Create the syncs from the config in the given store

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFLayoutSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFLayoutSyncManager.h
@@ -45,6 +45,7 @@ typedef void (^SFLayoutSyncCompletionBlock) (NSString * _Nonnull objectType, SFL
  * This class handles creating a soup, storing synched data and reading it into
  * a meaningful data structure, i.e. SFLayout.
  */
+NS_SWIFT_NAME(LayoutSyncManager)
 @interface SFLayoutSyncManager : NSObject
 
 @property (nonatomic, strong, readonly, nonnull) SFSmartStore *smartStore;

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFLayoutSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFLayoutSyncManager.h
@@ -38,7 +38,7 @@
  * @param objectType Object type.
  * @param layout Layout.
  */
-typedef void (^SFLayoutSyncCompletionBlock) (NSString * _Nonnull objectType, SFLayout  * _Nullable layout);
+typedef void (^SFLayoutSyncCompletionBlock) (NSString * _Nonnull objectType, SFLayout  * _Nullable layout) NS_SWIFT_NAME(LayoutSyncCompletionBlock);
 
 /**
  * Provides an easy way to fetch layout data using SFLayoutSyncDownTarget.

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFMetadataSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFMetadataSyncManager.h
@@ -37,7 +37,7 @@
  *
  * @param metadata Metadata.
  */
-typedef void (^SFMetadataSyncCompletionBlock) (SFMetadata  * _Nullable metadata);
+typedef void (^SFMetadataSyncCompletionBlock) (SFMetadata  * _Nullable metadata) NS_SWIFT_NAME(MetadataSyncCompletionBlock);
 
 /**
  * Provides an easy way to fetch metadata using SFMetadataSyncDownTarget.

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFMetadataSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFMetadataSyncManager.h
@@ -44,6 +44,7 @@ typedef void (^SFMetadataSyncCompletionBlock) (SFMetadata  * _Nullable metadata)
  * This class handles creating a soup, storing synched data and reading it into
  * a meaningful data structure, i.e. SFMetadata.
  */
+NS_SWIFT_NAME(MetadataSyncManager)
 @interface SFMetadataSyncManager : NSObject
 
 @property (nonatomic, strong, readonly, nonnull) SFSmartStore *smartStore;

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
@@ -59,14 +59,14 @@ NS_SWIFT_NAME(SyncManager)
  * @param user The user associated with the store.
  * @param storeName The name of the SmartStore associated with the user.
  */
-+ (instancetype)sharedInstanceForUser:(SFUserAccount*)user storeName:(nullable NSString *)storeName;
++ (instancetype)sharedInstanceForUser:(SFUserAccount*)user storeName:(nullable NSString *)storeName NS_SWIFT_NAME(sharedInstance(user:storeName:));
 
 /**
  * Singleton method for accessing sync manager instance by SmartStore store.
  *
  * @param store The store instance to configure.
  */
-+ (nullable instancetype)sharedInstanceForStore:(SFSmartStore*)store;
++ (nullable instancetype)sharedInstanceForStore:(SFSmartStore*)store NS_SWIFT_NAME(sharedInstance(store:));
 
 /**
  * Removes the shared instance associated with the specified user.
@@ -81,14 +81,14 @@ NS_SWIFT_NAME(SyncManager)
  * @param user The user associated with the store.
  * @param storeName The name of the store associated with the given user.
  */
-+ (void)removeSharedInstanceForUser:(SFUserAccount*)user storeName:(nullable NSString*)storeName;
++ (void)removeSharedInstanceForUser:(SFUserAccount*)user storeName:(nullable NSString*)storeName NS_SWIFT_NAME(removeSharedInstance(user:storeName:));
 
 /**
  * Removes the shared instance associated with the specified store.
  *
  * @param store The store instance.
  */
-+ (void)removeSharedInstanceForStore:(SFSmartStore*)store;
++ (void)removeSharedInstanceForStore:(SFSmartStore*)store NS_SWIFT_NAME(removeSharedInstance(store:));
 
 /**
  * Removes all shared instances
@@ -107,28 +107,28 @@ NS_SWIFT_NAME(SyncManager)
  *
  * @param syncName Sync name.
  */
-- (nullable SFSyncState*)getSyncStatusByName:(NSString*)syncName;
+- (nullable SFSyncState*)getSyncStatusByName:(NSString*)syncName NS_SWIFT_NAME(getSyncStatus(syncName:));
 
 /**
  * Returns YES if a sync with the given name exists.
  * @param syncName Sync name.
  * @return YES a sync with the given name exists.
  */
-- (BOOL)hasSyncWithName:(NSString*)syncName;
+- (BOOL)hasSyncWithName:(NSString*)syncName NS_SWIFT_NAME(hasSync(syncName:));
 
 /**
  * Delete a sync.
  *
  * @param syncId Sync ID.
  */
-- (void)deleteSyncById:(NSNumber*)syncId;
+- (void)deleteSyncById:(NSNumber*)syncId NS_SWIFT_NAME(deleteSync(syncId:));
 
 /**
  * Delete a sync by name.
  *
  * @param syncName Sync name.
  */
-- (void)deleteSyncByName:(NSString*)syncName;
+- (void)deleteSyncByName:(NSString*)syncName NS_SWIFT_NAME(deleteSync(syncName:));
 
 
 /**
@@ -148,7 +148,7 @@ NS_SWIFT_NAME(SyncManager)
  * @param updateBlock The block to be called with updates.
  * @return The sync state associated with this sync down.
  */
-- (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+- (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncDown(target:soupName:onUpdate:));
 
 /**
  * Creates and runs a sync down.
@@ -157,7 +157,7 @@ NS_SWIFT_NAME(SyncManager)
  * @param soupName The soup name where the local entries are stored.
  * @param updateBlock The block to be called with updates.
  */
-- (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+- (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncDown(target:options:soupName:onUpdate:));
 
 /**
  * Creates and runs a named sync down.
@@ -167,21 +167,21 @@ NS_SWIFT_NAME(SyncManager)
  * @param syncName The name for this sync.
  * @param updateBlock The block to be called with updates.
  */
-- (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName syncName:(nullable NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+- (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName syncName:(nullable NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncDown(target:options:soupName:syncName:onUpdate:));
 
 /**
  * Performs a resync.
  * @param syncId Sync ID.
  * @param updateBlock The block to be called with updates.
  */
-- (nullable SFSyncState*) reSync:(NSNumber*)syncId updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+- (nullable SFSyncState*) reSync:(NSNumber*)syncId updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(reSync(syncId:onUpdate:));
 
 /**
  * Performs a resync by name.
  * @param syncName Sync name.
  * @param updateBlock The block to be called with updates.
  */
-- (nullable SFSyncState*) reSyncByName:(NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+- (nullable SFSyncState*) reSyncByName:(NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(reSync(syncName:onUpdate:));
 
 /**
  * Create a sync up without running it.
@@ -201,7 +201,7 @@ NS_SWIFT_NAME(SyncManager)
  * @param updateBlock The block to be called with updates.
  * @return The sync state associated with this sync up.
  */
-- (SFSyncState*) syncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+- (SFSyncState*) syncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncUp(options:soupName:onUpdate:));
 
 /**
  * Creates and runs a sync up with the configured SFSyncUpTarget.
@@ -215,7 +215,7 @@ NS_SWIFT_NAME(SyncManager)
 - (SFSyncState*) syncUpWithTarget:(SFSyncUpTarget*)target
                           options:(SFSyncOptions*)options
                          soupName:(NSString*)soupName
-                      updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+                      updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncUp(target:options:soupName:onUpdate:));
 
 /**
  * Creates and runs a named sync up.
@@ -231,7 +231,7 @@ NS_SWIFT_NAME(SyncManager)
                           options:(SFSyncOptions*)options
                          soupName:(NSString*)soupName
                          syncName:(nullable NSString*)syncName
-                      updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;
+                      updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncUp(target:options:soupName:syncName:onUpdate:));
 
 /**
  * Removes local copies of records that have been deleted on the server
@@ -240,7 +240,7 @@ NS_SWIFT_NAME(SyncManager)
  * @param syncId Sync ID.
  * @param completionStatusBlock Completion status block.
  */
-- (void) cleanResyncGhosts:(NSNumber*)syncId completionStatusBlock:(SFSyncSyncManagerCompletionStatusBlock)completionStatusBlock;
+- (void) cleanResyncGhosts:(NSNumber*)syncId completionStatusBlock:(SFSyncSyncManagerCompletionStatusBlock)completionStatusBlock NS_SWIFT_NAME(cleanResyncGhosts(syncId:onComplete:));
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
@@ -39,6 +39,7 @@ typedef void (^SFSyncSyncManagerCompletionStatusBlock) (SFSyncStateStatus syncSt
 /**
  * This class provides methods for doing synching records to/from the server from/to the smartstore.
  */
+NS_SWIFT_NAME(SyncManager)
 @interface SFSmartSyncSyncManager : NSObject
 
 @property (nonatomic, strong, readonly) SFSmartStore *store;

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
@@ -33,8 +33,8 @@ NS_ASSUME_NONNULL_BEGIN
 @class SFUserAccount;
 
 // block type
-typedef void (^SFSyncSyncManagerUpdateBlock) (SFSyncState* sync);
-typedef void (^SFSyncSyncManagerCompletionStatusBlock) (SFSyncStateStatus syncStatus, NSUInteger numRecords);
+typedef void (^SFSyncSyncManagerUpdateBlock) (SFSyncState* sync) NS_SWIFT_NAME(SyncUpdateBlock);
+typedef void (^SFSyncSyncManagerCompletionStatusBlock) (SFSyncStateStatus syncStatus, NSUInteger numRecords) NS_SWIFT_NAME(SyncCompletionBlock);
 
 /**
  * This class provides methods for doing synching records to/from the server from/to the smartstore.

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -517,8 +517,7 @@ static NSMutableDictionary *syncMgrList = nil;
         return;
     }
     
-    NSString* idStr = [(NSNumber*) recordIds[i] stringValue];
-    NSMutableDictionary* record = [[target getFromLocalStore:self soupName:soupName storeId:idStr] mutableCopy];
+    NSMutableDictionary* record = [[target getFromLocalStore:self soupName:soupName storeId:recordIds[i]] mutableCopy];
     [SFSDKSmartSyncLogger d:[self class] format:@"syncUpOneRecord:%@", record];
 
     // Do we need to do a create, update or delete

--- a/libs/SmartSync/SmartSync/Classes/Model/SFLayout.h
+++ b/libs/SmartSync/SmartSync/Classes/Model/SFLayout.h
@@ -38,6 +38,7 @@
  *
  * @see https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_responses_record_layout.htm
  */
+NS_SWIFT_NAME(Layout)
 @interface SFLayout : NSObject
 
 @property (nonatomic, strong, readonly, nullable) NSString *id;

--- a/libs/SmartSync/SmartSync/Classes/Model/SFMetadata.h
+++ b/libs/SmartSync/SmartSync/Classes/Model/SFMetadata.h
@@ -34,6 +34,7 @@
  *
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/dome_sobject_describe.htm
  */
+NS_SWIFT_NAME(Metadata)
 @interface SFMetadata : NSObject
 
 @property (nonatomic, readonly, assign) BOOL activateable;

--- a/libs/SmartSync/SmartSync/Classes/Model/SFObject.h
+++ b/libs/SmartSync/SmartSync/Classes/Model/SFObject.h
@@ -27,6 +27,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NS_SWIFT_NAME(SObject)
 @interface SFObject : SFSmartSyncPersistableObject <NSCoding>
 
 /** Object Id */

--- a/libs/SmartSync/SmartSync/Classes/Model/SFSmartSyncPersistableObject.h
+++ b/libs/SmartSync/SmartSync/Classes/Model/SFSmartSyncPersistableObject.h
@@ -24,6 +24,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NS_SWIFT_NAME(PersistableObject)
 @interface SFSmartSyncPersistableObject : NSObject
 
 @property (nonatomic, strong) NSDictionary *rawData;

--- a/libs/SmartSync/SmartSync/Classes/Target/SFAdvancedSyncUpTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFAdvancedSyncUpTarget.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
  Protocol for advanced sync up target where records are not simply created/updated/deleted
  With advanced sync up target, sync manager simply calls the method: syncUpRecord
  */
+NS_SWIFT_NAME(AdvancedSyncUpTarget)
 @protocol SFAdvancedSyncUpTarget
 
 

--- a/libs/SmartSync/SmartSync/Classes/Target/SFLayoutSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFLayoutSyncDownTarget.h
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Sync down target for object layouts. This uses the '/ui-api/layout' API to fetch object layouts.
  * The easiest way to use this sync target is through SFLayoutSyncManager.
  */
+NS_SWIFT_NAME(LayoutSyncDownTarget)
 @interface SFLayoutSyncDownTarget : SFSyncDownTarget
 
 @property (nonatomic, strong, readonly) NSString *objectType;

--- a/libs/SmartSync/SmartSync/Classes/Target/SFMetadataSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFMetadataSyncDownTarget.h
@@ -32,6 +32,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NS_SWIFT_NAME(MetadataSyncDownTarget)
 @interface SFMetadataSyncDownTarget : SFSyncDownTarget
 
 @property (nonatomic, strong, readonly) NSString *objectType;

--- a/libs/SmartSync/SmartSync/Classes/Target/SFMruSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFMruSyncDownTarget.h
@@ -26,7 +26,7 @@
 #import "SFSyncDownTarget.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
+NS_SWIFT_NAME(MruSyncDownTarget)
 @interface SFMruSyncDownTarget : SFSyncDownTarget
 
 @property (nonatomic, strong, readonly) NSString* objectType;

--- a/libs/SmartSync/SmartSync/Classes/Target/SFParentChildrenSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFParentChildrenSyncDownTarget.h
@@ -28,7 +28,7 @@
 #import "SFSoqlSyncDownTarget.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
+NS_SWIFT_NAME(ParentChildrenSyncDownTarget)
 @interface SFParentChildrenSyncDownTarget : SFSoqlSyncDownTarget
 
 /** Factory methods

--- a/libs/SmartSync/SmartSync/Classes/Target/SFParentChildrenSyncUpTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFParentChildrenSyncUpTarget.h
@@ -29,7 +29,7 @@
 #import "SFAdvancedSyncUpTarget.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
+NS_SWIFT_NAME(ParentChildrenSyncUpTarget)
 @interface SFParentChildrenSyncUpTarget : SFSyncUpTarget <SFAdvancedSyncUpTarget>
 
 /** Factory methods

--- a/libs/SmartSync/SmartSync/Classes/Target/SFRefreshSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFRefreshSyncDownTarget.h
@@ -26,7 +26,7 @@
 #import "SFSyncDownTarget.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
+NS_SWIFT_NAME(RefreshSyncDownTarget)
 @interface SFRefreshSyncDownTarget : SFSyncDownTarget
 
 @property (nonatomic, strong, readonly) NSString* soupName;

--- a/libs/SmartSync/SmartSync/Classes/Target/SFRefreshSyncDownTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFRefreshSyncDownTarget.m
@@ -229,7 +229,7 @@ static NSUInteger const kSFSyncTargetRefreshDefaultCountIdsPerSoql = 500;
     //     since not all records will have changed
     if (self.page == 0) {
         NSError* error = nil;
-        self.totalSize = [syncManager.store countWithQuerySpec:querySpec error:&error];
+        self.totalSize = [[syncManager.store countWithQuerySpec:querySpec error:&error] unsignedIntegerValue];
         if (error != nil) {
             errorBlock(error);
             return;

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSoqlSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSoqlSyncDownTarget.h
@@ -26,7 +26,7 @@
 #import "SFSyncDownTarget.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
+NS_SWIFT_NAME(SoqlSyncDownTarget)
 @interface SFSoqlSyncDownTarget : SFSyncDownTarget
 
 @property (nonatomic, copy) NSString* query;

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSoslSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSoslSyncDownTarget.h
@@ -26,7 +26,7 @@
 #import "SFSyncDownTarget.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
+NS_SWIFT_NAME(SoslSyncDownTarget)
 @interface SFSoslSyncDownTarget : SFSyncDownTarget
 
 @property (nonatomic, strong, readonly) NSString* query;

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncDownTarget.h
@@ -62,14 +62,14 @@ NS_SWIFT_NAME(SyncDownTarget)
 - (void) startFetch:(SFSmartSyncSyncManager*)syncManager
        maxTimeStamp:(long long)maxTimeStamp
          errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
-      completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock;
+      completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock NS_SWIFT_NAME(startFetch(syncManager:maxTimeStamp:onFail:onComplete:));
 
 /**
  * Continue fetching records conforming to target if any
  */
 - (void) continueFetch:(SFSmartSyncSyncManager*)syncManager
             errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
-         completeBlock:(nullable SFSyncDownTargetFetchCompleteBlock)completeBlock;
+         completeBlock:(nullable SFSyncDownTargetFetchCompleteBlock)completeBlock NS_SWIFT_NAME(continueFetch(syncManager:onFail:onComplete:));
 
 /**
  * Gets the latest modification timestamp from the array of records. Note: inheriting classes can
@@ -95,7 +95,7 @@ NS_SWIFT_NAME(SyncDownTarget)
            soupName:(NSString *)soupName
              syncId:(NSNumber *)syncId
          errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
-      completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock;
+      completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock NS_SWIFT_NAME(cleanGhosts(syncManager:soupName:syncId:onFail:onComplete:));
 
 /**
  * Get ids of records that should not be written over

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncDownTarget.h
@@ -41,8 +41,9 @@ typedef NS_ENUM(NSInteger, SFSyncDownTargetQueryType) {
   SFSyncDownTargetQueryTypeCustom,
   SFSyncDownTargetQueryTypeMetadata,
   SFSyncDownTargetQueryTypeLayout
-};
+} NS_SWIFT_NAME(SyncDownTargetQueryType);
 
+NS_SWIFT_NAME(SyncDownTarget)
 @interface SFSyncDownTarget : SFSyncTarget
 
 @property (nonatomic,assign) SFSyncDownTargetQueryType queryType;

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncDownTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncDownTarget.h
@@ -29,8 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class SFSmartSyncSyncManager;
 
-typedef void (^SFSyncDownTargetFetchCompleteBlock) (NSArray* _Nullable records);
-typedef void (^SFSyncDownTargetFetchErrorBlock) (NSError * _Nullable e);
+typedef void (^SFSyncDownTargetFetchCompleteBlock) (NSArray* _Nullable records) NS_SWIFT_NAME(SyncDownCompletionBlock);
+typedef void (^SFSyncDownTargetFetchErrorBlock) (NSError * _Nullable e) NS_SWIFT_NAME(SyncDownErrorBlock);
 
 typedef NS_ENUM(NSInteger, SFSyncDownTargetQueryType) {
   SFSyncDownTargetQueryTypeMru,
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, SFSyncDownTargetQueryType) {
   SFSyncDownTargetQueryTypeCustom,
   SFSyncDownTargetQueryTypeMetadata,
   SFSyncDownTargetQueryTypeLayout
-} NS_SWIFT_NAME(SyncDownTargetQueryType);
+} NS_SWIFT_NAME(SyncDownTarget.QueryType);
 
 NS_SWIFT_NAME(SyncDownTarget)
 @interface SFSyncDownTarget : SFSyncTarget

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.h
@@ -25,7 +25,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SFSmartSyncSyncManager;
-
+NS_SWIFT_NAME(SyncTarget)
 @interface SFSyncTarget : NSObject
 
 extern NSString * const kSyncTargetLocal;

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.h
@@ -65,7 +65,7 @@ extern NSString * const kSyncTargetLastError;
  * @param soupName The soup
  * @param record The record
  */
-- (void) cleanAndSaveInLocalStore:(SFSmartSyncSyncManager*)syncManager soupName:(NSString*)soupName record:(NSDictionary*)record;
+- (void) cleanAndSaveInLocalStore:(SFSmartSyncSyncManager*)syncManager soupName:(NSString*)soupName record:(NSDictionary*)record NS_SWIFT_NAME(cleanAndSaveInLocalStore(syncManager:soupName:record:));
 
 /**
  * Save records in local store (marked as clean)
@@ -74,7 +74,7 @@ extern NSString * const kSyncTargetLastError;
  * @param records The records to save
  * @param syncId The sync id
  */
-- (void)cleanAndSaveRecordsToLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString *)soupName records:(NSArray *)records syncId:(NSNumber *)syncId;
+- (void)cleanAndSaveRecordsToLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString *)soupName records:(NSArray *)records syncId:(NSNumber *)syncId NS_SWIFT_NAME(cleanAndSaveRecordsToLocalStore(syncManager:soupName:records:syncId:));
 
 /**
  * @param record The record
@@ -123,7 +123,7 @@ extern NSString * const kSyncTargetLastError;
  * @param soupName The soup
  * @param record The record to delete
  */
-- (void) deleteFromLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString*)soupName record:(NSDictionary*)record;
+- (void) deleteFromLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString*)soupName record:(NSDictionary*)record NS_SWIFT_NAME(deleteFromLocalStore(syncManager:soupName:record:));
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.h
@@ -115,7 +115,7 @@ extern NSString * const kSyncTargetLastError;
  * @param storeId The soup entry id
  * @return Record from local store by storeId
  */
-- (NSDictionary*) getFromLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString*)soupName storeId:(NSString*)storeId;
+- (NSDictionary*) getFromLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString*)soupName storeId:(NSNumber*)storeId;
 
 /**
  * Delete record from local store

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncTarget.m
@@ -118,7 +118,7 @@ NSString * const kSyncTargetLastError = @"__last_error__";
 
 }
 
-- (NSDictionary*) getFromLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString*)soupName storeId:(NSString*)storeId {
+- (NSDictionary*) getFromLocalStore:(SFSmartSyncSyncManager *)syncManager soupName:(NSString*)soupName storeId:(NSNumber*)storeId {
     return [syncManager.store retrieveEntries:@[storeId] fromSoup:soupName][0];
 }
 

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
@@ -122,7 +122,7 @@ NS_SWIFT_NAME(SyncUpTarget)
  Creates a new instance of a server target from a serialized dictionary.
  @param dict The dictionary with the serialized server target.
  */
-+ (nullable instancetype)newFromDict:(NSDictionary *)dict;
++ (nullable instancetype)newFromDict:(NSDictionary *)dict NS_SWIFT_NAME(build(dict:));
 
 /**
  Converts a string representation of a target type into its target type.
@@ -167,7 +167,7 @@ NS_SWIFT_NAME(SyncUpTarget)
                 record:(NSDictionary*)record
              fieldlist:(NSArray*)fieldlist
        completionBlock:(SFSyncUpTargetCompleteBlock)completionBlock
-             failBlock:(SFSyncUpTargetErrorBlock)failBlock;
+             failBlock:(SFSyncUpTargetErrorBlock)failBlock NS_SWIFT_NAME(createOnServer(syncManager:record:fieldlist:onComplete:onFail:));
 
 /**
  Save locally updated record back to server
@@ -181,7 +181,7 @@ NS_SWIFT_NAME(SyncUpTarget)
                 record:(NSDictionary*)record
              fieldlist:(NSArray*)fieldlist
        completionBlock:(SFSyncUpTargetCompleteBlock)completionBlock
-             failBlock:(SFSyncUpTargetErrorBlock)failBlock;
+             failBlock:(SFSyncUpTargetErrorBlock)failBlock NS_SWIFT_NAME(updateOnServer(syncManager:record:fieldlist:onComplete:onFail:));
 
 /**
  Delete locally deleted record from server
@@ -193,7 +193,7 @@ NS_SWIFT_NAME(SyncUpTarget)
 - (void)deleteOnServer:(SFSmartSyncSyncManager *)syncManager
                 record:(NSDictionary*)record
        completionBlock:(SFSyncUpTargetCompleteBlock)completionBlock
-             failBlock:(SFSyncUpTargetErrorBlock)failBlock;
+             failBlock:(SFSyncUpTargetErrorBlock)failBlock NS_SWIFT_NAME(deleteOnServer(syncManager:record:onComplete:onFail:));
 
 
 /**
@@ -211,7 +211,7 @@ NS_SWIFT_NAME(SyncUpTarget)
  */
 - (void) saveRecordToLocalStoreWithLastError:(SFSmartSyncSyncManager*)syncManager
                                     soupName:(NSString*) soupName
-                                      record:(NSDictionary*) record;
+                                      record:(NSDictionary*) record NS_SWIFT_NAME(saveRecordToLocalStoreWithLastError(syncManager:soupName:record));
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
@@ -211,7 +211,7 @@ NS_SWIFT_NAME(SyncUpTarget)
  */
 - (void) saveRecordToLocalStoreWithLastError:(SFSmartSyncSyncManager*)syncManager
                                     soupName:(NSString*) soupName
-                                      record:(NSDictionary*) record NS_SWIFT_NAME(saveRecordToLocalStoreWithLastError(syncManager:soupName:record));
+                                      record:(NSDictionary*) record NS_SWIFT_NAME(saveRecordToLocalStoreWithLastError(syncManager:soupName:record:));
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
@@ -43,7 +43,7 @@ typedef NS_ENUM(NSUInteger, SFSyncUpTargetType) {
      */
     SFSyncUpTargetTypeCustom NS_SWIFT_NAME(custom),
     
-} NS_SWIFT_NAME(SyncUpTargetType);
+} NS_SWIFT_NAME(SyncUpTarget.TargetType);
 
 /**
  Enumeration of the types of actions that can be executed against the server target.
@@ -68,22 +68,22 @@ typedef NS_ENUM(NSUInteger, SFSyncUpTargetAction) {
      Data will be deleted from the server.
      */
     SFSyncUpTargetActionDelete
-};
+} NS_SWIFT_NAME(SyncUpTarget.Action);
 
 /**
  Block definition for returning whether a records changed on server.
  */
-typedef void (^SFSyncUpRecordNewerThanServerBlock)(BOOL isNewerThanServer);
+typedef void (^SFSyncUpRecordNewerThanServerBlock)(BOOL isNewerThanServer) NS_SWIFT_NAME(RecordNewerThanServerBlock);
 
 /**
  Block definition for calling a sync up completion block.
  */
-typedef void (^SFSyncUpTargetCompleteBlock)(NSDictionary * _Nullable syncUpResult);
+typedef void (^SFSyncUpTargetCompleteBlock)(NSDictionary * _Nullable syncUpResult) NS_SWIFT_NAME(SyncUpcompletionBlock);
 
 /**
  Block definition for calling a sync up failure block.
  */
-typedef void (^SFSyncUpTargetErrorBlock)(NSError *error);
+typedef void (^SFSyncUpTargetErrorBlock)(NSError *error) NS_SWIFT_NAME(SyncUpErrorBlock);
 
 /**
  Helper class for isNewerThanServer

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
@@ -36,13 +36,14 @@ typedef NS_ENUM(NSUInteger, SFSyncUpTargetType) {
     /**
      The default server target, which uses standard REST requests to post updates.
      */
-    SFSyncUpTargetTypeRestStandard,
+    SFSyncUpTargetTypeRestStandard NS_SWIFT_NAME(standard),
     
     /**
      Server target is a custom target, that manages its own server update logic.
      */
-    SFSyncUpTargetTypeCustom,
-};
+    SFSyncUpTargetTypeCustom NS_SWIFT_NAME(custom),
+    
+} NS_SWIFT_NAME(SyncUpTargetType);
 
 /**
  Enumeration of the types of actions that can be executed against the server target.
@@ -98,6 +99,7 @@ typedef void (^SFSyncUpTargetErrorBlock)(NSError *error);
 /**
  Base class for a server target, used to manage sync ups to the configured service.
  */
+NS_SWIFT_NAME(SyncUpTarget)
 @interface SFSyncUpTarget : SFSyncTarget
 
 /**

--- a/libs/SmartSync/SmartSync/Classes/Util/SFChildrenInfo.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFChildrenInfo.h
@@ -32,6 +32,7 @@ extern NSString * const kSFChildrenInfoParentIdFieldName;
 /**
  * Simple object to capture details of children in parent-child relationship
  */
+NS_SWIFT_NAME(ChildrenInfo)
 @interface SFChildrenInfo : SFParentInfo
 
 @property (nonatomic, readonly) NSString* sobjectTypePlural;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFParentChildrenSyncHelper.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFParentChildrenSyncHelper.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSInteger, SFParentChildrenRelationshipType) {
     SFParentChildrenRelationpshipMasterDetail,
     SFParentChildrenRelationpshipLookup
-};
+} NS_SWIFT_NAME(RelationshipType);
 
 extern NSString * const kSFParentChildrenSyncTargetParent;
 extern NSString * const kSFParentChildrenSyncTargetChildren;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFParentChildrenSyncHelper.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFParentChildrenSyncHelper.h
@@ -48,6 +48,7 @@ extern NSString * const kSFParentChildrenSyncTargetChildrenUpdateFieldlist;
 extern NSString * const kSFParentChildrenRelationshipMasterDetail;
 extern NSString * const kSFParentChildrenRelationshipLookup;
 
+NS_SWIFT_NAME(ParentChildrenSyncHelper)
 @interface SFParentChildrenSyncHelper : NSObject
 
 + (void)registerAppFeature;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFParentInfo.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFParentInfo.h
@@ -34,6 +34,7 @@ extern NSString * const kSFParentInfoModifificationDateFieldName;
 /**
  * Simple object to capture details of parent in parent-child relationship
  */
+NS_SWIFT_NAME(ParentInfo)
 @interface SFParentInfo : NSObject
 
 @property (nonatomic, readonly) NSString* sobjectType;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSDKSmartSyncLogger.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSDKSmartSyncLogger.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString * _Nonnull const kSFSDKSmartSyncComponentName;
 
+NS_SWIFT_NAME(SmartSyncLogger)
 @interface SFSDKSmartSyncLogger : SFSDKLogger
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncConstants.h
@@ -73,4 +73,4 @@ typedef NS_ENUM(NSInteger, SFSDKFetchMode) {
     SFSDKFetchModeCacheOnly = 0,
     SFSDKFetchModeCacheFirst,
     SFSDKFetchModeServerFirst
-};
+} NS_SWIFT_NAME(FetchMode);

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncNetworkUtils.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncNetworkUtils.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Class to provide network utilities related to SmartSync actions.
  */
+NS_SWIFT_NAME(NetworkUtils)
 @interface SFSmartSyncNetworkUtils : NSObject
 
 /**

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncObjectUtils.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncObjectUtils.h
@@ -26,6 +26,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NS_SWIFT_NAME(ObjectUtils)
 @interface SFSmartSyncObjectUtils : NSObject
 
 + (nullable NSString *)formatValue:(nullable id)value;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncOptions.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncOptions.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString * const kSFSyncOptionsFieldlist;
 extern NSString * const kSFSyncOptionsMergeMode;
 
+NS_SWIFT_NAME(SyncOptions)
 @interface SFSyncOptions : NSObject
 
 @property (nonatomic, strong, readonly) NSArray*  fieldlist;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -54,7 +54,7 @@ extern NSString * const kSFSyncStateEndTime;
 typedef NS_ENUM(NSInteger, SFSyncStateSyncType) {
     SFSyncStateSyncTypeDown,
     SFSyncStateSyncTypeUp,
-};
+} NS_SWIFT_NAME(SyncType);
 
 extern NSString * const kSFSyncStateTypeDown;
 extern NSString * const kSFSyncStateTypeUp;
@@ -65,7 +65,7 @@ typedef NS_ENUM(NSInteger, SFSyncStateStatus) {
     SFSyncStateStatusRunning,
     SFSyncStateStatusDone,
     SFSyncStateStatusFailed
-};
+} NS_SWIFT_NAME(SyncStatus);
 
 extern NSString * const kSFSyncStateStatusNew;
 extern NSString * const kSFSyncStateStatusRunning;
@@ -77,11 +77,12 @@ typedef NS_ENUM(NSInteger, SFSyncStateMergeMode) {
     SFSyncStateMergeModeOverwrite,
     SFSyncStateMergeModeLeaveIfChanged
     
-};
+} NS_SWIFT_NAME(MergeMode);
 
 extern NSString * const kSFSyncStateMergeModeOverwrite;
 extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 
+NS_SWIFT_NAME(SyncState)
 @interface SFSyncState : NSObject <NSCopying>
 
 @property (nonatomic, readonly) NSInteger syncId;

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -77,7 +77,7 @@ typedef NS_ENUM(NSInteger, SFSyncStateMergeMode) {
     SFSyncStateMergeModeOverwrite,
     SFSyncStateMergeModeLeaveIfChanged
     
-} NS_SWIFT_NAME(MergeMode);
+} NS_SWIFT_NAME(SyncMergeMode);
 
 extern NSString * const kSFSyncStateMergeModeOverwrite;
 extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
@@ -121,13 +121,13 @@ NS_SWIFT_NAME(SyncState)
 
 /** Methods to translate to/from dictionary
  */
-+ (nullable SFSyncState*) newFromDict:(NSDictionary *)dict;
++ (nullable SFSyncState*) newFromDict:(NSDictionary *)dict NS_SWIFT_NAME(build(forDict:));
 - (NSDictionary*) asDict;
 
 /** Method for easy status check
  */
-- (BOOL)isDone;
-- (BOOL)hasFailed;
+- (BOOL) isDone;
+- (BOOL) hasFailed;
 - (BOOL) isRunning;
 
 /** Enum to/from string helper methods

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -107,21 +107,21 @@ NS_SWIFT_NAME(SyncState)
 
 /** Factory methods
  */
-+ (nullable SFSyncState *)newSyncDownWithOptions:(SFSyncOptions *)options target:(SFSyncDownTarget *)target soupName:(NSString *)soupName name:(nullable NSString *) name store:(SFSmartStore*)store;
-+ (nullable SFSyncState *)newSyncUpWithOptions:(SFSyncOptions *)options target:(SFSyncUpTarget *)target soupName:(NSString *)soupName name:(nullable NSString *)name store:(SFSmartStore *)store;
-+ (nullable SFSyncState*) newSyncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName store:(SFSmartStore*)store;
++ (nullable SFSyncState *)newSyncDownWithOptions:(SFSyncOptions *)options target:(SFSyncDownTarget *)target soupName:(NSString *)soupName name:(nullable NSString *) name store:(SFSmartStore*)store NS_SWIFT_NAME(buildSyncDown(options:target:soupName:name:store:));
++ (nullable SFSyncState *)newSyncUpWithOptions:(SFSyncOptions *)options target:(SFSyncUpTarget *)target soupName:(NSString *)soupName name:(nullable NSString *)name store:(SFSmartStore *)store NS_SWIFT_NAME(buildSyncUp(options:target:soupName:name:store:));
++ (nullable SFSyncState*) newSyncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName store:(SFSmartStore*)store NS_SWIFT_NAME(buildSyncUp(options:soupName:name:store:));;
 
 /** Methods to save/retrieve/delete from smartstore
  */
 + (nullable SFSyncState*)byId:(NSNumber *)syncId store:(SFSmartStore*)store;
 + (nullable SFSyncState*)byName:(NSString *)name store:(SFSmartStore*)store;
 - (void) save:(SFSmartStore*)store;
-+ (void) deleteById:(NSNumber*)syncId store:(SFSmartStore*)store;
-+ (void) deleteByName:(NSString*)name store:(SFSmartStore*)store;
++ (void) deleteById:(NSNumber*)syncId store:(SFSmartStore*)store NS_SWIFT_NAME(delete(syncId:store:));
++ (void) deleteByName:(NSString*)name store:(SFSmartStore*)store NS_SWIFT_NAME(delete(syncName:store:));
 
 /** Methods to translate to/from dictionary
  */
-+ (nullable SFSyncState*) newFromDict:(NSDictionary *)dict NS_SWIFT_NAME(build(forDict:));
++ (nullable SFSyncState*) newFromDict:(NSDictionary *)dict NS_SWIFT_NAME(build(dict:));
 - (NSDictionary*) asDict;
 
 /** Method for easy status check

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -109,7 +109,7 @@ NS_SWIFT_NAME(SyncState)
  */
 + (nullable SFSyncState *)newSyncDownWithOptions:(SFSyncOptions *)options target:(SFSyncDownTarget *)target soupName:(NSString *)soupName name:(nullable NSString *) name store:(SFSmartStore*)store NS_SWIFT_NAME(buildSyncDown(options:target:soupName:name:store:));
 + (nullable SFSyncState *)newSyncUpWithOptions:(SFSyncOptions *)options target:(SFSyncUpTarget *)target soupName:(NSString *)soupName name:(nullable NSString *)name store:(SFSmartStore *)store NS_SWIFT_NAME(buildSyncUp(options:target:soupName:name:store:));
-+ (nullable SFSyncState*) newSyncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName store:(SFSmartStore*)store NS_SWIFT_NAME(buildSyncUp(options:soupName:name:store:));;
++ (nullable SFSyncState*) newSyncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName store:(SFSmartStore*)store NS_SWIFT_NAME(buildSyncUp(options:soupName:store:));;
 
 /** Methods to save/retrieve/delete from smartstore
  */

--- a/libs/SmartSync/SmartSyncTests/SFLayoutSyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SFLayoutSyncManagerTests.m
@@ -153,7 +153,7 @@ static NSString * const kQuery = @"SELECT {%@:_soup} FROM {%@} WHERE {%@:Id} = '
     [self waitForExpectationsWithTimeout:30.0 handler:nil];
     [self validateResult:objType layout:layoutData];
     SFQuerySpec *querySpec = [SFQuerySpec newSmartQuerySpec:[NSString stringWithFormat:kQuery, kSoupName, kSoupName, kSoupName, kAccount, kCompact] withPageSize:2];
-    long numRows = [self.layoutSyncManager.smartStore countWithQuerySpec:querySpec error:nil];
+    long numRows = [[self.layoutSyncManager.smartStore countWithQuerySpec:querySpec error:nil] longValue];
     XCTAssertEqual(numRows, 1, "Number of rows should be 1");
 }
 

--- a/libs/SmartSync/SmartSyncTests/SFMetadataSyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SFMetadataSyncManagerTests.m
@@ -142,7 +142,7 @@ static NSString * const kQuery = @"SELECT {%@:_soup} FROM {%@} WHERE {%@:Id} = '
     [self waitForExpectationsWithTimeout:30.0 handler:nil];
     [self validateResult:metadataResult];
     SFQuerySpec *querySpec = [SFQuerySpec newSmartQuerySpec:[NSString stringWithFormat:kQuery, kSoupName, kSoupName, kSoupName, kAccount] withPageSize:2];
-    long numRows = [self.metadataSyncManager.smartStore countWithQuerySpec:querySpec error:nil];
+    long numRows = [[self.metadataSyncManager.smartStore countWithQuerySpec:querySpec error:nil] longValue];
     XCTAssertEqual(numRows, 1, "Number of rows should be 1");
 }
 


### PR DESCRIPTION
Using NS_SWIFT_NAME in SmartStore/SmartSync to make classes / methods / enums more Swift friendly.