### PR TITLE
Fixing my domain config fetching for unauthenticated users

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -247,7 +247,7 @@ static NSString * const kSFECParameter = @"ec";
                         [strongSelf.oauthCoordinatorFlow beginUserAgentFlow];
                     }
                 });
-            } oauthCredentials:self.credentials];
+            } loginDomain:self.credentials.domain];
         }
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.h
@@ -28,6 +28,7 @@
 
 #import "SFOAuthOrgAuthConfiguration.h"
 #import "SFOAuthCredentials.h"
+#import "SalesforceSDKConstants.h"
 
 @interface SFSDKAuthConfigUtil : NSObject
 
@@ -35,6 +36,6 @@ typedef void (^ _Nonnull MyDomainAuthConfigBlock)(SFOAuthOrgAuthConfiguration * 
 
 + (void)getMyDomainAuthConfig:(nonnull MyDomainAuthConfigBlock)authConfigBlock loginDomain:(nonnull NSString *)loginDomain;
 
-+ (void)getMyDomainAuthConfig:(nonnull MyDomainAuthConfigBlock)authConfigBlock oauthCredentials:(nonnull SFOAuthCredentials *)oauthCredentials;
++ (void)getMyDomainAuthConfig:(nonnull MyDomainAuthConfigBlock)authConfigBlock oauthCredentials:(nonnull SFOAuthCredentials *)oauthCredentials SFSDK_DEPRECATED(7.1, 8.0, "Use getMyDomainConfig:authConfigBlock loginDomain:loginDomain instead.");
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.h
@@ -33,6 +33,8 @@
 
 typedef void (^ _Nonnull MyDomainAuthConfigBlock)(SFOAuthOrgAuthConfiguration * _Nullable authConfig, NSError * _Nullable error);
 
++ (void)getMyDomainAuthConfig:(nonnull MyDomainAuthConfigBlock)authConfigBlock loginDomain:(nonnull NSString *)loginDomain;
+
 + (void)getMyDomainAuthConfig:(nonnull MyDomainAuthConfigBlock)authConfigBlock oauthCredentials:(nonnull SFOAuthCredentials *)oauthCredentials;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
@@ -35,7 +35,11 @@ static NSString * const kSFOAuthEndPointAuthConfiguration = @"/.well-known/auth-
 @implementation SFSDKAuthConfigUtil
 
 + (void)getMyDomainAuthConfig:(MyDomainAuthConfigBlock)authConfigBlock oauthCredentials:(SFOAuthCredentials *)oauthCredentials {
-    NSString *orgConfigUrl = [NSString stringWithFormat:@"%@://%@%@", oauthCredentials.protocol, oauthCredentials.domain, kSFOAuthEndPointAuthConfiguration];
+    [SFSDKAuthConfigUtil getMyDomainAuthConfig:authConfigBlock loginDomain:oauthCredentials.domain];
+}
+
++ (void)getMyDomainAuthConfig:(MyDomainAuthConfigBlock)authConfigBlock loginDomain:(NSString *)loginDomain {
+    NSString *orgConfigUrl = [NSString stringWithFormat:@"https://%@%@", loginDomain, kSFOAuthEndPointAuthConfiguration];
     [SFSDKCoreLogger d:[self class] format:@"%@ Advanced authentication configured. Retrieving auth configuration from %@", NSStringFromSelector(_cmd), orgConfigUrl];
     NSMutableURLRequest *orgConfigRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:orgConfigUrl]];
     SFNetwork *network = [[SFNetwork alloc] initWithEphemeralSession];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthConfigUtilTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthConfigUtilTests.m
@@ -54,7 +54,7 @@ static NSString * const kSFSandboxEndpoint = @"test.salesforce.com";
         XCTAssertNotNil(authConfig, @"Auth config should not be nil");
         XCTAssertNotNil(authConfig.authConfigDict, @"Auth config dictionary should not be nil");
         [expect fulfill];
-    } oauthCredentials:credentials];
+    } loginDomain:credentials.domain];
     [self waitForExpectationsWithTimeout:20 handler:nil];
 }
 
@@ -68,7 +68,7 @@ static NSString * const kSFSandboxEndpoint = @"test.salesforce.com";
         XCTAssertNotNil(authConfig.authConfigDict, @"Auth config dictionary should not be nil");
         XCTAssertTrue(authConfig.useNativeBrowserForAuth, @"Browser based login should be enabled");
         [expect fulfill];
-    } oauthCredentials:credentials];
+    } loginDomain:credentials.domain];
     [self waitForExpectationsWithTimeout:20 handler:nil];
 }
 
@@ -83,7 +83,7 @@ static NSString * const kSFSandboxEndpoint = @"test.salesforce.com";
         XCTAssertNotNil(authConfig.ssoUrls, @"SSO URLs should not be nil");
         XCTAssertTrue(authConfig.ssoUrls.count >= 1, @"SSO URLs should have at least 1 valid entry");
         [expect fulfill];
-    } oauthCredentials:credentials];
+    } loginDomain:credentials.domain];
     [self waitForExpectationsWithTimeout:20 handler:nil];
 }
 
@@ -97,7 +97,7 @@ static NSString * const kSFSandboxEndpoint = @"test.salesforce.com";
         XCTAssertNotNil(authConfig.authConfigDict, @"Auth config dictionary should not be nil");
         XCTAssertTrue(authConfig.ssoUrls.count == 0, @"SSO URLs should be empty");
         [expect fulfill];
-    } oauthCredentials:credentials];
+    } loginDomain:credentials.domain];
     [self waitForExpectationsWithTimeout:20 handler:nil];
 }
 
@@ -112,7 +112,7 @@ static NSString * const kSFSandboxEndpoint = @"test.salesforce.com";
         XCTAssertNotNil(authConfig.loginPageUrl, @"Login page URL should not be nil");
         XCTAssertTrue([authConfig.loginPageUrl containsString:kSFAlternateMyDomainEndpoint], @"Login page URL should contain correct URL");
         [expect fulfill];
-    } oauthCredentials:credentials];
+    } loginDomain:credentials.domain];
     [self waitForExpectationsWithTimeout:20 handler:nil];
 }
 
@@ -123,7 +123,7 @@ static NSString * const kSFSandboxEndpoint = @"test.salesforce.com";
     [SFSDKAuthConfigUtil getMyDomainAuthConfig:^(SFOAuthOrgAuthConfiguration *authConfig, NSError *error) {
         XCTAssertNil(authConfig, @"Auth config should be nil");
         [expect fulfill];
-    } oauthCredentials:credentials];
+    } loginDomain:credentials.domain];
     [self waitForExpectationsWithTimeout:20 handler:nil];
 }
 


### PR DESCRIPTION
The whole point of fetching domain config from `.well-known` is that it can be used to determine the type of authentication, i.e. should not be tied to a user account. The existing API encourages callers to pass in `user.credentials`, which breaks in the unauthenticated use case because our code constructs a request to `null://null`, which fails. All we need is `loginDomain` to make the request to. This lines up the implementation with how it is on `Android`. I mentioned this briefly to @trooper2013 earlier this week. I'll have a related PR for the hybrid repo too.