### PR TITLE
Enables NavBar for Host Selection View in Advanced Auth mode

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.h
@@ -46,6 +46,12 @@ NS_SWIFT_NAME(LoginHostListViewController)
 @property (nonatomic, weak) id<SFSDKLoginHostDelegate> delegate;
 
 /**
+ * If you have used a navigation controller to present this view controller,
+ * a cancel button is automatically added to the left bar button item.
+ */
+@property (nonatomic,assign) BOOL hidesCancelButton;
+
+/**
  * Adds a new login host.
  * This method updates the underlying storage and refreshes the list of login hosts.
  * @param host The login host to be added.
@@ -55,10 +61,13 @@ NS_SWIFT_NAME(LoginHostListViewController)
 
 /**
  * Use this method to display a view for adding a new login host.
- * If you have used a navigation controller to present this view controller, an add button is automatically added to the right bar button item.
+ * If you have used a navigation controller to present this view controller,
+ * an add button is automatically added to the right bar button item.
  * @see addLoginHost: for adding a login host programmatically without showing the UI.
  */
 - (void)showAddLoginHost;
+
+
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -138,7 +138,9 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
                                              style:UIBarButtonItemStylePlain
                                              target:nil
                                              action:nil];
-    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelLoginPicker:)];
+    if (!self.hidesCancelButton) {
+        self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelLoginPicker:)];
+    }
     
     // Make sure the current login host exists.
     NSUInteger index = [self indexOfCurrentLoginHost];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -415,12 +415,16 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     }
     // If no delegates implement authManagerDidCancelBrowserFlow, display Login Host List
     if (!handledByDelegate) {
+        
         SFSDKLoginHostListViewController *hostListViewController = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
         hostListViewController.delegate = self;
+        SFSDKNavigationController *controller = [[SFSDKNavigationController alloc] initWithRootViewController:hostListViewController];
+        hostListViewController.hidesCancelButton = YES;
+    
         __weak typeof (self) weakSelf = self;
         [self.authWindow presentWindowAnimated:NO withCompletion:^{
             __strong typeof (weakSelf) strongSelf = weakSelf;
-            [strongSelf.authWindow.viewController presentViewController:hostListViewController animated:NO completion:nil];
+            [strongSelf.authWindow.viewController presentViewController:controller animated:NO completion:nil];
         }];
         
     }


### PR DESCRIPTION
The navbar is missing in the host selection view in adv. auth mode. That means  users can select another host but not add one.   This change enables the nav bar and its functionality.