### PR TITLE
Using constructors instead of factory methods in SFBatchingSyncUpTarget

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/SFBatchingSyncUpTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/SFBatchingSyncUpTarget.h
@@ -34,12 +34,15 @@ NS_SWIFT_NAME(BatchingSyncUpTarget)
  */
 @interface SFBatchingSyncUpTarget : SFSyncUpTarget <SFAdvancedSyncUpTarget>
 
-/** Factory methods
+/** Constructor
  */
+- (instancetype)initWithCreateFieldlist:(nullable NSArray *)createFieldlist
+                        updateFieldlist:(nullable NSArray *)updateFieldlist
+                           maxBatchSize:(nullable NSNumber *)maxBatchSize;
+ 
 
-+ (instancetype)newSyncTargetWithCreateFieldlist:(nullable NSArray *)createFieldlist
-                                 updateFieldlist:(nullable NSArray *)updateFieldList
-                                    maxBatchSize:(nullable NSNumber*)maxBatchSize;
+/** Factory method
+ */
 
 + (instancetype)newFromDict:(nullable NSDictionary *)dict;
 

--- a/libs/SmartSync/SmartSync/Classes/SFBatchingSyncUpTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/SFBatchingSyncUpTarget.h
@@ -36,8 +36,8 @@ NS_SWIFT_NAME(BatchingSyncUpTarget)
 
 /** Constructor
  */
-- (instancetype)initWithCreateFieldlist:(nullable NSArray *)createFieldlist
-                        updateFieldlist:(nullable NSArray *)updateFieldlist
+- (instancetype)initWithCreateFieldlist:(nullable NSArray<NSString*> *)createFieldlist
+                        updateFieldlist:(nullable NSArray<NSString*> *)updateFieldlist
                            maxBatchSize:(nullable NSNumber *)maxBatchSize;
  
 

--- a/libs/SmartSync/SmartSync/Classes/SFBatchingSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/SFBatchingSyncUpTarget.m
@@ -54,13 +54,13 @@ static NSUInteger const kSFMaxSubRequestsCompositeAPI = 25;
     return [self initWithCreateFieldlist:nil updateFieldlist:nil maxBatchSize:nil];
 }
 
-- (instancetype)initWithCreateFieldlist:(nullable NSArray *)createFieldlist
-                        updateFieldlist:(nullable NSArray *)updateFieldlist {
+- (instancetype)initWithCreateFieldlist:(nullable NSArray<NSString*> *)createFieldlist
+                        updateFieldlist:(nullable NSArray<NSString*> *)updateFieldlist {
     return [self initWithCreateFieldlist:nil updateFieldlist:nil maxBatchSize:nil];
 }
 
-- (instancetype)initWithCreateFieldlist:(NSArray *)createFieldlist
-                        updateFieldlist:(NSArray *)updateFieldlist
+- (instancetype)initWithCreateFieldlist:(NSArray<NSString*> *)createFieldlist
+                        updateFieldlist:(NSArray<NSString*> *)updateFieldlist
                            maxBatchSize:(NSNumber*)maxBatchSize;
 {
     self = [super initWithCreateFieldlist:createFieldlist updateFieldlist:updateFieldlist];

--- a/libs/SmartSync/SmartSync/Classes/SFBatchingSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/SFBatchingSyncUpTarget.m
@@ -54,6 +54,11 @@ static NSUInteger const kSFMaxSubRequestsCompositeAPI = 25;
     return [self initWithCreateFieldlist:nil updateFieldlist:nil maxBatchSize:nil];
 }
 
+- (instancetype)initWithCreateFieldlist:(nullable NSArray *)createFieldlist
+                        updateFieldlist:(nullable NSArray *)updateFieldlist {
+    return [self initWithCreateFieldlist:nil updateFieldlist:nil maxBatchSize:nil];
+}
+
 - (instancetype)initWithCreateFieldlist:(NSArray *)createFieldlist
                         updateFieldlist:(NSArray *)updateFieldlist
                            maxBatchSize:(NSNumber*)maxBatchSize;
@@ -67,14 +72,7 @@ static NSUInteger const kSFMaxSubRequestsCompositeAPI = 25;
     return self;
 }
 
