### PR TITLE
Start time should be set when sync goes from not running to running

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.m
@@ -257,7 +257,7 @@ NSString * const kSFSyncStateMergeModeLeaveIfChanged = @"LEAVE_IF_CHANGED";
 #pragma mark - Setter for status
 - (void) setStatus: (SFSyncStateStatus) newStatus
 {
-    if (_status == SFSyncStateStatusNew && newStatus == SFSyncStateStatusRunning) {
+    if (_status != SFSyncStateStatusRunning && newStatus == SFSyncStateStatusRunning) {
         self.startTime = [[NSDate date] timeIntervalSince1970] * 1000; // milliseconds expecteed
     }
     if (_status == SFSyncStateStatusRunning


### PR DESCRIPTION
Right now start time is only set on the first run (not during re sync) => our ailtn logs for resyncs have the wrong start time / duration.