### PR TITLE
SFRestAPI Upgrades, Ability to invoke endpoints in an unauthenticated context

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
@@ -125,7 +125,7 @@
 }
 
 - (NSString *)communitiesUrlPathIfRequired {
-    if (!self.user.credentials.communityId) {
+    if (!self.user.communityId) {
         return @"";
     }
     return [NSString stringWithFormat:@"/communities/%@", self.user.communityId];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
@@ -27,7 +27,7 @@
 #import <SalesforceSDKCommon/SFJsonUtils.h>
 #import "SFRestAPI+Files.h"
 #import "SFRestRequest+Internal.h"
-
+#import "SFOAuthCredentials.h"
 #define ME @"me"
 #define PAGE @"page"
 #define VERSION @"versionNumber"
@@ -40,28 +40,28 @@
 @implementation SFRestAPI (Files)
 
 - (SFRestRequest *) requestForOwnedFilesList:(NSString *)userId page:(NSUInteger)page {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect/files/users/%@", self.apiVersion, (userId == nil ? ME : userId)];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/%@", self.apiVersion,[self communitiesUrlPathIfRequired],  (userId == nil ? ME : userId)];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (page) params[PAGE] = @(page);
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
 }
 
 - (SFRestRequest *) requestForFilesInUsersGroups:(NSString *)userId page:(NSUInteger)page {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect/files/users/%@/filter/groups", self.apiVersion, (userId == nil ? ME : userId)];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/%@/filter/groups", self.apiVersion, [self communitiesUrlPathIfRequired], (userId == nil ? ME : userId)];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (page) params[PAGE] = @(page);
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
 }
 
 - (SFRestRequest *) requestForFilesSharedWithUser:(NSString *)userId page:(NSUInteger)page {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect/files/users/%@/filter/sharedwithme", self.apiVersion, (userId == nil ? ME : userId)];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/%@/filter/sharedwithme", self.apiVersion, [self communitiesUrlPathIfRequired],(userId == nil ? ME : userId)];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (page) params[PAGE] = @(page);
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
 }
 
 - (SFRestRequest *) requestForFileDetails:(NSString *)sfdcId forVersion:(NSString *)version {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect/files/%@", self.apiVersion, sfdcId];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@", self.apiVersion,[self communitiesUrlPathIfRequired], sfdcId];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (version) params[VERSION] = version;
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
@@ -69,12 +69,12 @@
 
 - (SFRestRequest *) requestForBatchFileDetails:(NSArray *)sfdcIds {
     NSString *ids = [sfdcIds componentsJoinedByString:@","];
-    NSString *path = [NSString stringWithFormat:@"/%@/connect/files/batch/%@", self.apiVersion, ids];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/batch/%@", self.apiVersion, [self communitiesUrlPathIfRequired], ids];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
 }
 
 - (SFRestRequest *) requestForFileRendition:(NSString *)sfdcId version:(NSString *)version renditionType:(NSString *)renditionType page:(NSUInteger)page {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect/files/%@/rendition", self.apiVersion, sfdcId];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@/rendition", self.apiVersion,[self communitiesUrlPathIfRequired], sfdcId];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     params[RENDITION_TYPE] = renditionType;
     if (page) params[PAGE] = @(page);
@@ -84,7 +84,7 @@
 }
 
 - (SFRestRequest *) requestForFileContents:(NSString *) sfdcId version:(NSString*) version {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect/files/%@/content", self.apiVersion, sfdcId];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@/content", self.apiVersion,[self communitiesUrlPathIfRequired], sfdcId];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (version) params[VERSION] = version;
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
@@ -92,7 +92,7 @@
 }
 
 - (SFRestRequest *) requestForFileShares:(NSString *)sfdcId page:(NSUInteger)page {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect/files/%@/file-shares", self.apiVersion, sfdcId];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@/file-shares", self.apiVersion,[self communitiesUrlPathIfRequired], sfdcId];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (page) params[PAGE] = @(page);
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
@@ -118,10 +118,17 @@
 }
 
 - (SFRestRequest *) requestForUploadFile:(NSData *)data name:(NSString *)name description:(NSString *)description mimeType:(NSString *)mimeType {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect/files/users/me", self.apiVersion];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/me", self.apiVersion,[self communitiesUrlPathIfRequired]];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
     [request addPostFileData:data paramName:FILE_DATA description:description fileName:name mimeType:mimeType];
     return request;
 }
 
+- (NSString *)communitiesUrlPathIfRequired {
+    if (!self.user.credentials.communityId) {
+        return @"";
+    }
+    return [NSString stringWithFormat:@"/communities/%@", self.user.communityId];
+    
+}
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
@@ -153,6 +153,11 @@ NS_SWIFT_NAME(RestClient)
 @property (class, nonatomic, readonly) SFRestAPI *sharedInstance NS_SWIFT_NAME(shared);
 
 /**
+ * Returns the singleton instance of `SFRestAPI` for unauthenticated calls.
+ */
+@property (class, nonatomic, readonly) SFRestAPI *sharedGlobalInstance NS_SWIFT_NAME(sharedGlobal);
+
+/**
  * Returns the singleton instance of `SFRestAPI` associated with the specified user.
  */
 + (nullable SFRestAPI *)sharedInstanceWithUser:(nonnull SFUserAccount *)userAccount NS_SWIFT_NAME(restClient(for:));

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -101,13 +101,30 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 }
 
 #pragma mark - singleton
