### PR TITLE
Making factory methods available in Swift

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppConfig.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppConfig.h
@@ -87,14 +87,14 @@ NS_SWIFT_NAME(BootConfig)
 /**
  * @return The app config from the default configuration file location.
  */
-+ (nullable instancetype)fromDefaultConfigFile NS_SWIFT_UNAVAILABLE("Use init(.defaultFilePath) instead");
++ (nullable instancetype)fromDefaultConfigFile;
 
 /**
  * Create an app config from the config file at the specified file path.
  * @param configFilePath The file path to the configuration file, relative to the resources root path.
  * @return The app config from the given file path.
  */
-+ (nullable instancetype)fromConfigFile:(NSString *)configFilePath NS_SWIFT_UNAVAILABLE("Use init(_:) instead");
++ (nullable instancetype)fromConfigFile:(NSString *)configFilePath;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppConfig.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppConfig.m
@@ -63,10 +63,10 @@ static BOOL const kDefaultShouldAuthenticate = YES;
     return self;
 }
 
-- (instancetype)initWithConfigFile:(NSString *)configFilePath {
+- (instancetype)initWithConfigFile:(NSString *)configFile {
     self = [super init];
     if (self) {
-        NSString *fullPath = [[NSBundle mainBundle].resourcePath stringByAppendingPathComponent:configFilePath];
+        NSString *fullPath = [[NSBundle mainBundle].resourcePath stringByAppendingPathComponent:configFile];
         if (![[NSFileManager defaultManager] fileExistsAtPath:fullPath]) {
             [SFSDKCoreLogger i:[self class] format:@"%@ Config file does not exist at path '%@'", NSStringFromSelector(_cmd), fullPath];
             return nil;


### PR DESCRIPTION
@trooper2013 For some reason, in a `Swift` hybrid project, calling any of the `init:` methods in `SFHybridViewConfig` from `Swift` skips over and directly goes to the implementation in the base class, i.e. `SFSDKAppConfig`. I tried the following fixes and none of them worked.
- Removing `NS_SWIFT_NAME` from the `init:` APIs in `SFSDKAppConfig`.
- Adding the `init:` method declarations in the public header of `SFHybridViewConfig`.
Ultimately, the only thing that worked was to switch back to using the factory methods. I discussed with @wmathurin and we thought it's probably best to continue to allow that for now, until we can figure out what's going on.