### PR TITLE
Supports sharing of SmartStore using plain text header for encrypted sqlite files.

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore+Internal.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore+Internal.h
@@ -211,6 +211,11 @@ typedef NS_ENUM(NSUInteger, SFSmartStoreFtsExtension) {
 + (NSString *)encKey;
 
 /**
+ @return The key used to encrypt the store for shared mode. Sqlite headers are maintained in plain text for database.
+ */
++ (NSString *)salt;
+
+/**
  FOR UNIT TESTING.  Removes all of the shared smart store objects from memory (persisted stores remain).
  */
 + (void)clearSharedStoreMemoryState;

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -50,10 +50,21 @@ extern NSString * const kSFSmartStoreErrorLoadExternalSoup NS_SWIFT_NAME(SmartSt
  */
 extern NSString * const kSFSmartStoreEncryptionKeyLabel NS_SWIFT_NAME(SmartStore.encryptionKeyLabel);
 
+
+/**
+ The label used to interact with the encryption key.
+ */
+extern NSString * const kSFSmartStoreEncryptionSaltLabel NS_SWIFT_NAME(SmartStore.encryptionSaltLabel);
+
 /**
  Block typedef for generating an encryption key.
  */
 typedef SFEncryptionKey*  _Nullable (^SFSmartStoreEncryptionKeyBlock)(void) NS_SWIFT_NAME(EncryptionKeyBlock);
+
+/**
+ Block typedef for generating a md5 hash for sharing data betwween multiple apps.
+ */
+typedef NSString* _Nullable (^SFSmartStoreEncryptionSaltBlock)(void) NS_SWIFT_NAME(EncryptionSaltBlock);
 
 /**
  The columns of a soup table
@@ -173,6 +184,11 @@ NS_SWIFT_NAME(SmartStore)
  Sticking with the default encryption key derivation is recommended.
  */
 @property (nonatomic, class, readonly)  SFSmartStoreEncryptionKeyBlock encryptionKeyBlock;
+
+/**
+ Block used to generate the salt. The salt is maintained in the keychain. Used only when database needs to be shared between apps.
+ */
+@property (nonatomic, class, readonly)  SFSmartStoreEncryptionSaltBlock encryptionSaltBlock;
 
 /**
  Use this method to obtain a shared store instance with a particular name for the current user.

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager+Internal.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager+Internal.h
@@ -47,14 +47,16 @@ static NSString * const kStoresDirectory          = @"stores";
                                 name:(NSString *)storeName
                               oldKey:(NSString *)oldKey
                               newKey:(NSString *)newKey
+                                salt:(NSString *)salt
                                error:(NSError **)error;
 
-+ (FMDatabase *)openDatabaseWithPath:(NSString *)dbPath key:(NSString *)key error:(NSError **)error;
++ (FMDatabase *)openDatabaseWithPath:(NSString *)dbPath key:(NSString *)key salt:(NSString *)salt error:(NSError **)error;
 + (FMDatabase *)encryptOrUnencryptDb:(FMDatabase *)db
                                 name:(NSString *)storeName
                                 path:(NSString *)storePath
                               oldKey:(NSString *)oldKey
                               newKey:(NSString *)newKey
+                                salt:(NSString *)salt
                                error:(NSError **)error;
 
 @end

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.h
@@ -75,7 +75,7 @@ NS_SWIFT_NAME(DatabaseManager)
  @param error Returned if there's an error with the process.
  @return The FMDatabase instance representing the DB, or nil if the create/open failed.
  */
-- (nullable FMDatabase *)openStoreDatabaseWithName:(NSString *)storeName key:(NSString *)key salt:(NSString *)salt  error:(NSError **)error;
+- (nullable FMDatabase *)openStoreDatabaseWithName:(NSString *)storeName key:(NSString *)key salt:(nullable NSString *)salt  error:(NSError **)error;
 
 /**
  Creates or opens an existing store DB.
@@ -85,7 +85,7 @@ NS_SWIFT_NAME(DatabaseManager)
  @param error Returned if there's an error with the process.
  @return The FMDatabaseQueue instance to access the DB, or nil if the create/open failed.
  */
-- (nullable FMDatabaseQueue *)openStoreQueueWithName:(NSString *)storeName key:(NSString *)key salt:(NSString *)salt error:(NSError **)error;
+- (nullable FMDatabaseQueue *)openStoreQueueWithName:(NSString *)storeName key:(NSString *)key salt:(nullable NSString *)salt error:(NSError **)error;
 
 /**
  Encrypts an existing unencrypted database.
@@ -96,7 +96,7 @@ NS_SWIFT_NAME(DatabaseManager)
  @param error Returned if there's an error with encrypting the data.
  @return The newly-encrypted DB, or the original DB if the encryption fails at any point in the process.
  */
-- (FMDatabase *)encryptDb:(FMDatabase *)db name:(NSString *)storeName key:(NSString *)key salt:(NSString *)salt error:(NSError **)error;
+- (FMDatabase *)encryptDb:(FMDatabase *)db name:(NSString *)storeName key:(NSString *)key salt:(nullable NSString *)salt error:(NSError **)error;
 
 /**
  Encrypts an existing store
@@ -107,7 +107,7 @@ NS_SWIFT_NAME(DatabaseManager)
  @param error Returned if there's an error with encrypting the data.
  @return YES if the encryption was successful, or NO if the encryption fails at any point in the process.
  */
-+(BOOL)encryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key salt:(NSString *)salt  error:(NSError **)error;
++(BOOL)encryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key salt:(nullable NSString *)salt  error:(NSError **)error;
 
 /**
  Unencrypts an encrypted database, back to plaintext.
@@ -118,7 +118,7 @@ NS_SWIFT_NAME(DatabaseManager)
  @param error Returned if there's an error during the process.
  @return The unencrypted database, or the original encrypted database if the process fails at any point.
  */
-- (FMDatabase *)unencryptDb:(FMDatabase *)db name:(NSString *)storeName oldKey:(NSString *)oldKey salt:(NSString *)salt error:(NSError **)error;
+- (FMDatabase *)unencryptDb:(FMDatabase *)db name:(NSString *)storeName oldKey:(NSString *)oldKey salt:(nullable NSString *)salt error:(NSError **)error;
 
 /**
  Unencrypts an encrypted store, back to plaintext.
@@ -129,7 +129,7 @@ NS_SWIFT_NAME(DatabaseManager)
  @param error Returned if there's an error during the process.
  @return YES if the existing store was successfully unencrypted, or NO if the process fails at any point.
  */
-+ (BOOL)unencryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key salt:(NSString *)salt  error:(NSError **)error;
++ (BOOL)unencryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key salt:(nullable NSString *)salt  error:(NSError **)error;
 
 /**
  Creates the directory for the store, on the filesystem.

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.h
@@ -59,6 +59,7 @@ NS_SWIFT_NAME(DatabaseManager)
  */
 + (void)removeSharedManagerForUser:(SFUserAccount *)user;
 
+
 /**
  Whether the store with the given name exists.
  @param storeName The name of the store to query.
@@ -70,59 +71,65 @@ NS_SWIFT_NAME(DatabaseManager)
  Creates or opens an existing store DB.
  @param storeName The name of the store to create or open.
  @param key The encryption key associated with the store.
+@param salt Specified when database header should be stored in plain text (Shared mode).
  @param error Returned if there's an error with the process.
  @return The FMDatabase instance representing the DB, or nil if the create/open failed.
  */
-- (nullable FMDatabase *)openStoreDatabaseWithName:(NSString *)storeName key:(NSString *)key error:(NSError **)error;
+- (nullable FMDatabase *)openStoreDatabaseWithName:(NSString *)storeName key:(NSString *)key salt:(NSString *)salt  error:(NSError **)error;
 
 /**
  Creates or opens an existing store DB.
  @param storeName The name of the store to create or open.
  @param key The encryption key associated with the store.
+ @param salt Specified when database header should be stored in plain text (Shared mode).
  @param error Returned if there's an error with the process.
  @return The FMDatabaseQueue instance to access the DB, or nil if the create/open failed.
  */
-- (nullable FMDatabaseQueue *)openStoreQueueWithName:(NSString *)storeName key:(NSString *)key error:(NSError **)error;
+- (nullable FMDatabaseQueue *)openStoreQueueWithName:(NSString *)storeName key:(NSString *)key salt:(NSString *)salt error:(NSError **)error;
 
 /**
  Encrypts an existing unencrypted database.
  @param db The DB to encrypt.
  @param storeName The name of the store representing the DB.
  @param key The encryption key to be used for encrypting the database.
+ @param salt Specified when database header should be stored in plain text (Shared mode).
  @param error Returned if there's an error with encrypting the data.
  @return The newly-encrypted DB, or the original DB if the encryption fails at any point in the process.
  */
-- (FMDatabase *)encryptDb:(FMDatabase *)db name:(NSString *)storeName key:(NSString *)key error:(NSError **)error;
+- (FMDatabase *)encryptDb:(FMDatabase *)db name:(NSString *)storeName key:(NSString *)key salt:(NSString *)salt error:(NSError **)error;
 
 /**
  Encrypts an existing store
  @param storeName The name of the store representing the DB.
  @param storePath The path specifying the store location.
  @param key The encryption key to be used for encrypting the database.
+@param salt Specified when database header should be stored in plain text (Shared mode).
  @param error Returned if there's an error with encrypting the data.
  @return YES if the encryption was successful, or NO if the encryption fails at any point in the process.
  */
-+(BOOL)encryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key error:(NSError **)error;
++(BOOL)encryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key salt:(NSString *)salt  error:(NSError **)error;
 
 /**
  Unencrypts an encrypted database, back to plaintext.
  @param db The database to unencrypt.
  @param storeName The name of the store associated with the DB.
  @param oldKey The original encryption key of the database.
+ @param salt Specified when database header should be stored in plain text (Shared mode).
  @param error Returned if there's an error during the process.
  @return The unencrypted database, or the original encrypted database if the process fails at any point.
  */
-- (FMDatabase *)unencryptDb:(FMDatabase *)db name:(NSString *)storeName oldKey:(NSString *)oldKey error:(NSError **)error;
+- (FMDatabase *)unencryptDb:(FMDatabase *)db name:(NSString *)storeName oldKey:(NSString *)oldKey salt:(NSString *)salt error:(NSError **)error;
 
 /**
  Unencrypts an encrypted store, back to plaintext.
  @param storeName The name of the store associated with the DB.
  @param storePath The path specifying the store location.
  @param key The original encryption key of the database.
+ @param salt Specified when database header should be stored in plain text (Shared mode).
  @param error Returned if there's an error during the process.
  @return YES if the existing store was successfully unencrypted, or NO if the process fails at any point.
  */
-+ (BOOL)unencryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key error:(NSError **)error;
++ (BOOL)unencryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key salt:(NSString *)salt  error:(NSError **)error;
 
 /**
  Creates the directory for the store, on the filesystem.

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
@@ -27,9 +27,12 @@
 #import <SalesforceSDKCore/NSData+SFAdditions.h>
 #import <SalesforceSDKCore/NSString+SFAdditions.h>
 #import <SalesforceSDKCommon/SFFileProtectionHelper.h>
+#import <SalesforceSDKCommon/SFSDKDatasharingHelper.h>
 #import <SalesforceSDKCore/SFUserAccountManager.h>
 #import <SalesforceSDKCore/SFUserAccount.h>
 #import <SalesforceSDKCore/SFDirectoryManager.h>
+#import <SalesforceSDKCore/SFKeychainItemWrapper.h>
+#import <sqlite3.h>
 #import "SFSmartStoreUtils.h"
 #import "FMDatabase.h"
 #import "FMDatabaseQueue.h"
@@ -137,15 +140,15 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     return [manager fileExistsAtPath:fullDbFilePath];
 }
 
-- (FMDatabase *)openStoreDatabaseWithName:(NSString *)storeName key:(NSString *)key error:(NSError **)error {
+- (FMDatabase *)openStoreDatabaseWithName:(NSString *)storeName key:(NSString *)key salt:(NSString *)salt error:(NSError **)error {
     NSString *fullDbFilePath = [self fullDbFilePathForStoreName:storeName];
-    return [[self class] openDatabaseWithPath:fullDbFilePath key:key error:error];
+    return [[self class] openDatabaseWithPath:fullDbFilePath key:key salt:salt error:error];
 }
 
 // If you created your database with an app based on Mobile SDK 5.3.0 using cocoapod
 // Then the key was never applied, and the database can be read directly
 // This method checks for that situation and encrypt the database if needed
-- (void)fixFor530Bug:(NSString *)storeName key:(NSString *)key {
+- (void)fixFor530Bug:(NSString *)storeName key:(NSString *)key salt:(NSString *)salt {
     NSString *fullDbFilePath = [self fullDbFilePathForStoreName:storeName];
     
     __block BOOL needEncrypting = NO;
@@ -158,32 +161,32 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     }];
     
     if (needEncrypting) {
-        [[self class] encryptDbWithStoreName:storeName storePath:fullDbFilePath key:key error:nil];
+        [[self class] encryptDbWithStoreName:storeName storePath:fullDbFilePath key:key salt:salt error:nil];
     }
 }
 
-- (FMDatabaseQueue *)openStoreQueueWithName:(NSString *)storeName key:(NSString *)key error:(NSError * __autoreleasing *)error {
-    [self fixFor530Bug:storeName key:key];
+- (FMDatabaseQueue *)openStoreQueueWithName:(NSString *)storeName key:(NSString *)key salt:(NSString *)salt error:(NSError * __autoreleasing *)error {
+    [self fixFor530Bug:storeName key:key salt:salt];
     
     __block BOOL result = YES;
     NSString *fullDbFilePath = [self fullDbFilePathForStoreName:storeName];
     FMDatabaseQueue *queue = [FMDatabaseQueue databaseQueueWithPath:fullDbFilePath];
     [queue inDatabase:^(FMDatabase* db) {
-        result = ([[self class] setKeyForDb:db key:key error:error] != nil);
+        result = ([[self class] setKeyForDb:db key:key salt:salt error:error] != nil);
     }];
     return (result ? queue : nil);
 }
 
-+ (FMDatabase *)openDatabaseWithPath:(NSString *)dbPath key:(NSString *)key error:(NSError **)error {
++ (FMDatabase *)openDatabaseWithPath:(NSString *)dbPath key:(NSString *)key salt:(NSString *)salt error:(NSError **)error {
     FMDatabase *db = [FMDatabase databaseWithPath:dbPath];
-    return [self setKeyForDb:db key:key error:error];
+    return [self setKeyForDb:db key:key salt:salt error:error];
 }
 
-+ (FMDatabase*) setKeyForDb:(FMDatabase*) db key:(NSString *)key error:(NSError **)error {
++ (FMDatabase*) setKeyForDb:(FMDatabase*) db key:(NSString *)key salt:(NSString *)salt error:(NSError **)error {
     [db setLogsErrors:YES];
     [db setCrashOnErrors:NO];
     
-    FMDatabase* unlockedDb = [self unlockDatabase:db key:key];
+    FMDatabase* unlockedDb = [self unlockDatabase:db key:key salt:salt];
     
     if (!unlockedDb) {
         [SFSDKSmartStoreLogger d:[self class] format:@"Couldn't open store db at: %@ error: %@", [db databasePath],[db lastErrorMessage]];
@@ -194,7 +197,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     return unlockedDb;
 }
 
-+ (FMDatabase*) unlockDatabase:(FMDatabase*)db key:(NSString*)key {
++ (FMDatabase*) unlockDatabase:(FMDatabase*)db key:(NSString*)key salt:(NSString *)salt {
     if ([db open]) {
         // Using sqlcipher 3.x default settings
         // => should open 3.x databases without any migration
@@ -202,10 +205,18 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
         // Using sqlcipher 2.x kdf iter because 3.x default (64000) and 4.x default (256000) are too slow
         // => should open 2.x databases without any migration
         [[db executeQuery:@"PRAGMA cipher_default_kdf_iter = 4000"] close];
-
+        
         if(key) {
             [db setKey:key];
         }
+        
+        if (salt){
+            [[db executeQuery:@"PRAGMA cipher_plaintext_header_size = 32"] close];
+            NSString *pragma = [NSString stringWithFormat:@"PRAGMA cipher_salt = \"x'%@'\"",salt];
+            [[db executeQuery:pragma] close];
+            sqlite3_exec(db.sqliteHandle, "PRAGMA journal_mode = WAL;",0,0,0);
+        }
+        
     }
     BOOL accessible = [self verifyDatabaseAccess:db error:nil];
     if (accessible) {
@@ -217,15 +228,15 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     }
 }
 
-- (FMDatabase *)encryptDb:(FMDatabase *)db name:(NSString *)storeName key:(NSString *)key error:(NSError **)error
+- (FMDatabase *)encryptDb:(FMDatabase *)db name:(NSString *)storeName key:(NSString *)key salt:(NSString *)salt error:(NSError **)error
 {
-    return [self encryptOrUnencryptDb:db name:storeName oldKey:@"" newKey:key error:error];
+    return [self encryptOrUnencryptDb:db name:storeName oldKey:@"" newKey:key salt:salt error:error];
 }
 
-+ (BOOL)encryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key error:(NSError **)error
++ (BOOL)encryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key salt:(NSString *)salt  error:(NSError **)error
 {
     NSError *openDbError = nil;
-    FMDatabase *db = [self openDatabaseWithPath:storePath key:@"" error:&openDbError];
+    FMDatabase *db = [self openDatabaseWithPath:storePath key:@"" salt:salt error:&openDbError];
     if (openDbError != nil) {
         if (db) {
             [db close];
@@ -237,7 +248,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     }
     
     NSError *encryptDbError = nil;
-    db = [self encryptOrUnencryptDb:db name:storeName path:storePath oldKey:@"" newKey:key error:&encryptDbError];
+    db = [self encryptOrUnencryptDb:db name:storeName path:storePath oldKey:@"" newKey:key salt:salt error:&encryptDbError];
     if (encryptDbError != nil) {
         if (db) {
             [db close];
@@ -252,15 +263,15 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     return YES;
 }
 
-- (FMDatabase *)unencryptDb:(FMDatabase *)db name:(NSString *)storeName oldKey:(NSString *)oldKey error:(NSError **)error
+- (FMDatabase *)unencryptDb:(FMDatabase *)db name:(NSString *)storeName oldKey:(NSString *)oldKey salt:(NSString *)salt  error:(NSError **)error
 {
-    return [self encryptOrUnencryptDb:db name:storeName oldKey:oldKey newKey:@"" error:error];
+    return [self encryptOrUnencryptDb:db name:storeName oldKey:oldKey newKey:@"" salt:salt error:error];
 }
 
-+ (BOOL)unencryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key error:(NSError **)error
++ (BOOL)unencryptDbWithStoreName:(NSString *)storeName storePath:(NSString *)storePath key:(NSString *)key salt:(NSString *)salt error:(NSError **)error
 {
     NSError *openDbError = nil;
-    FMDatabase *db = [self openDatabaseWithPath:storePath key:key error:&openDbError];
+    FMDatabase *db = [self openDatabaseWithPath:storePath key:key salt:salt error:&openDbError];
     if (openDbError != nil) {
         if (db) {
             [db close];
@@ -272,7 +283,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     }
     
     NSError *encryptDbError = nil;
-    db = [self encryptOrUnencryptDb:db name:storeName path:storePath oldKey:key newKey:@"" error:&encryptDbError];
+    db = [self encryptOrUnencryptDb:db name:storeName path:storePath oldKey:key newKey:@"" salt:salt error:&encryptDbError];
     if (encryptDbError != nil) {
         if (db) {
             [db close];
@@ -291,10 +302,11 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
                                 name:(NSString *)storeName
                               oldKey:(NSString *)oldKey
                               newKey:(NSString *)newKey
+                                salt:(NSString *)salt
                                error:(NSError **)error
 {
     NSString *storePath = [self fullDbFilePathForStoreName:storeName];
-    return [[self class] encryptOrUnencryptDb:db name:storeName path:storePath oldKey:oldKey newKey:newKey error:error];
+    return [[self class] encryptOrUnencryptDb:db name:storeName path:storePath oldKey:oldKey newKey:newKey salt:salt error:error];
 }
 
 + (FMDatabase *)encryptOrUnencryptDb:(FMDatabase *)db
@@ -302,6 +314,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
                                 path:(NSString *)storePath
                               oldKey:(NSString *)oldKey
                               newKey:(NSString *)newKey
+                                salt:(NSString *)salt
                                error:(NSError **)error
 {
     if (newKey == nil) newKey = @"";
@@ -356,7 +369,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     
     // As a sanity check, verify that the new encrypted DB can be opened and read.
     NSError *openNewlyEncryptedDbError = nil;
-    FMDatabase *newlyEncryptedDb = [self openDatabaseWithPath:encDbPath key:newKey error:&openNewlyEncryptedDbError];
+    FMDatabase *newlyEncryptedDb = [self openDatabaseWithPath:encDbPath key:newKey salt:salt error:&openNewlyEncryptedDbError];
     if (!newlyEncryptedDb) {
         if (error != nil) {
             NSString *errorDesc = [NSString stringWithFormat:kSFSmartStoreVerifyDbErrorDesc, encDbPath, [openNewlyEncryptedDbError localizedDescription]];
@@ -385,7 +398,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
                                      userInfo:@{NSLocalizedDescriptionKey: errorDesc}];
         }
         [manager removeItemAtPath:encDbPath error:nil];
-        return [self setKeyForDb:db key:oldKey error:nil];
+        return [self setKeyForDb:db key:oldKey salt:salt error:nil];
     }
     fileOpSuccess = [manager moveItemAtPath:encDbPath toPath:storePath error:error];
     if (!fileOpSuccess) {
@@ -397,17 +410,17 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
         }
         [manager removeItemAtPath:encDbPath error:nil];
         [manager moveItemAtPath:backupPath toPath:storePath error:nil];
-        return [self setKeyForDb:db key:oldKey error:nil];
+        return [self setKeyForDb:db key:oldKey salt:salt error:nil];
     }
     
-    FMDatabase *encDb = [self openDatabaseWithPath:storePath key:newKey error:nil];
+    FMDatabase *encDb = [self openDatabaseWithPath:storePath key:newKey salt:salt error:nil];
     if (encDb) {
         [manager removeItemAtPath:backupPath error:nil];
         return encDb;
     } else {
         [manager removeItemAtPath:storePath error:nil];
         [manager moveItemAtPath:backupPath toPath:storePath error:nil];
-        return [self setKeyForDb:db key:oldKey error:nil];
+        return [self setKeyForDb:db key:oldKey salt:salt error:nil];
     }
 }
 

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -982,7 +982,7 @@
         // Encrypt the DB, verify access.
         NSString *encKey = @"BigSecret";
         NSError *encryptError = nil;
-        FMDatabase *encryptedDb = [dbMgr encryptDb:unencryptedDb name:storeName key:encKey error:&encryptError];
+        FMDatabase *encryptedDb = [dbMgr encryptDb:unencryptedDb name:storeName key:encKey salt:nil error:&encryptError];
         XCTAssertNotNil(encryptedDb, @"Encrypted DB should be a valid object.");
         XCTAssertNil(encryptError, @"Error encrypting the DB: %@", [encryptError localizedDescription]);
         isTableNameInMaster = [self tableNameInMaster:tableName db:encryptedDb];
@@ -1035,6 +1035,7 @@
         FMDatabase *unencryptedDb2 = [dbMgr unencryptDb:encryptedDb2
                                                    name:storeName
                                                  oldKey:encKey
+                                                   salt:nil
                                                   error:&unencryptError];
         XCTAssertNil(unencryptError, @"Error unencrypting the database: %@", [unencryptError localizedDescription]);
         isTableNameInMaster = [self tableNameInMaster:tableName db:unencryptedDb2];
@@ -1225,7 +1226,7 @@
     // Unencrypted store
     FMDatabase *storeDb = [self openDatabase:unencryptedStoreName withManager:[SFSmartStoreDatabaseManager sharedManager] key:encKey openShouldFail:NO];
     NSError *unencryptStoreError = nil;
-    storeDb = [[SFSmartStoreDatabaseManager sharedManager] unencryptDb:storeDb name:unencryptedStoreName oldKey:encKey error:&unencryptStoreError];
+    storeDb = [[SFSmartStoreDatabaseManager sharedManager] unencryptDb:storeDb name:unencryptedStoreName oldKey:encKey salt:nil error:&unencryptStoreError];
     XCTAssertNotNil(storeDb, @"Failed to unencrypt '%@': %@", unencryptedStoreName, [unencryptStoreError localizedDescription]);
     [storeDb close];
     [SFSmartStoreUpgrade setUsesKeyStoreEncryption:NO forUser:[SFUserAccountManager sharedInstance].currentUser store:unencryptedStoreName];
@@ -1336,7 +1337,7 @@
 - (FMDatabase *)openDatabase:(NSString *)dbName withManager:(SFSmartStoreDatabaseManager *)dbMgr key:(NSString *)key openShouldFail:(BOOL)openShouldFail
 {
     NSError *openDbError = nil;
-    FMDatabase *db = [dbMgr openStoreDatabaseWithName:dbName key:key error:&openDbError];
+    FMDatabase *db = [dbMgr openStoreDatabaseWithName:dbName key:key salt:nil error:&openDbError];
     if (openShouldFail) {
         XCTAssertNil(db, @"Opening database should have failed.");
     } else {


### PR DESCRIPTION
This PR does the following

- Allows for encrypted sqlite files to be shared between apps. It does so by enabling the ability for sqlcipher to store the headers for the sqlite file in plain text. Usually any app holding a write lock to a file is jetsam'd  by the jetsam monitor when the app is suspended. This rule applies to all files but sqlite files. SQLCipher encrypts the sqlite files and jetsam monitor is not able to detect the sqlite file causing the app to be jetsam'd 

- Switches the journaling mode for the database. 

- Stores the salt in keychain, since the salt is not stored with the database anymore. The salt  is applied subsequently using pragma. 

- Switches the DB to this shared mode only if app groups have been enabled. 


Note: Various upgrade scenarios have to be tested.  Will push out another PR for handling that situation.
