### PR TITLE
Sync manager cleans up interrupted syncs state at startup

### DIFF
--- a/libs/SmartSync/SmartSync.xcodeproj/project.pbxproj
+++ b/libs/SmartSync/SmartSync.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		4F307E3A1EBD4A010040CFC4 /* SFParentChildrenSyncHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F307E381EBD4A010040CFC4 /* SFParentChildrenSyncHelper.m */; };
 		4F307E3F1EC273780040CFC4 /* SyncManagerTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F307E3E1EC273780040CFC4 /* SyncManagerTestCase.m */; };
 		4F307E421EC2750C0040CFC4 /* ParentChildrenSyncTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F307E411EC2750C0040CFC4 /* ParentChildrenSyncTests.m */; };
+		4F3903732252B89800122833 /* SyncStateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F3903722252B89800122833 /* SyncStateTests.m */; };
 		4F3D60361FBFB0AF00D1830F /* globalsyncs.json in Resources */ = {isa = PBXBuildFile; fileRef = 4F3D60351FBFB0AF00D1830F /* globalsyncs.json */; };
 		4F3D603B1FBFB11C00D1830F /* usersyncs.json in Resources */ = {isa = PBXBuildFile; fileRef = 4F3D603A1FBFB11C00D1830F /* usersyncs.json */; };
 		4F3DF86B1ECCF44900D1D9AF /* SFParentChildrenSyncDownTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F3DF8671ECCF44900D1D9AF /* SFParentChildrenSyncDownTarget.m */; };
