### PR TITLE
enable cookie for user agent oauth flow

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -468,7 +468,7 @@ static NSString * const kSFECParameter = @"ec";
     }
     
     NSString *approvalUrlString = [self generateApprovalUrlString];
-    [self loadWebViewWithUrlString:approvalUrlString cookie:NO];
+    [self loadWebViewWithUrlString:approvalUrlString cookie:YES];
 }
 
 - (void)beginJwtTokenExchangeFlow {


### PR DESCRIPTION
@wmathurin  @trooper2013  @bhariharan 

Enable cookie support on iOS for user agent base OAuth flow, which is what we do on Android already