### PR TITLE
Deprecating requiresAuthentication Attribute on SFRequest

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -210,7 +210,7 @@ static dispatch_once_t pred;
 #pragma mark - send method
 
 - (void)send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate {
-    [self send:request delegate:delegate shouldRetry:self.requiresAuthentication];
+    [self send:request delegate:delegate shouldRetry:self.requiresAuthentication && request.requiresAuthentication];
 }
 
 - (void)send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate shouldRetry:(BOOL)shouldRetry {
@@ -218,10 +218,9 @@ static dispatch_once_t pred;
         request.delegate = delegate;
     }
     
-    SFSDK_USE_DEPRECATED_BEGIN
-        NSAssert(!request.requiresAuthentication, @"Use SFRestAPI, sharedGlobalInstance for unauthenticated requests or sharedInstance for authenticated requests");
-    SFSDK_USE_DEPRECATED_END
-    
+    if (!self.requiresAuthentication) {
+         NSAssert(!request.requiresAuthentication , @"Use SFRestAPI sharedInstance for authenticated requests");
+    }
     // Adds this request to the list of active requests if it's not already on the list.
     [self.activeRequests addObject:request];
     __weak __typeof(self) weakSelf = self;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -414,9 +414,7 @@ static dispatch_once_t pred;
     @synchronized (self) {
         NSSet *pendingRequests = [self.activeRequests asSet];
         for (SFRestRequest *request in pendingRequests) {
-            if (self.requiresAuthentication) {
-                [self send:request delegate:request.delegate shouldRetry:NO];
-            }
+           [self send:request delegate:request.delegate shouldRetry:NO];
         }
         self.pendingRequestsBeingProcessed = NO;
     }
