### PR TITLE
Allows for applications to handle creation of NSURLSession

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.h
@@ -29,6 +29,13 @@
 
 #import <Foundation/Foundation.h>
 #import "SalesforceSDKConstants.h"
+
+NS_SWIFT_NAME(NetworkManaging)
+@protocol SFNetworkSessionManaging
+- (nonnull NSURLSession *)ephemeralSession:(nonnull NSURLSessionConfiguration *)sessionConfig;
+- (nonnull NSURLSession *)backgroundSession:(nonnull NSURLSessionConfiguration *)sessionConfig;
+@end
+
 NS_SWIFT_NAME(Network)
 @interface SFNetwork : NSObject
 
@@ -65,5 +72,12 @@ typedef void (^SFDataResponseBlock) (NSData * _Nullable data, NSURLResponse * _N
  * @param sessionConfig Session configuration to be used.
  */
 + (void)setSessionConfiguration:(nonnull NSURLSessionConfiguration *)sessionConfig;
+
+/**
+ * Delegates the creation of NSURLSession to an external object.
+ *
+ * @param manager object implementing the SFNetworkSessionManaging protocol.
+ */
++ (void)setSessionManager:(id<SFNetworkSessionManaging>)manager;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.h
@@ -78,6 +78,6 @@ typedef void (^SFDataResponseBlock) (NSData * _Nullable data, NSURLResponse * _N
  *
  * @param manager object implementing the SFNetworkSessionManaging protocol.
  */
-+ (void)setSessionManager:(id<SFNetworkSessionManaging>)manager;
++ (void)setSessionManager:(nonnull id<SFNetworkSessionManaging>)manager;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
@@ -39,6 +39,7 @@
 @implementation SFNetwork
 
 static NSURLSessionConfiguration *kSFSessionConfig;
+__weak static id<SFNetworkSessionManaging> kSFNetworkManager;
 
 - (instancetype)initWithEphemeralSession {
     self = [super init];
@@ -47,7 +48,11 @@ static NSURLSessionConfiguration *kSFSessionConfig;
         if (kSFSessionConfig) {
             ephemeralSessionConfig = kSFSessionConfig;
         }
-        self.activeSession = [NSURLSession sessionWithConfiguration:ephemeralSessionConfig];
+        if (kSFNetworkManager) {
+            self.activeSession = [kSFNetworkManager ephemeralSession:ephemeralSessionConfig];
+        } else {
+            self.activeSession = [NSURLSession sessionWithConfiguration:ephemeralSessionConfig];
+        }
     }
     return self;
 }
@@ -60,7 +65,11 @@ static NSURLSessionConfiguration *kSFSessionConfig;
         if (kSFSessionConfig) {
             backgroundSessionConfig = kSFSessionConfig;
         }
-        self.activeSession = [NSURLSession sessionWithConfiguration:backgroundSessionConfig];
+        if (kSFNetworkManager) {
+            self.activeSession = [kSFNetworkManager backgroundSession:backgroundSessionConfig];
+        } else {
+            self.activeSession = [NSURLSession sessionWithConfiguration:backgroundSessionConfig];
+        }
     }
     return self;
 }
@@ -82,6 +91,10 @@ static NSURLSessionConfiguration *kSFSessionConfig;
 
 + (void)setSessionConfiguration:(NSURLSessionConfiguration *)sessionConfig {
     kSFSessionConfig = sessionConfig;
+}
+
++ (void)setSessionManager:(id<SFNetworkSessionManaging>)manager {
+    kSFNetworkManager = manager;
 }
 
 @end


### PR DESCRIPTION
Apps that require to control the creation  of NSURLSessions for the mobileSDK beyond for capabilities beyond just setting the NSURLSessionConfiguration, now should be able to manage creation/sharing  of NSURLSessions as needed.

e.g. in Swift
```
Network.setSessionManager(self)

extension AppDelegate : NetworkManaging {
    
    func ephemeralSession(_ sessionConfig: URLSessionConfiguration) -> URLSession {
       //  create a url session or used a shared session
        return urlSession
    }
    
    func backgroundSession(_ sessionConfig: URLSessionConfiguration) -> URLSession {
         //  create a url background session or used a shared session
        return urlSession
    }

}


```