### PR TITLE
Generate salt using key from key store

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -139,15 +139,10 @@ NSString *const EXPLAIN_ROWS = @"rows";
     
     if (!_encryptionSaltBlock) {
         _encryptionSaltBlock = ^ {
-            NSString *salt = nil;
-            if ([[SFSDKDatasharingHelper sharedInstance] appGroupEnabled]) {
-                SFKeychainItemWrapper *saltItem = [SFKeychainItemWrapper itemWithIdentifier:kSFSmartStoreEncryptionSaltLabel account:nil];
-                salt = [saltItem valueString];
-                if (!salt){
-                    // First Create a Salt 32 byte long
-                    salt = [[SFSDKCryptoUtils randomByteDataWithLength:32] md5];
-                    [saltItem setValueString:salt];
-                }
+            NSString* salt = nil;
+            if ([[SFKeyStoreManager sharedInstance] keyWithLabelExists:kSFSmartStoreEncryptionSaltLabel] || [[SFSDKDatasharingHelper sharedInstance] appGroupEnabled]) {
+                SFEncryptionKey *saltKey = [[SFKeyStoreManager sharedInstance]   retrieveKeyWithLabel:kSFSmartStoreEncryptionSaltLabel autoCreate:YES];
+                salt = [[saltKey key] md5];
             }
             return salt;
         };


### PR DESCRIPTION
In shared mode for SmartStore, we are expected to generate and store a salt. We have to do that since SQlCipher is told to store the sqlite  header as plain text. See PR #2820  Once the developer switches to shared mode all files are moved to shared (appgroups) location and sqlite db headers are adjusted to be in plain text. Moving back from shared mode (exception) would require that the salt is patched pack to the header of the sqlite file. Instead we continue to use the salt that has been generated and stored in the keychain.  