+static dispatch_once_t pred;
+
++ (SFRestAPI *)sharedGlobalInstance {
+    dispatch_once(&pred, ^{
+        sfRestApiList = [[SFSDKSafeMutableDictionary alloc] init];
+    });
+    
+    @synchronized ([SFRestAPI class]) {
+        NSString *key = SFKeyForGlobalScope();
+        id sfRestApi = [sfRestApiList objectForKey:key];
+        if (!sfRestApi) {
+            sfRestApi = [[SFRestAPI alloc] initWithUser:nil];
+            [sfRestApiList setObject:sfRestApi forKey:key];
+        }
+        return sfRestApi;
+   }
+}
 
 + (SFRestAPI *)sharedInstance {
     return [SFRestAPI sharedInstanceWithUser:[SFUserAccountManager sharedInstance].currentUser];
 }
 
 + (SFRestAPI *)sharedInstanceWithUser:(SFUserAccount *)user {
-    static dispatch_once_t pred;
+    
     dispatch_once(&pred, ^{
         sfRestApiList = [[SFSDKSafeMutableDictionary alloc] init];
     });

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -289,7 +289,7 @@ static dispatch_once_t pred;
                 [strongSelf notifyDelegateOfResponse:delegate request:request data:dataForDelegate rawResponse:response];
             }
             // 401 (and sometimes 403) indicates refresh is required.
