### PR TITLE
Adding Passcode enablement for subsequent post-auth launch when using AuthHelper class.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -680,14 +680,14 @@ static NSString *const SFSDKShowDevDialogNotification = @"SFSDKShowDevDialogNoti
         }
     }];
     
-    // Don't present snapshot during advanced authentication
-    // =====================================================
+    // Don't present snapshot during advanced authentication or Passcode Presentation
+    // ==============================================================================
     // During advanced authentication, application is briefly backgrounded then foregrounded
     // The SFAuthenticationSession's view controller is pushed into the key window
     // If we make the snapshot window the active window now, that's where the SFAuthenticationSession's view controller will end up
     // Then when the application is foregrounded and the snapshot window is dismissed, we will lose the SFAuthenticationSession
     SFSDKWindowContainer* activeWindow = [SFSDKWindowManager sharedManager].activeWindow;
-    if ([activeWindow isAuthWindow] && ![activeWindow.topViewController isKindOfClass:[SFLoginViewController class]]) {
+    if (([activeWindow isAuthWindow]  && ![activeWindow.topViewController isKindOfClass:[SFLoginViewController class]]) ||  [activeWindow isPasscodeWindow]) {
         return;
     }
   

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthHelper.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthHelper.m
@@ -61,7 +61,6 @@
         // delegate handler will catch and pass on.  We just log the error and reset launch
         // state here.
         [SFSDKCoreLogger e:[self class] format:@"Passcode validation failed.  Logging the user out."];
-        [[SFUserAccountManager sharedInstance] logout];
     }];
     [SFSecurityLockout lock];
 }


### PR DESCRIPTION
Seems like I missed this flow in the auth helper class during the last refactor. Also figured out that when biometric auth is launched the app swizzles out. Added an interim fix like the one done for adv auth.