### PR TITLE
Pointing to most recent fmdb/sqlcipher

### DIFF
--- a/SmartStore.podspec
+++ b/SmartStore.podspec
@@ -20,8 +20,8 @@ Pod::Spec.new do |s|
   s.subspec 'SmartStore' do |smartstore|
 
       smartstore.dependency 'SalesforceSDKCore'
-      smartstore.dependency 'FMDB/SQLCipher', '~> 2.7.2'
-      smartstore.dependency 'SQLCipher/fts', '~> 3.4.1'
+      smartstore.dependency 'FMDB/SQLCipher', '~> 2.7.5'
+      smartstore.dependency 'SQLCipher/fts', '~> 3.4.2'
       smartstore.source_files = 'libs/SmartStore/SmartStore/Classes/**/*.{h,m}', 'libs/SmartStore/SmartStore/SmartStore.h'
       smartstore.public_header_files = 'libs/SmartStore/SmartStore/Classes/SFAlterSoupLongOperation.h', 'libs/SmartStore/SmartStore/Classes/SFQuerySpec.h', 'libs/SmartStore/SmartStore/Classes/SFSDKSmartStoreLogger.h', 'libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.h', 'libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStore.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreInspectorViewController.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreUtils.h', 'libs/SmartStore/SmartStore/Classes/SFSoupIndex.h', 'libs/SmartStore/SmartStore/Classes/SFSoupSpec.h', 'libs/SmartStore/SmartStore/Classes/SFStoreCursor.h', 'libs/SmartStore/SmartStore/SmartStore.h', 'libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.h'
       smartstore.prefix_header_contents = '#import "SFSDKSmartStoreLogger.h"', '#import <SalesforceSDKCore/SalesforceSDKConstants.h>'


### PR DESCRIPTION
NB: because of the ~> those were the versions already in use by apps

it's good to make it explicit (especially the fmdb one, since versions before 2.7.5 don't work with cocoapod 1.5 or above)