@@ -473,6 +471,7 @@ static dispatch_once_t pred;
 - (SFRestRequest *)requestForVersions {
     NSString *path = @"/";
     SFRestRequest* request = [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
+    request.requiresAuthentication = NO;
     return request;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -220,7 +220,7 @@ NS_SWIFT_NAME(RestRequest)
  * Whether or not this request requires authentication.  If YES, the credentials will be added to
  * the request headers before sending the request.  If NO, they will not.
  */
-@property (nonatomic, assign) BOOL requiresAuthentication SFSDK_DEPRECATED(7.1, 8.0, "Use SFRestAPI:sharedGlobalInstance for unauthenticated calls or SFRestAPI:sharedInstance for authenticated calls");
+@property (nonatomic, assign) BOOL requiresAuthentication;
 ;
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -220,7 +220,7 @@ NS_SWIFT_NAME(RestRequest)
  * Whether or not this request requires authentication.  If YES, the credentials will be added to
  * the request headers before sending the request.  If NO, they will not.
  */
-@property (nonatomic, assign) BOOL requiresAuthentication SFSDK_DEPRECATED(7.1, 8.0, "Use SFRestAPI:globalSharedInstance for unauthenticated calls or SFRestAPI:sharedInstance for authenticated calls");
+@property (nonatomic, assign) BOOL requiresAuthentication SFSDK_DEPRECATED(7.1, 8.0, "Use SFRestAPI:sharedGlobalInstance for unauthenticated calls or SFRestAPI:sharedInstance for authenticated calls");
 ;
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -220,7 +220,8 @@ NS_SWIFT_NAME(RestRequest)
  * Whether or not this request requires authentication.  If YES, the credentials will be added to
  * the request headers before sending the request.  If NO, they will not.
  */
-@property (nonatomic, assign) BOOL requiresAuthentication;
+@property (nonatomic, assign) BOOL requiresAuthentication SFSDK_DEPRECATED(7.1, 8.0, "Use SFRestAPI:globalSharedInstance for unauthenticated calls or SFRestAPI:sharedInstance for authenticated calls");
+;
 
 /**
  * Used to specify if the SDK should attempt to refresh tokens on HTTP 403. If YES, the SDK will

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -38,6 +38,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         self.serviceHostType = hostType;
         self.baseURL = baseURL;
         self.path = path;
+        self.requiresAuthentication = YES;
         self.queryParams = [queryParams mutableCopy];
         self.endpoint = (hostType == SFSDKRestServiceHostTypeCustom)?@"":kSFDefaultRestEndpoint;
         self.parseResponse = YES;
@@ -57,6 +58,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
 
 + (instancetype)customUrlRequestWithMethod:(SFRestMethod)method baseURL:(NSString *)baseURL path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams {
     SFRestRequest *request = [[self alloc] initWithMethod:method  serviceHostType:SFSDKRestServiceHostTypeCustom baseURL:baseURL path:path queryParams:queryParams];
+    request.requiresAuthentication = NO;
     return request;
 }
 
@@ -194,7 +196,8 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         [self.request setHTTPMethod:[SFRestRequest httpMethodFromSFRestMethod:self.method]];
 
         // Sets OAuth Bearer token header on the request (if not already present).
-        if (user && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"Authorization"]) {
+        // Allows Authenticated clients to make api calls that dont require access token.
+        if (self.requiresAuthentication && user && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"Authorization"]) {
             NSString *bearer = [NSString stringWithFormat:@"Bearer %@", user.credentials.accessToken];
             [self.request setValue:bearer forHTTPHeaderField:@"Authorization"];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -40,7 +40,6 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         self.path = path;
         self.queryParams = [queryParams mutableCopy];
         self.endpoint = (hostType == SFSDKRestServiceHostTypeCustom)?@"":kSFDefaultRestEndpoint;
-        self.requiresAuthentication = YES;
         self.parseResponse = YES;
         self.shouldRefreshOn403 = YES;
         self.request = [[NSMutableURLRequest alloc] init];
@@ -58,7 +57,6 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
 
 + (instancetype)customUrlRequestWithMethod:(SFRestMethod)method baseURL:(NSString *)baseURL path:(NSString *)path queryParams:(nullable NSDictionary<NSString*, id> *)queryParams {
     SFRestRequest *request = [[self alloc] initWithMethod:method  serviceHostType:SFSDKRestServiceHostTypeCustom baseURL:baseURL path:path queryParams:queryParams];
-    request.requiresAuthentication = NO;
     return request;
 }
 
@@ -196,7 +194,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         [self.request setHTTPMethod:[SFRestRequest httpMethodFromSFRestMethod:self.method]];
 
         // Sets OAuth Bearer token header on the request (if not already present).
-        if (user && self.requiresAuthentication && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"Authorization"]) {
+        if (user && ![self.request.allHTTPHeaderFields.allKeys containsObject:@"Authorization"]) {
             NSString *bearer = [NSString stringWithFormat:@"Bearer %@", user.credentials.accessToken];
             [self.request setValue:bearer forHTTPHeaderField:@"Authorization"];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -1457,62 +1457,6 @@ static NSException *authException = nil;
     XCTAssertFalse([newAccessToken isEqualToString:invalidAccessToken], @"access token wasn't refreshed");
 }
 
-// - set an invalid access token (simulate expired)
-// - make multiple simultaneous requests (some not requiring authentication)
-// - requests not requiring authentication should succeed and only be sent once
-// - other requests will fail in some arbitrary order
-// - ensure that a new access token is retrieved using refresh token
-// - ensure that all requests eventually succeed
-//
--(void)testInvalidAccessToken_UnAuthAndAuthRequests {
-    
-    // save invalid token
-    NSString *invalidAccessToken = @"xyz";
-    [self changeOauthTokens:invalidAccessToken refreshToken:nil];
-
-    // create requests (some that require authentications and some that don't)
-    SFRestRequest* unauthenticatedRequest1 = [[SFRestAPI sharedInstance] requestForVersions];
-    SFRestRequest* unauthenticatedRequest2 = [[SFRestAPI sharedInstance] requestForVersions];
-    SFRestRequest* authenticatedRequest1 = [[SFRestAPI sharedInstance] requestForUserInfo];
-    SFRestRequest* authenticatedRequest2 = [[SFRestAPI sharedInstance] requestForUserInfo];
-
-    SFNativeRestRequestListener* unauthenticatedListener1 = [[SFNativeRestRequestListener alloc] initWithRequest:unauthenticatedRequest1];
-    unauthenticatedListener1.sleepDuringLoad = 0.5;
-    SFNativeRestRequestListener* unauthenticatedListener2 = [[SFNativeRestRequestListener alloc] initWithRequest:unauthenticatedRequest2];
-    unauthenticatedListener2.sleepDuringLoad = 0.5;
-    SFNativeRestRequestListener* authenticatedListener1 = [[SFNativeRestRequestListener alloc] initWithRequest:authenticatedRequest1];
-    SFNativeRestRequestListener* authenticatedListener2 = [[SFNativeRestRequestListener alloc] initWithRequest:authenticatedRequest2];
-    
-    NSArray<SFNativeRestRequestListener*>* listeners = @[unauthenticatedListener1, authenticatedListener1, unauthenticatedListener2, authenticatedListener2];
-    
-    // send requests
-    for (SFNativeRestRequestListener* listener in listeners) {
-        [[SFRestAPI sharedInstance] send:listener.request delegate:listener];
-    }
-    
-    // wait for requests to complete
-    for (SFNativeRestRequestListener* listener in listeners) {
-        [listener waitForCompletion];
-    }
-    
-    // make sure they all succeeded
-    for (SFNativeRestRequestListener* listener in listeners) {
-        XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"a request failed");
-    }
-
-    // make sure unauthenticated requests don't complete a second time
-    for (SFNativeRestRequestListener* listener in @[unauthenticatedListener1, unauthenticatedListener2]) {
-        // reset listener return status and lower max wait time
-        listener.returnStatus = kTestRequestStatusWaiting;
-        listener.maxWaitTime = 2.0;
-        XCTAssertEqualObjects([listener waitForCompletion], kTestRequestStatusDidTimeout, @"Unauthenticated user should not have completed a second time");
-    }
-
-    // let's make sure we have a new access token
-    NSString *newAccessToken = _currentUser.credentials.accessToken;
-    XCTAssertFalse([newAccessToken isEqualToString:invalidAccessToken], @"access token wasn't refreshed");
-}
-
 // - sets an invalid accessToken
 // - sets an invalid refreshToken
 // - issue multiple valid requests

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -149,6 +149,13 @@ static NSException *authException = nil;
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
 }
 
+- (void)testGetVersionsUnAuthenticated {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForVersions];
+    request.requiresAuthentication = NO;
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"Unauthenticated request failed");
+}
+
 - (void)testGetVersion_SetDelegate {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForVersions];
     SFNativeRestRequestListener *listener = [[SFNativeRestRequestListener alloc] initWithRequest:request];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -195,8 +195,7 @@ static NSException *authException = nil;
     RestApiAssertionCheckHandler *assertionHandler = [[RestApiAssertionCheckHandler alloc] initWithExpectation:assertExpectation];
     [[[NSThread currentThread] threadDictionary] setValue:assertionHandler
                                                    forKey:NSAssertionHandlerKey];
-    SFRestRequest* request = [[SFRestAPI sharedGlobalInstance] requestForVersions];
-    request.requiresAuthentication = YES;
+    SFRestRequest* request = [[SFRestAPI sharedGlobalInstance] requestForResources];
     @try {
         [[SFRestAPI sharedGlobalInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *  rawResponse) {
             


### PR DESCRIPTION
Moving forward unauthenticated requests should be sent using [SFRestAPI sharedGlobalInstance]  
and requests requiring authentication context(accessToken) should  use [SFRestAPI sharedInstance:..].