-            else if (request.shouldRefreshOn403 ? (statusCode == 401 || statusCode == 403) : (statusCode == 401)) {
+            else if (request.requiresAuthentication && request.shouldRefreshOn403 ? (statusCode == 401 || statusCode == 403) : (statusCode == 401)) {
                 if (shouldRetry) {
                     [strongSelf replayRequest:request response:response delegate:delegate];
                 } else {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -209,7 +209,7 @@ static dispatch_once_t pred;
 #pragma mark - send method
 
 - (void)send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate {
-    [self send:request delegate:delegate shouldRetry:YES];
+    [self send:request delegate:delegate shouldRetry:request.requiresAuthentication];
 }
 
 - (void)send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate shouldRetry:(BOOL)shouldRetry {
@@ -289,7 +289,7 @@ static dispatch_once_t pred;
                 [strongSelf notifyDelegateOfResponse:delegate request:request data:dataForDelegate rawResponse:response];
             }
             // 401 (and sometimes 403) indicates refresh is required.
-            else if (request.requiresAuthentication && request.shouldRefreshOn403 ? (statusCode == 401 || statusCode == 403) : (statusCode == 401)) {
+            else if (request.shouldRefreshOn403 ? (statusCode == 401 || statusCode == 403) : (statusCode == 401)) {
                 if (shouldRetry) {
                     [strongSelf replayRequest:request response:response delegate:delegate];
                 } else {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -334,13 +334,22 @@ NS_SWIFT_NAME(RestRequest)
 + (instancetype)requestWithMethod:(SFRestMethod)method baseURL:(NSString *)baseURL path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams;
 
 /**
- * Creates an `SFRestRequest` object to be used with a custom endpoint. See SFRestMethod. If you need to set body on the request, use one of the 'setCustomRequestBody...' methods to do so with the instance returned by this method.
+ * Creates an `SFRestRequest` object to be used with non-Salesforce endpoints. See SFRestMethod. If you need to set body on the request, use one of the 'setCustomRequestBody...' methods to do so with the instance returned by this method.
  * @param method the HTTP method
  * @param baseURL the request URL
  * @param path the request path
  * @param queryParams the parameters of the request (could be nil)
  */
 + (instancetype)customUrlRequestWithMethod:(SFRestMethod)method baseURL:(NSString *)baseURL path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams;
+
+/**
+ * Creates an `SFRestRequest` object to be used with custom Salesforce endpoints. See SFRestMethod. If you need to set body on the request, use one of the 'setCustomRequestBody...' methods to do so with the instance returned by this method.
+ * @param method the HTTP method
+ * @param path the request path
+ * @param queryParams the parameters of the request (could be nil)
+ */
+
++ (instancetype)customEndPointRequestWithMethod:(SFRestMethod)method endPoint:(NSString *)endPoint path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -42,11 +42,11 @@ typedef NS_ENUM(NSInteger, SFRestMethod) {
  * HTTP methods for requests.
  */
 typedef NS_ENUM(NSInteger, SFNetworkServiceType) {
-    SFNetworkServiceTypeDefault = NSURLNetworkServiceTypeDefault,
-    SFNetworkServiceTypeResponsiveData = NSURLNetworkServiceTypeResponsiveData,
-    SFNetworkServiceTypeBackground = NSURLNetworkServiceTypeBackground,
+    SFNetworkServiceTypeDefault,
+    SFNetworkServiceTypeResponsiveData,
+    SFNetworkServiceTypeBackground,
    
-} NS_SWIFT_NAME(RestRequest.ServiceType);
+} NS_SWIFT_NAME(RestRequest.NetWorkServiceType);
 
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -333,6 +333,13 @@ NS_SWIFT_NAME(RestRequest)
  */
 + (instancetype)requestWithMethod:(SFRestMethod)method baseURL:(NSString *)baseURL path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams;
 
+/**
+ * Creates an `SFRestRequest` object to be used with a custom endpoint. See SFRestMethod. If you need to set body on the request, use one of the 'setCustomRequestBody...' methods to do so with the instance returned by this method.
+ * @param method the HTTP method
+ * @param baseURL the request URL
+ * @param path the request path
+ * @param queryParams the parameters of the request (could be nil)
+ */
 + (instancetype)customUrlRequestWithMethod:(SFRestMethod)method baseURL:(NSString *)baseURL path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -39,6 +39,17 @@ typedef NS_ENUM(NSInteger, SFRestMethod) {
 } NS_SWIFT_NAME(RestRequest.Method);
 
 /**
+ * HTTP methods for requests.
+ */
+typedef NS_ENUM(NSInteger, SFNetworkServiceType) {
+    SFNetworkServiceTypeDefault = NSURLNetworkServiceTypeDefault,
+    SFNetworkServiceTypeResponsiveData = NSURLNetworkServiceTypeResponsiveData,
+    SFNetworkServiceTypeBackground = NSURLNetworkServiceTypeBackground,
+   
+} NS_SWIFT_NAME(RestRequest.ServiceType);
+
+
+/**
  * The type of service host to use for Rest requests.
  */
 typedef NS_ENUM(NSUInteger, SFSDKRestServiceHostType) {
@@ -51,7 +62,12 @@ typedef NS_ENUM(NSUInteger, SFSDKRestServiceHostType) {
     /**
      *  Request uses the instance endpoint.
      */
-    SFSDKRestServiceHostTypeInstance
+    SFSDKRestServiceHostTypeInstance,
+    
+    /**
+     *  Request uses a custom endpoint.
+     */
+    SFSDKRestServiceHostTypeCustom
 } NS_SWIFT_NAME(RestRequest.ServiceHostType);
 
 NS_ASSUME_NONNULL_BEGIN
@@ -141,6 +157,11 @@ NS_SWIFT_NAME(RestRequest)
  * The HTTP method of the request. See SFRestMethod.
  */
 @property (nonatomic, assign, readwrite) SFRestMethod method;
+
+/**
+ * The HTTP method of the request. See SFRestMethod.
+ */
+@property (nonatomic, assign, readwrite) SFNetworkServiceType serviceType;
 
 /**
  * The type of service host for the request (e.g. login or instance).
@@ -311,6 +332,8 @@ NS_SWIFT_NAME(RestRequest)
  * @param queryParams the parameters of the request (could be nil)
  */
 + (instancetype)requestWithMethod:(SFRestMethod)method baseURL:(NSString *)baseURL path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams;
+
++ (instancetype)customUrlRequestWithMethod:(SFRestMethod)method baseURL:(NSString *)baseURL path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSInteger, SFRestMethod) {
 /**
  * HTTP methods for requests.
  */
-typedef NS_ENUM(NSInteger, SFNetworkServiceType) {
+typedef NS_ENUM(NSInteger, SFSDKNetworkServiceType) {
     SFNetworkServiceTypeDefault,
     SFNetworkServiceTypeResponsiveData,
     SFNetworkServiceTypeBackground,
@@ -161,7 +161,7 @@ NS_SWIFT_NAME(RestRequest)
 /**
  * The HTTP method of the request. See SFRestMethod.
  */
-@property (nonatomic, assign, readwrite) SFNetworkServiceType serviceType;
+@property (nonatomic, assign, readwrite) SFSDKNetworkServiceType networkServiceType;
 
 /**
  * The type of service host for the request (e.g. login or instance).

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -172,7 +172,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
     self.request = [[NSMutableURLRequest alloc] initWithURL:[[NSURL alloc] initWithString:fullUrl]];
 
     //Set the service host type
-    NSURLRequestNetworkServiceType serviceType = [self urlRequestServiceType:self.serviceType];
+    NSURLRequestNetworkServiceType serviceType = [self urlRequestServiceType:self.networkServiceType];
     [self.request setNetworkServiceType:serviceType];
     
     // Sets HTTP method on the request.
@@ -346,7 +346,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
     return queryString;
 }
 
-- (NSURLRequestNetworkServiceType)urlRequestServiceType:(SFNetworkServiceType) sfNetworkServiceType {
+- (NSURLRequestNetworkServiceType)urlRequestServiceType:(SFSDKNetworkServiceType) sfNetworkServiceType {
     switch (sfNetworkServiceType) {
         case SFNetworkServiceTypeBackground:
             return NSURLNetworkServiceTypeBackground;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -171,6 +171,10 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
     }
     self.request = [[NSMutableURLRequest alloc] initWithURL:[[NSURL alloc] initWithString:fullUrl]];
 
+    //Set the service host type
+    NSURLRequestNetworkServiceType serviceType = [self urlRequestServiceType:self.serviceType];
+    [self.request setNetworkServiceType:serviceType];
+    
     // Sets HTTP method on the request.
     [self.request setHTTPMethod:[SFRestRequest httpMethodFromSFRestMethod:self.method]];
 
@@ -340,6 +344,17 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         [queryString appendString:[parts componentsJoinedByString:@"&"]];
     }
     return queryString;
+}
+
+- (NSURLRequestNetworkServiceType)urlRequestServiceType:(SFNetworkServiceType) sfNetworkServiceType {
+    switch (sfNetworkServiceType) {
+        case SFNetworkServiceTypeBackground:
+            return NSURLNetworkServiceTypeBackground;
+        case SFNetworkServiceTypeResponsiveData:
+            return NSURLNetworkServiceTypeResponsiveData;
+         default:
+            return NSURLNetworkServiceTypeDefault;
+    }
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
@@ -192,6 +192,11 @@ NSString *_Nullable SFKeyForUserAndScope(SFUserAccount * _Nullable user, SFUserA
  */
 NSString *_Nullable SFKeyForUserIdAndScope(NSString *userId,NSString *orgId, NSString *_Nullable communityId, SFUserAccountScope scope);
 
+/** Function that returns a key for scope SFUserAccountScopeGlobal,
+  @return a key identifying this scope for the specified scope
+ */
+NSString *SFKeyForGlobalScope();
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
@@ -347,6 +347,10 @@ static NSString * const kGlobalScopingKey = @"-global-";
     }
 }
 
+NSString *SFKeyForGlobalScope() {
+    return  SFKeyForUserIdAndScope(nil,nil,nil,SFUserAccountScopeGlobal);
+}
+
 NSString *SFKeyForUserAndScope(SFUserAccount *user, SFUserAccountScope scope) {
     return  SFKeyForUserIdAndScope(user.credentials.userId,user.credentials.organizationId,user.credentials.communityId,scope);
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -1085,34 +1085,6 @@ static NSException *authException = nil;
     XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
     
 }
-
-- (void)testrequestForDeleteFileShareAndAddFileShareCommunity {
-    
-    // upload first file
-    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
-    creds.userId = @"USERID";
-    creds.organizationId = @"ORGID";
-    creds.communityId = @"COMMUNITYID";
-    creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
-    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
-    account.communityId = @"COMMUNITYID";
-    [account setLoginState:SFUserAccountLoginStateLoggedIn];
-    
-    SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
-    XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
-    SFRestRequest *request =  [restAPI  requestForDeleteFileShare:@"100"];
-    XCTAssertNotNil(request,@"Request should have been created");
-    NSURLRequest *urlRequest = [request prepareRequestForSend:account];
-    NSRange range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
-    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
-   
-    
-    request =  [restAPI  requestForFilesSharedWithUser:@"200" page:0];
-    urlRequest = [request prepareRequestForSend:account];
-    range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
-    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
-    
-}
 // Upload files / get owned files / delete files / get owned files again
 - (void)testUploadOwnedFilesDelete {
 
@@ -2086,7 +2058,6 @@ static NSException *authException = nil;
         [getExpectation fulfill];
     }];
     [self waitForExpectations:@[getExpectation] timeout:20];
-    XCTAssertTrue(error == nil,@"RestApi call to a public api should not fail");
     XCTAssertTrue(error == nil,@"RestApi call to a public api should not fail");
     XCTAssertFalse(response == nil,@"RestApi call to a public api should not have a nil response");
     XCTAssertTrue(response.count > 0 ,@"The reponse should have github/forcedotcom repos");

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -806,6 +806,46 @@ static NSException *authException = nil;
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
 }
 
+- (void)testOwnedFilesListWithCommunity {
+    // with nil for userId
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
+    creds.userId = @"USERID";
+    creds.organizationId = @"ORGID";
+    creds.communityId = @"COMMUNITYID";
+    creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    [account setLoginState:SFUserAccountLoginStateLoggedIn];
+    SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
+    XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
+    SFRestRequest *request = [restAPI requestForOwnedFilesList:creds.userId page:0];
+    XCTAssertNotNil(request,@"Request should have been created");
+    NSURLRequest *urlRequest = [request prepareRequestForSend:account];
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+}
+
+- (void)testOwnedFilesListWithCommunityWithHeaders {
+    // with nil for userId
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
+    creds.userId = @"USERID";
+    creds.organizationId = @"ORGID";
+    creds.communityId = @"COMMUNITYID";
+    creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    [account setLoginState:SFUserAccountLoginStateLoggedIn];
+    SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
+    XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
+    SFRestRequest *request = [restAPI requestForOwnedFilesList:creds.userId page:0];
+    NSString *simpleType = @"ASimpleType";
+    NSString *simpleTypeLength = @"100000";
+    [request setHeaderValue:simpleType forHeaderName:@"Content-type"];
+    [request setHeaderValue:simpleTypeLength forHeaderName:@"Content-Length"];
+    XCTAssertNotNil(request,@"Request should have been created");
+    NSURLRequest *urlRequest = [request prepareRequestForSend:account];
+    XCTAssertEqualObjects(simpleTypeLength,[urlRequest valueForHTTPHeaderField:@"Content-Length"]);
+    XCTAssertEqualObjects(simpleType,[urlRequest valueForHTTPHeaderField:@"Content-Type"]);
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+}
+
 // simple: just invoke requestForFilesInUsersGroups
 - (void)testFilesInUsersGroups {
     // with nil for userId
@@ -816,6 +856,24 @@ static NSException *authException = nil;
     request = [[SFRestAPI sharedInstance] requestForFilesInUsersGroups:_currentUser.credentials.userId page:0];
     listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+}
+
+// test url for  testFilesInUsersGroupsWithCommunity
+- (void)testFilesInUsersGroupsWithCommunity {
+    // with nil for userId
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
+    creds.userId = @"USERID";
+    creds.organizationId = @"ORGID";
+    creds.communityId = @"COMMUNITYID";
+    creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    [account setLoginState:SFUserAccountLoginStateLoggedIn];
+    SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
+    XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
+    SFRestRequest *request = [restAPI requestForFilesInUsersGroups:creds.userId page:0];
+    XCTAssertNotNil(request,@"Request should have been created");
+    NSURLRequest *urlRequest = [request prepareRequestForSend:account];
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
 }
 
 // simple: just invoke requestForFilesSharedWithUser
@@ -830,6 +888,26 @@ static NSException *authException = nil;
     listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
 }
+
+
+// test url for  testFileSharesWithUserCommunity
+- (void)testFileSharesWithUserCommunity {
+    // with nil for userId
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
+    creds.userId = @"USERID";
+    creds.organizationId = @"ORGID";
+    creds.communityId = @"COMMUNITYID";
+    creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    [account setLoginState:SFUserAccountLoginStateLoggedIn];
+    SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
+    XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
+    SFRestRequest* request = [restAPI requestForFilesSharedWithUser:@"someid" page:0];
+    XCTAssertNotNil(request,@"Request should have been created");
+    NSURLRequest *urlRequest = [request prepareRequestForSend:account];
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+}
+
 
 // Upload file / download content / download rendition (expect 403) / delete file / download again (expect 404)
 - (void)testUploadDownloadDeleteFile {
@@ -860,6 +938,35 @@ static NSException *authException = nil;
     XCTAssertEqual(listener.lastError.code, 404, @"invalid code");
 }
 
+// test url for  testUploadDownloadDeleteFileWithCommunity
+- (void)testUploadDownloadDeleteFileWithCommunity {
+    // with nil for userId
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
+    creds.userId = @"USERID";
+    creds.organizationId = @"ORGID";
+    creds.communityId = @"COMMUNITYID";
+    creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    [account setLoginState:SFUserAccountLoginStateLoggedIn];
+    
+    NSDictionary *fileAttrs = [self uploadFile];
+    SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
+    XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
+    SFRestRequest *request =  [restAPI requestForFileRendition:fileAttrs[LID] version:nil renditionType:@"PDF" page:0];
+    XCTAssertNotNil(request,@"Request should have been created");
+    NSURLRequest *urlRequest = [request prepareRequestForSend:account];
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    
+    request = [restAPI requestForDeleteWithObjectType:@"ContentDocument" objectId:fileAttrs[LID]];
+    urlRequest = [request prepareRequestForSend:account];
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    
+    request = [restAPI requestForFileContents:fileAttrs[LID] version:nil];
+    urlRequest = [request prepareRequestForSend:account];
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    
+}
+
 // Upload file / get details / delete file / get details again (expect 404)
 - (void)testUploadDetailsDeleteFile {
 
@@ -882,6 +989,26 @@ static NSException *authException = nil;
     listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidFail, @"request was supposed to fail");
     XCTAssertEqual(listener.lastError.code, 404, @"invalid code");
+}
+
+- (void)testUploadDetailsDeleteFileWithCommunity {
+    // with nil for userId
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
+    creds.userId = @"USERID";
+    creds.organizationId = @"ORGID";
+    creds.communityId = @"COMMUNITYID";
+    creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    [account setLoginState:SFUserAccountLoginStateLoggedIn];
+    
+    NSDictionary *fileAttrs = [self uploadFile];
+    SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
+    XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
+    SFRestRequest *request =  [restAPI requestForFileDetails:fileAttrs[LID] forVersion:nil];;
+    XCTAssertNotNil(request,@"Request should have been created");
+    NSURLRequest *urlRequest = [request prepareRequestForSend:account];
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    
 }
 
 // Upload files / get batch details / delete files / get batch details again (expect 404)
@@ -928,6 +1055,51 @@ static NSException *authException = nil;
     XCTAssertEqual([listener.dataResponse[RESULTS][1][STATUS_CODE] intValue], 404, @"expected 404");
 }
 
+- (void)testUploadBatchDetailsDeleteFilesCommunity {
+    
+    // upload first file
+    NSDictionary *fileAttrs = [self uploadFile];
+    NSDictionary *fileAttrs2 = [self uploadFile];
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
+    creds.userId = @"USERID";
+    creds.organizationId = @"ORGID";
+    creds.communityId = @"COMMUNITYID";
+    creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    [account setLoginState:SFUserAccountLoginStateLoggedIn];
+    
+    SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
+    XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
+    SFRestRequest *request =  [restAPI  requestForBatchFileDetails:@[fileAttrs[LID], fileAttrs2[LID]]];
+    XCTAssertNotNil(request,@"Request should have been created");
+    NSURLRequest *urlRequest = [request prepareRequestForSend:account];
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    
+}
+
+- (void)testrequestForDeleteFileShareAndAddFileShareCommunity {
+    
+    // upload first file
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
+    creds.userId = @"USERID";
+    creds.organizationId = @"ORGID";
+    creds.communityId = @"COMMUNITYID";
+    creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    [account setLoginState:SFUserAccountLoginStateLoggedIn];
+    
+    SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
+    XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
+    SFRestRequest *request =  [restAPI  requestForDeleteFileShare:@"100"];
+    XCTAssertNotNil(request,@"Request should have been created");
+    NSURLRequest *urlRequest = [request prepareRequestForSend:account];
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    
+    request =  [restAPI  requestForFilesSharedWithUser:@"200" page:0];
+    urlRequest = [request prepareRequestForSend:account];
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    
+}
 // Upload files / get owned files / delete files / get owned files again
 - (void)testUploadOwnedFilesDelete {
 
@@ -966,6 +1138,7 @@ static NSException *authException = nil;
     listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
 }
+
 
 // Upload file / share file / get file shares and shared files / unshare file / get file shares and shared files / delete file
 - (void)testUploadShareFileSharesSharedFilesUnshareDelete {
@@ -1870,6 +2043,44 @@ static NSException *authException = nil;
     NSString *restUrl = [SFRestRequest restUrlForBaseUrl:nil serviceHostType:SFSDKRestServiceHostTypeInstance credentials:creds];
     XCTAssertEqualObjects(restUrl, instanceUrl.absoluteString, @"Instance URL should take precedence");
 }
+
+#pragma mark Unauthenticated CLient tests
+
+- (void)testRestApiGlobalInstance {
+    
+    SFRestAPI *sharedInstance  = [SFRestAPI sharedInstance];
+    SFRestAPI *globalInstance = [SFRestAPI sharedGlobalInstance];
+    XCTAssertNotNil(globalInstance, @"SFRestAPI should have a gloabl instance available");
+    
+    XCTAssertTrue(globalInstance != sharedInstance, @"SFRestAPI globalInstance and sharedInstance must be different");
+}
+
+
+- (void)testPublicApiCalls {
+     XCTestExpectation *getExpectation = [self expectationWithDescription:@"Get"];
+    __block NSError *error = nil;
+    __block NSDictionary *response = nil;
+    SFRestRequest *request = [SFRestRequest customUrlRequestWithMethod:SFRestMethodGET baseURL:@"https://api.github.com" path:@"/orgs/forcedotcom/repos" queryParams:nil];
+    request.requiresAuthentication = NO;
+    XCTAssertEqual(request.baseURL, @"https://api.github.com", @"Base URL should match");
+    
+    [[SFRestAPI sharedGlobalInstance] sendRESTRequest:request failBlock:^(NSError *  e, NSURLResponse * rawResponse) {
+        error = e;
+        [getExpectation fulfill];
+        
+    } completeBlock:^(id  resp, NSURLResponse *  rawResponse) {
+        response = resp;
+        [getExpectation fulfill];
+    }];
+    [self waitForExpectations:@[getExpectation] timeout:20];
+    
+    XCTAssertFalse(response.count > 0 ,@"The reponse should have github/forcedotcom repos");
+    XCTAssertTrue(error == nil,@"RestApi call to a public api should not fail");
+    XCTAssertTrue(error == nil,@"RestApi call to a public api should not fail");
+    XCTAssertFalse(response == nil,@"RestApi call to a public api should not have a nil response");
+}
+
+
 
 - (SFOAuthCredentials *)getTestCredentialsWithDomain:(nonnull NSString *)domain
                                             instanceUrl:(nonnull NSURL *)instanceUrl

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -811,16 +811,17 @@ static NSException *authException = nil;
     SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
     creds.userId = @"USERID";
     creds.organizationId = @"ORGID";
-    creds.communityId = @"COMMUNITYID";
     creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
     SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    account.communityId = @"COMMUNITYID";
     [account setLoginState:SFUserAccountLoginStateLoggedIn];
     SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
     XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
     SFRestRequest *request = [restAPI requestForOwnedFilesList:creds.userId page:0];
     XCTAssertNotNil(request,@"Request should have been created");
     NSURLRequest *urlRequest = [request prepareRequestForSend:account];
-    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    NSRange range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
+    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
 }
 
 - (void)testOwnedFilesListWithCommunityWithHeaders {
@@ -828,9 +829,9 @@ static NSException *authException = nil;
     SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
     creds.userId = @"USERID";
     creds.organizationId = @"ORGID";
-    creds.communityId = @"COMMUNITYID";
     creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
     SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    account.communityId = @"COMMUNITYID";
     [account setLoginState:SFUserAccountLoginStateLoggedIn];
     SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
     XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
@@ -843,7 +844,8 @@ static NSException *authException = nil;
     NSURLRequest *urlRequest = [request prepareRequestForSend:account];
     XCTAssertEqualObjects(simpleTypeLength,[urlRequest valueForHTTPHeaderField:@"Content-Length"]);
     XCTAssertEqualObjects(simpleType,[urlRequest valueForHTTPHeaderField:@"Content-Type"]);
-    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    NSRange range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
+    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
 }
 
 // simple: just invoke requestForFilesInUsersGroups
@@ -864,16 +866,17 @@ static NSException *authException = nil;
     SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
     creds.userId = @"USERID";
     creds.organizationId = @"ORGID";
-    creds.communityId = @"COMMUNITYID";
     creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
     SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    account.communityId = @"COMMUNITYID";
     [account setLoginState:SFUserAccountLoginStateLoggedIn];
     SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
     XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
     SFRestRequest *request = [restAPI requestForFilesInUsersGroups:creds.userId page:0];
     XCTAssertNotNil(request,@"Request should have been created");
     NSURLRequest *urlRequest = [request prepareRequestForSend:account];
-    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    NSRange range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
+    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
 }
 
 // simple: just invoke requestForFilesSharedWithUser
