### PR TITLE
use atomic for communities

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
@@ -115,7 +115,7 @@ NS_SWIFT_NAME(UserAccount)
 
 /** The list of communities (as SFCommunityData item)
  */
-@property (nonatomic, copy, nullable) NSArray<SFCommunityData *> *communities;
+@property (atomic, copy, nullable) NSArray<SFCommunityData *> *communities;
 
 /** Returns YES if the user has an access token and, presumably,
  a valid session.


### PR DESCRIPTION
@brandonpage @trooper2013 @sgoldberg-sfdc 

We are seeing a crash on hockeyapp: https://rink.hockeyapp.net/manage/apps/31036/app_versions/179/crash_reasons/259010550?type=crashes

After some investigation, we think it is a read/write race condition when we try to change user.communities in a callback in main and also read user.communities in another background thread.
<img width="131" alt="screen shot 2019-01-31 at 12 03 53 pm" src="https://user-images.githubusercontent.com/3354167/52083899-97c18200-2555-11e9-9341-c608db08ac8c.png">

Thus change user.communities from nonatomic to atomic to make sure it is threadsafe.