@@ -416,6 +417,8 @@
 		4F307E3E1EC273780040CFC4 /* SyncManagerTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SyncManagerTestCase.m; sourceTree = "<group>"; };
 		4F307E401EC273AB0040CFC4 /* SyncManagerTestCase.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SyncManagerTestCase.h; sourceTree = "<group>"; };
 		4F307E411EC2750C0040CFC4 /* ParentChildrenSyncTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ParentChildrenSyncTests.m; sourceTree = "<group>"; };
+		4F3903722252B89800122833 /* SyncStateTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SyncStateTests.m; sourceTree = "<group>"; };
+		4F3903822252B8AC00122833 /* SyncStateTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SyncStateTests.h; sourceTree = "<group>"; };
 		4F3D60351FBFB0AF00D1830F /* globalsyncs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = globalsyncs.json; sourceTree = "<group>"; };
 		4F3D603A1FBFB11C00D1830F /* usersyncs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = usersyncs.json; sourceTree = "<group>"; };
 		4F3DF8671ECCF44900D1D9AF /* SFParentChildrenSyncDownTarget.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFParentChildrenSyncDownTarget.m; path = Target/SFParentChildrenSyncDownTarget.m; sourceTree = "<group>"; };
@@ -800,20 +803,22 @@
 		CEAAAE5E195911E600CBBFE9 /* SmartSyncTests */ = {
 			isa = PBXGroup;
 			children = (
-				828E0E511AB3987C004E0AF2 /* Targets */,
-				4F9079821A82EE5100E32659 /* SFSyncUpdateCallbackQueue.h */,
-				4F9079801A82EDF600E32659 /* SFSyncUpdateCallbackQueue.m */,
+				4FF9331622165CD30058807A /* BatchSyncUpTests.m */,
+				4F307E411EC2750C0040CFC4 /* ParentChildrenSyncTests.m */,
 				CEFB4B2F20B4951000D70F2B /* SFLayoutSyncManagerTests.m */,
 				CE01BB1D20B769DE008E91B6 /* SFMetadataSyncManagerTests.m */,
-				4F9732D51A816C2D006E2A86 /* SyncManagerTests.m */,
-				4F307E401EC273AB0040CFC4 /* SyncManagerTestCase.h */,
-				4F307E3E1EC273780040CFC4 /* SyncManagerTestCase.m */,
-				4F307E411EC2750C0040CFC4 /* ParentChildrenSyncTests.m */,
-				4FF9331622165CD30058807A /* BatchSyncUpTests.m */,
 				4FCA4AE71FBE7D4E00F081B3 /* SFSDKSyncsConfigTests.h */,
 				4FCA4AE81FBE7D6200F081B3 /* SFSDKSyncsConfigTests.m */,
-				4FF1357B221782D600D9D25A /* SyncUpTargetTests.m */,
+				4F9079821A82EE5100E32659 /* SFSyncUpdateCallbackQueue.h */,
+				4F9079801A82EDF600E32659 /* SFSyncUpdateCallbackQueue.m */,
+				4F307E401EC273AB0040CFC4 /* SyncManagerTestCase.h */,
+				4F307E3E1EC273780040CFC4 /* SyncManagerTestCase.m */,
+				4F9732D51A816C2D006E2A86 /* SyncManagerTests.m */,
+				4F3903822252B8AC00122833 /* SyncStateTests.h */,
+				4F3903722252B89800122833 /* SyncStateTests.m */,
 				4FF1358B2217A51200D9D25A /* SyncUpTargetTests.h */,
+				4FF1357B221782D600D9D25A /* SyncUpTargetTests.m */,
+				828E0E511AB3987C004E0AF2 /* Targets */,
 				CEAAAE5F195911E600CBBFE9 /* Supporting Files */,
 			);
 			path = SmartSyncTests;
@@ -1430,6 +1435,7 @@
 				CE01BB1E20B769DE008E91B6 /* SFMetadataSyncManagerTests.m in Sources */,
 				4FF9331722165CD30058807A /* BatchSyncUpTests.m in Sources */,
 				4FCA4AE91FBE7D6200F081B3 /* SFSDKSyncsConfigTests.m in Sources */,
+				4F3903732252B89800122833 /* SyncStateTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -162,6 +162,7 @@ static NSMutableDictionary *syncMgrList = nil;
         self.queue = dispatch_queue_create(kSyncManagerQueue,  DISPATCH_QUEUE_SERIAL);
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
         [SFSyncState setupSyncsSoupIfNeeded:self.store];
+        [SFSyncState cleanupSyncsSoupIfNeeded:self.store];
     }
     return self;
 }

--- a/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSyncState.h
@@ -63,12 +63,14 @@ extern NSString * const kSFSyncStateTypeUp;
 // Possible value for sync status
 typedef NS_ENUM(NSInteger, SFSyncStateStatus) {
     SFSyncStateStatusNew,
+    SFSyncStateStatusStopped,
     SFSyncStateStatusRunning,
     SFSyncStateStatusDone,
     SFSyncStateStatusFailed
 } NS_SWIFT_NAME(SyncStatus);
 
 extern NSString * const kSFSyncStateStatusNew;
+extern NSString * const kSFSyncStateStatusStopped;
 extern NSString * const kSFSyncStateStatusRunning;
 extern NSString * const kSFSyncStateStatusDone;
 extern NSString * const kSFSyncStateStatusFailed;
@@ -108,6 +110,13 @@ NS_SWIFT_NAME(SyncState)
 /** Setup soup that keeps track of sync operations
  */
 + (void) setupSyncsSoupIfNeeded:(SFSmartStore*)store;
+
+/**
+ * Cleanup syncs soup if needed
+ * At startup, no sync could be running already
+ * If a sync is in the running state, we change it to stopped
+ */
++ (void) cleanupSyncsSoupIfNeeded:(SFSmartStore*)store;
 
 /** Factory methods
  */

--- a/libs/SmartSync/SmartSyncTests/SyncStateTests.h
+++ b/libs/SmartSync/SmartSyncTests/SyncStateTests.h
@@ -1,0 +1,29 @@
+/*
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+
+@interface SyncStateTests : XCTestCase
+
+@end

--- a/libs/SmartSync/SmartSyncTests/SyncStateTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncStateTests.m
@@ -1,0 +1,153 @@
+/*
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SyncStateTests.h"
+#import <SmartStore/SmartStore.h>
+#import "SFSoqlSyncDownTarget.h"
+#import "SFSmartSyncSyncManager.h"
+#import "SFSyncState.h"
+
+
+#define DB_NAME @"testDb"
+
+@interface SyncStateTests ()
+
+@property (nonatomic, strong) SFSmartStore *store;
+
+@end
+
+@implementation SyncStateTests
+
+#pragma mark - setUp/tearDown
+
+- (void)setUp {
+    [super setUp];
+    self.store = [SFSmartStore sharedGlobalStoreWithName:DB_NAME];
+}
+
+- (void)tearDown {
+    [SFSmartStore removeSharedGlobalStoreWithName:DB_NAME];
+    [super tearDown];
+}
+
+#pragma mark - Tests
+
+/**
+ * Make sure syncs soup gets properly setup the first time around
+ */
+-(void) testSetupSyncsSoupFirstTime {
+    // Setup syncs soup
+    [SFSyncState setupSyncsSoupIfNeeded:self.store];
+    
+    // Check the soup
+    [self checkSyncsSoupIndexSpecs:self.store];
+}
+
+/**
+ * Make sure syncs soup gets properly setup when upgrading to 7.1
+ */
+-(void) testSetupSyncsSoupUpgradeTo71 {
+    // Manually syncs soup the pre 7.1 way
+    NSArray* indexSpecs = @[
+                            [[SFSoupIndex alloc] initWithPath:@"type" indexType:kSoupIndexTypeString columnName:nil],
+                            [[SFSoupIndex alloc] initWithPath:@"name" indexType:kSoupIndexTypeString columnName:nil]
+                            ];
+    [self.store registerSoup:kSFSyncStateSyncsSoupName withIndexSpecs:indexSpecs error:nil];
+    
+    // Fix syncs soup
+    [SFSyncState setupSyncsSoupIfNeeded:self.store];
+    
+    // Check the soup
+    [self checkSyncsSoupIndexSpecs:self.store];
+}
+
+/**
+ * Make sure syncs marked as running are "cleaned up" after restart
+ */
+-(void) testCleanupSyncsSoupIfNeeded {
+    // Setup syncs soup
+    [SFSyncState setupSyncsSoupIfNeeded:self.store];
+
+    // Create syncs - some in the running state
+    [self createSyncChangeStatus:@"newSyncUp" isSyncUp:YES status:SFSyncStateStatusNew];
+    [self createSyncChangeStatus:@"stoppedSyncUp" isSyncUp:YES status:SFSyncStateStatusStopped];
+    [self createSyncChangeStatus:@"runningSyncUp" isSyncUp:YES status:SFSyncStateStatusRunning];
+    [self createSyncChangeStatus:@"failedSyncUp" isSyncUp:YES status:SFSyncStateStatusFailed];
+    [self createSyncChangeStatus:@"doneSyncUp" isSyncUp:YES status:SFSyncStateStatusDone];
+    [self createSyncChangeStatus:@"newSyncDown" isSyncUp:NO status:SFSyncStateStatusNew];
+    [self createSyncChangeStatus:@"stoppedSyncDown" isSyncUp:NO status:SFSyncStateStatusStopped];
+    [self createSyncChangeStatus:@"runningSyncDown" isSyncUp:NO status:SFSyncStateStatusRunning];
+    [self createSyncChangeStatus:@"failedSyncDown" isSyncUp:NO status:SFSyncStateStatusFailed];
+    [self createSyncChangeStatus:@"doneSyncDown" isSyncUp:NO status:SFSyncStateStatusDone];
+
+    
+    // Cleanup syncs soup
+    [SFSyncState cleanupSyncsSoupIfNeeded:self.store];
+    
+    // Check the syncs
+    [self checkSyncsSoupIndexSpecs:self.store];
+}
+
+#pragma mark - Helper methods
+
+-(void) createSyncChangeStatus:(NSString*)name isSyncUp:(BOOL)isSyncUp status:(SFSyncStateStatus)status {
+    
+    SFSyncState* sync;
+    if (isSyncUp) {
+        sync = [SFSyncState newSyncUpWithOptions:[SFSyncOptions newSyncOptionsForSyncUp:@[@"Name"]]
+                                          target:[SFSyncUpTarget newFromDict:@{}]
+                                        soupName:@"Accounts"
+                                            name:name
+                                           store:self.store];
+    } else {
+        sync = [SFSyncState newSyncDownWithOptions:[SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged]
+                                            target:[SFSoqlSyncDownTarget newSyncTarget:@"SELECT Id, Name from Account"]
+                                          soupName:@"Accounts"
+                                              name:name
+                                             store:self.store];
+    }
+    
+    sync.status = status;
+    [sync save:self.store];
+}
+
+- (void) checkSyncStatus:(NSString*) name expectedStatus:(SFSyncStateStatus)expectedStatus {
+    SFSyncState* sync = [SFSyncState byName:name store:self.store];
+    XCTAssertEqual(expectedStatus, sync.status);
+}
+
+/**
+ * Check syncs soup index specs
+ */
+-(void) checkSyncsSoupIndexSpecs:(SFSmartStore*)store {
+    NSArray* indexSpecs = [store indicesForSoup:kSFSyncStateSyncsSoupName];
+    XCTAssertEqual(3, indexSpecs.count, @"Wrong number of index specs");
+
+    NSArray* expectedPaths = @[@"name", @"type", @"status"];
+    for (SFSoupIndex* indexSpec in indexSpecs) {
+        XCTAssertTrue([expectedPaths containsObject:indexSpec.path], @"Wrong index spec path");
+        XCTAssertEqualObjects(@"json1", indexSpec.indexType, @"Wrong index spec type");
+    }
+}
+@end


### PR DESCRIPTION
* Added index (on status) in syncs soup
* Changed indexes on syncs soup to json1
* Added STOPPED state to SFSyncState
* Added clean up method (and calling it at SyncManager creation) - changes syncs found in the RUNNING state at startup to STOPPED 
* Added tests
