### PR TITLE
Fixing compilation errors with consuming Swift project

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
@@ -38,7 +38,7 @@ typedef NS_ENUM(NSInteger, SFOAuthCredentialsStorageType){
      OAuth credentials will be stored securely within the keychain.
      */
     SFOAuthCredentialsStorageTypeKeychain,
-} NS_SWIFT_NAME(AuthCredentials.StorageType);
+} NS_SWIFT_NAME(OAuthCredentials.StorageType);
 
 /** Object representing an individual user account's logon credentials.
  

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewController.h
@@ -32,6 +32,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NS_SWIFT_NAME(AppLockViewController)
 @interface SFSDKAppLockViewController : SFSDKNavigationController
 
 - (instancetype)initWithMode:(SFAppLockControllerMode)mode andViewConfig:(SFSDKAppLockViewConfig *)config;


### PR DESCRIPTION
Without these, the bridging header won't be generated.