### PR TITLE
Always pass auth info with browser auth type when cancelling from browser flow

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -513,8 +513,9 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 
 - (BOOL)authClientDidCancelBrowserFlow:(SFSDKOAuthClient *)client {
     BOOL result = NO;
+    SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];
     NSDictionary *userInfo = @{ kSFNotificationUserInfoCredentialsKey: client.credentials,
-                                kSFNotificationUserInfoAuthTypeKey: client.context.authInfo };
+                                kSFNotificationUserInfoAuthTypeKey: authInfo };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserCancelledAuth
                                                         object:self userInfo:userInfo];
     if (self.authCancelledByUserHandlerBlock) {


### PR DESCRIPTION
When using a host configured for advanced browser auth, the user cancelling the process caused a notification to be posted with an SFOAuthInfo object with the wrong authentication type. Since only browser auth flows used this code path, it was suggested by @rao-r to build a new SFOAuthInfo with the browser auth type and send that.

Any suggestions on where to fix the root issue to avoid having to use this approach would be appreciated.