### PR TITLE
Decouples NavBar font & title color. Move styling to  common location.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -256,6 +256,10 @@
 		B7E1A7841F4C8844007AC36A /* SFSDKAuthViewHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B7E1A77D1F4C8844007AC36A /* SFSDKAuthViewHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B7E1A7851F4C8844007AC36A /* SFSDKAuthViewHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B7E1A77E1F4C8844007AC36A /* SFSDKAuthViewHandler.m */; };
 		B7E1A7861F4C8844007AC36A /* SFSDKAuthViewHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B7E1A77E1F4C8844007AC36A /* SFSDKAuthViewHandler.m */; };
+		B7E391122209E63E00D61D4D /* SFSDKViewUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = B7E391102209E63E00D61D4D /* SFSDKViewUtils.h */; };
+		B7E391132209E63E00D61D4D /* SFSDKViewUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B7E391112209E63E00D61D4D /* SFSDKViewUtils.m */; };
+		B7E3911A2209EB0C00D61D4D /* SFSDKViewUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B7E391112209E63E00D61D4D /* SFSDKViewUtils.m */; };
+		B7E3911B2209EB1300D61D4D /* SFSDKViewUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = B7E391102209E63E00D61D4D /* SFSDKViewUtils.h */; };
 		B7E8A2A51E7369DB007C0D92 /* SFDefaultUserAccountPersister.h in Headers */ = {isa = PBXBuildFile; fileRef = B7E8A2A31E7369DB007C0D92 /* SFDefaultUserAccountPersister.h */; };
 		B7E8A2A61E7369DB007C0D92 /* SFDefaultUserAccountPersister.m in Sources */ = {isa = PBXBuildFile; fileRef = B7E8A2A41E7369DB007C0D92 /* SFDefaultUserAccountPersister.m */; };
 		B7E8A2A81E74559B007C0D92 /* SFDefaultUserAccountPersister.h in Headers */ = {isa = PBXBuildFile; fileRef = B7E8A2A31E7369DB007C0D92 /* SFDefaultUserAccountPersister.h */; };
@@ -1134,6 +1138,8 @@
 		B7E1A77C1F4C8844007AC36A /* SFSDKOAuthClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKOAuthClient.m; sourceTree = "<group>"; };
 		B7E1A77D1F4C8844007AC36A /* SFSDKAuthViewHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKAuthViewHandler.h; sourceTree = "<group>"; };
 		B7E1A77E1F4C8844007AC36A /* SFSDKAuthViewHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKAuthViewHandler.m; sourceTree = "<group>"; };
+		B7E391102209E63E00D61D4D /* SFSDKViewUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKViewUtils.h; sourceTree = "<group>"; };
+		B7E391112209E63E00D61D4D /* SFSDKViewUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKViewUtils.m; sourceTree = "<group>"; };
 		B7E8A2A31E7369DB007C0D92 /* SFDefaultUserAccountPersister.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFDefaultUserAccountPersister.h; sourceTree = "<group>"; };
 		B7E8A2A41E7369DB007C0D92 /* SFDefaultUserAccountPersister.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFDefaultUserAccountPersister.m; sourceTree = "<group>"; };
 		B7E8A2AE1E77062E007C0D92 /* SFUserAccountManagerPersisterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFUserAccountManagerPersisterTests.m; path = SalesforceSDKCoreTests/SFUserAccountManagerPersisterTests.m; sourceTree = SOURCE_ROOT; };
@@ -1608,6 +1614,8 @@
 				CEC75D2120276ECD00A043AA /* SFSDKAuthConfigUtil.m */,
 				B78A238921014FCA00B19AB3 /* SFSDKAuthHelper.h */,
 				B78A238A21014FCA00B19AB3 /* SFSDKAuthHelper.m */,
