### PR TITLE
 Renaming resume as restart

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
@@ -50,12 +50,12 @@ extern NSString * const kSFSyncManagerStateStopped;
 // Errors
 extern NSString* const kSFSmartSyncErrorDomain;
 extern NSString* const kSFSyncManagerStoppedError;
-extern NSString* const kSFSyncManagerCannotResumeError;
+extern NSString* const kSFSyncManagerCannotRestartError;
 extern NSString* const kSFSyncAlreadyRunningError;
 extern NSString* const kSFSyncNotExistError;
 
 extern NSInteger const kSFSyncManagerStoppedErrorCode;
-extern NSInteger const kSFSyncManagerCannotResumeErrorCode;
+extern NSInteger const kSFSyncManagerCannotRestartErrorCode;
 extern NSInteger const kSFSyncAlreadyRunningErrorCode;
 extern NSInteger const kSFSyncNotExistErrorCode;
 
@@ -150,14 +150,14 @@ NS_SWIFT_NAME(SyncManager)
 - (BOOL) isStopped;
 
 /**
- * Resume this sync manager
+ * Restart this sync manager
  *
  * @param restartStoppedSyncs Pass YES to restart all stopped sync.
  * @param updateBlock The block to be called with updates.
  * @param error To get an error back (optional).
- * @return YES if resume started successfully.
+ * @return YES if restarted successfully.
  */
-- (BOOL) resume:(BOOL)restartStoppedSyncs updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**)error NS_SWIFT_NAME(resume(restartStoppedSyncs:onUpdate:));
+- (BOOL) restart:(BOOL)restartStoppedSyncs updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**)error NS_SWIFT_NAME(restart(restartStoppedSyncs:onUpdate:));
 
 /**
  * Check if sync manager is running

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.h
@@ -137,17 +137,17 @@ NS_SWIFT_NAME(SyncManager)
  * It might take a while for active syncs to actually get stopped
  * Call isStopped() to see if syncManager is fully paused
  */
-- (void) stop;
+- (void)stop;
 
 /**
  * @return YES if stop was requested but there are still active syncs
  */
-- (BOOL) isStopping;
+- (BOOL)isStopping;
 
 /**
  * @return YES if stop was requested and there no syncs are active anymore
  */
-- (BOOL) isStopped;
+- (BOOL)isStopped;
 
 /**
  * Restart this sync manager
@@ -157,7 +157,7 @@ NS_SWIFT_NAME(SyncManager)
  * @param error To get an error back (optional).
  * @return YES if restarted successfully.
  */
-- (BOOL) restart:(BOOL)restartStoppedSyncs updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**)error NS_SWIFT_NAME(restart(restartStoppedSyncs:onUpdate:));
+- (BOOL)restart:(BOOL)restartStoppedSyncs updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**)error NS_SWIFT_NAME(restart(restartStoppedSyncs:onUpdate:));
 
 /**
  * Check if sync manager is running
@@ -218,9 +218,9 @@ NS_SWIFT_NAME(SyncManager)
  * @param target The sync down target that will manage the sync down process.
  * @param soupName The soup name where the local entries are stored.
  * @param updateBlock The block to be called with updates.
- * @return The sync state associated with this sync down.
+ * @return The sync state associated with this sync or nil if it could not be created.
  */
-- (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncDown(target:soupName:onUpdate:));
+- (nullable SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncDown(target:soupName:onUpdate:));
 
 /**
  * Creates and runs a sync down.
@@ -228,8 +228,9 @@ NS_SWIFT_NAME(SyncManager)
  * @param options The options associated with this sync down.
  * @param soupName The soup name where the local entries are stored.
  * @param updateBlock The block to be called with updates.
+ * @return The sync state associated with this sync or nil if it could not be created.
  */
-- (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncDown(target:options:soupName:onUpdate:));
+- (nullable SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncDown(target:options:soupName:onUpdate:));
 
 /**
  * Creates and runs a named sync down.
@@ -238,8 +239,21 @@ NS_SWIFT_NAME(SyncManager)
  * @param soupName The soup name where the local entries are stored.
  * @param syncName The name for this sync.
  * @param updateBlock The block to be called with updates.
+ * @return The sync state associated with this sync or nil if it could not be created.
  */
