### PR TITLE
Thread Safety for  User Account

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -1086,6 +1086,7 @@
 		B716A383218F5E2D009D407F /* SalesforceSDKCommon.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceSDKCommon.xcodeproj; path = ../SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj; sourceTree = "<group>"; };
 		B716A38F218F5E37009D407F /* SalesforceAnalytics.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceAnalytics.xcodeproj; path = ../SalesforceAnalytics/SalesforceAnalytics.xcodeproj; sourceTree = "<group>"; };
 		B7282F3F1D8C70E700475F79 /* SalesforceSDKCoreTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SalesforceSDKCoreTestApp.entitlements; sourceTree = "<group>"; };
+		B73BB6F322090DEB0009A7DD /* SFUserAccountIdentity+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SFUserAccountIdentity+Internal.h"; sourceTree = "<group>"; };
 		B75233C01F4D390B00040B6E /* SFSDKOAuthClientContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKOAuthClientContext.h; sourceTree = "<group>"; };
 		B75233C11F4D390B00040B6E /* SFSDKOAuthClientContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKOAuthClientContext.m; sourceTree = "<group>"; };
 		B75233DC1F4DF0B700040B6E /* SFSDKAuthPreferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKAuthPreferences.h; sourceTree = "<group>"; };
@@ -1562,6 +1563,7 @@
 				B7CD6D641F79CFC900F99F81 /* SFUserAccountManager+URLHandlers.m */,
 				B70135601F87F63900995171 /* SFSDKAuthErrorManager.h */,
 				B70135611F87F63900995171 /* SFSDKAuthErrorManager.m */,
+				B73BB6F322090DEB0009A7DD /* SFUserAccountIdentity+Internal.h */,
 			);
 			path = Security;
 			sourceTree = "<group>";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -473,7 +473,7 @@ static NSString * const kSFMobileSDKNativeSwiftDesignator = @"NativeSwift";
 }
 
 - (NSString*) userToString:(SFUserAccount*)user {
-    return user ? user.userName : @"";
+    return user ? user.idData.username : @"";
 }
 
 - (NSString*) usersToString:(NSArray<SFUserAccount*>*)userAccounts {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthClient.m
@@ -37,6 +37,7 @@
 #import "SFSDKAuthErrorCommand.h"
 #import "SFSDKIDPInitCommand.h"
 #import "SFSDKAuthPreferences.h"
+#import "SFOAuthCredentials+Internal.h"
 
 @interface SFSDKIDPAuthClient()
 @property (nonatomic, strong) SFSDKOAuthClientContext *context;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
@@ -42,18 +42,33 @@ extern NSException * SFOAuthInvalidIdentifierException(void);
 
 @interface SFOAuthCredentials ()
 
-@property (nonatomic, strong) NSDictionary * additionalOAuthFields;
 
-// Facilitates NSCopying implementation.
-@property (nonatomic, readwrite) NSDictionary *legacyIdentityInformation;
+@property (nonatomic, readwrite, nullable) NSString *protocol;
+@property (nonatomic, readwrite, nullable) NSString *domain;
+@property (nonatomic,readwrite) NSString *identifier;
+@property (nonatomic, readwrite, nullable) NSString *clientId;
+@property (nonatomic, readwrite, nullable) NSString *redirectUri;
+@property (nonatomic, readwrite, nullable) NSString *jwt;
+@property (nonatomic, readwrite, nullable) NSString *refreshToken;
+@property (nonatomic, readwrite, nullable) NSString *accessToken;
+@property (nonatomic, readwrite, nullable) NSString *organizationId;
+@property (nonatomic, readwrite, nullable) NSURL *instanceUrl;
+@property (nonatomic, readwrite, nullable) NSString *communityId;
+@property (nonatomic, readwrite, nullable) NSURL *communityUrl;
+@property (nonatomic, readwrite, nullable) NSDate *issuedAt;
+@property (nonatomic, readwrite, nullable) NSURL *identityUrl;
+@property (nonatomic, readwrite, nullable) NSURL *apiUrl;
+@property (nonatomic, readwrite, nullable) NSString *userId;
 
-/** Holds the attributes that have changed during auth flow.
- */
-@property (nonatomic) NSMutableDictionary * credentialsChangeSet;
+@property (nonatomic, readwrite, strong, nullable) NSDictionary * additionalOAuthFields;
+@property (nonatomic, readwrite, nullable) NSString *challengeString;
+@property (nonatomic, readwrite, nullable) NSString *authCode;
+@property (nonatomic, readwrite, nullable) NSDictionary *legacyIdentityInformation;
+@property (nonatomic, readwrite, nullable) NSMutableDictionary * credentialsChangeSet;
 
-- (void)setPropertyForKey:(NSString *) key withValue:(id) newValue;
+- (void)setPropertyForKey:(NSString *_Nonnull) key withValue:(id _Nullable ) newValue;
 
-- (BOOL)hasPropertyValueChangedForKey:(NSString *) key;
+- (BOOL)hasPropertyValueChangedForKey:(NSString *_Nullable) key;
 
 /** Reset changes to credentials, called at the end of auth flow.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
@@ -33,19 +33,17 @@ typedef NS_ENUM(NSUInteger, SFOAuthCredsEncryptionType) {
     kSFOAuthCredsEncryptionTypeKeyStore
 };
 
-extern NSString * const kSFOAuthEncryptionTypeKey;
-extern NSString * const kSFOAuthServiceAccess;
-extern NSString * const kSFOAuthServiceRefresh;
-extern NSString * const kSFOAuthServiceActivation;
+extern NSString * _Nonnull const kSFOAuthEncryptionTypeKey;
+extern NSString * _Nonnull const kSFOAuthServiceAccess;
+extern NSString * _Nonnull const kSFOAuthServiceRefresh;
+extern NSString * _Nonnull const kSFOAuthServiceActivation;
 
-extern NSException * SFOAuthInvalidIdentifierException(void);
+extern NSException * _Nullable SFOAuthInvalidIdentifierException(void);
 
 @interface SFOAuthCredentials ()
-
-
 @property (nonatomic, readwrite, nullable) NSString *protocol;
 @property (nonatomic, readwrite, nullable) NSString *domain;
-@property (nonatomic,readwrite) NSString *identifier;
+@property (nonatomic,readwrite, nonnull) NSString *identifier;
 @property (nonatomic, readwrite, nullable) NSString *clientId;
 @property (nonatomic, readwrite, nullable) NSString *redirectUri;
 @property (nonatomic, readwrite, nullable) NSString *jwt;
@@ -59,11 +57,9 @@ extern NSException * SFOAuthInvalidIdentifierException(void);
 @property (nonatomic, readwrite, nullable) NSURL *identityUrl;
 @property (nonatomic, readwrite, nullable) NSURL *apiUrl;
 @property (nonatomic, readwrite, nullable) NSString *userId;
-
 @property (nonatomic, readwrite, strong, nullable) NSDictionary * additionalOAuthFields;
 @property (nonatomic, readwrite, nullable) NSString *challengeString;
 @property (nonatomic, readwrite, nullable) NSString *authCode;
-@property (nonatomic, readwrite, nullable) NSDictionary *legacyIdentityInformation;
 @property (nonatomic, readwrite, nullable) NSMutableDictionary * credentialsChangeSet;
 
 - (void)setPropertyForKey:(NSString *_Nonnull) key withValue:(id _Nullable ) newValue;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
@@ -75,7 +75,7 @@ NS_SWIFT_NAME(OAuthCredentials)
  The domain used to initiate a user login, for example _login.salesforce.com_
  or _test.salesforce.com_. The default is _login.salesforce.com_.
  */
-@property (nonatomic, copy, nullable) NSString *domain;
+@property (nonatomic, readonly, nullable) NSString *domain;
 
 /** Credential identifier used to uniquely identify this credential in the keychain. 
  
@@ -83,7 +83,7 @@ NS_SWIFT_NAME(OAuthCredentials)
  `nil` or empty value prior to accessing properties or methods identified in the documentation regarding this prohibition.
  @warning This property must not be modified while authenticating.
  */
-@property (copy, nonnull) NSString *identifier;
+@property (nonatomic, readonly, nonnull) NSString *identifier;
 
 /** Client consumer key.
  
@@ -92,13 +92,13 @@ NS_SWIFT_NAME(OAuthCredentials)
  @warning This property must not be `nil` or empty when authentication is initiated or an exception will be raised.
  @warning This property must not be modified while authenticating.
  */
-@property (copy, nullable) NSString *clientId;
+@property (nonatomic, readonly, nullable) NSString *clientId;
 
 /** Callback URL to load at the end of the authentication process.
  
  This must match the callback URL in the Remote Access object exactly, or authentication will fail.
  */
-@property (nonatomic, copy, nullable) NSString *redirectUri;
+@property (nonatomic, readonly, nullable) NSString *redirectUri;
 
 /** JWT.
  
@@ -106,7 +106,7 @@ NS_SWIFT_NAME(OAuthCredentials)
  @warning This property must not be modified while authenticating.
  @warning This property should be set to nil after authentication.
  */
-@property (nonatomic, copy, nullable) NSString *jwt;
+@property (nonatomic, readonly, nullable) NSString *jwt;
 
 /** Token used to refresh the user's session.
  
@@ -115,7 +115,7 @@ NS_SWIFT_NAME(OAuthCredentials)
  @warning The setter for this property is exposed publicly only for unit tests. Client code should use the revoke methods instead.
  @exception NSInternalInconsistencyException If this property is accessed when the identifier property is `nil`.
  */
-@property (nonatomic, copy, nullable) NSString *refreshToken;
+@property (nonatomic, readonly, nullable) NSString *refreshToken;
 
 /** The access token for the user's session.
  
@@ -124,7 +124,7 @@ NS_SWIFT_NAME(OAuthCredentials)
  @warning The setter for this property is exposed publicly only for unit tests. Client code should use the revoke methods instead.
  @exception NSInternalInconsistencyException If accessed while the identifier property is `nil`.
  */
-@property (nonatomic, copy, nullable) NSString *accessToken;
+@property (nonatomic, readonly, nullable) NSString *accessToken;
 
 /** A readonly convenience property returning the Salesforce Organization ID provided in the path component of the identityUrl.
  
@@ -133,7 +133,7 @@ NS_SWIFT_NAME(OAuthCredentials)
  @warning The setter for this property is exposed publicly only for unit tests. Client code should not set this property.
  @exception NSInternalInconsistencyException If accessed while the identifier property is `nil`.
  */
-@property (nonatomic, copy, nullable) NSString *organizationId;
+@property (nonatomic, readonly, nullable) NSString *organizationId;
 
 /** The URL of the server instance for this session. This URL always refers to the base organization
  instance, even if the user has logged through a community-based login flow.
@@ -144,21 +144,21 @@ NS_SWIFT_NAME(OAuthCredentials)
  
  @warning The setter for this property is exposed publicly only for unit tests. Client code should not set this property.
  */
-@property (nonatomic, copy, nullable) NSURL *instanceUrl;
+@property (nonatomic, readonly, nullable) NSURL *instanceUrl;
 
 /** The community ID the user choose to log into. This usually happens when the user
  logs into the app using a community-based login page
  
  Note: this property is nil of the user logs into the internal community or into an org that doesn't have communities.
  */
-@property (nonatomic, copy, nullable) NSString *communityId;
+@property (nonatomic, readonly, nullable) NSString *communityId;
 
 /** The community-base URL the user choose to log into. This usually happens when the user
  logs into the app using a community-based login page
  
  Note: this property is nil if the user logs into the internal community or into an org that doesn't have communities.
  */
-@property (nonatomic, copy, nullable) NSURL *communityUrl;
+@property (nonatomic, readonly, nullable) NSURL *communityUrl;
 
 /** The timestamp when the session access token was issued.
  
@@ -166,7 +166,7 @@ NS_SWIFT_NAME(OAuthCredentials)
  
  @warning The setter for this property is exposed publicly only for unit tests. Client code should not set this property.
  */
-@property (nonatomic, copy, nullable) NSDate *issuedAt;
+@property (nonatomic, readonly, nullable) NSDate *issuedAt;
 
 /** The identity URL for the user returned as part of a successful authentication response.
  The format of the URL is: _https://login.salesforce.com/ID/orgID/userID_ where orgId is the ID of the Salesforce organization 
@@ -176,11 +176,11 @@ NS_SWIFT_NAME(OAuthCredentials)
  
  @warning The setter for this property is exposed publicly only for unit tests. Client code should not set this property.
  */
-@property (nonatomic, copy, nullable) NSURL *identityUrl;
+@property (nonatomic, readonly, nullable) NSURL *identityUrl;
 
 /** The community URL, if present. The instance URL, otherwise.
  */
-@property (readonly, nullable) NSURL *apiUrl;
+@property (nonatomic, readonly, nullable) NSURL *apiUrl;
 
 /** A readonly convenience property returning the first 15 characters of the Salesforce User ID provided in the final path 
  component of the identityUrl.
@@ -189,7 +189,7 @@ NS_SWIFT_NAME(OAuthCredentials)
  
  @warning The setter for this property is exposed publicly only for unit tests. Client code should not set this property.
  */
-@property (nonatomic, copy, nullable) NSString *userId;
+@property (nonatomic, readonly, nullable) NSString *userId;
 
 /**
  Determines if sensitive data such as the `refreshToken` and `accessToken` are encrypted
@@ -202,9 +202,9 @@ NS_SWIFT_NAME(OAuthCredentials)
  */
 @property (nonatomic, readonly, nullable) NSDictionary * additionalOAuthFields;
 
-@property (nonatomic, copy, nullable) NSString *challengeString;
+@property (nonatomic, readonly, nullable) NSString *challengeString;
 
-@property (nonatomic, copy, nullable) NSString *authCode;
+@property (nonatomic, readonly, nullable) NSString *authCode;
 
 ///---------------------------------------------------------------------------------------
 /// @name Initialization

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -46,7 +46,7 @@ NSException * SFOAuthInvalidIdentifierException() {
 @interface SFOAuthCredentials () 
 
 //This property is intentionally readonly in the public header files.
-@property (nonatomic, readwrite, strong) NSString *protocol;
+//@property (nonatomic, readwrite, strong) NSString *protocol;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -43,13 +43,6 @@ NSException * SFOAuthInvalidIdentifierException() {
                                     userInfo:nil];
 }
 