+				B7E391102209E63E00D61D4D /* SFSDKViewUtils.h */,
+				B7E391112209E63E00D61D4D /* SFSDKViewUtils.m */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -2073,6 +2081,7 @@
 				CE88BD521D17065C00AE3BF7 /* SFSDKAILTNPublisher.h in Headers */,
 				CE4CE3171C0E523B009F6029 /* SFCrypto+Internal.h in Headers */,
 				CE4CE3111C0E523B009F6029 /* NSNotificationCenter+SFAdditions.h in Headers */,
+				B7E391122209E63E00D61D4D /* SFSDKViewUtils.h in Headers */,
 				B7C274421F814B5700CE539D /* SFSDKAuthCommand.h in Headers */,
 				CE675A331E0B2CC6002DBF5A /* SFSDKSoqlBuilder.h in Headers */,
 				B7A20FAD1F26C39700D1E4B0 /* SFSDKRootController.h in Headers */,
@@ -2282,6 +2291,7 @@
 				CEA882D51C18FB8E008D871B /* SFAuthErrorHandler.h in Headers */,
 				CEA882EB1C18FB8E008D871B /* SFKeyStoreKey.h in Headers */,
 				E1C80D171C5C365D001B3A21 /* SFLoginViewController.h in Headers */,
+				B7E3911B2209EB1300D61D4D /* SFSDKViewUtils.h in Headers */,
 				CEA882B11C18FB28008D871B /* SFIdentityCoordinator+Internal.h in Headers */,
 				CEA882BB1C18FB4D008D871B /* SFOAuthCoordinator.h in Headers */,
 				E1C80D2C1C5C367D001B3A21 /* SFSDKLoginHostStorage.h in Headers */,
@@ -2750,6 +2760,7 @@
 				CED452B81D808D0C009266EB /* SFRestAPI+Blocks.m in Sources */,
 				B7C274441F814B5700CE539D /* SFSDKAuthCommand.m in Sources */,
 				BE2B45981DAFFB1E004DA618 /* NSObject+SFBlocks.m in Sources */,
+				B7E391132209E63E00D61D4D /* SFSDKViewUtils.m in Sources */,
 				B71129121F8A780800436CFB /* SFSDKAlertMessage.m in Sources */,
 				B7C2744A1F814BF500CE539D /* SFSDKAuthRequestCommand.m in Sources */,
 				CED452BF1D808D0C009266EB /* SFRestAPI.m in Sources */,
@@ -2911,6 +2922,7 @@
 				CEA8828A1C18FAAB008D871B /* NSNotificationCenter+SFAdditions.m in Sources */,
 				B7E1A7821F4C8844007AC36A /* SFSDKOAuthClient.m in Sources */,
 				CED452E11D808D41009266EB /* SFRestAPI.m in Sources */,