-- (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName syncName:(nullable NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncDown(target:options:soupName:syncName:onUpdate:));
+- (nullable SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName syncName:(nullable NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock SFSDK_DEPRECATED(7.1, 8.0, "Use syncDownWithTarget:options:soupName:syncName:updateBlock:error instead");;
+
+/**
+ * Creates and runs a named sync down.
+ * @param target The sync down target that will manage the sync down process.
+ * @param options The options associated with this sync down.
+ * @param soupName The soup name where the local entries are stored.
+ * @param syncName The name for this sync.
+ * @param updateBlock The block to be called with updates.
+ * @param error Sets error if sync could not be created.
+ * @return The sync state associated with this sync or nil if it could not be created.
+ */
+- (nullable SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName syncName:(nullable NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**)error NS_SWIFT_NAME(syncDown(target:options:soupName:syncName:onUpdate:));
 
 /**
  * Performs a resync.
@@ -253,6 +267,7 @@ NS_SWIFT_NAME(SyncManager)
  * @param syncId Sync ID.
  * @param updateBlock The block to be called with updates.
  * @param error Sets error if sync could not be started.
+ * @return The sync state associated with this sync or nil if it could not be started.
  */
 - (nullable SFSyncState*) reSync:(NSNumber*)syncId updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**) error NS_SWIFT_NAME(reSync(id:onUpdate:));
 
@@ -260,6 +275,7 @@ NS_SWIFT_NAME(SyncManager)
  * Performs a resync by name.
  * @param syncName Sync name.
  * @param updateBlock The block to be called with updates.
+ * @return The sync state associated with this sync or nil if it could not be started.
  */
 - (nullable SFSyncState*) reSyncByName:(NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock SFSDK_DEPRECATED(7.1, 8.0, "Use reSyncByName:updateBlock:error instead");
 
@@ -268,6 +284,7 @@ NS_SWIFT_NAME(SyncManager)
  * @param syncName Sync name.
  * @param updateBlock The block to be called with updates.
  * @param error Sets error if sync could not be started.
+ * @return The sync state associated with this sync or nil if it could not be started.
  */
 - (nullable SFSyncState*) reSyncByName:(NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**)error NS_SWIFT_NAME(reSync(named:onUpdate:));
 
@@ -288,9 +305,9 @@ NS_SWIFT_NAME(SyncManager)
  * @param options The options associated with this sync up.
  * @param soupName The soup name where the local entries are stored.
  * @param updateBlock The block to be called with updates.
- * @return The sync state associated with this sync up.
+ * @return The sync state associated with this sync or nil if it could not be created.
  */
-- (SFSyncState*) syncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncUp(options:soupName:onUpdate:));
+- (nullable SFSyncState*) syncUpWithOptions:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncUp(options:soupName:onUpdate:));
 
 /**
  * Creates and runs a sync up with the configured SFSyncUpTarget.
@@ -299,12 +316,12 @@ NS_SWIFT_NAME(SyncManager)
  * @param options The options associated with this sync up.
  * @param soupName The soup name where the local entries are stored.
  * @param updateBlock The block to be called with updates.
- * @return The sync state associated with this sync up.
+ * @return The sync state associated with this sync or nil if it could not be created.
  */
-- (SFSyncState*) syncUpWithTarget:(SFSyncUpTarget*)target
-                          options:(SFSyncOptions*)options
-                         soupName:(NSString*)soupName
-                      updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncUp(target:options:soupName:onUpdate:));
+- (nullable SFSyncState*) syncUpWithTarget:(SFSyncUpTarget*)target
+                                   options:(SFSyncOptions*)options
+                                  soupName:(NSString*)soupName
+                               updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncUp(target:options:soupName:onUpdate:));
 
 /**
  * Creates and runs a named sync up.
@@ -314,13 +331,32 @@ NS_SWIFT_NAME(SyncManager)
  * @param soupName The soup name where the local entries are stored.
  * @param syncName The name for this sync.
  * @param updateBlock The block to be called with updates.
- * @return The sync state associated with this sync up.
+ * @return The sync state associated with this sync or nil if it could not be created.
  */