-#pragma mark - Factory methods
-                             
-+ (instancetype)newSyncTargetWithCreateFieldlist:(NSArray *)createFieldlist
-                                 updateFieldlist:(NSArray *)updateFieldList
-                                    maxBatchSize:(NSNumber*)maxBatchSize {
-
-    return [[SFBatchingSyncUpTarget alloc] initWithCreateFieldlist:createFieldlist updateFieldlist:updateFieldList maxBatchSize:maxBatchSize];
-}
+#pragma mark - Factory method
 
 + (instancetype)newFromDict:(NSDictionary *)dict {
     return [[SFBatchingSyncUpTarget alloc] initWithDict:dict];

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.h
@@ -114,12 +114,12 @@ NS_SWIFT_NAME(SyncUpTarget)
 /**
  Create field list (optional)
  */
-@property (nonatomic, strong, readonly) NSArray*  createFieldlist;
+@property (nonatomic, strong, readonly) NSArray<NSString*>*  createFieldlist;
 
 /**
  Update field list (optional)
  */
-@property (nonatomic, strong, readonly) NSArray*  updateFieldlist;
+@property (nonatomic, strong, readonly) NSArray<NSString*>*  updateFieldlist;
 
 /**
  Creates a new instance of a server target from a serialized dictionary.
@@ -144,8 +144,8 @@ NS_SWIFT_NAME(SyncUpTarget)
 /**
  * Constructor
  */
-- (instancetype)initWithCreateFieldlist:(nullable NSArray *)createFieldlist
-                        updateFieldlist:(nullable NSArray *)updateFieldlist;
+- (instancetype)initWithCreateFieldlist:(nullable NSArray<NSString*> *)createFieldlist
+                        updateFieldlist:(nullable NSArray<NSString*> *)updateFieldlist;
 
 /**
  Call resultBlock with YES if record is more recent than corresponding record on server

--- a/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFSyncUpTarget.m
@@ -70,8 +70,8 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
     return [self initWithCreateFieldlist:nil updateFieldlist:nil];
 }
 
-- (instancetype)initWithCreateFieldlist:(NSArray *)createFieldlist
-                        updateFieldlist:(NSArray *)updateFieldlist {
+- (instancetype)initWithCreateFieldlist:(NSArray<NSString*> *)createFieldlist
+                        updateFieldlist:(NSArray<NSString*> *)updateFieldlist {
     self = [super init];
     if (self) {
         self.targetType = SFSyncUpTargetTypeRestStandard;

--- a/libs/SmartSync/SmartSyncTests/BatchingSyncUpTests.m
+++ b/libs/SmartSync/SmartSyncTests/BatchingSyncUpTests.m
@@ -47,7 +47,7 @@
 #pragma mark - Tests
 
 - (void) testMaxBatchSizeExceeding25 {
-    SFBatchingSyncUpTarget* target = [SFBatchingSyncUpTarget newSyncTargetWithCreateFieldlist:nil updateFieldlist:nil maxBatchSize:@26];
+    SFBatchingSyncUpTarget* target = [[SFBatchingSyncUpTarget alloc] initWithCreateFieldlist:nil updateFieldlist:nil maxBatchSize:@26];
     XCTAssertEqual(target.maxBatchSize, 25, @"Max batch size should be 25");
 }
 
@@ -58,7 +58,7 @@
 }
 
 - (void) testFactoryMethod {
-    SFBatchingSyncUpTarget* target = [SFBatchingSyncUpTarget newSyncTargetWithCreateFieldlist:@[@"Name"] updateFieldlist:@[@"Name", @"Description"] maxBatchSize:@12];
+    SFBatchingSyncUpTarget* target = [[SFBatchingSyncUpTarget alloc] initWithCreateFieldlist:@[@"Name"] updateFieldlist:@[@"Name", @"Description"] maxBatchSize:@12];
 
     XCTAssertEqual(target.createFieldlist.count, 1, @"Wrong createFieldlist");
     XCTAssertEqualObjects(target.createFieldlist[0], @"Name", @"Wrong createFieldlist");
@@ -95,7 +95,7 @@
 
 
 - (void) testAsDict {
-    SFBatchingSyncUpTarget* target = [SFBatchingSyncUpTarget newSyncTargetWithCreateFieldlist:@[@"Name"] updateFieldlist:@[@"Name", @"Description"] maxBatchSize:@12];
+    SFBatchingSyncUpTarget* target = [[SFBatchingSyncUpTarget alloc] initWithCreateFieldlist:@[@"Name"] updateFieldlist:@[@"Name", @"Description"] maxBatchSize:@12];
     NSDictionary* actualTargetDict = [target asDict];
 
 
@@ -149,7 +149,7 @@
 #pragma mark - THE methods responsible for building sync up targets used in all the tests
 
 - (SFSyncUpTarget*) buildSyncUpTargetWithCreateFieldlist:(nullable NSArray*)createFieldlist updateFieldlist:(nullable NSArray*)updateFieldlist {
-    return [SFBatchingSyncUpTarget newSyncTargetWithCreateFieldlist:createFieldlist updateFieldlist:updateFieldlist maxBatchSize:@2];
+    return [[SFBatchingSyncUpTarget alloc] initWithCreateFieldlist:createFieldlist updateFieldlist:updateFieldlist maxBatchSize:@2];
 }
 
 @end

--- a/libs/SmartSync/SmartSyncTests/BatchingSyncUpTests.m
+++ b/libs/SmartSync/SmartSyncTests/BatchingSyncUpTests.m
@@ -57,9 +57,21 @@
     XCTAssertEqual(target.maxBatchSize, 25, @"Max batch size should be 25");
 }
 
-- (void) testFactoryMethod {
-    SFBatchingSyncUpTarget* target = [[SFBatchingSyncUpTarget alloc] initWithCreateFieldlist:@[@"Name"] updateFieldlist:@[@"Name", @"Description"] maxBatchSize:@12];
+- (void) testConstructors {
+    SFBatchingSyncUpTarget* target = [[SFBatchingSyncUpTarget alloc] init];
+    XCTAssertNil(target.createFieldlist, @"Wrong createFieldlist");
+    XCTAssertNil(target.updateFieldlist, @"Wrong updateFieldlist");
+    XCTAssertEqual(target.maxBatchSize, 25, @"Max batch size should be 25");
 
+    target = [[SFBatchingSyncUpTarget alloc] initWithCreateFieldlist:@[@"Name"] updateFieldlist:@[@"Name", @"Description"]];
+    XCTAssertEqual(target.createFieldlist.count, 1, @"Wrong createFieldlist");
+    XCTAssertEqualObjects(target.createFieldlist[0], @"Name", @"Wrong createFieldlist");
+    XCTAssertEqual(target.updateFieldlist.count, 2, @"Wrong updateFieldlist");
+    XCTAssertEqualObjects(target.updateFieldlist[0], @"Name", @"Wrong updateFieldlist");
+    XCTAssertEqualObjects(target.updateFieldlist[1], @"Description", @"Wrong updateFieldlist");
+    XCTAssertEqual(target.maxBatchSize, 25, @"Max batch size should be 25");
+
+    target = [[SFBatchingSyncUpTarget alloc] initWithCreateFieldlist:@[@"Name"] updateFieldlist:@[@"Name", @"Description"] maxBatchSize:@12];
     XCTAssertEqual(target.createFieldlist.count, 1, @"Wrong createFieldlist");
     XCTAssertEqualObjects(target.createFieldlist[0], @"Name", @"Wrong createFieldlist");
     XCTAssertEqual(target.updateFieldlist.count, 2, @"Wrong updateFieldlist");


### PR DESCRIPTION
More in line with super classes.