### PR TITLE
export dictionary method

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableDictionary.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableDictionary.h
@@ -44,6 +44,11 @@ NS_SWIFT_NAME(SafeMutableDictionary)
 - (NSArray *)allKeysForObject:(id)anObject;
 
 /**
+ * Get a NSDictionary from the mutable Dictionary (Thread Safe)
+ */
+- (NSDictionary *)dictionary;
+
+/**
  Sets object for key specified (Thread Safe)
  @param object to add to collection
  @param aKey for to map the object to
@@ -78,7 +83,6 @@ NS_SWIFT_NAME(SafeMutableDictionary)
  @param dictionary to set
  */
 - (void)setDictionary:(NSDictionary *)dictionary;
-
 
 @end
 


### PR DESCRIPTION
the method is added in class but not in header. https://github.com/forcedotcom/SalesforceMobileSDK-iOS/blob/dev/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKSafeMutableDictionary.m#L77