### PR TITLE
Add error message to SyncState for failed sync down

### DIFF
--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSmartSyncReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSmartSyncReactBridge.m
@@ -192,7 +192,8 @@ RCT_EXPORT_METHOD(syncUp:(NSDictionary *)args callback:(RCTResponseSenderBlock)c
     if (sync.status == SFSyncStateStatusDone) {
         callback(@[[NSNull null], syncDict]);
     } else if (sync.status == SFSyncStateStatusFailed) {
-        callback(@[RCTMakeError(@"Sync failed", nil, nil), syncDict]);
+        //Return sync to React Native with the error message in the JSON
+        callback(@[RCTMakeError(@"Sync failed", nil, syncDict), syncDict]);
     }
 }
 

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -253,6 +253,8 @@ static NSMutableDictionary *syncMgrList = nil;
 
     SyncFailBlock failSync = ^(NSString* failureMessage, NSError* error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
+        //Set error message to sync state
+        [sync setErrorJSON: (NSString*) [[error.userInfo valueForKey:@"error"] objectAtIndex:0]];
         [SFSDKSmartSyncLogger e:[strongSelf class] format:@"runSync failed:%@ cause:%@ error%@", sync, failureMessage, error];
         updateSync(kSFSyncStateStatusFailed, kSyncManagerUnchanged, kSyncManagerUnchanged, kSyncManagerUnchanged);
     };

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -254,8 +254,7 @@ static NSMutableDictionary *syncMgrList = nil;
     SyncFailBlock failSync = ^(NSString* failureMessage, NSError* error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         //Set error message to sync state
-//        [sync setErrorJSON:(NSString*) [[error.userInfo valueForKey:@"error"] objectAtIndex:0]];
-        [sync setErrorJSON:(NSString*) error.userInfo];
+        [sync setErrorJSON: error.userInfo];
         [SFSDKSmartSyncLogger e:[strongSelf class] format:@"runSync failed:%@ cause:%@ error%@", sync, failureMessage, error];
         updateSync(kSFSyncStateStatusFailed, kSyncManagerUnchanged, kSyncManagerUnchanged, kSyncManagerUnchanged);
     };

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -254,7 +254,7 @@ static NSMutableDictionary *syncMgrList = nil;
     SyncFailBlock failSync = ^(NSString* failureMessage, NSError* error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         //Set error message to sync state
-        [sync setErrorJSON: error.userInfo];
+        [sync setError: [error.userInfo description]];
         [SFSDKSmartSyncLogger e:[strongSelf class] format:@"runSync failed:%@ cause:%@ error%@", sync, failureMessage, error];
         updateSync(kSFSyncStateStatusFailed, kSyncManagerUnchanged, kSyncManagerUnchanged, kSyncManagerUnchanged);
     };

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -254,7 +254,7 @@ static NSMutableDictionary *syncMgrList = nil;
     SyncFailBlock failSync = ^(NSString* failureMessage, NSError* error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         //Set error message to sync state
-        [sync setErrorJSON: (NSString*) [[error.userInfo valueForKey:@"error"] objectAtIndex:0]];
+        [sync setErrorJSON:(NSString*) [[error.userInfo valueForKey:@"error"] objectAtIndex:0]];
         [SFSDKSmartSyncLogger e:[strongSelf class] format:@"runSync failed:%@ cause:%@ error%@", sync, failureMessage, error];
         updateSync(kSFSyncStateStatusFailed, kSyncManagerUnchanged, kSyncManagerUnchanged, kSyncManagerUnchanged);
     };

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -254,7 +254,8 @@ static NSMutableDictionary *syncMgrList = nil;
     SyncFailBlock failSync = ^(NSString* failureMessage, NSError* error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         //Set error message to sync state
-        [sync setErrorJSON:(NSString*) [[error.userInfo valueForKey:@"error"] objectAtIndex:0]];
+//        [sync setErrorJSON:(NSString*) [[error.userInfo valueForKey:@"error"] objectAtIndex:0]];
+        [sync setErrorJSON:(NSString*) error.userInfo];
         [SFSDKSmartSyncLogger e:[strongSelf class] format:@"runSync failed:%@ cause:%@ error%@", sync, failureMessage, error];
         updateSync(kSFSyncStateStatusFailed, kSyncManagerUnchanged, kSyncManagerUnchanged, kSyncManagerUnchanged);
     };

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -49,6 +49,7 @@ extern NSString * const kSFSyncStateTotalSize;
 extern NSString * const kSFSyncStateMaxTimeStamp;
 extern NSString * const kSFSyncStateStartTime;
 extern NSString * const kSFSyncStateEndTime;