@@ -896,16 +899,17 @@ static NSException *authException = nil;
     SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
     creds.userId = @"USERID";
     creds.organizationId = @"ORGID";
-    creds.communityId = @"COMMUNITYID";
     creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
     SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    account.communityId = @"COMMUNITYID";
     [account setLoginState:SFUserAccountLoginStateLoggedIn];
     SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
     XCTAssertNotNil(restAPI,@"RestApi instance for this user must exist");
     SFRestRequest* request = [restAPI requestForFilesSharedWithUser:@"someid" page:0];
     XCTAssertNotNil(request,@"Request should have been created");
     NSURLRequest *urlRequest = [request prepareRequestForSend:account];
-    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    NSRange range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
+    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
 }
 
 
@@ -944,9 +948,10 @@ static NSException *authException = nil;
     SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
     creds.userId = @"USERID";
     creds.organizationId = @"ORGID";
-    creds.communityId = @"COMMUNITYID";
+   
     creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
     SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    account.communityId = @"COMMUNITYID";
     [account setLoginState:SFUserAccountLoginStateLoggedIn];
     
     NSDictionary *fileAttrs = [self uploadFile];
@@ -955,15 +960,17 @@ static NSException *authException = nil;
     SFRestRequest *request =  [restAPI requestForFileRendition:fileAttrs[LID] version:nil renditionType:@"PDF" page:0];
     XCTAssertNotNil(request,@"Request should have been created");
     NSURLRequest *urlRequest = [request prepareRequestForSend:account];
