### PR TITLE
Change MD5_DIGEST_LENGTH to CC_MD5_DIGEST_LENGTH

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSData+SFAdditions.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSData+SFAdditions.m
@@ -362,7 +362,7 @@ void bufferDecode64(BYTE *destData, size_t *destLen, const char *srcData, size_t
 @implementation NSData (SFMD5)
 
 -(NSString *)md5 {
-	unsigned char digest[MD5_DIGEST_LENGTH];
+	unsigned char digest[CC_MD5_DIGEST_LENGTH];
 	digest[0] = 0;
     CC_MD5([self bytes], (CC_LONG)[self length], digest);
     NSMutableString *ms = [NSMutableString string];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSData+SFAdditions.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSData+SFAdditions.m
@@ -366,7 +366,7 @@ void bufferDecode64(BYTE *destData, size_t *destLen, const char *srcData, size_t
 	digest[0] = 0;
     CC_MD5([self bytes], (CC_LONG)[self length], digest);
     NSMutableString *ms = [NSMutableString string];
-    for(int i = 0; i < MD5_DIGEST_LENGTH; i++) {
+    for(int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
         [ms appendFormat:@"%02x", digest[i]];
     }
     return [ms copy];


### PR DESCRIPTION
-  MD5_DIGEST_LENGTH is no longer defined in SDK 12
-  MD5_DIGEST_LENGTH was always an alias for CC_MD5_DIGEST_LENGTH