### PR TITLE
Reading all bytes then converting to string when reading back file

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -864,7 +864,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
                                 key:(NSData*)key
                                  iv:(NSData*)iv
 {
-    NSMutableString* content = [NSMutableString new];
+    NSMutableData* content = [NSMutableData new];
     NSInputStream *inputStream = nil;
     if (key) {
         SFDecryptStream *decryptStream = [[SFDecryptStream alloc] initWithFileAtPath:filePath];
@@ -874,17 +874,20 @@ NSString *const EXPLAIN_ROWS = @"rows";
         inputStream = [[NSInputStream alloc] initWithFileAtPath:filePath];
     }
     
+    
+    //
+    // We get all the bytes and then convert them to a string
+    // If you convert each buffer's worth of bytes to a string
+    // you might end up corrupting the string (because a multi bytes character could have been split at the buffer boundary)
+    //
     uint8_t buffer[4096];
     NSInteger len;
     [inputStream open];
     while ((len = [inputStream read:buffer maxLength:sizeof(buffer)]) > 0) {
-        NSString* bufferAsString = [[NSString alloc] initWithBytes:buffer length:len encoding:NSUTF8StringEncoding];
-        if (bufferAsString) {
-            [content appendString:bufferAsString];
-        }
+        [content appendBytes:buffer length:len];
     }
     [inputStream close];
-    return content;
+    return [[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding];
 }
 
 - (void) writeToEncryptedFile:(NSString*)filePath


### PR DESCRIPTION
If you convert each buffer's worth of bytes to a string you might end up corrupting the string (because a multi bytes character could have been split at the buffer boundary.