### PR TITLE
Fix newline for file upload

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -297,9 +297,10 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
     NSString *newline = @"\r\n";
     NSString *bodyContentDisposition = [NSString stringWithFormat:@"Content-Disposition: form-data; name=\"%@\";", key];
     if (fileName) {
-        bodyContentDisposition = [bodyContentDisposition stringByAppendingFormat:@" filename=\"%@\"%@", fileName, newline];
+        bodyContentDisposition = [bodyContentDisposition stringByAppendingFormat:@" filename=\"%@\"", fileName];
     }
     [body appendData:[bodyContentDisposition dataUsingEncoding:NSUTF8StringEncoding]];
+    [body appendData:[newline dataUsingEncoding:NSUTF8StringEncoding]];
     [body appendData:[[NSString stringWithFormat:@"Content-Type: %@; charset=UTF-8%@",mimeType, newline] dataUsingEncoding:NSUTF8StringEncoding]];
     [body appendData:[newline dataUsingEncoding:NSUTF8StringEncoding]];
     [body appendData:fileData];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -1298,6 +1298,7 @@ static NSException *authException = nil;
     // check response
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
     XCTAssertEqualObjects(listener.dataResponse[@"title"], fileTitle, @"wrong title");
+    XCTAssertEqualObjects(listener.dataResponse[@"description"], fileDescription, @"wrong description");
     XCTAssertEqual([listener.dataResponse[@"contentSize"] intValue], [fileSize intValue], @"wrong content size");
     XCTAssertEqualObjects(listener.dataResponse[@"mimeType"], fileMimeType, @"wrong mime type");
     


### PR DESCRIPTION
If `fileName` isn't present, there's no newline between content-disposition and content-type. This was causing the description population to fail (it looks like the file title worked because it falls back to file name in the second entry)

body example:
```
--F55213D5-CCFC-4A5E-B4AA-FBD1F6DDB11D
Content-Disposition: form-data; name="json";Content-Type: application/json; charset=UTF-8

{
  "title" : "FileName576627683.080583.txt",
  "desc" : "FileDescription576627683.080583"
}
--F55213D5-CCFC-4A5E-B4AA-FBD1F6DDB11D
Content-Disposition: form-data; name="fileData"; filename="FileName576627683.080583.txt"
Content-Type: text/plain; charset=UTF-8

FileData576627683.080583
--F55213D5-CCFC-4A5E-B4AA-FBD1F6DDB11D--
```