### PR TITLE
Avoiding wasteful deserialization/serialization when querying smartstore

### DIFF
--- a/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
+++ b/libs/SalesforceHybridSDK/SalesforceHybridSDK/Classes/Plugins/SFSmartStore/SFSmartStorePlugin.m
@@ -293,6 +293,7 @@ NSString * const kStoreName           = @"storeName";
         SFSmartStore* store = [self getStoreInst:argsDict];
         NSError* error = nil;
         SFStoreCursor *cursor = [self cursorByCursorId:cursorId withArgs:argsDict];
+        [cursor setCurrentPageIndex:newPageIndex];
         NSString* cursorSerialized = [cursor getDataSerialized:store error:&error];
         if (error == nil) {
             return [CDVPluginResultWithSerializedMessage resultWithStatus:CDVCommandStatus_OK serializedMessage:cursorSerialized];

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
@@ -206,6 +206,7 @@ RCT_EXPORT_METHOD(moveCursorToPageIndex:(NSDictionary *)argsDict callback:(RCTRe
     SFSmartStore* store = [self getStoreInst:argsDict];
     NSError* error = nil;
     SFStoreCursor *cursor = [self cursorByCursorId:cursorId andArgs:argsDict];
+    [cursor setCurrentPageIndex:newPageIndex];
     NSString* cursorSerialized = [cursor getDataSerialized:store error:&error];
     if (error == nil) {
         callback(@[[NSNull null], [SFJsonUtils objectFromJSONString:cursorSerialized] /* TODO send the string and change the js to do a parse */]);

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
@@ -135,7 +135,7 @@ RCT_EXPORT_METHOD(querySoup:(NSDictionary *)argsDict callback:(RCTResponseSender
         dispatch_sync(self->_dispatchQueue, ^{
             self.cursorCache[internalCursorId] = cursor;
         });
-        callback(@[[NSNull null], [SFJsonUtils objectFromJSONString:cursorSerialized] /* TODO send the string and change the js to do a parse */]);
+        callback(@[[NSNull null], cursorSerialized]);
     } else {
         [SFSDKReactLogger e:[self class] format:@"No cursor for query: %@", querySpec];
         callback(@[RCTMakeError(@"No cursor for query", error, nil)]);
@@ -209,7 +209,7 @@ RCT_EXPORT_METHOD(moveCursorToPageIndex:(NSDictionary *)argsDict callback:(RCTRe
     [cursor setCurrentPageIndex:newPageIndex];
     NSString* cursorSerialized = [cursor getDataSerialized:store error:&error];
     if (error == nil) {
-        callback(@[[NSNull null], [SFJsonUtils objectFromJSONString:cursorSerialized] /* TODO send the string and change the js to do a parse */]);
+        callback(@[[NSNull null], cursorSerialized]);
     } else {
         callback(@[RCTMakeError(@"moveCursorToPageIndex failed", error, nil)]);
     }

--- a/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
+++ b/libs/SalesforceReact/SalesforceReact/Classes/SFSmartStoreReactBridge.m
@@ -25,6 +25,7 @@
 #import "SFSmartStoreReactBridge.h"
 #import <React/RCTUtils.h>
 #import <SalesforceSDKCore/NSDictionary+SFAdditions.h>
+#import <SalesforceSDKCore/SFJsonUtils.h>
 #import <SmartStore/SFStoreCursor.h>
 #import <SmartStore/SFSmartStore.h>
 #import <SmartStore/SFQuerySpec.h>
@@ -125,14 +126,16 @@ RCT_EXPORT_METHOD(querySoup:(NSDictionary *)argsDict callback:(RCTResponseSender
     NSDictionary *querySpecDict = [argsDict nonNullObjectForKey:kQuerySpecArg];
     SFQuerySpec* querySpec = [[SFQuerySpec alloc] initWithDictionary:querySpecDict withSoupName:soupName];
     [SFSDKReactLogger d:[self class] format:@"querySoup with name: %@, querySpec: %@", soupName, querySpecDict];
+    SFSmartStore* store = [self getStoreInst:argsDict];
     NSError* error = nil;
-    SFStoreCursor* cursor = [self runQuery:querySpec error:&error argsDict:argsDict];
-    if (cursor.cursorId) {
+    SFStoreCursor* cursor = [[SFStoreCursor alloc] initWithStore:store querySpec:querySpec];
+    NSString* cursorSerialized = [cursor getDataSerialized:store error:&error];
+    if (error == nil) {
         NSString *internalCursorId = [self internalCursorId:cursor.cursorId withArgs:argsDict];
         dispatch_sync(self->_dispatchQueue, ^{
             self.cursorCache[internalCursorId] = cursor;
         });
-        callback(@[[NSNull null], [cursor asDictionary]]);
+        callback(@[[NSNull null], [SFJsonUtils objectFromJSONString:cursorSerialized] /* TODO send the string and change the js to do a parse */]);
     } else {
         [SFSDKReactLogger e:[self class] format:@"No cursor for query: %@", querySpec];
         callback(@[RCTMakeError(@"No cursor for query", error, nil)]);
@@ -200,9 +203,15 @@ RCT_EXPORT_METHOD(moveCursorToPageIndex:(NSDictionary *)argsDict callback:(RCTRe
     NSString *cursorId = [argsDict nonNullObjectForKey:kCursorIdArg];
     NSNumber *newPageIndex = [argsDict nonNullObjectForKey:kIndexArg];
     [SFSDKReactLogger d:[self class] format:@"moveCursorToPageIndex with cursor ID: %@, page index: %@", cursorId, newPageIndex];
+    SFSmartStore* store = [self getStoreInst:argsDict];
+    NSError* error = nil;
     SFStoreCursor *cursor = [self cursorByCursorId:cursorId andArgs:argsDict];
-    [cursor setCurrentPageIndex:newPageIndex];
-    callback(@[[NSNull null],  [cursor asDictionary]]);
+    NSString* cursorSerialized = [cursor getDataSerialized:store error:&error];
+    if (error == nil) {
+        callback(@[[NSNull null], [SFJsonUtils objectFromJSONString:cursorSerialized] /* TODO send the string and change the js to do a parse */]);
+    } else {
+        callback(@[RCTMakeError(@"moveCursorToPageIndex failed", error, nil)]);
+    }
 }
 
 RCT_EXPORT_METHOD(clearSoup:(NSDictionary *)argsDict callback:(RCTResponseSenderBlock)callback)
@@ -392,22 +401,6 @@ RCT_EXPORT_METHOD(removeAllStores:(NSDictionary *)argsDict callback:(RCTResponse
         storeName = kDefaultSmartStoreName;
     }
     return storeName;
-}
-
-- (SFStoreCursor*) runQuery:(SFQuerySpec*)querySpec error:(NSError**)error argsDict:(NSDictionary*)argsDict
-{
-    if (!querySpec) {
-        // XXX we could populate error
-        return nil;
-    }
-    NSUInteger totalEntries = [[[self getStoreInst:argsDict] countWithQuerySpec:querySpec error:error] unsignedIntegerValue];
-    if (*error) {
-        return nil;
-    }
-    NSArray* firstPageEntries = (totalEntries > 0
-                                 ? [[self getStoreInst:argsDict] queryWithQuerySpec:querySpec pageIndex:0 error:error]
-                                 : @[]);
-    return [[SFStoreCursor alloc] initWithStore:[self getStoreInst:argsDict] querySpec:querySpec totalEntries:totalEntries firstPageEntries:firstPageEntries];
 }
 
 - (NSString *)internalCursorId:(NSString *) cursorId withArgs:(NSDictionary *) argsDict {

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -319,6 +319,26 @@ NS_SWIFT_NAME(SmartStore)
 - (NSArray * __nullable)queryWithQuerySpec:(SFQuerySpec *)querySpec pageIndex:(NSUInteger)pageIndex error:(NSError **)error NS_SWIFT_NAME(query(querySpec:pageIndex:));
 
 /**
+ Search for entries matching the given query spec without deserializing any JSON
+ 
+ @param resultString A mutable string to which the result (serialized) is appended
+ @param querySpec A native query spec.
+ @param pageIndex The page index to start the entries at (this supports paging).
+ @param error Sets/returns any error generated as part of the process.
+ */
+- (void) queryAsString:(NSMutableString*)resultString querySpec:(SFQuerySpec *)querySpec pageIndex:(NSUInteger)pageIndex error:(NSError **)error NS_SWIFT_NAME(query(result:querySpec:pageIndex:));
+
+
+/**
+ * Run a query given by its query Spec, only returned results from selected page
+ * without deserializing any JSON
+ *
+ * @param resultBuilder string builder to which results are appended
+ * @param querySpec
+ * @param pageIndex
+ */
+
+/**
  Search soup for entries exactly matching the soup entry IDs.
  
  @param soupName The name of the soup to query.

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -325,8 +325,10 @@ NS_SWIFT_NAME(SmartStore)
  @param querySpec A native query spec.
  @param pageIndex The page index to start the entries at (this supports paging).
  @param error Sets/returns any error generated as part of the process.
+ 
+ @return YES if successful
  */
-- (void) queryAsString:(NSMutableString*)resultString querySpec:(SFQuerySpec *)querySpec pageIndex:(NSUInteger)pageIndex error:(NSError **)error NS_SWIFT_NAME(query(result:querySpec:pageIndex:));
+- (BOOL) queryAsString:(NSMutableString*)resultString querySpec:(SFQuerySpec *)querySpec pageIndex:(NSUInteger)pageIndex error:(NSError **)error NS_SWIFT_NAME(query(result:querySpec:pageIndex:));
 
 
 /**

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -646,7 +646,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
             if (error != nil) {
                 *error = [self errorForException:exception];
             }
-            success = FALSE;
+            success = NO;
         }
     }];
     return success;
@@ -665,7 +665,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
             if (error != nil) {
                 *error = [self errorForException:exception];
             }
-            success = FALSE;
+            success = NO;
         }
     }];
     return success;

--- a/libs/SmartStore/SmartStore/Classes/SFStoreCursor.h
+++ b/libs/SmartStore/SmartStore/Classes/SFStoreCursor.h
@@ -33,17 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Defines a cursor into data stored in a soup.
  */
 NS_SWIFT_NAME(StoreCursor)
-@interface SFStoreCursor : NSObject {
-    SFSmartStore *_store;
-    NSString *_cursorId;
-    SFQuerySpec *_querySpec;
-    
-    NSArray *_currentPageOrderedEntries;
-    NSNumber *_currentPageIndex;
-    NSNumber *_pageSize;
-    NSNumber *_totalPages;
-    NSNumber *_totalEntries;
-}
+@interface SFStoreCursor : NSObject
 
 /**
  * A unique ID for this cursor.
@@ -85,17 +75,14 @@ NS_SWIFT_NAME(StoreCursor)
  * Initializes a new instance of a soup cursor.
  * @param store The store where the soup is contained.
  * @param querySpec The query used to retrieve the data.
- * @param totalEntries The total number of entries retrieved from the query.
- * @param firstPageEntries The entries of the first page
  */
-- (id)initWithStore:(SFSmartStore*)store querySpec:(SFQuerySpec*)querySpec totalEntries:(NSUInteger)totalEntries firstPageEntries:(NSArray*)firstPageEntries;
+- (id)initWithStore:(SFSmartStore*)store querySpec:(SFQuerySpec*)querySpec;
 
 /**
- * The NSDictionary representation of this object.
- * @return Dictionary representation of this object, for translation to JSON.
+ * Run query and resturn JSON serialized representation of the cursor.
+ * @return JSON serialized representation of this object.
  */
-- (NSDictionary*)asDictionary;
-
+- (NSString*)getDataSerialized:(SFSmartStore*)store error:(NSError**)error;
 
 /**
  Close this cursor when finished operating on it.

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -866,38 +866,6 @@
     XCTAssertEqual(querySpecPageSize, expectedPageSize, @"Page size value should reflect input value.");
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-
-- (void)testCursorTotalPages
-{
-    NSUInteger totalEntries = 50;
-    
-    // Entries divided evenly by the page size.
-    NSUInteger evenDividePageSize = 25;
-    NSUInteger expectedPageSize = totalEntries / evenDividePageSize;
-    NSDictionary *allQuery = @{kQuerySpecParamQueryType: kQuerySpecTypeRange,
-                                          kQuerySpecParamIndexPath: @"a",
-                                          kQuerySpecParamPageSize: @(evenDividePageSize)};
-    SFQuerySpec *querySpec = [[SFQuerySpec alloc] initWithDictionary:allQuery  withSoupName:kTestSoupName];
-    SFStoreCursor *cursor = [[SFStoreCursor alloc] initWithStore:nil querySpec:querySpec totalEntries:totalEntries firstPageEntries:nil];
-    XCTAssertEqual([cursor.totalEntries unsignedIntValue], totalEntries, @"Wrong value for totalEntries");
-    int cursorTotalPages = [cursor.totalPages intValue];
-    XCTAssertEqual(cursorTotalPages, expectedPageSize, @"%lu entries across a page size of %lu should make %lu total pages.", (unsigned long)totalEntries, (unsigned long)evenDividePageSize, (unsigned long)expectedPageSize);
-
-    // Entries not evenly divided across the page size.
-    NSUInteger unevenDividePageSize = 24;
-    expectedPageSize = totalEntries / unevenDividePageSize + 1;
-    allQuery = @{kQuerySpecParamQueryType: kQuerySpecTypeRange,
-                              kQuerySpecParamIndexPath: @"a",
-                              kQuerySpecParamPageSize: @(unevenDividePageSize)};
-    querySpec = [[SFQuerySpec alloc] initWithDictionary:allQuery  withSoupName:kTestSoupName];
-    cursor = [[SFStoreCursor alloc] initWithStore:nil querySpec:querySpec totalEntries:totalEntries firstPageEntries:nil];
-    XCTAssertEqual([cursor.totalEntries unsignedIntValue], totalEntries, @"Wrong value for totalEntries");
-    cursorTotalPages = [cursor.totalPages intValue];
-    XCTAssertEqual(cursorTotalPages, expectedPageSize, @"%lu entries across a page size of %lu should make %lu total pages.", (unsigned long)totalEntries, (unsigned long)unevenDividePageSize, (unsigned long)expectedPageSize);
-}
-
 #pragma clang diagnostic pop
 
 - (void)testPersistentStoreExists

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -866,8 +866,6 @@
     XCTAssertEqual(querySpecPageSize, expectedPageSize, @"Page size value should reflect input value.");
 }
 
-#pragma clang diagnostic pop
-
 - (void)testPersistentStoreExists
 {
     for (SFSmartStoreDatabaseManager *dbMgr in @[ [SFSmartStoreDatabaseManager sharedManager], [SFSmartStoreDatabaseManager sharedGlobalManager] ]) {


### PR DESCRIPTION
- smartstore query from hybrid or react native application no longer do any deserialization or serialization in native land / and there is no javascript code change required for hybrid app, however react.force.smartstore.js is changed (see https://github.com/forcedotcom/SalesforceMobileSDK-ReactNative/pull/89)
- native app only deserialize once the full result is built (*)
- SFStoreCursor refactored to be more like Android's StoreCursor (for instance the query doesn't have to be run the first time by the caller).

(*) probably not faster but that way the code is cleaner (query is calling queryAsString)