-@interface SFOAuthCredentials () 
-
-//This property is intentionally readonly in the public header files.
-//@property (nonatomic, readwrite, strong) NSString *protocol;
-
-@end
-
 @implementation SFOAuthCredentials
 
 @synthesize identifier                = _identifier;
@@ -63,7 +56,6 @@ NSException * SFOAuthInvalidIdentifierException() {
 @synthesize issuedAt                  = _issuedAt;
 @synthesize protocol                  = _protocol;
 @synthesize encrypted                 = _encrypted;
-@synthesize legacyIdentityInformation = _legacyIdentityInformation;
 @synthesize additionalOAuthFields     = _additionalOAuthFields;
 @synthesize jwt                       = _jwt;
 
@@ -106,7 +98,6 @@ NSException * SFOAuthInvalidIdentifierException() {
             _encrypted = (encryptedBool
                           ? [encryptedBool boolValue]
                           : [coder decodeBoolForKey:@"SFOAuthEncrypted"]);
-            _legacyIdentityInformation = [coder decodeObjectOfClass:[NSDictionary class] forKey:@"SFOAuthIdentityInformation"];
             
             if ([self isMemberOfClass:[SFOAuthCredentials class]]) {
                 self.refreshToken = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthRefreshToken"];
@@ -192,7 +183,6 @@ NSException * SFOAuthInvalidIdentifierException() {
     copyCreds.organizationId = self.organizationId;
     copyCreds.userId = self.userId;
     
-    copyCreds.legacyIdentityInformation = [self.legacyIdentityInformation copy];
     copyCreds.additionalOAuthFields = [self.additionalOAuthFields copy];
     
     return copyCreds;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -40,6 +40,7 @@
 #import "SFSDKWebViewStateManager.h"
 #import "SFSecurityLockout.h"
 #import "SFSDKIDPAuthClient.h"
+#import "SFOAuthCredentials+Internal.h"
 
 // Auth error handler name constants
 static NSString * const kSFInvalidCredentialsAuthErrorHandler = @"InvalidCredentialsErrorHandler";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserAccountPersister.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserAccountPersister.m
@@ -23,6 +23,7 @@
  */
 
 #import "SFUserAccountManager.h"
+#import "SFIdentityData.h"
 #import "SFDefaultUserAccountPersister.h"
 #import "SFDirectoryManager.h"
 #import "SFKeyStoreManager.h"
@@ -143,17 +144,17 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
             success= [manager removeItemAtPath:userDirectory error:&folderRemovalError];
             if (!success) {
                 [SFSDKCoreLogger d:[self class]
-                   format:@"Error removing the user folder for '%@': %@", user.userName, [folderRemovalError localizedDescription]];
+                   format:@"Error removing the user folder for '%@': %@", user.idData.username, [folderRemovalError localizedDescription]];
                 if (folderRemovalError && error) {
                     *error = folderRemovalError;
                 }
             }
         } else {
-            NSString *reason = [NSString stringWithFormat:@"User folder for user '%@' does not exist on the filesystem", user.userName];
+            NSString *reason = [NSString stringWithFormat:@"User folder for user '%@' does not exist on the filesystem", user.idData.username];
             NSError *ferror = [NSError errorWithDomain:SFUserAccountManagerErrorDomain
                                                   code:SFUserAccountManagerCannotReadDecryptedArchive
                                               userInfo:@{NSLocalizedDescriptionKey: reason}];
-            [SFSDKCoreLogger d:[self class] format:@"User folder for user '%@' does not exist on the filesystem.", user.userName];
+            [SFSDKCoreLogger d:[self class] format:@"User folder for user '%@' does not exist on the filesystem.", user.idData.username];
             if(error)
                 *error = ferror;
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementDetailViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementDetailViewController.m
@@ -26,7 +26,7 @@
 #import "SFDefaultUserManagementViewController+Internal.h"
 #import "SFUserAccountManager.h"
 #import "SFUserAccount.h"
-
+#import "SFIdentityData.h"
 static CGFloat const kButtonWidth = 150.0f;
 static CGFloat const kButtonHeight = 40.0f;
 static CGFloat const kButtonPadding = 10.0f;
@@ -70,14 +70,14 @@ static CGFloat const kControlVerticalPadding = 5.0f;
     
     // fullName label
     self.fullNameLabel = [[UILabel alloc] initWithFrame:CGRectZero];
-    self.fullNameLabel.text = _user.fullName;
+    self.fullNameLabel.text = [NSString stringWithFormat:@"%@ %@",_user.idData.firstName,_user.idData.lastName];
     self.fullNameLabel.textAlignment = NSTextAlignmentCenter;
     self.fullNameLabel.font = [UIFont systemFontOfSize:20.0];
     [self.view addSubview:self.fullNameLabel];
     
     // userName label
     self.userNameLabel = [[UILabel alloc] initWithFrame:CGRectZero];
-    self.userNameLabel.text = _user.userName;
+    self.userNameLabel.text = _user.idData.username;
     self.userNameLabel.textAlignment = NSTextAlignmentCenter;
     self.userNameLabel.font = [UIFont systemFontOfSize:16.0];
     [self.view addSubview:self.userNameLabel];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementListViewController.m
@@ -27,6 +27,7 @@
 #import "SFDefaultUserManagementDetailViewController.h"
 #import "SFUserAccountManager.h"
 #import "SFUserAccount.h"
+#import "SFIdentityData.h"
 
 @interface SFDefaultUserManagementListViewController ()
 {
@@ -160,8 +161,8 @@
     SFUserAccount *displayUser = (indexPath.section == 0 ?
                                   [SFUserAccountManager sharedInstance].currentUser :
                                   _userAccountList[indexPath.row]);
-    cell.textLabel.text = displayUser.fullName;
-    cell.detailTextLabel.text = displayUser.userName;
+    cell.textLabel.text = displayUser.idData.displayName;
+    cell.detailTextLabel.text = displayUser.idData.username;
     
 	cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
@@ -116,7 +116,7 @@ NS_SWIFT_NAME(UserAccount)
 
 /** The list of communities (as SFCommunityData item)
  */
-@property (nonatomic, copy, nullable) NSArray<SFCommunityData *> *communities;
+@property (nonatomic, copy, nullable) NSArray<SFCommunityData *> *communities SFSDK_DEPRECATED(7.1, 8.0, "Save these types of properties in your app.");
 
 /** Returns YES if the user has an access token and, presumably,
  a valid session.
@@ -150,7 +150,7 @@ NS_SWIFT_NAME(UserAccount)
  @param communityId The ID of the community
  @return The dictionary for the given community
  */
-- (nullable SFCommunityData*)communityWithId:(NSString*)communityId;
+- (nullable SFCommunityData*)communityWithId:(NSString*)communityId SFSDK_DEPRECATED(7.1, 8.0, "Store SFCommunityData in your app.");
 
 /** Set object in customData dictionary
  

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
@@ -25,12 +25,13 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "SFUserAccountConstants.h"
+#import "SFIdentityData.h"
+#import "SalesforceSDKConstants.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class SFCommunityData;
 @class SFUserAccountIdentity;
-@class SFIdentityData;
 @class SFOAuthCredentials;
 
 /**
@@ -84,19 +85,19 @@ NS_SWIFT_NAME(UserAccount)
 
 /** The user's email
  */
-@property (nonatomic, copy, nullable) NSString *email;
+@property (nonatomic, copy, nullable) NSString *email SFSDK_DEPRECATED(7.1, 8.0, "Use SFUserAccount.idData properties instead");
 
 /** The user's organization name
  */
-@property (nonatomic, copy) NSString *organizationName;
+@property (nonatomic, copy) NSString *organizationName SFSDK_DEPRECATED(7.1, 8.0, "Will be removed");
 
 /** The user's full name
  */
-@property (nonatomic, copy) NSString *fullName;
+@property (nonatomic, copy) NSString *fullName SFSDK_DEPRECATED(7.1, 8.0, "Use SFUserAccount.idData properties instead");
 
 /** The user's name
  */
-@property (nonatomic, copy) NSString *userName;
+@property (nonatomic, copy) NSString *userName SFSDK_DEPRECATED(7.1, 8.0, "Use SFUserAccount.idData properties instead");
 
 /** The user's photo. Usually store a thumbnail of the user.
  Note: the consumer of this class must set the photo at least once,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
@@ -190,12 +190,12 @@ NSString *_Nullable SFKeyForUserAndScope(SFUserAccount * _Nullable user, SFUserA
  @param scope The scope
  @return a key identifying this user account for the specified scope
  */
-NSString *_Nullable SFKeyForUserIdAndScope(NSString *userId,NSString *orgId, NSString *_Nullable communityId, SFUserAccountScope scope);
+NSString *_Nullable SFKeyForUserIdAndScope(NSString *_Nullable userId,NSString *_Nullable orgId, NSString *_Nullable communityId, SFUserAccountScope scope);
 
 /** Function that returns a key for scope SFUserAccountScopeGlobal,
   @return a key identifying this scope for the specified scope
  */
-NSString *SFKeyForGlobalScope();
+NSString *SFKeyForGlobalScope(void);
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
@@ -27,17 +27,12 @@
 #import "SFDirectoryManager.h"
 #import "SFOAuthCredentials.h"
 #import "SFCommunityData.h"
-#import "SFIdentityData.h"
 #import "SFSDKAppFeatureMarkers.h"
 #import "SFOAuthCredentials+Internal.h"
 #import "SFUserAccountIdentity+Internal.h"
 
 static NSString * const kUser_ACCESS_SCOPES       = @"accessScopes";
 static NSString * const kUser_CREDENTIALS         = @"credentials";
-static NSString * const kUser_EMAIL               = @"email";
-static NSString * const kUser_FULL_NAME           = @"fullName";
-static NSString * const kUser_ORGANIZATION_NAME   = @"organizationName";
-static NSString * const kUser_USER_NAME           = @"userName";
 static NSString * const kUser_COMMUNITY_ID        = @"communityId";
 static NSString * const kUser_COMMUNITIES         = @"communities";
 static NSString * const kUser_ID_DATA             = @"idData";
@@ -403,8 +398,8 @@ static NSString * const kGlobalScopingKey = @"-global-";
     NSString *theFullName = @"*****";
     
 #ifdef DEBUG
-    theUserName = self.userName;
-    theFullName = self.fullName;
+    theUserName = self.idData.username;
+    theFullName = [NSString stringWithFormat:@"%@ %@",self.idData.firstName,self.idData.lastName];
 #endif
     
     NSString * s = [NSString stringWithFormat:@"<SFUserAccount username=%@ fullName=%@ accessScopes=%@ credentials=%@, community=%@>",

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
@@ -186,10 +186,12 @@ static NSString * const kGlobalScopingKey = @"-global-";
         return nil;
     }
     __block NSURL *siteUrl = nil;
+    SFSDK_USE_DEPRECATED_BEGIN
     dispatch_sync(_syncQueue, ^{
         SFCommunityData *info = [self communityWithId:communityId];
         siteUrl = info.siteUrl;
     });
+    SFSDK_USE_DEPRECATED_END
     return siteUrl;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.m
@@ -29,6 +29,8 @@
 #import "SFCommunityData.h"
 #import "SFIdentityData.h"
 #import "SFSDKAppFeatureMarkers.h"
+#import "SFOAuthCredentials+Internal.h"
+#import "SFUserAccountIdentity+Internal.h"
 
 static NSString * const kUser_ACCESS_SCOPES       = @"accessScopes";
 static NSString * const kUser_CREDENTIALS         = @"credentials";
@@ -54,9 +56,7 @@ static NSString * const kGlobalScopingKey = @"-global-";
 {
     BOOL _observingCredentials;
     dispatch_queue_t _syncQueue;
-
 }
-
 @property (nonatomic, strong) NSMutableDictionary *customData;
 
 - (id)initWithCoder:(NSCoder*)decoder NS_DESIGNATED_INITIALIZER;
@@ -68,6 +68,9 @@ static NSString * const kGlobalScopingKey = @"-global-";
 @synthesize photo = _photo;
 @synthesize accountIdentity = _accountIdentity;
 @synthesize credentials = _credentials;
+@synthesize communities = _communities;
+@synthesize accessScopes = _accessScopes;
+@synthesize idData = _idData;
 
 + (NSSet*)keyPathsForValuesAffectingApiUrl {
     return [NSSet setWithObjects:@"communityId", @"credentials", nil];
@@ -84,10 +87,11 @@ static NSString * const kGlobalScopingKey = @"-global-";
 - (instancetype)initWithCredentials:(SFOAuthCredentials*) credentials {
     self = [super init];
     if (self) {
+        _syncQueue = dispatch_queue_create(kSyncQueue, DISPATCH_QUEUE_CONCURRENT);
         _observingCredentials = NO;
         self.credentials = credentials;
         _loginState = (credentials.refreshToken.length > 0 ? SFUserAccountLoginStateLoggedIn : SFUserAccountLoginStateNotLoggedIn);
-        _syncQueue = dispatch_queue_create(kSyncQueue, NULL);
+        _accountIdentity = [[SFUserAccountIdentity alloc] initWithUserId:_credentials.userId orgId:_credentials.organizationId];
         if (_loginState == SFUserAccountLoginStateLoggedIn) {
             [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureOAuth];
         }
@@ -97,198 +101,273 @@ static NSString * const kGlobalScopingKey = @"-global-";
 
 - (void)dealloc {
     if (_observingCredentials) {
-        [self.credentials removeObserver:self forKeyPath:kCredentialsUserIdPropName];
-        [self.credentials removeObserver:self forKeyPath:kCredentialsOrgIdPropName];
+        [_credentials removeObserver:self forKeyPath:kCredentialsUserIdPropName];
+        [_credentials removeObserver:self forKeyPath:kCredentialsOrgIdPropName];
     }
 }
 
 - (void)encodeWithCoder:(NSCoder*)encoder {
     [encoder encodeObject:_accessScopes forKey:kUser_ACCESS_SCOPES];
-    [encoder encodeObject:_email forKey:kUser_EMAIL];
-    [encoder encodeObject:_fullName forKey:kUser_FULL_NAME];
-    [encoder encodeObject:_organizationName forKey:kUser_ORGANIZATION_NAME];
-    [encoder encodeObject:_userName forKey:kUser_USER_NAME];
     [encoder encodeObject:_credentials forKey:kUser_CREDENTIALS];
     [encoder encodeObject:_idData forKey:kUser_ID_DATA];
     [encoder encodeObject:_communityId forKey:kUser_COMMUNITY_ID];
     [encoder encodeObject:_communities forKey:kUser_COMMUNITIES];
-    __weak __typeof(self) weakSelf = self;
-    dispatch_sync(_syncQueue, ^{
-        [encoder encodeObject:weakSelf.customData forKey:kUser_CUSTOM_DATA];
-    });
-    
+    [encoder encodeObject:_customData forKey:kUser_CUSTOM_DATA];
     [encoder encodeInteger:_accessRestrictions forKey:kUser_ACCESS_RESTRICTIONS];
 }
 
 - (id)initWithCoder:(NSCoder*)decoder {
-	self = [super init];
-	if (self) {
+    self = [super init];
+    if (self) {
+        _syncQueue = dispatch_queue_create(kSyncQueue, DISPATCH_QUEUE_CONCURRENT);
         _accessScopes     = [decoder decodeObjectOfClass:[NSSet class] forKey:kUser_ACCESS_SCOPES];
-        _email            = [decoder decodeObjectOfClass:[NSString class] forKey:kUser_EMAIL];
-        _fullName         = [decoder decodeObjectOfClass:[NSString class] forKey:kUser_FULL_NAME];
-        _credentials      = [decoder decodeObjectOfClass:[SFOAuthCredentials class] forKey:kUser_CREDENTIALS];
+         _accountIdentity = [[SFUserAccountIdentity alloc] init];
+        self.credentials      = [decoder decodeObjectOfClass:[SFOAuthCredentials class] forKey:kUser_CREDENTIALS];
         _idData           = [decoder decodeObjectOfClass:[SFIdentityData class] forKey:kUser_ID_DATA];
-        _organizationName = [decoder decodeObjectOfClass:[NSString class] forKey:kUser_ORGANIZATION_NAME];
-        _userName         = [decoder decodeObjectOfClass:[NSString class] forKey:kUser_USER_NAME];
         _communityId      = [decoder decodeObjectOfClass:[NSString class] forKey:kUser_COMMUNITY_ID];
         _communities      = [decoder decodeObjectOfClass:[NSArray class] forKey:kUser_COMMUNITIES];
         _customData       = [[decoder decodeObjectOfClass:[NSDictionary class] forKey:kUser_CUSTOM_DATA] mutableCopy];
         _accessRestrictions = [decoder decodeIntegerForKey:kUser_ACCESS_RESTRICTIONS];
         _loginState = (_credentials.refreshToken.length > 0 ? SFUserAccountLoginStateLoggedIn : SFUserAccountLoginStateNotLoggedIn);
-        _syncQueue = dispatch_queue_create(kSyncQueue, NULL);
         if (_loginState == SFUserAccountLoginStateLoggedIn) {
             [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureOAuth];
         }
-	}
-	return self;
+    }
+    return self;
 }
 
 - (SFUserAccountIdentity *)accountIdentity
 {
-    if (_accountIdentity == nil) {
-        _accountIdentity = [[SFUserAccountIdentity alloc] initWithUserId:self.credentials.userId orgId:self.credentials.organizationId];
-    }
-    
-    return _accountIdentity;
+    __block SFUserAccountIdentity *identity = nil;
+    dispatch_sync(_syncQueue, ^{
+        identity = self->_accountIdentity;
+    });
+    return identity;
 }
 
 - (NSURL*)apiUrl {
-    if (self.communityId) {
-        NSURL *communityUrl = [self communityUrlWithId:self.communityId];
-        if (communityUrl) {
-            return communityUrl;
-        }
+    NSString *communityId = _communityId;
+    __block NSURL *url = _credentials.apiUrl;
+    if (communityId) {
+        dispatch_sync(_syncQueue, ^{
+            NSURL *communityUrl = [self communityUrlWithId:communityId];
+            if (communityUrl) {
+                url =  communityUrl;
+            }
+        });
     }
-    return self.credentials.apiUrl;
+    return url;
+}
+
+- (NSString *)email {
+    __block NSString *email = nil;
+    SFIdentityData *data = _idData;
+    dispatch_sync(_syncQueue, ^{
+        email = data.email;
+    });
+    return email;
+}
+
+- (NSString *)fullName {
+    __block NSString *fullName = nil;
+    SFIdentityData *data = _idData;
+    dispatch_sync(_syncQueue, ^{
+        fullName = [NSString stringWithFormat:@"%@ %@",data.firstName,data.lastName];
+    });
+    return fullName;
+}
+
+- (NSString *)userName {
+    __block NSString *userName = nil;
+    SFIdentityData *data = _idData;
+    dispatch_sync(_syncQueue, ^{
+        userName = [NSString stringWithFormat:@"%@",data.username];
+    });
+    return userName;
 }
 
 - (NSURL*)communityUrlWithId:(NSString *)communityId {
     if (!communityId) {
         return nil;
     }
-    
-    SFCommunityData *info = [self communityWithId:communityId];
-    return info.siteUrl;
+    __block NSURL *siteUrl = nil;
+    dispatch_sync(_syncQueue, ^{
+        SFCommunityData *info = [self communityWithId:communityId];
+        siteUrl = info.siteUrl;
+    });
+    return siteUrl;
 }
 
 - (SFCommunityData*)communityWithId:(NSString*)communityId {
-    for (SFCommunityData *info in self.communities) {
-        if ([info.entityId isEqualToString:communityId]) {
-            return info;
+    if (!communityId || !_communities) return nil;
+    
+    __block SFCommunityData *communityData = nil;
+    __block  NSArray<SFCommunityData *> *communitiesCopy = [_communities copy];
+    dispatch_sync(_syncQueue, ^{
+        for (SFCommunityData *info in communitiesCopy) {
+            if ([info.entityId isEqualToString:communityId]) {
+                communityData = info;
+                break;
+            }
         }
-    }
-    return nil;
+    });
+    return communityData;
+}
+
+- (NSArray<SFCommunityData *> *)communities {
+    __block NSArray<SFCommunityData *> *communitiesLocal = nil;
+    dispatch_sync(_syncQueue, ^{
+        communitiesLocal = self->_communities;
+    });
+    return communitiesLocal;
+}
+
+- (void)setCommunities:(NSArray<SFCommunityData *> *)communities {
+    dispatch_barrier_async(_syncQueue, ^{
+        self->_communities = communities;
+    });
+}
+
+- (void)setAccessScopes:(NSSet<NSString *> *)accessScopes {
+    dispatch_barrier_async(_syncQueue, ^{
+        self->_accessScopes = accessScopes;
+    });
 }
 
 /** Returns the path to the user's photo.
  */
 - (NSString*)photoPath {
-    NSString *userPhotoPath = [[SFDirectoryManager sharedManager] directoryForUser:self type:NSLibraryDirectory components:@[@"mobilesdk", @"photos"]];
+    __block NSString *userPhotoPath = nil;
+    dispatch_sync(_syncQueue, ^{
+        userPhotoPath = [self photoPathInternal];
+    });
+    return userPhotoPath;
+}
+
+- (NSString *)photoPathInternal {
+    NSString *userPhotoPath =  [[SFDirectoryManager sharedManager] directoryForOrg:_credentials.organizationId user:_credentials.userId  community:_communityId?:kDefaultCommunityName type:NSLibraryDirectory components:@[@"mobilesdk", @"photos"]];
     [SFDirectoryManager ensureDirectoryExists:userPhotoPath error:nil];
-    return [userPhotoPath stringByAppendingPathComponent:[SFDirectoryManager safeStringForDiskRepresentation:self.credentials.userId]];
+    return [userPhotoPath stringByAppendingPathComponent:[SFDirectoryManager safeStringForDiskRepresentation:_credentials.userId]];
 }
 
 - (UIImage*)photo {
     if (nil == _photo) {
-        NSString *photoPath = [self photoPath];
-        NSFileManager *manager = [[NSFileManager alloc] init];
-        if ([manager fileExistsAtPath:photoPath]) {
-            _photo = [[UIImage alloc] initWithContentsOfFile:photoPath];
-        }
+        __weak __typeof(self) weakSelf = self;
+        dispatch_sync(_syncQueue, ^{
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            NSString *photoPath = [strongSelf photoPathInternal];
+            NSFileManager *manager = [[NSFileManager alloc] init];
+            if ([manager fileExistsAtPath:photoPath]) {
+                strongSelf->_photo = [[UIImage alloc] initWithContentsOfFile:photoPath];
+            }
+        });
     }
     return _photo;
 }
 
 - (void)setPhoto:(UIImage *)photo {
-    NSError *error = nil;
-    NSString *photoPath = [self photoPath];
-    if (photoPath) {
-        NSFileManager *fm = [NSFileManager defaultManager];
-        if ([fm fileExistsAtPath:photoPath]) {
-            if (![fm removeItemAtPath:photoPath error:&error]) {
-                [SFSDKCoreLogger e:[self class] format:@"Unable to remove previous photo from disk: %@", error];
+    dispatch_barrier_async(_syncQueue, ^{
+        NSError *error = nil;
+        NSString *photoPath = [self photoPathInternal];
+        if (photoPath) {
+            NSFileManager *fm = [NSFileManager defaultManager];
+            if ([fm fileExistsAtPath:photoPath]) {
+                if (![fm removeItemAtPath:photoPath error:&error]) {
+                    [SFSDKCoreLogger e:[self class] format:@"Unable to remove previous photo from disk: %@", error];
+                }
             }
+            NSData *data = UIImagePNGRepresentation(photo);
+            if (![data writeToFile:photoPath options:NSDataWritingAtomic error:&error]) {
+                [SFSDKCoreLogger e:[self class] format:@"Unable to write photo to disk: %@", error];
+            }
+            [self willChangeValueForKey:@"photo"];
+            self->_photo = photo;
+            [self didChangeValueForKey:@"photo"];
         }
-        NSData *data = UIImagePNGRepresentation(photo);
-        if (![data writeToFile:photoPath options:NSDataWritingAtomic error:&error]) {
-            [SFSDKCoreLogger e:[self class] format:@"Unable to write photo to disk: %@", error];
-        }
-        
-        [self willChangeValueForKey:@"photo"];
-        _photo = photo;
-        [self didChangeValueForKey:@"photo"];
-    }
+    });
+}
+
+- (SFIdentityData *) idData{
+    __block SFIdentityData *idData = nil;
+    dispatch_sync(_syncQueue, ^{
+        idData = self->_idData;
+    });
+    return idData;
 }
 
 - (void)setIdData:(SFIdentityData *)idData {
-    if (idData != _idData) {
-        _idData = idData;
-    }
-    
-    // Set other account properties from latest identity data.
-    self.fullName = idData.displayName;
-    self.email = idData.email;
-    self.userName = idData.username;
+    dispatch_barrier_async(_syncQueue, ^{
+        if (idData != self->_idData) {
+            self->_idData = idData;
+        }
+    });
+}
+
+- (SFOAuthCredentials *)credentials {
+    __block SFOAuthCredentials *creds = nil;
+    dispatch_sync(_syncQueue, ^{
+        creds = self->_credentials;
+    });
+    return creds;
 }
 
 - (void)setCredentials:(SFOAuthCredentials *)credentials
 {
-    if (credentials != _credentials) {
-        if (_observingCredentials) {
-            [_credentials removeObserver:self forKeyPath:kCredentialsUserIdPropName];
-            [_credentials removeObserver:self forKeyPath:kCredentialsOrgIdPropName];
-            _observingCredentials = NO;
+    SFOAuthCredentials *currentCredentials = _credentials;
+    SFUserAccountIdentity *accIdentity =  _accountIdentity;
+    dispatch_barrier_async(_syncQueue, ^{
+        if (credentials != currentCredentials) {
+            if (self->_observingCredentials) {
+                [currentCredentials removeObserver:self  forKeyPath:kCredentialsUserIdPropName];
+                [currentCredentials removeObserver:self  forKeyPath:kCredentialsOrgIdPropName];
+                self->_observingCredentials = NO;
+            }
+            if (credentials != nil) {
+                [credentials addObserver:self forKeyPath:kCredentialsUserIdPropName options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) context:NULL];
+                [credentials addObserver:self forKeyPath:kCredentialsOrgIdPropName options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) context:NULL];
+                self->_observingCredentials = YES;
+            }
+            self->_credentials = credentials;
+            if (accIdentity) {
+                accIdentity.userId = credentials.userId;
+                accIdentity.orgId =  credentials.organizationId;
+            }
         }
-        if (credentials != nil) {
-            [credentials addObserver:self forKeyPath:kCredentialsUserIdPropName options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) context:NULL];
-            [credentials addObserver:self forKeyPath:kCredentialsOrgIdPropName options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) context:NULL];
-            _observingCredentials = YES;
-        }
-        
-        _credentials = credentials;
-        self.accountIdentity.userId = _credentials.userId;
-        self.accountIdentity.orgId = _credentials.organizationId;
-    }
+    });
 }
 
 - (void)setCustomDataObject:(id<NSCoding>)object forKey:(id<NSCopying>)key {
-    __weak __typeof(self) weakSelf = self;
-    dispatch_sync(_syncQueue, ^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        if(!strongSelf.customData) {
-            strongSelf.customData = [NSMutableDictionary dictionary];
+    dispatch_barrier_async(_syncQueue, ^{
+        if(!self->_customData) {
+            self->_customData = [NSMutableDictionary dictionary];
         }
-        [strongSelf.customData setObject:object forKey:key];
+        [self->_customData setObject:object forKey:key];
     });
 }
 
 - (void)removeCustomDataObjectForKey:(id)key {
-    __weak __typeof(self) weakSelf = self;
-    dispatch_sync(_syncQueue, ^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        if(!strongSelf.customData) {
-            strongSelf.customData = [NSMutableDictionary dictionary];
+    dispatch_barrier_async(_syncQueue, ^{
+        if(!self->_customData) {
+            self->_customData = [NSMutableDictionary dictionary];
         }
-        [strongSelf.customData removeObjectForKey:key];
+        [self->_customData removeObjectForKey:key];
     });
 }
 
 - (id)customDataObjectForKey:(id)key {
-    __weak __typeof(self) weakSelf = self;
     __block id object;
-    dispatch_sync(_syncQueue, ^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        if(!strongSelf.customData) {
-            strongSelf.customData = [NSMutableDictionary dictionary];
+    dispatch_barrier_sync(_syncQueue, ^{
+        if(!self->_customData) {
+            self->_customData = [NSMutableDictionary dictionary];
         }
-        object = [strongSelf.customData objectForKey:key];
+        object = [self->_customData objectForKey:key];
     });
     return object;
 }
 
 - (BOOL)transitionToLoginState:(SFUserAccountLoginState)newLoginState {
     __block BOOL transitionSucceeded;
-    dispatch_sync(_syncQueue, ^{
+    dispatch_barrier_sync(_syncQueue, ^{
         switch (newLoginState) {
             case SFUserAccountLoginStateLoggedIn:
                 transitionSucceeded = (self.loginState == SFUserAccountLoginStateNotLoggedIn || self.loginState == SFUserAccountLoginStateLoggedIn);
@@ -312,10 +391,9 @@ static NSString * const kGlobalScopingKey = @"-global-";
 }
 
 - (BOOL)isSessionValid {
-
     // A session is considered "valid" when the user
     // has an access token as well as the identity data
-    return self.credentials.accessToken != nil && self.idData != nil;
+    return _credentials.accessToken != nil && _idData != nil;
 }
 
 
@@ -330,7 +408,7 @@ static NSString * const kGlobalScopingKey = @"-global-";
 #endif
     
     NSString * s = [NSString stringWithFormat:@"<SFUserAccount username=%@ fullName=%@ accessScopes=%@ credentials=%@, community=%@>",
-                    theUserName, theFullName, self.accessScopes, self.credentials, self.communityId];
+                    theUserName, theFullName, _accessScopes, _credentials, _communityId];
     return s;
 }
 
@@ -355,8 +433,8 @@ NSString *SFKeyForUserAndScope(SFUserAccount *user, SFUserAccountScope scope) {
     return  SFKeyForUserIdAndScope(user.credentials.userId,user.credentials.organizationId,user.credentials.communityId,scope);
 }
 
-NSString *SFKeyForUserIdAndScope(NSString *userId,NSString *orgId, NSString *communityId, SFUserAccountScope scope) {
-    NSString *key = nil;
+NSString *SFKeyForUserIdAndScope(NSString *userId,NSString *orgId,NSString *communityId, SFUserAccountScope scope) {
+    NSString *key = @"";
     switch (scope) {
         case SFUserAccountScopeGlobal:
             key = kGlobalScopingKey;
@@ -384,18 +462,11 @@ NSString *SFKeyForUserIdAndScope(NSString *userId,NSString *orgId, NSString *com
     return key;
 }
 
-#pragma mark - Credentials property changes
-// Disable automatic KVO notificaiton for the photo property, as we implement manual KVO in setPhoto
-+ (BOOL)automaticallyNotifiesObserversForKey:(NSString *)key {
-    if ([key isEqualToString:@"photo"]) {
-        return NO;
-    }
-    return YES;
-}
+//#pragma mark - Credentials property changes
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    if (!(object == self.credentials && ([keyPath isEqualToString:kCredentialsUserIdPropName] || [keyPath isEqualToString:kCredentialsOrgIdPropName]))) {
+    if (!(object == _credentials && ([keyPath isEqualToString:kCredentialsUserIdPropName] || [keyPath isEqualToString:kCredentialsOrgIdPropName]))) {
         return;
     }
     
@@ -403,11 +474,11 @@ NSString *SFKeyForUserIdAndScope(NSString *userId,NSString *orgId, NSString *com
     NSString *newKey = change[NSKeyValueChangeNewKey];
     if ([oldKey isEqual:[NSNull null]]) oldKey = nil;
     if ([newKey isEqual:[NSNull null]]) newKey = nil;
-    
+    SFUserAccountIdentity *identity = _accountIdentity;
     if ([keyPath isEqualToString:kCredentialsUserIdPropName]) {
-        self.accountIdentity.userId = newKey;
+        identity.userId = newKey;
     } else if ([keyPath isEqualToString:kCredentialsOrgIdPropName]) {
-        self.accountIdentity.orgId = newKey;
+        identity.orgId = newKey;
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity+Internal.h
@@ -1,0 +1,38 @@
+/*
+ SFUserAccountIdentity+Internal.h
+ SalesforceSDKCore
+ 
+ Created by Raj Rao on 2/5/19.
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SFUserAccountIdentity ()
+
+@property (nonatomic, readwrite, nonnull) NSString *userId;
+@property (nonatomic, readwrite, nonnull) NSString *orgId;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity.h
@@ -37,12 +37,12 @@ NS_SWIFT_NAME(UserAccountIdentity)
 /**
  The user ID associated with the account.
  */
-@property (nonatomic, copy, nonnull) NSString *userId;
+@property (nonatomic, readonly, nonnull) NSString *userId;
 
 /**
  The organization ID associated with the account.
  */
-@property (nonatomic, copy, nonnull) NSString *orgId;
+@property (nonatomic, readonly, nonnull) NSString *orgId;
 
 /**
  Convenience method to return a new account identity with the given User ID and Org ID.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountIdentity.m
@@ -22,10 +22,9 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "SFUserAccountIdentity.h"
+#import "SFUserAccountIdentity+Internal.h"
 #import "SFUserAccount.h"
 #import "NSString+SFAdditions.h"
-#import "SFOAuthCredentials.h"
 
 static NSString * const kUserAccountIdentityUserIdKey = @"userIdKey";
 static NSString * const kUserAccountIdentityOrgIdKey = @"orgIdKey";
@@ -49,8 +48,8 @@ static NSString * const kUserAccountIdentityOrgIdKey = @"orgIdKey";
 {
     self = [super init];
     if (self) {
-        self.userId = userId;
-        self.orgId = orgId;
+        _userId = userId;
+        _orgId = orgId;
     }
     return self;
 }
@@ -76,8 +75,8 @@ static NSString * const kUserAccountIdentityOrgIdKey = @"orgIdKey";
 {
     self = [super init];
     if (self) {
-        self.userId = [aDecoder decodeObjectOfClass:[NSString class] forKey:kUserAccountIdentityUserIdKey];
-        self.orgId = [aDecoder decodeObjectOfClass:[NSString class] forKey:kUserAccountIdentityOrgIdKey];
+        _userId = [aDecoder decodeObjectOfClass:[NSString class] forKey:kUserAccountIdentityUserIdKey];
+        _orgId = [aDecoder decodeObjectOfClass:[NSString class] forKey:kUserAccountIdentityOrgIdKey];
     }
     
     return self;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+URLHandlers.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+URLHandlers.m
@@ -40,6 +40,7 @@
 #import "SFSDKAlertMessage.h"
 #import "SFSDKAlertMessageBuilder.h"
 #import "SFSDKStartURLHandler.h"
+#import "SFOAuthCredentials+Internal.h"
 @implementation SFUserAccountManager (URLHandlers)
 
 - (BOOL)handleNativeAuthResponse:(NSURL *_Nonnull)appUrlResponse options:(NSDictionary *_Nullable)options {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -1006,6 +1006,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
         SFCommunityData *communityData = [[SFCommunityData alloc] init];
         communityData.entityId = credentials.communityId;
         communityData.siteUrl = credentials.communityUrl;
+        SFSDK_USE_DEPRECATED_BEGIN
         if (![currentAccount communityWithId:credentials.communityId]) {
             if (currentAccount.communities) {
                 currentAccount.communities = [currentAccount.communities arrayByAddingObject:communityData];
@@ -1013,6 +1014,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
                 currentAccount.communities = @[communityData];
             }
         }
+        SFSDK_USE_DEPRECATED_END
     }
 
     [self saveAccountForUser:currentAccount error:nil];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -332,7 +332,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
         return;
     }
 
-    [SFSDKCoreLogger d:[self class] format:@"Logging out user '%@'.", user.userName];
+    [SFSDKCoreLogger d:[self class] format:@"Logging out user '%@'.", user.idData.username];
     
     //save for use with didLogout notification
     NSString *userId = user.credentials.userId;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -670,7 +670,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 }
 
 -(NSMutableDictionary *)userAccountMap {
-    if(!_userAccountMap || _userAccountMap.count < 1) {
+    if(!_userAccountMap) {
         [self reload];
     }
     return _userAccountMap;
@@ -823,8 +823,11 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 
     NSError *internalError = nil;
     NSDictionary<SFUserAccountIdentity *,SFUserAccount *> *accounts = [self.accountPersister fetchAllAccounts:&internalError];
-    [_userAccountMap removeAllObjects];
-    _userAccountMap = [NSMutableDictionary  dictionaryWithDictionary:accounts];
+    
+    if (_userAccountMap)
+        [_userAccountMap removeAllObjects];
+    
+    _userAccountMap = [NSMutableDictionary dictionaryWithDictionary:accounts];
 
     if (internalError)
         success = NO;
@@ -895,7 +898,8 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 - (void)clearAllAccountState {
     [_accountsLock lock];
     _currentUser = nil;
-    [self.userAccountMap removeAllObjects];
+    [_userAccountMap removeAllObjects];
+    _userAccountMap = nil;
     [[SFSDKOAuthClientCache sharedInstance] removeAllClients];
     [_accountsLock unlock];
 }
@@ -1082,7 +1086,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
         [self notifyUserChange:SFUserAccountManagerDidChangeUserNotification withUser:_currentUser andChange:SFUserAccountChangeCurrentUser];
 }
 
--(SFUserAccountIdentity *) currentUserIdentity {
+- (SFUserAccountIdentity *)currentUserIdentity {
     SFUserAccountIdentity *accountIdentity = nil;
     [_accountsLock lock];
     if (!_currentUser) {
@@ -1546,12 +1550,6 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 
     if(!_accountPersister)
         _accountPersister = [SFDefaultUserAccountPersister new];
-
-    if (!_userAccountMap)
-        _userAccountMap = [NSMutableDictionary new];
-    else
-        [_userAccountMap removeAllObjects];
-
     [self loadAccounts:nil];
     [_accountsLock unlock];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
@@ -29,7 +29,7 @@
 #import "SFUserAccount.h"
 #import "SFSDKTestRequestListener.h"
 #import "SFSDKTestCredentialsData.h"
-
+#import "SFOAuthCredentials+Internal.h"
 
 static SFOAuthCredentials *credentials = nil;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.h
@@ -40,6 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
                 <internal> : internal community or base org
                 [<communityId>]* : zero or more community specific folder
  */
+
+FOUNDATION_EXTERN NSString * const kDefaultCommunityName NS_SWIFT_NAME(SFDirectoryManager.defaultCommunityName);
+
 @interface SFDirectoryManager : NSObject
 
 /** Returns the singleton of this manager

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
@@ -29,7 +29,7 @@
 #import <SalesforceSDKCommon/SFSDKDatasharingHelper.h>
 
 static NSString * const kDefaultOrgName = @"org";
-static NSString * const kDefaultCommunityName = @"internal";
+NSString * const kDefaultCommunityName = @"internal";
 static NSString * const kSharedLibraryLocation = @"Library";
 static NSString * const kFilesSharedKey = @"filesShared";
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorFlowTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorFlowTests.m
@@ -27,6 +27,9 @@
 #import "SFOAuthCoordinator+Internal.h"
 #import "SFOAuthTestFlow.h"
 #import "SFOAuthTestFlowCoordinatorDelegate.h"
+#import "SFOAuthCredentials+Internal.h"
+#import "SFUserAccount+Internal.h"
+#import "SFUserAccountIdentity+Internal.h"
 
 @interface SFOAuthCoordinatorFlowTests : XCTestCase
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
@@ -27,6 +27,8 @@
 #import "SFOAuthSessionRefresher+Internal.h"
 #import "SFOAuthCoordinator+Internal.h"
 #import "SFOAuthTestFlow.h"
+#import "SFUserAccount+Internal.h"
+#import "SFOAuthCredentials+Internal.h"
 
 @interface SFOAuthSessionRefresherTests : XCTestCase
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPreferencesTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPreferencesTests.m
@@ -27,7 +27,9 @@
 #import "SFUserAccount.h"
 #import "SFUserAccountManager+Internal.h"
 #import "SFDirectoryManager.h"
-
+#import "SFUserAccount+Internal.h"
+#import "SFUserAccountIdentity+Internal.h"
+#import "SFOAuthCredentials+Internal.h"
 /** Class that tests the various scoped preferences
  */
 @interface SFPreferencesTests : XCTestCase
@@ -50,7 +52,7 @@
 
 - (void)testOrgLevelPreferences {
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"happy-user" clientId:[SFUserAccountManager  sharedInstance].oauthClientId encrypted:YES];
-    SFUserAccount *user =[[SFUserAccount alloc] initWithCredentials:credentials];
+    SFUserAccount *user = [[SFUserAccount alloc] initWithCredentials:credentials];
     NSError *error = nil;
     BOOL success = [[SFUserAccountManager sharedInstance] saveAccountForUser:user error:&error];
     XCTAssertNil(error, @"Should be able to create user account");

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPushNotificationManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPushNotificationManagerTests.m
@@ -30,7 +30,8 @@
 #import "SFUserAccountManager.h"
 #import "SFIdentityData.h"
 #import "SFPreferences.h"
-
+#import "SFUserAccount+Internal.h"
+#import "SFOAuthCredentials+Internal.h"
 // needs to match what is defined in SFPushNotificationManager
 static NSString* const kSFDeviceSalesforceId = @"deviceSalesforceId";
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
@@ -34,6 +34,9 @@
 #import "SFOAuthCoordinator+Internal.h"
 #import "SFSDKOAuthClientCache.h"
 #import "SFUserAccountManager+Internal.h"
+#import "SFUserAccount+Internal.h"
+#import "SFOAuthCredentials+Internal.h"
+
 @class SFSDKTestOAuthClient;
 
 @interface SFSDKTestOAuthClient : SFSDKOAuthClient

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthConfigUtilTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthConfigUtilTests.m
@@ -30,6 +30,8 @@
 #import "SFSDKAuthConfigUtil.h"
 #import "TestSetupUtils.h"
 #import "SFUserAccountManager.h"
+#import "SFUserAccount+Internal.h"
+#import "SFOAuthCredentials+Internal.h"
 
 static NSString * const kSFTestId = @"test_id";
 static NSString * const kSFTestClientId = @"test_client_id";

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKErrorManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKErrorManagerTests.m
@@ -26,6 +26,7 @@
 #import "SFOAuthInfo.h"
 #import "SFOAuthCoordinator.h"
 #import "SFUserAccountManager+Internal.h"
+#import "SFOAuthCredentials+Internal.h"
 @interface SFSDKErrorManagerTests : XCTestCase {
     SFUserAccount *_origCurrentUser;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerPersisterTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerPersisterTests.m
@@ -27,6 +27,9 @@
 #import "SFDefaultUserAccountPersister.h"
 #import "SFUserAccountPersisterEphemeral.h"
 #import "SFUserAccountManager+Internal.h"
+#import "SFUserAccountIdentity+Internal.h"
+#import "SFUserAccount+Internal.h"
+#import "SFOAuthCredentials+Internal.h"
 
 static NSString * const kUserIdFormatString = @"005R0000000Dsl%lu";
 static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -30,6 +30,7 @@
 #import "SFDefaultUserAccountPersister.h"
 #import "SFSDKOAuthClient.h"
 #import "SFSDKOAuthClientConfig.h"
+#import "SFOAuthCredentials+Internal.h"
 
 static NSString * const kUserIdFormatString = @"005R0000000Dsl%lu";
 static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
@@ -165,7 +165,6 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     NSURL *identityUrlToCheck = [NSURL URLWithString:@"https://login.salesforce.com/id/someOrg/someUser"];
     NSString *userIdToCheck = @"userID";
     NSDictionary *additionalFieldsToCheck = @{ @"field1": @"field1Val" };
-    NSDictionary *legacyIdInfoToCheck = @{ @"idInfo1": @"idInfo1Val" };
     
     SFOAuthCredentials *origCreds = [[SFOAuthCredentials alloc] initWithIdentifier:kIdentifier clientId:kClientId encrypted:YES];
     origCreds.domain = domainToCheck;
@@ -185,7 +184,6 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     origCreds.userId = userIdToCheck;
     
     origCreds.additionalOAuthFields = additionalFieldsToCheck;
-    origCreds.legacyIdentityInformation = legacyIdInfoToCheck;
     
     SFOAuthCredentials *copiedCreds = [origCreds copy];
     
@@ -202,7 +200,6 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     origCreds.identityUrl = nil;
     origCreds.userId = nil;
     origCreds.additionalOAuthFields = nil;
-    origCreds.legacyIdentityInformation = nil;
     
     XCTAssertNotEqual(origCreds, copiedCreds);
     XCTAssertEqual(copiedCreds.domain, domainToCheck);
@@ -234,8 +231,6 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     XCTAssertNotEqual(origCreds.userId, copiedCreds.userId);
     XCTAssertEqual(copiedCreds.additionalOAuthFields, additionalFieldsToCheck);
     XCTAssertNotEqual(origCreds.additionalOAuthFields, copiedCreds.additionalOAuthFields);
-    XCTAssertEqual(copiedCreds.legacyIdentityInformation, legacyIdInfoToCheck);
-    XCTAssertNotEqual(origCreds.legacyIdentityInformation, copiedCreds.legacyIdentityInformation);
 }
 
 /** Test the SFOAuthCoordinator

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -28,7 +28,7 @@
 #import "SFRestRequest+Internal.h"
 #import "SFNativeRestRequestListener.h"
 #import "SFUserAccount+Internal.h"
- 
+#import "SFOAuthCredentials+Internal.h"
  // Constants only used in the tests below
 #define ENTITY_PREFIX_NAME @"RestClientTestsiOS"
 #define ACCOUNT @"Account"

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
@@ -30,6 +30,7 @@
 #import "SFSDKSalesforceAnalyticsManager.h"
 #import "SFSDKAppConfig.h"
 #import "SFUserAccount+Internal.h"
+#import "SFOAuthCredentials+Internal.h"
 
 static NSTimeInterval const kTimeDelaySecsBetweenLaunchSteps = 0.5;
 static NSString* const kTestAppName = @"OverridenAppName";

--- a/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
@@ -27,6 +27,10 @@
  */
 
 #import "SFMultipleSmartStoresTest.h"
+@interface SFOAuthCredentials ()
+@property (nonatomic, readwrite, nullable) NSURL *identityUrl;
+
+@end
 @interface SFMultipleSmartStoresTests()
 
 @property (nonatomic, strong) SFUserAccount *smartStoreUser;

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
@@ -28,7 +28,10 @@
 #import "SFSoupIndex.h"
 #import "SFQuerySpec.h"
 #import <SalesforceSDKCommon/SFJsonUtils.h>
+@interface SFOAuthCredentials ()
+@property (nonatomic, readwrite, nullable) NSURL *identityUrl;
 
+@end
 @interface SFSmartSqlTests ()
 
 @property (nonatomic, strong) SFSmartStore *store;

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
@@ -28,7 +28,10 @@
 #import "SFSmartStore+Internal.h"
 #import "FMDatabaseQueue.h"
 #import "FMDatabase.h"
+@interface SFOAuthCredentials ()
+@property (nonatomic, readwrite, nullable) NSURL *identityUrl;
 
+@end
 @implementation SFSmartStoreTestCase
 
 #pragma mark - helper methods for comparing json

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/RootViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/RootViewController.swift
@@ -109,6 +109,13 @@ class RootViewController: UIViewController {
     fileprivate var responseContractedTopConstraint:NSLayoutConstraint!
     fileprivate var responseExpandedTopConstraint:NSLayoutConstraint!
     
+    fileprivate var fullName: String {
+        if let currentAccount = UserAccountManager.shared.currentUserAccount, let id =  currentAccount.idData  {
+            return (id.firstName ?? "") + " " + (id.lastName)
+        }
+        return ""
+    }
+    
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
@@ -753,7 +760,8 @@ extension RootViewController: ActionTableViewDelegate {
                         }
                         request = restApi.request(forSearch: s)
                     case .searchScopeAndOrder:
-                        request = restApi.requestForSearchScopeAndOrder()                    case .searchResultLayout:
+                        request = restApi.requestForSearchScopeAndOrder()
+                    case .searchResultLayout:
                         guard let objList = objectList else {
                             self.showMissingFieldError(objectTypes)
                             return
@@ -810,11 +818,10 @@ extension RootViewController: ActionTableViewDelegate {
                         request = restApi.request(forDeleteFileShare: objId)
                     case .currentUserInfo:
                         guard let currentAccount = UserAccountManager.shared.currentUserAccount else {return}
-                        var userInfoString = "Name: " + currentAccount.fullName
-                        userInfoString = userInfoString + "\nID: " + currentAccount.userName
-                        if let e = currentAccount.email {
-                            userInfoString = userInfoString + "\nEmail: " + e
-                        }
+                        guard let idData = currentAccount.idData else {return}
+                        var userInfoString = "Name: " + self.fullName
+                        userInfoString = userInfoString + "\nID: " + idData.username
+                        userInfoString = userInfoString + "\nEmail: " + idData.email
                         self.showAlert("User Info", message:userInfoString)
                         return
                     case .enableBiometric:


### PR DESCRIPTION
This PR attempts to make read-write(s) to UserAccount Thread Safe.

1. SFUserAccount thread safety is implemented using dispatch barrier.
2. Made SFUserAccountIdentity and SFOAuthCredential properties readOnly for public apis.
3. Some SFUserAccountProperties are backed by credentials and identity, the rest are Deprecated. 
 
