### PR TITLE
Always running SFSDKWebViewStateManager's removeSession on main thread

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWebViewStateManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKWebViewStateManager.m
@@ -43,6 +43,13 @@ static WKProcessPool *_processPool = nil;
 }
 
 + (void)removeSession {
+    if (![NSThread isMainThread]) {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [SFSDKWebViewStateManager removeSession];
+        });
+        return;
+    }
+    
     //reset UIWebView related state if any
     [self removeUIWebViewCookies:@[SID_COOKIE] fromDomains:self.domains];
     [self removeWKWebViewCookies:self.domains withCompletion:NULL];


### PR DESCRIPTION
* If you do a SFRestAPI send, and no credentials are available, SFUserAccountManager's loginWithCompletion is called, which calls SFUserAccountManager's authenticateWithcompletion => so you will be on whatever thread SFRestAPI send was invoked from.
* However if you do a SFRestAPI send and a refresh is needed and the refresh fails (e.g. refresh token was expired), then SFUserAccountManager's logoutUser is called, but that call happens is dispatched from the main thread.