### PR TITLE
Added backward compatibility for SFSDKLogger

### DIFF
--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SFLogger.h
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SFLogger.h
@@ -90,6 +90,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)log:(Class)cls level:(SFLogLevel)level format:(NSString *)format args:(va_list)args;
 
+@optional
++ (nonnull instancetype)sharedInstanceWithComponent:(nonnull NSString *)componentName;
 @end
 
 @interface SFLogger : NSObject

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SFLogger.m
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SFLogger.m
@@ -47,7 +47,13 @@ static SFSDKSafeMutableDictionary *loggerList = nil;
 - (instancetype)init:(NSString *)componentName {
     self = [super init];
     if (self) {
-        self.logger = [[InstanceClass alloc] initWithComponent:componentName];
+        //for backward compatibility with SFSDKLogger
+        //invoke the shared instance instead.
+        if ([InstanceClass respondsToSelector:@selector(sharedInstanceWithComponent:)]) {
+            self.logger = [InstanceClass sharedInstanceWithComponent:componentName];
+        } else {
+            self.logger = [[InstanceClass alloc] initWithComponent:componentName];
+        }
     }
     return self;
 }


### PR DESCRIPTION
A check to use sharedInstanceWithComponent instead of initializer for SFSDKLogger. 