-    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    NSRange range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
+    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
     
     request = [restAPI requestForDeleteWithObjectType:@"ContentDocument" objectId:fileAttrs[LID]];
     urlRequest = [request prepareRequestForSend:account];
-    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"].location >= 0, "The URL must have communities pasth");
     
     request = [restAPI requestForFileContents:fileAttrs[LID] version:nil];
     urlRequest = [request prepareRequestForSend:account];
-    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
+    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
     
 }
 
@@ -996,9 +1003,9 @@ static NSException *authException = nil;
     SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
     creds.userId = @"USERID";
     creds.organizationId = @"ORGID";
-    creds.communityId = @"COMMUNITYID";
     creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
     SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    account.communityId = @"COMMUNITYID";
     [account setLoginState:SFUserAccountLoginStateLoggedIn];
     
     NSDictionary *fileAttrs = [self uploadFile];
@@ -1007,7 +1014,8 @@ static NSException *authException = nil;
     SFRestRequest *request =  [restAPI requestForFileDetails:fileAttrs[LID] forVersion:nil];;
     XCTAssertNotNil(request,@"Request should have been created");
     NSURLRequest *urlRequest = [request prepareRequestForSend:account];
-    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    NSRange range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
+    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
     
 }
 
@@ -1063,9 +1071,9 @@ static NSException *authException = nil;
     SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"CLIENT ID"  clientId:@"CLIENT ID" encrypted:NO];
     creds.userId = @"USERID";
     creds.organizationId = @"ORGID";
