### PR TITLE
Fixing null handling regression

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -1681,7 +1681,10 @@ NSString *const EXPLAIN_ROWS = @"rows";
         }
         NSString* columnName = [frs columnNameForIndex:i];
         id value = valuesMap[columnName];
-        if ([value isKindOfClass:[NSString class]] &&
+        if ([value isKindOfClass:[NSNull class]]) {
+            [resultString appendString:@"null"];
+        }
+        else if ([value isKindOfClass:[NSString class]] &&
             ([columnName isEqualToString:SOUP_COL] || [columnName hasPrefix:[NSString stringWithFormat:@"%@:", SOUP_COL]])) {
             [resultString appendString:value];
         }

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.h
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.h
@@ -63,5 +63,5 @@
 - (void) testSmartQueryReturningSoupStringAndInteger;
 - (void) testSmartQueryWithPaging;
 - (void) testSmartQueryWithSpecialFields;
-- (void) testSmartQueryMatchingNullField;
+- (void) testSmartQueryWithNullField;
 @end

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
@@ -283,7 +283,7 @@
     XCTAssertEqualObjects(christineJson[@"_soupLastModifiedDate"], result[0][2], @"Wrong soupLastModifiedDate");
 }
 
-- (void) testSmartQueryMatchingNullField
+- (void) testSmartQueryWithNullField
 {
     NSDictionary* createdEmployee;
     
@@ -317,6 +317,11 @@
     querySpec = [SFQuerySpec newSmartQuerySpec:@"select {employees:employeeId} from {employees} where {employees:deptCode} = \"\" order by {employees:employeeId}" withPageSize:4];
     result = [self.store queryWithQuerySpec:querySpec pageIndex:0  error:nil];
     [self assertSameJSONArrayWithExpected:[SFJsonUtils objectFromJSONString:@"[[\"003\"]]"] actual:result message:@"Wrong result"];
+    
+    // Smart sql returning null values
+    querySpec = [SFQuerySpec newSmartQuerySpec:@"select {employees:employeeId},{employees:deptCode},{employees:deptCode} from {employees} order by {employees:employeeId}" withPageSize:4];
+    result = [self.store queryWithQuerySpec:querySpec pageIndex:0  error:nil];
+    [self assertSameJSONArrayWithExpected:[SFJsonUtils objectFromJSONString:@"[[\"001\",\"xyz\",\"xyz\"],[\"002\",null,null],[\"003\",\"\",\"\"],[\"004\",null,null]]"] actual:result message:@"Wrong result"];
 }
 
 - (void) testSmartQueryMachingBooleanInJSON1Field

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlWithExternalStorageTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlWithExternalStorageTests.m
@@ -150,9 +150,9 @@
     [super testSmartQueryWithSpecialFields];
 }
 
-- (void) testSmartQueryMatchingNullField
+- (void) testSmartQueryWithNullField
 {
-    [super testSmartQueryMatchingNullField];
+    [super testSmartQueryWithNullField];
 }
 
 - (void) testSmartQueryMachingBooleanInJSON1Field


### PR DESCRIPTION
Expanded test that was doing query on null to also return nulls (test fails without fix).
Null handling in result sets broken by https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/2665
NB: Android code is already correct (see [here](https://github.com/forcedotcom/SalesforceMobileSDK-Android/blob/master/libs/SmartStore/src/com/salesforce/androidsdk/smartstore/store/SmartStore.java#L868))