+				B7E3911A2209EB0C00D61D4D /* SFSDKViewUtils.m in Sources */,
 				CEA882E71C18FB8E008D871B /* SFGeneratedKeyStore.m in Sources */,
 				CEA8830E1C18FB8E008D871B /* SFUserAccountManager.m in Sources */,
 				B716A2F5218F4CCC009D407F /* SFSDKPasscodeVerifyController.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -179,8 +179,17 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
         self.navigationController.navigationBar.tintColor = config.navBarTextColor;
     }
     
-    if (config.navBarFont && config.navBarTitleColor) {
-        [self.navigationController.navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName: config.navBarTitleColor, NSFontAttributeName: config.navBarFont}];
+    NSMutableDictionary *textAttributes = [[NSMutableDictionary alloc]init];
+    if (config.navBarTitleColor){
+        [textAttributes setObject:config.navBarTitleColor forKey:NSForegroundColorAttributeName];
+    }
+    
+    if (config.navBarFont) {
+        [textAttributes setObject:config.navBarFont forKey:NSFontAttributeName];
+    }
+    
+    if ([textAttributes count] > 0) {
+        [self.navigationController.navigationBar setTitleTextAttributes:textAttributes];
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -170,27 +170,7 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
 
 - (void)setupBrandingForNavBar {
     [self.navigationController.navigationBar setTranslucent:NO];
-    
-    SFSDKLoginViewControllerConfig *config = [SFUserAccountManager sharedInstance].loginViewControllerConfig;
-    if (config.navBarColor) {
-        [self.navigationController.navigationBar setBarTintColor:config.navBarColor];
-    }
-    if (config.navBarTextColor) {
-        self.navigationController.navigationBar.tintColor = config.navBarTextColor;
-    }
-    
-    NSMutableDictionary *textAttributes = [[NSMutableDictionary alloc]init];
-    if (config.navBarTitleColor){
-        [textAttributes setObject:config.navBarTitleColor forKey:NSForegroundColorAttributeName];
-    }
-    
-    if (config.navBarFont) {
-        [textAttributes setObject:config.navBarFont forKey:NSFontAttributeName];
-    }
-    
-    if ([textAttributes count] > 0) {
-        [self.navigationController.navigationBar setTitleTextAttributes:textAttributes];
-    }
+    [SFSDKViewUtils styleNavigationBar:self.navigationController.navigationBar config:[SFUserAccountManager sharedInstance].loginViewControllerConfig];
 }
 
 #pragma mark - Action Methods

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -33,7 +33,7 @@
 #import "SFSDKResourceUtils.h"
 #import "SFManagedPreferences.h"
 #import "SFUserAccountManager.h"
-
+#import "SFSDKViewUtils.h"
 static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCellIdentifier";
 
 @interface SFSDKLoginHostListViewController () <UINavigationControllerDelegate>

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.h
@@ -69,7 +69,10 @@ NS_SWIFT_NAME(SalesforceLoginViewController)
 @property (nonatomic, strong, nullable) UIFont * navBarFont NS_SWIFT_NAME(navigationBarFont);
 
 /** Specify the text color to use for navigation bar header text. */