-    creds.communityId = @"COMMUNITYID";
     creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
     SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    account.communityId = @"COMMUNITYID";
     [account setLoginState:SFUserAccountLoginStateLoggedIn];
     
     SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
@@ -1073,7 +1081,8 @@ static NSException *authException = nil;
     SFRestRequest *request =  [restAPI  requestForBatchFileDetails:@[fileAttrs[LID], fileAttrs2[LID]]];
     XCTAssertNotNil(request,@"Request should have been created");
     NSURLRequest *urlRequest = [request prepareRequestForSend:account];
-    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    NSRange range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
+    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
     
 }
 
@@ -1086,6 +1095,7 @@ static NSException *authException = nil;
     creds.communityId = @"COMMUNITYID";
     creds.instanceUrl = [NSURL URLWithString:@"https://sample.domain"];
     SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    account.communityId = @"COMMUNITYID";
     [account setLoginState:SFUserAccountLoginStateLoggedIn];
     
     SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:account];
@@ -1093,11 +1103,14 @@ static NSException *authException = nil;
     SFRestRequest *request =  [restAPI  requestForDeleteFileShare:@"100"];
     XCTAssertNotNil(request,@"Request should have been created");
     NSURLRequest *urlRequest = [request prepareRequestForSend:account];
-    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    NSRange range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
+    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
+   
     
     request =  [restAPI  requestForFilesSharedWithUser:@"200" page:0];
     urlRequest = [request prepareRequestForSend:account];