+extern NSString * const kSFSyncStateError;
 
 // Possible values for sync type
 typedef NS_ENUM(NSInteger, SFSyncStateSyncType) {
@@ -100,6 +101,9 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 @property (nonatomic, readonly) NSInteger startTime;
 @property (nonatomic, readonly) NSInteger endTime;
 
+// Error JSON string
+@property (nonatomic, readonly) NSString* errorJSON;
+
 /** Setup soup that keeps track of sync operations
  */
 + (void) setupSyncsSoupIfNeeded:(SFSmartStore*)store;
@@ -137,6 +141,11 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 + (NSString*) syncStatusToString:(SFSyncStateStatus)syncStatus;
 + (SFSyncStateMergeMode) mergeModeFromString:(NSString*)mergeMode;
 + (NSString*) mergeModeToString:(SFSyncStateMergeMode)mergeMode;
+
+/** Setter and getter of property errorJSON
+ */
+- (void) setErrorJSON:(NSString * _Nonnull)errorJSON;
+- (NSString*) errorJSON;
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -102,7 +102,7 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 @property (nonatomic, readonly) NSInteger endTime;
 
 // Error JSON string
-@property (nonatomic, readonly) NSDictionary* errorJSON;
+@property (nonatomic, readonly) NSString* error;
 
 /** Setup soup that keeps track of sync operations
  */
@@ -144,7 +144,7 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 
 /** Setter for errorJSON
  */
-- (void) setErrorJSON:(NSDictionary * _Nonnull)errorJSON;
+- (void) setError:(NSString * _Nonnull)error;
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -142,10 +142,9 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 + (SFSyncStateMergeMode) mergeModeFromString:(NSString*)mergeMode;
 + (NSString*) mergeModeToString:(SFSyncStateMergeMode)mergeMode;
 
-/** Setter and getter of property errorJSON
+/** Setter for errorJSON
  */
 - (void) setErrorJSON:(NSString * _Nonnull)errorJSON;
-- (NSString*) errorJSON;
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -102,7 +102,7 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 @property (nonatomic, readonly) NSInteger endTime;
 
 // Error JSON string
-@property (nonatomic, readonly) NSString* errorJSON;
+@property (nonatomic, readonly) NSDictionary* errorJSON;
 
 /** Setup soup that keeps track of sync operations
  */
@@ -144,7 +144,7 @@ extern NSString * const kSFSyncStateMergeModeLeaveIfChanged;
 
 /** Setter for errorJSON
  */
-- (void) setErrorJSON:(NSString * _Nonnull)errorJSON;
+- (void) setErrorJSON:(NSDictionary * _Nonnull)errorJSON;
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -48,6 +48,7 @@ NSString * const kSFSyncStateTotalSize = @"totalSize";
 NSString * const kSFSyncStateMaxTimeStamp = @"maxTimeStamp";
 NSString * const kSFSyncStateStartTime = @"startTime";
 NSString * const kSFSyncStateEndTime = @"endTime";
+NSString * const kSFSyncStateError = @"error";
 
 // Possible value for sync type
 NSString * const kSFSyncStateTypeDown = @"syncDown";
@@ -73,10 +74,13 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
 @property (nonatomic, strong, readwrite) SFSyncOptions* options;
 @property (nonatomic, readwrite) NSInteger startTime;
 @property (nonatomic, readwrite) NSInteger endTime;
+@property (nonatomic, readwrite) NSString* errorJSON;
 
 @end
 
 @implementation SFSyncState
+
+@synthesize errorJSON = _errorJSON;
 
 # pragma mark - Setup
 
@@ -112,7 +116,8 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
             kSFSyncStateProgress: [NSNumber numberWithInteger:0],
             kSFSyncStateTotalSize: [NSNumber numberWithInteger:-1],
             kSFSyncStateStartTime: [NSNumber numberWithInteger:0],
-            kSFSyncStateEndTime: [NSNumber numberWithInteger:0]
+            kSFSyncStateEndTime: [NSNumber numberWithInteger:0],
+            kSFSyncStateError: @""
     }];
     if (name) dict[kSFSyncStateName] = name;
     