-@property (nonatomic, strong, nullable) UIColor * navBarTextColor  NS_SWIFT_NAME(navigationBarTextColor);
+@property (nonatomic, strong, nullable) UIColor * navBarTintColor  NS_SWIFT_NAME(navigationBarTintColor);
+
+/** Specify the text color to use for navigation bar header text. */
+@property (nonatomic, strong, nullable) UIColor * navBarTitleColor  NS_SWIFT_NAME(navigationBarTitleColor);
 
 /** Specify navigation bar color. This color will be used by the login view header.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -223,6 +223,7 @@
     UILabel *item = [[UILabel alloc] initWithFrame:CGRectZero];
     if (self.config.navBarTitleColor) {
         item.textColor = self.config.navBarTextColor;
+        item.textColor = self.config.navBarTitleColor;
     }
     if (self.config.navBarFont) {
         item.font = self.config.navBarFont;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -107,12 +107,20 @@
     self.config.navBarFont = navBarFont;
 }
 
-- (UIColor *)navBarTextColor {
-    return self.config.navBarTextColor;
+- (UIColor *)navBarTintColor {
+    return self.config.navBarTintColor;
 }
 
-- (void)setNavBarTextColor:(UIColor *)color {
-    self.config.navBarTextColor = color;
+- (void)setNavBarTintColor:(UIColor *)color {
+    self.config.navBarTintColor = color;
+}
+
+- (UIColor *)navBarTitleColor {
+    return self.config.navBarTitleColor;
+}
+
+- (void)setNavBarTitleColor:(UIColor *)color {
+    self.config.navBarTitleColor = color;
 }
 
 - (UIColor *)navBarColor {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -38,7 +38,7 @@
 #import "SFOAuthInfo.h"
 #import "SFSDKWindowManager.h"
 #import "SFSDKNavigationController.h"
-
+#import "SFSDKViewUtils.h"
 @interface SFLoginViewController () <SFSDKLoginHostDelegate, SFUserAccountManagerDelegate>
 
 @property (nonatomic, strong) UINavigationBar *navBar;
@@ -48,8 +48,6 @@
 
 // Reference to previous user account
 @property (nonatomic, strong) SFUserAccount *previousUserAccount;
-
-
 @end
 
 @implementation SFLoginViewController
@@ -222,7 +220,6 @@
     // Setup top item.
     UILabel *item = [[UILabel alloc] initWithFrame:CGRectZero];
     if (self.config.navBarTitleColor) {
-        item.textColor = self.config.navBarTextColor;
         item.textColor = self.config.navBarTitleColor;
     }
     if (self.config.navBarFont) {
@@ -293,26 +290,11 @@
 
 #pragma mark - Styling Methods for Nav bar
 
-- (void) styleNavigationBar:(UINavigationBar *)navigationBar {
+- (void)styleNavigationBar:(UINavigationBar *)navigationBar {
     if (!navigationBar) {
         return;
     }
-    if (self.navBarColor) {
-        UIImage *backgroundImage = [self headerBackgroundImage];
-        [navigationBar setBackgroundImage:backgroundImage forBarMetrics:UIBarMetricsDefault];
-    }
-    if (self.navBarTextColor) {
-        navigationBar.tintColor = self.navBarTextColor;
-        [navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName: self.navBarTextColor}];
-        
-    } else {
-        // default color
-        navigationBar.tintColor = [UIColor whiteColor];
-    }
-    if (self.navBarFont && self.navBarTextColor) {
-        [navigationBar setTitleTextAttributes:@{ NSForegroundColorAttributeName: self.navBarTextColor,
-                                                 NSFontAttributeName: self.navBarFont}];
-    }
+    [SFSDKViewUtils styleNavigationBar:navigationBar config:self.config];
 }
 
 #pragma mark - SFSDKLoginHostDelegate Methods
@@ -360,21 +342,8 @@
         self.previousUserAccount = fromUser;
 }
 
-- ( UIImage * _Nonnull )headerBackgroundImage {
-    UIImage *backgroundImage = [[self class] imageFromColor:self.navBarColor];
-    return backgroundImage;
-}
 
-+ (UIImage *)imageFromColor:(UIColor *)color {
-    CGRect rect = CGRectMake(0, 0, 1, 1);
-    UIGraphicsBeginImageContext(rect.size);
-    CGContextRef context = UIGraphicsGetCurrentContext();
-    CGContextSetFillColorWithColor(context, [color CGColor]);
-    CGContextFillRect(context, rect);
-    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    return image;
-}
+
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFSDKLoginViewControllerConfig.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFSDKLoginViewControllerConfig.h
@@ -43,7 +43,7 @@ NS_SWIFT_NAME(SalesforceLoginViewControllerConfig)
 @property (nonatomic, strong, nullable) UIFont * navBarFont NS_SWIFT_NAME(navigationBarFont);
 
 /** Specify the text color to use for navigation bar header text. */
