### PR TITLE
Passcode & Biometric bugfixes from UX/PM Review

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKBiometricViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKBiometricViewController.m
@@ -208,10 +208,10 @@ static CGFloat      const kSFBioViewBorderWidth                = 1.0f;
     
     if (self.verificationMode) {
         [context setLocalizedCancelTitle:[SFSDKResourceUtils localizedString:@"biometricFallbackActionLabel"]];
-        [context setLocalizedFallbackTitle:@""];
         [self hideAll];
     }
     
+    [context setLocalizedFallbackTitle:@""];
     [context evaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics localizedReason:[SFSDKResourceUtils localizedString:@"biometricReason"] reply:^(BOOL success, NSError *authenticationError) {
         dispatch_async(dispatch_get_main_queue(), ^{
             __weak typeof (weakSelf) strongSelf = weakSelf;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeCreateController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeCreateController.m
@@ -163,7 +163,7 @@ static CGFloat      const kSFViewBoarderWidth                  = 1.0f;
     CGFloat xView = (0 - kSFViewBoarderWidth);
     CGFloat yView = yIns + hIns + (kSFDefaultPadding / 2.0);
     CGFloat wView = self.view.bounds.size.width + (kSFViewBoarderWidth * 2);
-    CGFloat hView = kSFPasscodeViewHeight;
+    CGFloat hView = kSFPasscodeViewHeight + (kSFViewBoarderWidth * 2);
     self.passcodeTextView.frame = CGRectMake(xView, yView, wView, hView);
     self.passcodeTextView.layer.frame = CGRectMake(xView, yView, wView, hView);
     [self.passcodeTextView refreshView];
@@ -213,12 +213,11 @@ static CGFloat      const kSFViewBoarderWidth                  = 1.0f;
             self.initialPasscode = [[NSString alloc] initWithString:self.passcodeTextView.passcodeInput];
             [self.passcodeTextView clearPasscode];
             [self.passcodeTextView refreshView];
-            [self.passcodeInstructionsLabel setText:[SFSDKResourceUtils localizedString:@"passcodeVerifyInstructions"]];
             self.firstPasscodeValidated = YES;
             
             //Change labels for confirm passcode
             [self.navigationItem setTitle:[SFSDKResourceUtils localizedString:@"verifyPasscodeNavTitle"]];
-            [self.passcodeInstructionsLabel setText:[SFSDKResourceUtils localizedString:@"passcodeVerifyInstructions"]];
+            [self.passcodeInstructionsLabel setText:[SFSDKResourceUtils localizedString:@"passcodeConfirmInstructions"]];
             [self.passcodeInstructionsLabel setFont:self.viewConfig.instructionFont];
             [self layoutSubviews];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeCreateController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeCreateController.m
@@ -166,6 +166,7 @@ static CGFloat      const kSFViewBoarderWidth                  = 1.0f;
     CGFloat hView = kSFPasscodeViewHeight;
     self.passcodeTextView.frame = CGRectMake(xView, yView, wView, hView);
     self.passcodeTextView.layer.frame = CGRectMake(xView, yView, wView, hView);
+    [self.passcodeTextView refreshView];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -198,11 +199,15 @@ static CGFloat      const kSFViewBoarderWidth                  = 1.0f;
     if ([self.passcodeTextView.passcodeInput length] == self.viewConfig.passcodeLength) {
         if (self.firstPasscodeValidated) {
             if ([self.passcodeTextView.passcodeInput isEqualToString:self.initialPasscode] ) {
+                if ([self.passcodeTextView isFirstResponder]) {
+                    [self.passcodeTextView resignFirstResponder];
+                }
                 [self.createDelegate passcodeCreated:self.passcodeTextView.passcodeInput updateMode:self.updateMode];
             } else {
                 [self.passcodeTextView clearPasscode];
                 [self.passcodeTextView refreshView];
                 [self.passcodeInstructionsLabel setText:[SFSDKResourceUtils localizedString:@"passcodesDoNotMatchError"]];
+                self.firstPasscodeValidated = NO;
             }
         } else {
             self.initialPasscode = [[NSString alloc] initWithString:self.passcodeTextView.passcodeInput];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeTextField.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeTextField.m
@@ -29,10 +29,12 @@
 #import "UIColor+SFSDKPasscodeView.h"
 #import "SFSDKAppLockViewConfig.h"
 
+static CGFloat      const kDefaultLineWidth                  = 1;
 static NSUInteger   const kMaxPasscodeLength                 = 8;
-static CGFloat      const kDefaultPadding                    = 20.0f;
-static CGFloat      const kPasscodeCircleDiameter            = 24.f;
+static CGFloat      const kDefaultPadding                    = 20.f;
 static CGFloat      const kPasscodeCircleSpacing             = 16.f;
+// Because of the outline weight, a value of 22 is need to make a circle with diameter 24.
+static CGFloat      const kPasscodeCircleDiameter            = 22.f;
 
 @interface SFSDKPasscodeTextField()
 @property (nonatomic, strong) UIColor * fillColor;
@@ -92,6 +94,7 @@ static CGFloat      const kPasscodeCircleSpacing             = 16.f;
     int openCircleSpacingX = 0;
     int filledCircleSpacingX = 0;
     NSUInteger lengthForSpacing = (self.passcodeLengthKnown) ? self.passcodeLength : kMaxPasscodeLength;
+    int positionY = -1 * ((diameter + (kDefaultLineWidth * 2)) / 2);  // Have to add outline line width to diameter
     int startX = (self.bounds.size.width - (diameter * lengthForSpacing) - (horizontalSpacing * (lengthForSpacing - 1))) / 2;
     
     if (self.passcodeLengthKnown) {
@@ -99,12 +102,12 @@ static CGFloat      const kPasscodeCircleSpacing             = 16.f;
         for (int count=0 ; count < self.passcodeLength; count++) {
             CAShapeLayer *openCircle = [CAShapeLayer layer];
             // Make a circular shape
-            openCircle.path = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, -12, diameter, diameter)cornerRadius:diameter].CGPath;
+            openCircle.path = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, positionY, diameter, diameter)cornerRadius:diameter].CGPath;
             // Center the shape in self.view
-            openCircle.position = CGPointMake(startX + openCircleSpacingX, diameter);
+            openCircle.position = CGPointMake(startX + openCircleSpacingX, diameter + (kDefaultLineWidth * 4));
             openCircle.fillColor = [UIColor clearColor].CGColor;
             openCircle.strokeColor = self.fillColor.CGColor;
-            openCircle.lineWidth = 2;
+            openCircle.lineWidth = kDefaultLineWidth * 2;
             openCircle.zPosition = 5;
             openCircleSpacingX += (diameter + horizontalSpacing);
             [self.subLayerRefs addObject:openCircle];
@@ -119,13 +122,13 @@ static CGFloat      const kPasscodeCircleSpacing             = 16.f;
     for (int count=0 ; count < noOfChars; count++) {
         CAShapeLayer *filledCircle = [CAShapeLayer layer];
         // Make a circular shape
-        filledCircle.path = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, -12, diameter, diameter)cornerRadius:diameter].CGPath;
+        filledCircle.path = [UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, positionY, diameter, diameter)cornerRadius:diameter].CGPath;
         
         // Center the shape in self.view
-        filledCircle.position = CGPointMake(startX + filledCircleSpacingX, diameter);
+        filledCircle.position = CGPointMake(startX + filledCircleSpacingX, diameter + (kDefaultLineWidth * 4));
         filledCircle.fillColor = self.fillColor.CGColor;
         filledCircle.strokeColor = self.fillColor.CGColor;
-        filledCircle.lineWidth = 1;
+        filledCircle.lineWidth = kDefaultLineWidth;
         filledCircle.zPosition = 5;
         filledCircleSpacingX += (diameter + horizontalSpacing);
         [self.subLayerRefs addObject:filledCircle];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeVerifyController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeVerifyController.m
@@ -201,7 +201,7 @@ NSUInteger const kSFMaxNumberofAttempts = 10;
     CGFloat xView = (0 - kSFViewBoarderWidth);
     CGFloat yView = yIns + hIns + (kSFDefaultPadding / 2.0);
     CGFloat wView = self.view.bounds.size.width + (kSFViewBoarderWidth * 2);
-    CGFloat hView = kSFPasscodeViewHeight;
+    CGFloat hView = kSFPasscodeViewHeight + (kSFViewBoarderWidth * 2);
     self.passcodeTextView.frame = CGRectMake(xView, yView, wView, hView);
     self.passcodeTextView.layer.frame = CGRectMake(xView, yView, wView, hView);
     [self.passcodeTextView refreshView];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeVerifyController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeVerifyController.m
@@ -204,6 +204,7 @@ NSUInteger const kSFMaxNumberofAttempts = 10;
     CGFloat hView = kSFPasscodeViewHeight;
     self.passcodeTextView.frame = CGRectMake(xView, yView, wView, hView);
     self.passcodeTextView.layer.frame = CGRectMake(xView, yView, wView, hView);
+    [self.passcodeTextView refreshView];
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/UIColor+SFSDKPasscodeView.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/UIColor+SFSDKPasscodeView.m
@@ -34,7 +34,7 @@
 }
 
 + (UIColor *)textColor {
-    return [UIColor colorWithRed:62.0f/255.0f green:62.0f/255.0f blue:60.0f/255.0f alpha:1.0f];
+    return [UIColor colorWithRed:22.0f/255.0f green:50.0f/255.0f blue:92.0f/255.0f alpha:1.0f];
 }
 
 + (UIColor *)borderColor {

--- a/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
+++ b/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
@@ -29,19 +29,19 @@
 // Passcode view controller
 "createPasscodeNavTitle" = "Passcode";
 "confirmPasscodeNavTitle" = "Passcode";
-"verifyPasscodeNavTitle" = "Unlock";
-"passcodeCreateInstructions" = "Set up a passcode";
-"passcodeChangeInstructions" = "Set up a passcode";
+"verifyPasscodeNavTitle" = "Passcode";
+"passcodeCreateInstructions" = "Create a passcode";
+"passcodeChangeInstructions" = "Create a passcode";
 "passcodeConfirmInstructions" = "Verify passcode";
-"passcodeVerifyInstructions" = "Verify passcode";
+"passcodeVerifyInstructions" = "Enter passcode";
 "passcodesDoNotMatchError" = "Passcodes do not match";
 "passcodeInvalidError" = "Incorrect passcode. %d attempts remaining.";
 "biometricEnableFaceIdNavTitle" = "Face ID";
 "biometricEnableTouchIdNavTitle" = "Touch ID";
 "biometricEnableTitleFaceId" = "Set up Face ID";
 "biometricEnableTitleTouchId" = "Set up Touch ID";
-"biometricEnableInstructionsFaceId" = "You can now unlock %@ using your face for extra security and convenience.";
-"biometricEnableInstructionsTouchId" = "You can now unlock %@ using your fingerprint for extra security and convenience.";
+"biometricEnableInstructionsFaceId" = "You can now unlock %@ using Face ID for extra security and convenience.";
+"biometricEnableInstructionsTouchId" = "You can now unlock %@ using Touch ID for extra security and convenience.";
 "biometricEnableButtonText" = "Enable";
 "biometricCancelButtonText" = "Not Now";
 "verifyPasscodeButtontext" = "Verify Passcode";

--- a/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
+++ b/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
@@ -34,7 +34,7 @@
 "passcodeChangeInstructions" = "Create a passcode";
 "passcodeConfirmInstructions" = "Verify passcode";
 "passcodeVerifyInstructions" = "Enter passcode";
-"passcodesDoNotMatchError" = "Passcodes do not match";
+"passcodesDoNotMatchError" = "Passcodes do not match. Try again.";
 "passcodeInvalidError" = "Incorrect passcode. %d attempts remaining.";
 "biometricEnableFaceIdNavTitle" = "Face ID";
 "biometricEnableTouchIdNavTitle" = "Touch ID";


### PR DESCRIPTION
- Fix passcode bubble centering after rotation.
- Label updates
- Non-matching passcodes entered during creation now makes forces the same passcode to be entered twice in a row.
- Remove "Enter Passcode" biometric fallback during passcode creation.
- Change Text color to #16325c 

Waiting for a response on two more issues. 
