### PR TITLE
Add lifetime to properties to remove warnings

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -128,7 +128,7 @@ NS_SWIFT_NAME(SalesforceManager)
  *
  * @return App name.
  */
-@property (class,nonatomic)NSString *ailtnAppName NS_SWIFT_NAME(analyticsAppName);
+@property (class,nonatomic,retain)NSString *ailtnAppName NS_SWIFT_NAME(analyticsAppName);
 
 
 /**

--- a/libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.h
+++ b/libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @return The singleton instance of the SDK Manager.
  */
-@property(class,nonatomic) SmartStoreSDKManager *sharedManager NS_SWIFT_NAME(shared);
+@property(class,nonatomic,retain) SmartStoreSDKManager *sharedManager NS_SWIFT_NAME(shared);
 
 @end
 

--- a/libs/SmartSync/SmartSync/Classes/Manager/SmartSyncSDKManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SmartSyncSDKManager.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @return The singleton instance of the SDK Manager.
  */
-@property(class,nonatomic)SmartSyncSDKManager *sharedManager NS_SWIFT_NAME(shared);
+@property(class,nonatomic,retain)SmartSyncSDKManager *sharedManager NS_SWIFT_NAME(shared);
 
 @end
 


### PR DESCRIPTION
The missing lifetime properties in this pr cause warnings which when you turn on warning as errors cause errors in the code. 

Seems reasonable to have lifetime attributes here since the default assign doesn't make that much sense.

@trooper2013 @wmathurin 