-@property (nonatomic, strong, nullable) UIColor * navBarTextColor  NS_SWIFT_NAME(navigationBarTextColor);
+@property (nonatomic, strong, nullable) UIColor * navBarTintColor  NS_SWIFT_NAME(navigationBarTintColor);
 
 /** Specify navigation bar color. This color will be used by the login view header.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFSDKLoginViewControllerConfig.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFSDKLoginViewControllerConfig.m
@@ -41,8 +41,8 @@
     if (self) {
         _navBarColor = [UIColor salesforceBlueColor];
         _navBarTitleColor = [UIColor whiteColor];
+        _navBarTintColor = [UIColor whiteColor];
         _navBarFont = nil;
-        _navBarTextColor = [UIColor whiteColor];
         _showNavbar = YES;
         _showSettingsIcon = YES;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.h
@@ -3,7 +3,7 @@
  SalesforceSDKCore
  
  Created by Raj Rao on 2/5/19.
- Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.h
@@ -1,0 +1,40 @@
+/*
+ SFSDKViewUtils.h
+ SalesforceSDKCore
+ 
+ Created by Raj Rao on 2/5/19.
+ Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SFSDKLoginViewControllerConfig;
+
+@interface SFSDKViewUtils : NSObject
+
++ (void)styleNavigationBar:(UINavigationBar *)navigationBar config:(SFSDKLoginViewControllerConfig *) config;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.m
@@ -3,7 +3,7 @@
  SalesforceSDKCore
  
  Created by Raj Rao on 2/5/19.
- Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.m
@@ -41,9 +41,9 @@
         [navigationBar setBackgroundImage:backgroundImage forBarMetrics:UIBarMetricsDefault];
     }
     
-    if (config.navBarTextColor) {
-        navigationBar.tintColor = config.navBarTextColor;
-        [navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName: config.navBarTextColor}];
+    if (config.navBarTintColor) {
+        navigationBar.tintColor = config.navBarTintColor;
+        [navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName: config.navBarTintColor}];
         
     } else {
         // default color

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.m
@@ -1,0 +1,82 @@
+/*
+ SFSDKViewUtils.m
+ SalesforceSDKCore
+ 
+ Created by Raj Rao on 2/5/19.
+ Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#import "SFSDKViewUtils.h"
+#import "SFSDKLoginViewControllerConfig.h"
+
+@implementation SFSDKViewUtils
+
++ (void)styleNavigationBar:(UINavigationBar *)navigationBar config:(SFSDKLoginViewControllerConfig *) config {
+    
+    if (!navigationBar && !config) {
+        return;
+    }
+    
+    if (config.navBarColor) {
+        UIImage *backgroundImage = [self headerBackgroundImage:config.navBarColor];
+        [navigationBar setBackgroundImage:backgroundImage forBarMetrics:UIBarMetricsDefault];
+    }
+    
+    if (config.navBarTextColor) {
+        navigationBar.tintColor = config.navBarTextColor;
+        [navigationBar setTitleTextAttributes:@{NSForegroundColorAttributeName: config.navBarTextColor}];
+        
+    } else {
+        // default color
+        navigationBar.tintColor = [UIColor whiteColor];
+    }
+    
+    NSMutableDictionary *textAttributes = [[NSMutableDictionary alloc]init];
+    if (config.navBarTitleColor){
+        [textAttributes setObject:config.navBarTitleColor forKey:NSForegroundColorAttributeName];
+    }
+    
+    if (config.navBarFont) {
+        [textAttributes setObject:config.navBarFont forKey:NSFontAttributeName];
+    }
+    
+    if ([textAttributes count] > 0) {
+        [navigationBar setTitleTextAttributes:textAttributes];
+    }
+}
+
++ ( UIImage * _Nonnull )headerBackgroundImage:(UIColor *)color {
+    UIImage *backgroundImage = [self  imageFromColor:color];
+    return backgroundImage;
+}
+
++ (UIImage *)imageFromColor:(UIColor *)color {
+    CGRect rect = CGRectMake(0, 0, 1, 1);
+    UIGraphicsBeginImageContext(rect.size);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextSetFillColorWithColor(context, [color CGColor]);
+    CGContextFillRect(context, rect);
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return image;
+}
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLoginHostTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLoginHostTests.m
@@ -91,7 +91,7 @@
     SFLoginViewController *loginViewController = [[SFLoginViewController alloc] init];
     //Test default values
     XCTAssertNotNil(loginViewController.navBarColor, "Nav bar color should not be nil");
-    XCTAssertNotNil(loginViewController.navBarTextColor, "Nav bar text color should not be nil");
+    XCTAssertNotNil(loginViewController.navBarTintColor, "Nav bar tint color should not be nil");
     XCTAssertNil(loginViewController.navBarFont, "Nav bar font should be nil");
     XCTAssertEqual(YES, loginViewController.showNavbar, "Show Nav bar should be set to yes by default");
     XCTAssertEqual(YES, loginViewController.showSettingsIcon, "Show Settings Icon should be set to yes by default");


### PR DESCRIPTION
This PR does the following. 
- Fixes #2766 and refactors the common navbar styling to a common util class. 
- Renamed the property in SFLoginViewControllerConfig from navBarTextColor to navBarTintColor.
- Adds a property for titleColor to the SFLoginViewController. Renames the navBarTextColor to navBarTintColor