-- (SFSyncState*) syncUpWithTarget:(SFSyncUpTarget*)target
-                          options:(SFSyncOptions*)options
-                         soupName:(NSString*)soupName
-                         syncName:(nullable NSString*)syncName
-                      updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock NS_SWIFT_NAME(syncUp(target:options:soupName:syncName:onUpdate:));
+- (nullable SFSyncState*) syncUpWithTarget:(SFSyncUpTarget*)target
+                                   options:(SFSyncOptions*)options
+                                  soupName:(NSString*)soupName
+                                  syncName:(nullable NSString*)syncName
+                               updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock SFSDK_DEPRECATED(7.1, 8.0, "Use syncUpWithTarget:options:soupName:syncName:updateBlock:error instead");
+
+/**
+ * Creates and runs a named sync up.
+ *
+ * @param target The sync up target that will manage the sync up process.
+ * @param options The options associated with this sync up.
+ * @param soupName The soup name where the local entries are stored.
+ * @param syncName The name for this sync.
+ * @param updateBlock The block to be called with updates.
+ * @param error Sets error if sync could not be created.
+ * @return The sync state associated with this sync or nil if it could not be created.
+ */
+- (nullable SFSyncState*) syncUpWithTarget:(SFSyncUpTarget*)target
+                                   options:(SFSyncOptions*)options
+                                  soupName:(NSString*)soupName
+                                  syncName:(nullable NSString*)syncName
+                               updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock
+                                     error:(NSError**)error NS_SWIFT_NAME(syncUp(target:options:soupName:syncName:onUpdate:));
+
 
 /**
  * Removes local copies of records that have been deleted on the server

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -223,7 +223,7 @@ static NSMutableDictionary *syncMgrList = nil;
             if (restartStoppedSyncs) {
                 NSArray* stoppedSyncs = [SFSyncState getSyncsWithStatus:self.store status:SFSyncStateStatusStopped];
                 for (SFSyncState* sync in stoppedSyncs) {
-                    [SFSDKSmartSyncLogger d:[self class] format:@"resuming %@", @(sync.syncId)];
+                    [SFSDKSmartSyncLogger d:[self class] format:@"restarting %@", @(sync.syncId)];
                     [self reSync:@(sync.syncId) updateBlock:updateBlock error:nil];
                 }
             }

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -53,12 +53,12 @@ NSString * const kSFSyncManagerStateStopped = @"stopped";
 // Errors
 NSString* const kSFSmartSyncErrorDomain = @"com.salesforce.SmartSync.ErrorDomain";
 NSString* const kSFSyncManagerStoppedError = @"SyncManagerStoppedError";
-NSString* const kSFSyncManagerCannotResumeError = @"SyncManagerCannotError";
+NSString* const kSFSyncManagerCannotRestartError = @"SyncManagerCannotRestartError";
 NSString* const kSFSyncAlreadyRunningError = @"SyncAlreadyRunningError";
 NSString* const kSFSyncNotExistError = @"SyncNotExistError";
 
 NSInteger const kSFSyncManagerStoppedErrorCode = 900;
-NSInteger const kSFSyncManagerCannotResumeErrorCode = 901;
+NSInteger const kSFSyncManagerCannotRestartErrorCode = 901;
 NSInteger const kSFSyncAlreadyRunningErrorCode = 902;
 NSInteger const kSFSyncNotExistErrorCode = 903;
 
@@ -187,7 +187,7 @@ static NSMutableDictionary *syncMgrList = nil;
     return self;
 }
 
-#pragma mark - stop / resume methods
+#pragma mark - stop / restart methods
 
 - (void) setState:(SFSyncManagerState)state {
     if (_state != state) {
@@ -216,7 +216,7 @@ static NSMutableDictionary *syncMgrList = nil;
     return self.state == SFSyncManagerStateStopped;
 }
 
-- (BOOL) resume:(BOOL)restartStoppedSyncs updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**)error {
+- (BOOL) restart:(BOOL)restartStoppedSyncs updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**)error {
     @synchronized (self) {
         if ([self isStopped]) {
             self.state = SFSyncManagerStateAcceptingSyncs;
@@ -230,8 +230,8 @@ static NSMutableDictionary *syncMgrList = nil;
             return YES;
         } else {
             if (error) {
-                NSString* description = [NSString stringWithFormat:@"resume() called on a sync manager that has state: %@", [SFSmartSyncSyncManager stateToString:self.state]];
-                *error = [self errorWithType:kSFSyncManagerCannotResumeError code:kSFSyncManagerCannotResumeErrorCode description:description];
+                NSString* description = [NSString stringWithFormat:@"restart() called on a sync manager that has state: %@", [SFSmartSyncSyncManager stateToString:self.state]];
+                *error = [self errorWithType:kSFSyncManagerCannotRestartError code:kSFSyncManagerCannotRestartErrorCode description:description];
             }
             return NO;
         }

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSmartSyncSyncManager.m
@@ -348,10 +348,6 @@ static NSMutableDictionary *syncMgrList = nil;
 /** Run a previously created sync
  */
 - (void) runSync:(SFSyncState*) sync updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**)error {
-    if (![self checkAcceptingSyncs:error]) {
-        return;
-    }
-    
     SFSyncTask* task;
     switch (sync.type) {
         case SFSyncStateSyncTypeDown:
@@ -381,10 +377,18 @@ static NSMutableDictionary *syncMgrList = nil;
 }
 
 - (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock {
-   return [self syncDownWithTarget:target options:options soupName:soupName syncName:nil updateBlock:updateBlock];
+    return [self syncDownWithTarget:target options:options soupName:soupName syncName:nil updateBlock:updateBlock error:nil];
 }
 
 - (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName syncName:(NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock {
+    return [self syncDownWithTarget:target options:options soupName:soupName syncName:syncName updateBlock:updateBlock error:nil];
+}
+
+- (SFSyncState*) syncDownWithTarget:(SFSyncDownTarget*)target options:(SFSyncOptions*)options soupName:(NSString*)soupName syncName:(NSString*)syncName updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**)error {
+    if (![self checkAcceptingSyncs:error]) {
+        return nil;
+    }
+
     SFSyncState *sync = [self createSyncDown:target options:options soupName:soupName syncName:syncName];
     [self runSync:sync updateBlock:updateBlock error:nil];
     return [sync copy];
@@ -427,7 +431,7 @@ static NSMutableDictionary *syncMgrList = nil;
 }
 
 - (SFSyncState*) reSyncWithSync:(SFSyncState*)sync updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock error:(NSError**)error {
-    if (![self checkNotRunning:@(sync.syncId) error:error]) {
+    if (![self checkAcceptingSyncs:error] || ![self checkNotRunning:@(sync.syncId) error:error]) {
         return nil;
     }
     
@@ -457,14 +461,27 @@ static NSMutableDictionary *syncMgrList = nil;
                          options:(SFSyncOptions *)options
                         soupName:(NSString *)soupName
                      updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock {
-    return [self syncUpWithTarget:target options:options soupName:soupName syncName:nil updateBlock:updateBlock];
+    return [self syncUpWithTarget:target options:options soupName:soupName syncName:nil updateBlock:updateBlock error:nil];
+}
+
+- (SFSyncState*) syncUpWithTarget:(SFSyncUpTarget *)target
+                          options:(SFSyncOptions *)options
+                         soupName:(NSString *)soupName
+                         syncName:(NSString*)syncName
+                      updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock {
+    return [self syncUpWithTarget:target options:options soupName:soupName syncName:syncName updateBlock:updateBlock error:nil];
 }
 
 - (SFSyncState*) syncUpWithTarget:(SFSyncUpTarget *)target
                          options:(SFSyncOptions *)options
                         soupName:(NSString *)soupName
                         syncName:(NSString*)syncName
-                     updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock {
+                     updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock
+                            error:(NSError**)error {
+    if (![self checkAcceptingSyncs:error]) {
+        return nil;
+    }
+
     SFSyncState *sync = [self createSyncUp:target options:options soupName:soupName syncName:syncName];
     [self runSync:sync updateBlock:updateBlock error:nil];
     return [sync copy];

--- a/libs/SmartSync/SmartSyncTests/SFSyncUpdateCallbackQueue.h
+++ b/libs/SmartSync/SmartSyncTests/SFSyncUpdateCallbackQueue.h
@@ -41,9 +41,9 @@
 - (SFSyncState*)runReSyncByName:(NSString*)syncName syncManager:(SFSmartSyncSyncManager*)syncManager error:(NSError**)error;
 
 /**
- Resume sync manager
+ Restart sync manager
  */
-- (BOOL)resume:(SFSmartSyncSyncManager*)syncManager restartStoppedSyncs:(BOOL)restartStoppedSyncs restartSterror:(NSError**)error;
+- (BOOL)restart:(SFSmartSyncSyncManager*)syncManager restartStoppedSyncs:(BOOL)restartStoppedSyncs restartSterror:(NSError**)error;
 
 /**
  Get next sync update

--- a/libs/SmartSync/SmartSyncTests/SFSyncUpdateCallbackQueue.m
+++ b/libs/SmartSync/SmartSyncTests/SFSyncUpdateCallbackQueue.m
@@ -81,8 +81,8 @@
     } error:error];
 }
 
-- (BOOL) resume:(SFSmartSyncSyncManager*)syncManager restartStoppedSyncs:(BOOL)restartStoppedSyncs restartSterror:(NSError**)error {
-    return [syncManager resume:restartStoppedSyncs updateBlock:^(SFSyncState *sync) {
+- (BOOL) restart:(SFSmartSyncSyncManager*)syncManager restartStoppedSyncs:(BOOL)restartStoppedSyncs restartSterror:(NSError**)error {
+    return [syncManager restart:restartStoppedSyncs updateBlock:^(SFSyncState *sync) {
         @synchronized(self.queue) {
             [self.queue addObject:[sync copy]];
         }

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -996,7 +996,7 @@
     XCTAssertEqual(kSFSyncManagerStoppedErrorCode, error.code, @"Wrong error code");
     XCTAssertEqualObjects(kSFSyncManagerStoppedError, error.userInfo[@"error"], @"Wrong error type");
     
-    // Resuming sync manager without restarting syncs
+    // Restarting sync manager without restarting syncs
     error = nil;
     BOOL resultOfRestart = [queue restart:self.syncManager restartStoppedSyncs:NO restartSterror:&error];
     XCTAssertTrue(resultOfRestart);
@@ -1009,7 +1009,7 @@
     // Stop sync manager
     [self stopSyncManager:0];
 
-    // Resuming sync manager restarting syncs
+    // Restarting sync manager restarting syncs
     error = nil;
     resultOfRestart = [queue restart:self.syncManager restartStoppedSyncs:YES restartSterror:&error];
     XCTAssertTrue(resultOfRestart);
@@ -1076,7 +1076,7 @@
     [self checkSyncState:@(syncId1) expectedTimeStamp:[target1 dateForPositionAsMillis:numberOfRecordsFetched1-1] expectedStatus:SFSyncStateStatusStopped];
     [self checkSyncState:@(syncId2) expectedTimeStamp:-1 expectedStatus:SFSyncStateStatusStopped];
 
-    // Resuming sync manager without restarting syncs
+    // Restarting sync manager without restarting syncs
     XCTAssertTrue([queue restart:self.syncManager restartStoppedSyncs:NO restartSterror:&error]);
     XCTAssertNil(error);
     XCTAssertFalse([self.syncManager isStopped], @"Stopped should be false");
@@ -1104,7 +1104,7 @@
     [self checkDbForAfterTestSyncDown:target1 soupName:ACCOUNTS_SOUP expectedNumberOfRecords:numberOfRecordsFetched1];
     [self checkDbForAfterTestSyncDown:target2 soupName:ACCOUNTS_SOUP expectedNumberOfRecords:numberOfRecordsFetched2];
 
-    // Resuming sync manager restarting syncs
+    // Restarting sync manager restarting syncs
     XCTAssertTrue([queue restart:self.syncManager restartStoppedSyncs:YES restartSterror:&error]);
     XCTAssertNil(error);
     XCTAssertFalse([self.syncManager isStopped], @"Stopped should be false");

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTests.m
@@ -953,9 +953,9 @@
 /**
  * Test running and stopping a single sync down (using TestSyncDownTarget)
  */
-- (void) testStopResumeSingleSyncDown {
+- (void) testStopRestartSingleSyncDown {
     [self createAccountsSoup];
-    NSString* syncName = @"testStopResumeSingleSyncDown";
+    NSString* syncName = @"testStopRestartSingleSyncDown";
     NSUInteger numberOfRecords = 10;
     TestSyncDownTarget* target = [[TestSyncDownTarget alloc] initWithPrefix:@"test" numberOfRecords:numberOfRecords numberOfRecordsPerPage:1 sleepPerFetch:0.1];
     SFSyncOptions* options = [SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeLeaveIfChanged];
@@ -998,8 +998,8 @@
     
     // Resuming sync manager without restarting syncs
     error = nil;
-    BOOL resultOfResume = [queue resume:self.syncManager restartStoppedSyncs:NO restartSterror:&error];
-    XCTAssertTrue(resultOfResume);
+    BOOL resultOfRestart = [queue restart:self.syncManager restartStoppedSyncs:NO restartSterror:&error];
+    XCTAssertTrue(resultOfRestart);
     XCTAssertNil(error);
     XCTAssertFalse([self.syncManager isStopped], @"Stopped should be false");
     
@@ -1011,8 +1011,8 @@
 
     // Resuming sync manager restarting syncs
     error = nil;
-    resultOfResume = [queue resume:self.syncManager restartStoppedSyncs:YES restartSterror:&error];
-    XCTAssertTrue(resultOfResume);
+    resultOfRestart = [queue restart:self.syncManager restartStoppedSyncs:YES restartSterror:&error];
+    XCTAssertTrue(resultOfRestart);
     XCTAssertNil(error);
     XCTAssertFalse([self.syncManager isStopped], @"Stopped should be false");
 
@@ -1032,10 +1032,10 @@
 /**
  * Test running and stopping multiple (using TestSyncDownTarget)
  */
-- (void) testStopResumeMultipleSyncDowns {
+- (void) testStopRestartMultipleSyncDowns {
     [self createAccountsSoup];
-    NSString* syncName1 = @"testStopResumeMultipleSyncDowns1";
-    NSString* syncName2 = @"testStopResumeMultipleSyncDowns2";
+    NSString* syncName1 = @"testStopRestartMultipleSyncDowns1";
+    NSString* syncName2 = @"testStopRestartMultipleSyncDowns2";
     NSUInteger numberOfRecords1 = 5;
     NSUInteger numberOfRecords2 = 4;
     
@@ -1077,7 +1077,7 @@
     [self checkSyncState:@(syncId2) expectedTimeStamp:-1 expectedStatus:SFSyncStateStatusStopped];
 
     // Resuming sync manager without restarting syncs
-    XCTAssertTrue([queue resume:self.syncManager restartStoppedSyncs:NO restartSterror:&error]);
+    XCTAssertTrue([queue restart:self.syncManager restartStoppedSyncs:NO restartSterror:&error]);
     XCTAssertNil(error);
     XCTAssertFalse([self.syncManager isStopped], @"Stopped should be false");
     
@@ -1105,7 +1105,7 @@
     [self checkDbForAfterTestSyncDown:target2 soupName:ACCOUNTS_SOUP expectedNumberOfRecords:numberOfRecordsFetched2];
 
     // Resuming sync manager restarting syncs
-    XCTAssertTrue([queue resume:self.syncManager restartStoppedSyncs:YES restartSterror:&error]);
+    XCTAssertTrue([queue restart:self.syncManager restartStoppedSyncs:YES restartSterror:&error]);
     XCTAssertNil(error);
     XCTAssertFalse([self.syncManager isStopped], @"Stopped should be false");
     [self checkStatus:[queue getNextSyncUpdate] expectedType:SFSyncStateSyncTypeDown expectedId:syncId1 expectedTarget:target1 expectedOptions:options expectedStatus:SFSyncStateStatusRunning expectedProgress:0 expectedTotalSize:-1];


### PR DESCRIPTION
Also fixing comments and adding syncDown and syncUp that accepts an NSError (also returning nil when an error occurs -> otherwise we won't get a throw in Swift).