### PR TITLE
Better encapsulation in SFKeyStore/SFKeyStoreKey/SFEncryptionKey

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -130,10 +130,10 @@ static NSMutableDictionary *analyticsManagerList = nil;
         
         SFEncryptionKey *encKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:kEventStoreEncryptionKeyLabel autoCreate:YES];
         DataEncryptorBlock dataEncryptorBlock = ^NSData*(NSData *data) {
-            return [SFSDKCryptoUtils aes256EncryptData:data withKey:encKey.key iv:encKey.initializationVector];
+            return [encKey encryptData:data];
         };
         DataDecryptorBlock dataDecryptorBlock = ^NSData*(NSData *data) {
-            return [SFSDKCryptoUtils aes256DecryptData:data withKey:encKey.key iv:encKey.initializationVector];
+            return [encKey decryptData:data];
         };
         _analyticsManager = [[SFSDKAnalyticsManager alloc] initWithStoreDirectory:rootStoreDir dataEncryptorBlock:dataEncryptorBlock dataDecryptorBlock:dataDecryptorBlock deviceAttributes:deviceAttributes];
         _eventStoreManager = self.analyticsManager.storeManager;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFCrypto.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFCrypto.m
@@ -122,7 +122,7 @@ static NSString * const kKeychainIdentifierSimulatorBaseAppId = @"com.salesforce
 
 + (NSData *)secretWithKey:(NSString *)key {
     SFKeychainItemWrapper *passcodeWrapper = [SFKeychainItemWrapper itemWithIdentifier:kKeychainIdentifierPasscode account:nil];
-    NSString *passcode = [passcodeWrapper passcode];
+    NSString *passcode = [passcodeWrapper valueString];
     
     NSString *baseAppId = [self baseAppIdentifier];
     NSString *strSecret = [baseAppId stringByAppendingString:key];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFKeychainItemWrapper.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFKeychainItemWrapper.h
@@ -62,20 +62,9 @@ extern NSString * _Nullable const kSFKeychainItemExceptionErrorCodeKey;
 @interface SFKeychainItemWrapper : NSObject
 
 /**
- Determines if the keychain wrapper should encrypt/decrypt keychain sensitive data like refreshtoken
- */
-@property (nonatomic) BOOL encrypted;
-
-/**
  Returns the accessible attribute used to store this keychain item
  */
 @property (nonatomic, readonly, nullable) CFTypeRef accessibleAttribute;
-
-/**
- The passcode length.
- */
-@property (nonatomic) NSUInteger passcodeLength;
- 
 
 /**
  @return Whether or not keychain access errors cause a fatal exception.  Default is YES.
@@ -110,29 +99,25 @@ extern NSString * _Nullable const kSFKeychainItemExceptionErrorCodeKey;
  */
 - (BOOL)resetKeychainItem;
 
-/* Passcode related methods */
-
-/**
- Sets the passcode in the keychain.
- @param passcode Plain text passcode
- */
-- (void)setPasscode:(nullable NSString *)passcode;
-
-/** The passcode.
- */
-- (nullable NSString *)passcode;
-
-/** Performs passcode verification.
- @param passcode The passcode to verify.
- */
-- (BOOL)verifyPasscode:(nullable NSString *)passcode;
-
 /**
  Store arbitrary data to the keychain for the service (identifier) and account specified in the initializer.
  @param data Arbitrary data to store to in the keychain. May be `nil`.
  @return The status of the keychain update request.
  */
 - (OSStatus)setValueData:(nullable NSData *)data;
+
+/**
+ Read arbitrary string from the keychain for the service (identifier) and account specified in the initializer.
+ @return Arbitrary string read from the keychain. May be `nil`.
+ */
+- (nullable NSString *)valueString;
+
+/**
+ Store arbitrary string to the keychain for the service (identifier) and account specified in the initializer.
+ @param string Arbitrary string to store to in the keychain. May be `nil`.
+ @return The status of the keychain update request.
+ */
+- (OSStatus)setValueString:(nullable NSString *)string;
 
 /**
  Read arbitrary data from the keychain for the service (identifier) and account specified in the initializer.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFKeychainItemWrapper.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFKeychainItemWrapper.m
@@ -36,8 +36,6 @@
 
 @implementation SFKeychainItemWrapper
 
-@synthesize passcodeLength = _passcodeLength;
-
 // NSException constants
 NSString * const kSFKeychainItemExceptionType         = @"com.salesforce.security.keychainException";
 NSString * const kSFKeychainItemExceptionErrorCodeKey = @"com.salesforce.security.keychainException.errorCode";
@@ -427,50 +425,15 @@ static CFTypeRef sKeychainAccessibleAttribute;
     }
 }
 
-#pragma mark passcode methods
-
-- (void)setPasscode:(NSString *)passcode {
+- (OSStatus)setValueString:(NSString *)string {
     @synchronized (self) {
-        NSData *hashedData = [passcode sha256];
-        NSString *strBaseEncode = [hashedData base64Encode];
-        [self setObject:strBaseEncode forKey:(id)kSecValueData];
+        return [self setObject:string forKey:(id)kSecValueData];
     }
 }
 
-- (NSString *)passcode {
+- (NSString *)valueString {
     @synchronized (self) {
         return [self stringForKey:(id)kSecValueData];
-    }
-}
-
-- (BOOL)verifyPasscode:(NSString *)passcode {
-    NSString *strBaseEncode = [[passcode sha256] base64Encode];    
-    NSString *passcodeString = [self passcode];
-    
-    if (!passcodeString) {
-		[SFSDKCoreLogger e:[self class] format:@"cannot verify password: passcode from keychain is nil"];
-	}
-    
-    BOOL matches = [passcodeString isEqualToString:strBaseEncode];
-	if (!matches) {
-		[SFSDKCoreLogger d:[self class] format:@"Passcode does not match!"];
-	}       
-    return matches;
-}
-
-- (void)setPasscodeLength:(NSUInteger)length
-{
-    @synchronized (self) {
-        [self setObject:[NSString stringWithFormat:@"%lu",(unsigned long)length] forKey:(id)kSecValueData];
-        [self.keychainData setObject:[NSString stringWithFormat:@"%lu",(unsigned long)length] forKey:(id)kSecValueData];
-        SecItemAdd((CFDictionaryRef)[self dictionaryToSecItemFormat:self.keychainData], NULL);
-    }
-}
-
-- (NSUInteger)passcodeLength
-{
-    @synchronized (self) {
-        return [[self stringForKey:(id)kSecValueData] intValue];
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthKeychainCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthKeychainCredentials.m
@@ -115,9 +115,7 @@ NSString * const kSFOAuthEncryptionTypeKey = @"com.salesforce.oauth.creds.encryp
     }
     
     if (self.isEncrypted) {
-        NSData *decryptedData = [SFSDKCryptoUtils aes256DecryptData:accessTokenData
-                                                            withKey:encryptionKey.key
-                                                                 iv:encryptionKey.initializationVector];
+        NSData *decryptedData = [encryptionKey decryptData:accessTokenData];
         return [[NSString alloc] initWithData:decryptedData encoding:NSUTF8StringEncoding];
     } else {
         return [[NSString alloc] initWithData:accessTokenData encoding:NSUTF8StringEncoding];
@@ -181,9 +179,7 @@ NSString * const kSFOAuthEncryptionTypeKey = @"com.salesforce.oauth.creds.encryp
     }
     
     if (self.isEncrypted) {
-        NSData *decryptedData = [SFSDKCryptoUtils aes256DecryptData:refreshTokenData
-                                                            withKey:encryptionKey.key
-                                                                 iv:encryptionKey.initializationVector];
+        NSData *decryptedData = [encryptionKey decryptData:refreshTokenData];
         return [[NSString alloc] initWithData:decryptedData encoding:NSUTF8StringEncoding];
     } else {
         return [[NSString alloc] initWithData:refreshTokenData encoding:NSUTF8StringEncoding];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthKeychainCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthKeychainCredentials.m
@@ -128,9 +128,7 @@ NSString * const kSFOAuthEncryptionTypeKey = @"com.salesforce.oauth.creds.encryp
     NSData *tokenData = ([token length] > 0 ? [token dataUsingEncoding:NSUTF8StringEncoding] : nil);
     if (tokenData != nil) {
         if (self.isEncrypted) {
-            tokenData = [SFSDKCryptoUtils aes256EncryptData:tokenData
-                                                    withKey:encryptionKey.key
-                                                         iv:encryptionKey.initializationVector];
+            tokenData = [encryptionKey encryptData:tokenData];
         }
     }
     
@@ -196,9 +194,7 @@ NSString * const kSFOAuthEncryptionTypeKey = @"com.salesforce.oauth.creds.encryp
     NSData *tokenData = ([token length] > 0 ? [token dataUsingEncoding:NSUTF8StringEncoding] : nil);
     if (tokenData != nil) {
         if (self.isEncrypted) {
-            tokenData = [SFSDKCryptoUtils aes256EncryptData:tokenData
-                                                    withKey:encryptionKey.key
-                                                         iv:encryptionKey.initializationVector];
+            tokenData = [encryptionKey encryptData:tokenData];
         }
     } else {
         self.instanceUrl = nil;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.h
@@ -23,6 +23,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "SFEncryptionKey.h"
 #import "SFCryptChunks.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -32,6 +33,12 @@ NS_ASSUME_NONNULL_BEGIN
  * SFCryptChunks is used to perform the decryption.
  */
 @interface SFDecryptStream : NSInputStream <SFCryptChunksDelegate>
+
+/**
+ *  Setup for decryption. You must call this method before using the stream.
+ *  @param decKey the decryption key
+ */
+- (void)setupWithDecryptionKey:(SFEncryptionKey* )decKey;
 
 /**
  *  Setup for decryption. You must call this method before using the stream.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.m
@@ -76,12 +76,17 @@
 
 #pragma mark - Public Methods
 
-- (void)setupWithKey:(NSData *)key andInitializationVector:(nullable NSData *)iv {
+- (void)setupWithDecryptionKey:(SFEncryptionKey *)decKey {
     NSAssert(!_cryptChunks, @"SFDecryptStream - setup is only allowed once.");
     if (!_cryptChunks) {
-        _cryptChunks = [[SFCryptChunks alloc] initForDecryptionWithKey:key initializationVector:iv];
+        _cryptChunks = [[SFCryptChunks alloc] initForDecryptionWithKey:decKey.key initializationVector:decKey.initializationVector];
         _cryptChunks.delegate = self;
     }
+}
+
+- (void)setupWithKey:(NSData *)key andInitializationVector:(nullable NSData *)iv {
+    SFEncryptionKey* decryptionKey = [[SFEncryptionKey alloc] initWithData:key initializationVector:iv];
+    [self setupWithDecryptionKey:decryptionKey];
 }
 
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserAccountPersister.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserAccountPersister.m
@@ -213,7 +213,7 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
 
     // Encrypt it.
     SFEncryptionKey *encKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:kUserAccountEncryptionKeyLabel autoCreate:YES];
-    NSData *encryptedArchiveData = [SFSDKCryptoUtils aes256EncryptData:archiveData withKey:encKey.key iv:encKey.initializationVector];
+    NSData *encryptedArchiveData = [encKey encryptData:archiveData];
     if (!encryptedArchiveData) {
         NSString *reason = [NSString stringWithFormat:@"User account data could not be encrypted.  %@",filePath];
         [SFSDKCoreLogger w:[self class] format:reason];
@@ -260,7 +260,7 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
             return NO;
         }
         SFEncryptionKey *encKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:kUserAccountEncryptionKeyLabel autoCreate:YES];
-        NSData *decryptedArchiveData = [SFSDKCryptoUtils aes256DecryptData:encryptedUserAccountData withKey:encKey.key iv:encKey.initializationVector];
+        NSData *decryptedArchiveData = [encKey decryptData:encryptedUserAccountData];
         if (!decryptedArchiveData) {
             if (error) {
                 *error = [NSError errorWithDomain:SFUserAccountManagerErrorDomain

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.h
@@ -24,6 +24,7 @@
 
 #import <Foundation/Foundation.h>
 #import "SFCryptChunks.h"
+#import "SFEncryptionKey.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,6 +33,12 @@ NS_ASSUME_NONNULL_BEGIN
  *  SFCryptChunks is used to perform the encryption.
  */
 @interface SFEncryptStream : NSOutputStream <SFCryptChunksDelegate>
+
+/**
+ *  Setup for encryption. You must call this method before using the stream.
+ *  @param encKey the encryption key
+ */
+- (void)setupWithEncryptionKey:(SFEncryptionKey* )encKey;
 
 /**
  *  Setup for encryption. You must call this method before using the stream.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.m
@@ -77,12 +77,17 @@
 
 #pragma mark - Public Methods
 
-- (void)setupWithKey:(NSData *)key andInitializationVector:(nullable NSData *)iv {
+- (void)setupWithEncryptionKey:(SFEncryptionKey* )encKey {
     NSAssert(!_cryptChunks, @"SFEncryptStream - setup is only allowed once.");
     if (!_cryptChunks) {
-        _cryptChunks = [[SFCryptChunks alloc] initForEncryptionWithKey:key initializationVector:iv];
+        _cryptChunks = [[SFCryptChunks alloc] initForEncryptionWithKey:encKey.key initializationVector:encKey.initializationVector];
         _cryptChunks.delegate = self;
     }
+}
+
+- (void)setupWithKey:(NSData *)key andInitializationVector:(nullable NSData *)iv {
+    SFEncryptionKey* encryptionKey = [[SFEncryptionKey alloc] initWithData:key initializationVector:iv];
+    [self setupWithEncryptionKey:encryptionKey];
 }
 
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param keyData The key component, represented as NSData.
  @param iv The initialization vector, represented as NSData.
  */
-- (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv SFSDK_DEPRECATED(7.1, 8.0, "Use SFEncryptionKey:createKey instead");
+- (id)initWithData:(NSData *)keyData initializationVector:(nullable NSData *)iv;
 
 /**
  Generate an encryption key

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.h
@@ -35,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
  Designated initializer.
  Generate an encryption key
  */
-+ (SFEncryptionKey*) generateKey;
++ (SFEncryptionKey*) createKey;
 
 /**
  Encrypt given data

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.h
@@ -33,10 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Designated initializer.
- @param keyData The key component, represented as NSData.
- @param iv The initialization vector, represented as NSData.
+ Generate an encryption key
  */
-- (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv;
++ (SFEncryptionKey*) generateKey;
 
 /**
  Encrypt given data

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.h
@@ -39,6 +39,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv;
 
 /**
+ Encrypt given data
+ @param dataToEncrypt The data to encrypt
+ */
+- (NSData*)encryptData:(NSData *)dataToEncrypt;
+
+/**
+ Decrypt given data
+ @param dataToDecrypt The data to decrypt
+ */
+- (NSData*)decryptData:(NSData *)dataToDecrypt;
+
+/**
  The key component of the object.
  */
 @property (nonatomic, copy, nullable) NSData *key;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.h
@@ -33,6 +33,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Designated initializer.
+ @param keyData The key component, represented as NSData.
+ @param iv The initialization vector, represented as NSData.
+ */
+- (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv SFSDK_DEPRECATED(7.1, 8.0, "Use SFEncryptionKey:createKey instead");
+
+/**
  Generate an encryption key
  */
 + (SFEncryptionKey*) createKey;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.m
@@ -23,6 +23,7 @@
  */
 
 #import "SFEncryptionKey.h"
+#import "SFSDKCryptoUtils.h"
 
 // NSCoding constants
 static NSString * const kEncryptionKeyCodingValue = @"com.salesforce.encryption.key.data";
@@ -95,5 +96,20 @@ static NSString * const kInitializationVectorCodingValue = @"com.salesforce.encr
     result = 43 * result + [_initializationVector hash];
     return result;
 }
+
+- (NSData*)encryptData:(NSData *)dataToEncrypt
+{
+    return [SFSDKCryptoUtils aes256EncryptData:dataToEncrypt
+                                       withKey:self.key
+                                            iv:self.initializationVector];
+}
+
+- (NSData*)decryptData:(NSData *)dataToDecrypt
+{
+    return [SFSDKCryptoUtils aes256DecryptData:dataToDecrypt
+                                       withKey:self.key
+                                            iv:self.initializationVector];
+}
+
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.m
@@ -24,6 +24,7 @@
 
 #import "SFEncryptionKey.h"
 #import "SFSDKCryptoUtils.h"
+#import <CommonCrypto/CommonCrypto.h>
 
 // NSCoding constants
 static NSString * const kEncryptionKeyCodingValue = @"com.salesforce.encryption.key.data";
@@ -33,6 +34,14 @@ static NSString * const kInitializationVectorCodingValue = @"com.salesforce.encr
 
 @synthesize key = _key;
 @synthesize initializationVector = _initializationVector;
+
++ (SFEncryptionKey*) generateKey
+{
+    NSData *keyData = [SFSDKCryptoUtils randomByteDataWithLength:kCCKeySizeAES256];
+    NSData *iv = [SFSDKCryptoUtils randomByteDataWithLength:kCCBlockSizeAES128];
+    SFEncryptionKey *key = [[SFEncryptionKey alloc] initWithData:keyData initializationVector:iv];
+    return key;
+}
 
 - (id)initWithData:(NSData *)key initializationVector:(NSData *)iv
 {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptionKey.m
@@ -35,7 +35,7 @@ static NSString * const kInitializationVectorCodingValue = @"com.salesforce.encr
 @synthesize key = _key;
 @synthesize initializationVector = _initializationVector;
 
-+ (SFEncryptionKey*) generateKey
++ (SFEncryptionKey*) createKey
 {
     NSData *keyData = [SFSDKCryptoUtils randomByteDataWithLength:kCCKeySizeAES256];
     NSData *iv = [SFSDKCryptoUtils randomByteDataWithLength:kCCBlockSizeAES128];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStore.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStore.m
@@ -88,9 +88,7 @@
     
     NSData *encryptedData = dictionaryData;
     if (theEncryptionKey != nil) {
-        encryptedData = [SFSDKCryptoUtils aes256EncryptData:dictionaryData
-                                                    withKey:theEncryptionKey.key
-                                                         iv:theEncryptionKey.initializationVector];
+        encryptedData = [theEncryptionKey encryptData:dictionaryData];
     }
     
     return encryptedData;
@@ -101,9 +99,7 @@
     
     NSData *decryptedDictionaryData = dictionaryData;
     if (decryptKey != nil) {
-        decryptedDictionaryData = [SFSDKCryptoUtils aes256DecryptData:dictionaryData
-                                                              withKey:decryptKey.key
-                                                                   iv:decryptKey.initializationVector];
+        decryptedDictionaryData = [decryptKey decryptData:dictionaryData];
     }
     if (decryptedDictionaryData == nil)
         return nil;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStore.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStore.m
@@ -79,7 +79,7 @@
     }
 }
 
-- (NSData *)encryptDictionary:(NSDictionary *)dictionary withKey:(SFEncryptionKey *)storeKey
+- (NSData *)encryptDictionary:(NSDictionary *)dictionary withKey:(SFKeyStoreKey *)storeKey
 {
     NSMutableData *dictionaryData = [NSMutableData data];
     NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:dictionaryData];
@@ -94,12 +94,12 @@
     return encryptedData;
 }
 
-- (NSDictionary *)decryptDictionaryData:(NSData *)dictionaryData withKey:(SFEncryptionKey *)decryptKey
+- (NSDictionary *)decryptDictionaryData:(NSData *)dictionaryData withKey:(SFKeyStoreKey *)storeKey
 {
     
     NSData *decryptedDictionaryData = dictionaryData;
-    if (decryptKey != nil) {
-        decryptedDictionaryData = [decryptKey decryptData:dictionaryData];
+    if (storeKey != nil) {
+        decryptedDictionaryData = [storeKey decryptData:dictionaryData];
     }
     if (decryptedDictionaryData == nil)
         return nil;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreKey.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreKey.h
@@ -33,17 +33,22 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SFKeyStoreKey : NSObject <NSCoding, NSCopying>
 
 /**
+ Create a new SFKeyStoreKey
+ */
++ (instancetype) createKey;
+
+/**
  Designated initializer.
  @param key The encryption key for the key store.
  */
-- (id)initWithKey:(SFEncryptionKey *)key;
+- (instancetype)initWithKey:(SFEncryptionKey *)key;
 
 /**
  Read from key chain
  @param keychainId Identifier in the key chain
  @param archiverKey Key used in archiver
  */
-+ (nullable id)fromKeyChain:(NSString*)keychainId archiverKey:(NSString*)archiverKey;
++ (nullable instancetype)fromKeyChain:(NSString*)keychainId archiverKey:(NSString*)archiverKey;
 
 /**
  Save to key chain

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreKey.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreKey.h
@@ -39,6 +39,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)initWithKey:(SFEncryptionKey *)key;
 
 /**
+ Read from key chain
+ @param keychainId Identifier in the key chain
+ @param archiverKey Key used in archiver
+ */
++ (nullable id)fromKeyChain:(NSString*)keychainId archiverKey:(NSString*)archiverKey;
+
+/**
+ Save to key chain
+ @param keychainId Identifier in the key chain
+ @param archiverKey Key to use in archiver
+ */
+- (OSStatus) toKeyChain:(NSString*)keychainId archiverKey:(NSString*)archiverKey;
+
+/**
  The encryption key for the key store.
  */
 @property (nonatomic, strong) SFEncryptionKey *encryptionKey;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreKey.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreKey.m
@@ -30,7 +30,14 @@ static NSString * const kKeyStoreKeyDataArchiveKey = @"com.salesforce.keystore.k
 
 @implementation SFKeyStoreKey
 
-- (id)initWithKey:(SFEncryptionKey *)key
++ (instancetype) createKey
+{
+    SFEncryptionKey *encKey = [SFEncryptionKey createKey];
+    SFKeyStoreKey *keyStoreKey = [[SFKeyStoreKey alloc] initWithKey:encKey];
+    return keyStoreKey;
+}
+
+- (instancetype)initWithKey:(SFEncryptionKey *)key
 {
     self = [super init];
     if (self) {
@@ -39,7 +46,7 @@ static NSString * const kKeyStoreKeyDataArchiveKey = @"com.salesforce.keystore.k
     return self;
 }
 
-- (id)initWithCoder:(NSCoder *)aDecoder
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
     self = [super init];
     if (self) {
@@ -53,14 +60,14 @@ static NSString * const kKeyStoreKeyDataArchiveKey = @"com.salesforce.keystore.k
     [aCoder encodeObject:self.encryptionKey forKey:kKeyStoreKeyDataArchiveKey];
 }
 
-- (id)copyWithZone:(NSZone *)zone
+- (instancetype)copyWithZone:(NSZone *)zone
 {
     SFKeyStoreKey *keyCopy = [[[self class] allocWithZone:zone] init];
     keyCopy.encryptionKey = [self.encryptionKey copy];
     return keyCopy;
 }
 
-+ (nullable id)fromKeyChain:(NSString*)keychainId archiverKey:(NSString*)archiverKey
++ (nullable instancetype)fromKeyChain:(NSString*)keychainId archiverKey:(NSString*)archiverKey
 {
     SFKeyStoreKey* keyStoreKey;
     SFKeychainItemWrapper *keychainItem = [SFKeychainItemWrapper itemWithIdentifier:keychainId account:nil];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.h
@@ -40,8 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Retrieves a key with the given label from the key store, or `nil` depending on the autoCreate value.
- Key will be stored with the default encryption type of 'passcode', and will fall back to a 'generated'
- store encryption if a passcode is not configured.
  @param keyLabel The label associated with the stored key.
  @param create Indicates whether a new key should be created if one does not exist.
  @return The encryption key, or `nil` depending on the autoCreate value.
@@ -49,33 +47,24 @@ NS_ASSUME_NONNULL_BEGIN
 - (SFEncryptionKey *)retrieveKeyWithLabel:(NSString *)keyLabel autoCreate:(BOOL)create;
 
 /**
- Stores a key with the given label in the key store, with a default encryption type of 'passcode'.  If
- a passcode is not configured, the key will be encrypted with a generated key.
+ Stores a key with the given label in the key store encrypted by the store's key.
  @param key The encryption key to store.
  @param keyLabel The label associated with the key.
  */
 - (void)storeKey:(SFEncryptionKey *)key withLabel:(NSString *)keyLabel;
 
 /**
- Removes the key with the given label from the key store holding passcode-based encrypted keys.
+ Removes the key with the given label from the key store.
  @param keyLabel The label associated with the key to remove.
  */
 - (void)removeKeyWithLabel:(NSString *)keyLabel;
 
 /**
- Determines whether a key with the given label, and encrypted with passcode-based encryption, exists.
+ Determines whether a key with the given label exists.
  @param keyLabel The label associated with the key to query.
  @return YES if the key exists in the key store, NO otherwise.
  */
 - (BOOL)keyWithLabelExists:(NSString *)keyLabel;
-
-/**
- Returns a key with a random value for the key and initialization vector.  The key size
- will be the size for the AES-256 algorithm (kCCKeySizeAES256), and the initialization
- vector will be the block size associated with AES encryption (kCCBlockSizeAES128).
- @return An instance of SFEncryptionKey with the described values.
- */
-- (SFEncryptionKey *)keyWithRandomValue;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.h
@@ -66,6 +66,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)keyWithLabelExists:(NSString *)keyLabel;
 
+/**
+ Returns a key with a random value for the key and initialization vector.  The key size
+ will be the size for the AES-256 algorithm (kCCKeySizeAES256), and the initialization
+ vector will be the block size associated with AES encryption (kCCBlockSizeAES128).
+ @return An instance of SFEncryptionKey with the described values.
+ */
+- (SFEncryptionKey *)keyWithRandomValue SFSDK_DEPRECATED(7.1, 8.0, "Use SFEncryptionKey:createKey instead");
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.m
@@ -68,8 +68,7 @@ static NSString * const kKeyStoreDecryptionFailedMessage = @"Could not decrypt k
         key = (self.generatedKeyStore.keyStoreDictionary)[typedKeyLabel];
 
         if (!key && create) {
-            SFEncryptionKey *newKey = [self keyWithRandomValue];
-            key = [[SFKeyStoreKey alloc] initWithKey:newKey];
+            key = [SFKeyStoreKey createKey];
             [self storeKeyStoreKey:key withLabel:keyLabel];
         }
         
@@ -103,11 +102,6 @@ static NSString * const kKeyStoreDecryptionFailedMessage = @"Could not decrypt k
         SFEncryptionKey *key = [self retrieveKeyWithLabel:keyLabel autoCreate:NO];
         return (key != nil);
     }
-}
-
-- (SFEncryptionKey *)keyWithRandomValue
-{
-    return [SFEncryptionKey generateKey];
 }
 
 #pragma mark - Private methods
@@ -182,9 +176,7 @@ static NSString * const kKeyStoreDecryptionFailedMessage = @"Could not decrypt k
 
 - (SFKeyStoreKey *)createDefaultKey
 {
-    SFEncryptionKey *encKey = [self keyWithRandomValue];
-    SFKeyStoreKey *keyStoreKey = [[SFKeyStoreKey alloc] initWithKey:encKey];
-    return keyStoreKey;
+    return [SFKeyStoreKey createKey];
 }
 
 + (NSData *)keyStringToData:(NSString *)keyString

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.m
@@ -104,6 +104,11 @@ static NSString * const kKeyStoreDecryptionFailedMessage = @"Could not decrypt k
     }
 }
 
+- (SFEncryptionKey *)keyWithRandomValue
+{
+    return [SFEncryptionKey createKey];
+}
+
 #pragma mark - Private methods
 
 - (void)initializeKeyStores

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.m
@@ -107,10 +107,7 @@ static NSString * const kKeyStoreDecryptionFailedMessage = @"Could not decrypt k
 
 - (SFEncryptionKey *)keyWithRandomValue
 {
-    NSData *keyData = [SFSDKCryptoUtils randomByteDataWithLength:kCCKeySizeAES256];
-    NSData *iv = [SFSDKCryptoUtils randomByteDataWithLength:kCCBlockSizeAES128];
-    SFEncryptionKey *key = [[SFEncryptionKey alloc] initWithData:keyData initializationVector:iv];
-    return key;
+    return [SFEncryptionKey generateKey];
 }
 
 #pragma mark - Private methods

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPBKDF2PasscodeProvider.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPBKDF2PasscodeProvider.m
@@ -150,7 +150,7 @@ static NSString * const kPBKDFArchiveDataKey = @"pbkdfDataArchive";
     
     // Set Passcode length
     SFKeychainItemWrapper *keychainWrapper = [SFKeychainItemWrapper itemWithIdentifier:kKeychainIdentifierPasscodeLength account:nil];
-    keychainWrapper.passcodeLength = passcode.length;
+    [keychainWrapper setValueString:[NSString stringWithFormat:@"%lu",(unsigned long)passcode.length]];
     
     return encodedKey;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFEncryptionKeyTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFEncryptionKeyTests.m
@@ -25,6 +25,11 @@
 #import <XCTest/XCTest.h>
 #import "SFEncryptionKey.h"
 
+@interface SFEncryptionKey ()
+
+- (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv;
+
+@end;
 
 @interface SFEncryptionKeyTests : XCTestCase
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFEncryptionKeyTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFEncryptionKeyTests.m
@@ -25,11 +25,6 @@
 #import <XCTest/XCTest.h>
 #import "SFEncryptionKey.h"
 
-@interface SFEncryptionKey ()
-
-- (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv;
-
-@end;
 
 @interface SFEncryptionKeyTests : XCTestCase
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFKeyStoreManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFKeyStoreManagerTests.m
@@ -56,7 +56,7 @@
 
 // ensure storing a key, we can check to see if the key exists
 - (void)testStoreKeyGetsBackOriginal {
-    SFEncryptionKey *key =  [mgr keyWithRandomValue];
+    SFEncryptionKey *key =  [SFEncryptionKey createKey];
     [mgr storeKey:key withLabel:@"key"];
     
     XCTAssertTrue([mgr keyWithLabelExists:@"key"], @"Key type should exist.");
@@ -64,7 +64,7 @@
 
 // ensure removing a key works
 - (void)testRemoveKey {
-    SFEncryptionKey *key =  [mgr keyWithRandomValue];
+    SFEncryptionKey *key =  [SFEncryptionKey createKey];
     [mgr storeKey:key withLabel:@"key"];
     [mgr removeKeyWithLabel:@"key"];
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFKeyStoreTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFKeyStoreTests.m
@@ -50,7 +50,7 @@
 // ensure we get an empty/initialized dictionary
 -(void)testGetKeyStoreDictionaryDefaultsToEmpty {
     // set up the keystore
-    SFEncryptionKey *encKey = [mgr keyWithRandomValue];
+    SFEncryptionKey *encKey = [SFEncryptionKey createKey];
     SFKeyStoreKey *key = [[SFKeyStoreKey alloc] initWithKey:encKey];
 
     SFKeyStore *keyStore = [[SFGeneratedKeyStore alloc] init];
@@ -63,8 +63,7 @@
 
 // ensures we can set and get the dictionary
 -(void)testSetAndGetDictionary {
-    SFEncryptionKey *encKey = [mgr keyWithRandomValue];
-    SFKeyStoreKey *key = [[SFKeyStoreKey alloc] initWithKey:encKey];
+    SFKeyStoreKey *key = [SFKeyStoreKey createKey];
     
     SFKeyStore *keyStore = [[SFGeneratedKeyStore alloc] init];
     keyStore.keyStoreKey = key;
@@ -72,18 +71,17 @@
     NSDictionary *data = @{@"one":@"", @"two":@""};
     
     // set
-    [keyStore setKeyStoreDictionary:data withKey:encKey];
+    [keyStore setKeyStoreDictionary:data withKey:key];
     
     // get
-    NSDictionary *retrievedData = [keyStore keyStoreDictionaryWithKey:encKey];
+    NSDictionary *retrievedData = [keyStore keyStoreDictionaryWithKey:key];
     
     XCTAssertTrue([data isEqualToDictionary:retrievedData], @"Dictionaries should be equal");
 }
 
-// try to decrpt with bad enc key
+// try to decrypt with bad key
 -(void)testAttemptToDecryptWithBadEncKey {
-    SFEncryptionKey *encKey = [mgr keyWithRandomValue];
-    SFKeyStoreKey *key = [[SFKeyStoreKey alloc] initWithKey:encKey];
+    SFKeyStoreKey *key = [SFKeyStoreKey createKey];
     
     SFKeyStore *keyStore = [[SFGeneratedKeyStore alloc] init];
     keyStore.keyStoreKey = key;
@@ -91,11 +89,11 @@
     NSDictionary *data = @{@"one":@"", @"two":@""};
     
     // set
-    [keyStore setKeyStoreDictionary:data withKey:encKey];
+    [keyStore setKeyStoreDictionary:data withKey:key];
     
     // get
-    SFEncryptionKey *badEncKey = [mgr keyWithRandomValue];
-    NSDictionary *retrievedData = [keyStore keyStoreDictionaryWithKey:badEncKey];
+    SFKeyStoreKey *badKey = [SFKeyStoreKey createKey];
+    NSDictionary *retrievedData = [keyStore keyStoreDictionaryWithKey:badKey];
     
     XCTAssertNil(retrievedData, @"Data retrieved with wrong enc key should be nil");
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSecurityTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSecurityTests.m
@@ -29,6 +29,12 @@
 
 static NSUInteger const kNumThreadsInSafetyTest = 100;
 
+@interface SFEncryptionKey ()
+
+- (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv;
+
+@end;
+
 @interface SFKeyStoreManager ()
 
 - (void)renameKeysWithKeyTypePasscode:(SFGeneratedKeyStore*)generatedKeyStore;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSecurityTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSecurityTests.m
@@ -29,12 +29,6 @@
 
 static NSUInteger const kNumThreadsInSafetyTest = 100;
 
-@interface SFEncryptionKey ()
-
-- (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv;
-
-@end;
-
 @interface SFKeyStoreManager ()
 
 - (void)renameKeysWithKeyTypePasscode:(SFGeneratedKeyStore*)generatedKeyStore;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSecurityTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSecurityTests.m
@@ -103,7 +103,7 @@ static NSUInteger const kNumThreadsInSafetyTest = 100;
     
     // Manually inserting key with key type passcode in generated store
     SFPasscodeKeyStore *passcodeKeyStore = [[SFPasscodeKeyStore alloc] init]; // only used to create the right label for the key
-    SFEncryptionKey *encryptionKey = [mgr keyWithRandomValue];
+    SFEncryptionKey *encryptionKey = [SFEncryptionKey createKey];
     SFKeyStoreKey *keyStoreKey = [[SFKeyStoreKey alloc] initWithKey:encryptionKey];
     NSString *originalKeyLabel = [passcodeKeyStore keyLabelForString:keyLabel];
     XCTAssertEqualObjects(@"keyLabel__Passcode", originalKeyLabel);
@@ -160,7 +160,7 @@ static NSUInteger const kNumThreadsInSafetyTest = 100;
     passcodeKeyStore.keyStoreKey = [[SFKeyStoreKey alloc] initWithKey:encKey];
 
     // Insert key to passcode key store
-    SFEncryptionKey *encryptionKey = [mgr keyWithRandomValue];
+    SFEncryptionKey *encryptionKey = [SFEncryptionKey createKey];
     SFKeyStoreKey *keyStoreKey = [[SFKeyStoreKey alloc] initWithKey:encryptionKey];
     NSString *originalKeyLabel = [passcodeKeyStore keyLabelForString:keyLabel];
     XCTAssertEqualObjects(@"keyLabel__Passcode", originalKeyLabel);
@@ -209,7 +209,7 @@ static NSUInteger const kNumThreadsInSafetyTest = 100;
     
     // generate a new key
     NSString *keyName = [NSString stringWithFormat:@"%@%ld", @"threadSafeKeyName", (unsigned long)keyId++];
-    SFEncryptionKey *origKey = [mgr keyWithRandomValue];
+    SFEncryptionKey *origKey = [SFEncryptionKey createKey];
     
     // store it
     [mgr storeKey:origKey withLabel:keyName];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
@@ -36,6 +36,12 @@ static NSString * const kClientId   = @"SfdcMobileChatteriOS";
 static NSString * const kTestAccessToken = @"AccessGranted!";
 static NSString * const kTestRefreshToken = @"HowRefreshing";
 
+@interface SFEncryptionKey ()
+
+- (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv;
+
+@end;
+
 @interface SalesforceOAuthUnitTests ()
 
 - (void)verifySuccessfulTokenUpdate:(NSString *)accessToken refreshToken:(NSString *)refreshToken;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
@@ -36,12 +36,6 @@ static NSString * const kClientId   = @"SfdcMobileChatteriOS";
 static NSString * const kTestAccessToken = @"AccessGranted!";
 static NSString * const kTestRefreshToken = @"HowRefreshing";
 
-@interface SFEncryptionKey ()
-
-- (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv;
-
-@end;
-
 @interface SalesforceOAuthUnitTests ()
 
 - (void)verifySuccessfulTokenUpdate:(NSString *)accessToken refreshToken:(NSString *)refreshToken;

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -777,7 +777,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
     if (keyBlock) {
         SFEncryptStream *encryptStream = [[SFEncryptStream alloc] initToFileAtPath:filePath append:NO];
         SFEncryptionKey *encKey = keyBlock();
-        [encryptStream setupWithKey:encKey.key andInitializationVector:encKey.initializationVector];
+        [encryptStream setupWithEncryptionKey:encKey];
         outputStream = encryptStream;
     } else {
         outputStream = [[NSOutputStream alloc] initToFileAtPath:filePath append:NO];
@@ -874,8 +874,10 @@ NSString *const EXPLAIN_ROWS = @"rows";
     NSInputStream *inputStream = nil;
     if (encKey) {
         SFDecryptStream *decryptStream = [[SFDecryptStream alloc] initWithFileAtPath:filePath];
-        [decryptStream setupWithKey:encKey.key
-            andInitializationVector:(useNilIV ? nil : encKey.initializationVector)];
+        if (useNilIV) {
+            encKey = [[SFEncryptionKey alloc] initWithData:encKey.key initializationVector:nil];
+        }
+        [decryptStream setupWithDecryptionKey:encKey];
         inputStream = decryptStream;
     } else {
         inputStream = [[NSInputStream alloc] initWithFileAtPath:filePath];
@@ -901,7 +903,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
     NSOutputStream *outputStream = nil;
     if (encKey) {
         SFEncryptStream *encryptStream = [[SFEncryptStream alloc] initToFileAtPath:filePath append:NO];
-        [encryptStream setupWithKey:encKey.key andInitializationVector:encKey.initializationVector];
+        [encryptStream setupWithEncryptionKey:encKey];
         outputStream = encryptStream;
     } else {
         outputStream = [[NSOutputStream alloc] initToFileAtPath:filePath append:NO];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -815,15 +815,13 @@ NSString *const EXPLAIN_ROWS = @"rows";
                                              soupTableName:soupTableName];
     
     SFSmartStoreEncryptionKeyBlock keyBlock = [SFSmartStore encryptionKeyBlock];
-    NSData* key;
-    NSData* initializationVector;
+    SFEncryptionKey* encKey;
     if (keyBlock) {
-        SFEncryptionKey *encKey = keyBlock();
-        key = encKey.key;
-        initializationVector = encKey.initializationVector;
+        encKey = keyBlock();
     }
     
-    NSString* entryAsString = [self readFromEncryptedFile:filePath key:key iv:initializationVector];
+    NSString* entryAsString = [self readFromEncryptedFile:filePath
+                                                   encKey:encKey];
     
     // Before 6.2, we were using nill IV when encrypting.
     // Starting in 6.2, we are using a non-nil IV when encrypting.
@@ -833,17 +831,19 @@ NSString *const EXPLAIN_ROWS = @"rows";
         NSDictionary* entry = [SFJsonUtils objectFromJSONString:entryAsString];
         
         if(!entry) {
-            if (initializationVector) {
-                entryAsString = [self readFromEncryptedFile:filePath key:key iv:nil];
+            if (encKey.initializationVector) {
+                entryAsString = [self readFromEncryptedFile:filePath encKey:encKey useNilIV:YES];
                 if ([entryAsString length] > 0) {
-                    [self writeToEncryptedFile:filePath content:entryAsString key:key iv:initializationVector];
+                    [self writeToEncryptedFile:filePath
+                                       content:entryAsString
+                                        encKey:encKey];
                 } else {
                     [SFSDKSmartStoreLogger e:[self class] format:@"Attempt to migrate an encrypted externally saved soup '%@' with a null IV  failed.", soupTableName];
                 }
             } else {
                 NSError* error = [SFJsonUtils lastError];
                 NSString *errorMessage = [NSString stringWithFormat:@"Loading external soup from file failed! encrypted: %@, soupEntryId: %@, soupTableName: %@, filePath: '%@', error: %@.",
-                                          key ? @"YES" : @"NO",
+                                          encKey ? @"YES" : @"NO",
                                           soupEntryId,
                                           soupTableName,
                                           filePath,
@@ -861,14 +861,21 @@ NSString *const EXPLAIN_ROWS = @"rows";
 }
 
 - (NSString*) readFromEncryptedFile:(NSString*)filePath
-                                key:(NSData*)key
-                                 iv:(NSData*)iv
+                             encKey:(SFEncryptionKey*)encKey
+{
+    return [self readFromEncryptedFile:filePath encKey:encKey useNilIV:NO];
+}
+
+- (NSString*) readFromEncryptedFile:(NSString*)filePath
+                             encKey:(SFEncryptionKey*)encKey
+                           useNilIV:(BOOL)useNilIV
 {
     NSMutableString* content = [NSMutableString new];
     NSInputStream *inputStream = nil;
-    if (key) {
+    if (encKey) {
         SFDecryptStream *decryptStream = [[SFDecryptStream alloc] initWithFileAtPath:filePath];
-        [decryptStream setupWithKey:key andInitializationVector:iv];
+        [decryptStream setupWithKey:encKey.key
+            andInitializationVector:(useNilIV ? nil : encKey.initializationVector)];
         inputStream = decryptStream;
     } else {
         inputStream = [[NSInputStream alloc] initWithFileAtPath:filePath];
@@ -889,13 +896,12 @@ NSString *const EXPLAIN_ROWS = @"rows";
 
 - (void) writeToEncryptedFile:(NSString*)filePath
                        content:(NSString *)content
-                          key:(NSData*)key
-                           iv:(NSData*)iv
+                       encKey:(SFEncryptionKey*)encKey
 {
     NSOutputStream *outputStream = nil;
-    if (key) {
+    if (encKey) {
         SFEncryptStream *encryptStream = [[SFEncryptStream alloc] initToFileAtPath:filePath append:NO];
-        [encryptStream setupWithKey:key andInitializationVector:iv];
+        [encryptStream setupWithKey:encKey.key andInitializationVector:encKey.initializationVector];
         outputStream = encryptStream;
     } else {
         outputStream = [[NSOutputStream alloc] initToFileAtPath:filePath append:NO];

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreWithExternalStorageTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreWithExternalStorageTests.m
@@ -37,12 +37,6 @@ NSString * const kSSAlphabets = @"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST
 
 static NSInteger const kSSMegaBytePayloadSize = 1024 * 1024;
 
-@interface SFEncryptionKey ()
-
-- (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv;
-
-@end;
-
 @interface SFSmartStoreWithExternalStorageTests : SFSmartStoreTests
 
 @end

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreWithExternalStorageTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreWithExternalStorageTests.m
@@ -37,6 +37,12 @@ NSString * const kSSAlphabets = @"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST
 
 static NSInteger const kSSMegaBytePayloadSize = 1024 * 1024;
 
+@interface SFEncryptionKey ()
+
+- (id)initWithData:(NSData *)keyData initializationVector:(NSData *)iv;
+
+@end;
+
 @interface SFSmartStoreWithExternalStorageTests : SFSmartStoreTests
 
 @end


### PR DESCRIPTION
That will allow us to introduce alternate encryption methods (backed by secure enclave).

* SFEncryptionKey also has methods for: creating a new encryption key, encrypting/decrypting data
* SFKeyStoreKey now has methods for: creating a new store key, encrypting/decrypting data, reading/writing itself to key chain
* SFKeyStoreManager / SFKeyStore use the new methods on SFKeyStoreKey for creating keys, encrypting/decrypting data, reading/writing to key chain instead of "reaching in"
* SFKeychainItemWrapper no longer has passcode related methods (they should not have been there in the first place)

