### PR TITLE
 Fixes Default Handling of error for unreachable host

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKNewLoginHostViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKNewLoginHostViewController.m
@@ -84,9 +84,7 @@ static NSString * const SFSDKNewLoginHostCellIdentifier = @"SFSDKNewLoginHostCel
     if (host && httpsRange.length > 0) {
         host = [host substringFromIndex:httpsRange.location + httpsRange.length];
     }
-    if (host) {
-        [self.loginHostListViewController addLoginHost:[SFSDKLoginHost hostWithName:hostName host:host  deletable:YES]];
-    }
+    [self.loginHostListViewController addLoginHost:[SFSDKLoginHost hostWithName:hostName host:host  deletable:YES]];
 }
 
 #pragma mark - Table view data source

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKNewLoginHostViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKNewLoginHostViewController.m
@@ -75,9 +75,18 @@ static NSString * const SFSDKNewLoginHostCellIdentifier = @"SFSDKNewLoginHostCel
  * Invoked when the user taps on the done button to add the login host to the list of hosts.
  */
 - (void)addNewServer:(id)sender {
-    [self.loginHostListViewController addLoginHost:[SFSDKLoginHost hostWithName:[self.name.text stringByTrimmingCharactersInSet:
-                                                                                 [NSCharacterSet whitespaceCharacterSet]] host:[self.server.text stringByTrimmingCharactersInSet:
-                                                                                                     [NSCharacterSet whitespaceCharacterSet]] deletable:YES]];
+    
+    
+    NSString *hostName = [self.name.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    NSString *host = [self.server.text stringByTrimmingCharactersInSet:
+                          [NSCharacterSet whitespaceCharacterSet]];
+    NSRange httpsRange = [host rangeOfString:@"://"];
+    if (host && httpsRange.length > 0) {
+        host = [host substringFromIndex:httpsRange.location + httpsRange.length];
+    }
+    if (host) {
+        [self.loginHostListViewController addLoginHost:[SFSDKLoginHost hostWithName:hostName host:host  deletable:YES]];
+    }
 }
 
 #pragma mark - Table view data source
@@ -118,7 +127,7 @@ static NSString * const SFSDKNewLoginHostCellIdentifier = @"SFSDKNewLoginHostCel
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
 
     // Enable the Done button only if there is something in the URL field
-    if (textField == self.server) {
+        if (textField == self.server) {
         NSString *resultingString = [textField.text stringByReplacingCharactersInRange:range withString:string];
         self.navigationItem.rightBarButtonItem.enabled = [resultingString length] > 0;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKNewLoginHostViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKNewLoginHostViewController.m
@@ -75,8 +75,6 @@ static NSString * const SFSDKNewLoginHostCellIdentifier = @"SFSDKNewLoginHostCel
  * Invoked when the user taps on the done button to add the login host to the list of hosts.
  */
 - (void)addNewServer:(id)sender {
-    
-    
     NSString *hostName = [self.name.text stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
     NSString *host = [self.server.text stringByTrimmingCharactersInSet:
                           [NSCharacterSet whitespaceCharacterSet]];
@@ -125,7 +123,7 @@ static NSString * const SFSDKNewLoginHostCellIdentifier = @"SFSDKNewLoginHostCel
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string {
 
     // Enable the Done button only if there is something in the URL field
-        if (textField == self.server) {
+    if (textField == self.server) {
         NSString *resultingString = [textField.text stringByReplacingCharactersInRange:range withString:string];
         self.navigationItem.rightBarButtonItem.enabled = [resultingString length] > 0;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -1200,10 +1200,13 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
         [strongSelf showErrorAlertWithMessage:alertMessage buttonTitle:okButton andCompletion:^() {
             [client cancelAuthentication:YES];
             [strongSelf disposeOAuthClient:client];
-            [weakSelf notifyUserCancelledOrDismissedAuth:client.credentials andAuthInfo:client.context.authInfo];
+            [strongSelf notifyUserCancelledOrDismissedAuth:client.credentials andAuthInfo:client.context.authInfo];
             SFSDKLoginHost *host = [[SFSDKLoginHostStorage sharedInstance] loginHostAtIndex:0];
             strongSelf.loginHost = host.host;
-            [strongSelf switchToNewUser];
+            SFOAuthCredentials *credentials = [strongSelf newClientCredentials];
+            [strongSelf dismissAuthViewControllerIfPresent];
+            SFSDKOAuthClient *newClient = [strongSelf fetchOAuthClient:credentials  completion:client.config.successCallbackBlock failure:client.config.failureCallbackBlock];
+            [newClient refreshCredentials];
         }];
     };
     


### PR DESCRIPTION
Checks for urls with a prefix. This has been an issue hanging around for a while now.  In addition  handles default handling of errors when connecting to host (after host add). Previously switchToNewUser was being used to clear user and invoke completion/ re launch. Prior to moving away from launch, the method to switchToNewUser and launch would work normally.  Moving to the initializeSDK model, in the event of a failure to add a new host,  we re-attempt the auth flow with the first host in the list i.e. if apps have  not registered any interest in handling the error situation.  