@@ -141,7 +146,8 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
             kSFSyncStateProgress: [NSNumber numberWithInteger:0],
             kSFSyncStateTotalSize: [NSNumber numberWithInteger:-1],
             kSFSyncStateStartTime: [NSNumber numberWithInteger:0],
-            kSFSyncStateEndTime: [NSNumber numberWithInteger:0]
+            kSFSyncStateEndTime: [NSNumber numberWithInteger:0],
+            kSFSyncStateError: @""
     }];
     if (name) dict[kSFSyncStateName] = name;
     
@@ -214,6 +220,7 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     self.maxTimeStamp = [(NSNumber*) dict[kSFSyncStateMaxTimeStamp] longLongValue];
     self.startTime = [(NSNumber*) dict[kSFSyncStateStartTime] integerValue];
     self.endTime = [(NSNumber*) dict[kSFSyncStateEndTime] integerValue];
+    self.errorJSON = dict[kSFSyncStateError];
 }
 
 - (NSDictionary*) asDict {
@@ -230,6 +237,7 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     dict[kSFSyncStateMaxTimeStamp] = [NSNumber numberWithLongLong:self.maxTimeStamp];
     dict[kSFSyncStateStartTime] = [NSNumber numberWithInteger:self.startTime];
     dict[kSFSyncStateEndTime] = [NSNumber numberWithInteger:self.endTime];
+    dict[kSFSyncStateError] = self.errorJSON;
     return dict;
 }
 
@@ -338,6 +346,18 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     SFSyncState* clone = [SFSyncState new];
     [clone fromDict:[self asDict]];
     return clone;
+}
+
+#pragma mark - Setter and getter of property errorJSON
+- (void) setErrorJSON:(NSString *)errorJSON:(NSString *)e {
+    NSLog(@"Setting errorJSON to: %@", e);
+    
+    _errorJSON = e;
+}
+
+- (NSString*) errorJSON {
+    NSLog(@"Returning errorJSON: %@", _errorJSON);
+    return _errorJSON;
 }
 
 @end

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -74,7 +74,7 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
 @property (nonatomic, strong, readwrite) SFSyncOptions* options;
 @property (nonatomic, readwrite) NSInteger startTime;
 @property (nonatomic, readwrite) NSInteger endTime;
-@property (nonatomic, readwrite) NSString* errorJSON;
+@property (nonatomic, readwrite) NSDictionary* errorJSON;
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -74,13 +74,13 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
 @property (nonatomic, strong, readwrite) SFSyncOptions* options;
 @property (nonatomic, readwrite) NSInteger startTime;
 @property (nonatomic, readwrite) NSInteger endTime;
-@property (nonatomic, readwrite) NSDictionary* errorJSON;
+@property (nonatomic, readwrite) NSString* error;
 
 @end
 
 @implementation SFSyncState
 
-@synthesize errorJSON = _errorJSON;
+@synthesize error = _error;
 
 # pragma mark - Setup
 
@@ -220,7 +220,7 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     self.maxTimeStamp = [(NSNumber*) dict[kSFSyncStateMaxTimeStamp] longLongValue];
     self.startTime = [(NSNumber*) dict[kSFSyncStateStartTime] integerValue];
     self.endTime = [(NSNumber*) dict[kSFSyncStateEndTime] integerValue];
-    self.errorJSON = dict[kSFSyncStateError];
+    self.error = dict[kSFSyncStateError];
 }
 
 - (NSDictionary*) asDict {
@@ -237,7 +237,7 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     dict[kSFSyncStateMaxTimeStamp] = [NSNumber numberWithLongLong:self.maxTimeStamp];
     dict[kSFSyncStateStartTime] = [NSNumber numberWithInteger:self.startTime];
     dict[kSFSyncStateEndTime] = [NSNumber numberWithInteger:self.endTime];
-    dict[kSFSyncStateError] = self.errorJSON;
+    dict[kSFSyncStateError] = self.error;
     return dict;
 }
 

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -348,16 +348,4 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
     return clone;
 }
 
-#pragma mark - Setter and getter of property errorJSON
-- (void) setErrorJSON:(NSString *)errorJSON:(NSString *)e {
-    NSLog(@"Setting errorJSON to: %@", e);
-    
-    _errorJSON = e;
-}
-
-- (NSString*) errorJSON {
-    NSLog(@"Returning errorJSON: %@", _errorJSON);
-    return _errorJSON;
-}
-
 @end


### PR DESCRIPTION
Set message from error to current sync state
Return sync state to react native instead of "Sync failed" for sync failure

Please also refer to: https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/1786