-    XCTAssertTrue([[[urlRequest URL] absoluteString] rangeOfString:@"/communities/COMMUNITYID/connect"].location >= 0, "The URL must have communities pasth");
+    range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
+    XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
     
 }
 // Upload files / get owned files / delete files / get owned files again
@@ -2073,11 +2086,10 @@ static NSException *authException = nil;
         [getExpectation fulfill];
     }];
     [self waitForExpectations:@[getExpectation] timeout:20];
-    
-    XCTAssertFalse(response.count > 0 ,@"The reponse should have github/forcedotcom repos");
     XCTAssertTrue(error == nil,@"RestApi call to a public api should not fail");
     XCTAssertTrue(error == nil,@"RestApi call to a public api should not fail");
     XCTAssertFalse(response == nil,@"RestApi call to a public api should not have a nil response");
+    XCTAssertTrue(response.count > 0 ,@"The reponse should have github/forcedotcom repos");
 }
 
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -2029,6 +2029,23 @@ static NSException *authException = nil;
     XCTAssertEqualObjects(restUrl, instanceUrl.absoluteString, @"Instance URL should take precedence");
 }
 
+- (void)testRestUrlForNetworkServiceType {
+    SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodGET baseURL:@"http://www.apple.com" path:@"/test/testing" queryParams:nil];
+    
+    request.networkServiceType = SFNetworkServiceTypeDefault;
+    NSURLRequest *finalRequest = [request prepareRequestForSend:_currentUser];
+    XCTAssertTrue(finalRequest.networkServiceType == NSURLNetworkServiceTypeDefault,  @"Network Service Type should have been set to NSURLNetworkServiceTypeDefault");
+    
+    request.networkServiceType = SFNetworkServiceTypeResponsiveData;
+    finalRequest = [request prepareRequestForSend:_currentUser];
+    
+    XCTAssertTrue(finalRequest.networkServiceType == NSURLNetworkServiceTypeResponsiveData,  @"Network Service Type should have been set to NSURLNetworkServiceTypeResponsiveData");
+   
+    request.networkServiceType = SFNetworkServiceTypeBackground;
+    finalRequest = [request prepareRequestForSend:_currentUser];
+    XCTAssertTrue(finalRequest.networkServiceType == NSURLNetworkServiceTypeBackground,  @"Network Service Type should have been set to NSURLNetworkServiceTypeBackground");
+}
+
 #pragma mark Unauthenticated CLient tests
 
 - (void)testRestApiGlobalInstance {


### PR DESCRIPTION
 @bhariharan @wmathurin please review. This PR Does the following. 

Note: All Core,SmartStore & SmartSync tests are passing. Im still testing all sample apps to ensure that the result is as expected.

1. Fixes issues related to community files api(s). [Read about the required changes](https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_resources_files_rendition.htm).

2. Adds a sharedGlobalInstance of SFRestAPI for use in unauthenticated context.

3. Allows ability to invoke custom REST API endpoints.

```
 SFRestRequest *request = [SFRestRequest customUrlRequestWithMethod:SFRestMethodGET baseURL:@"https://api.github.com" path:@"/orgs/forcedotcom/repos" queryParams:nil];
 request.requiresAuthentication = NO;  
 [[SFRestAPI sharedGlobalInstance] sendRESTRequest:request failBlock:^(NSError *  e, 
      NSURLResponse * rawResponse) {
       
  } completeBlock:^(id  resp, NSURLResponse *  rawResponse) {
           NSDictionary *response = resp;
           // response should have forcedotcom repos      
  }];
```
4. Allows the setting of service type in Request. This enables the OS to prioritize requests.  
[Read](https://developer.apple.com/documentation/foundation/nsurlrequestnetworkservicetype?language=objc).

5. Added Unit tests for most of the changes. 
