### PR TITLE
Fixes configuring of mdm settings for non-launch flow

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		B716A2F4218F4CBB009D407F /* SFSDKBiometricViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A3161D0D2181113800437BD2 /* SFSDKBiometricViewController.m */; };
 		B716A3A3218F5E5B009D407F /* SalesforceAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B716A398218F5E37009D407F /* SalesforceAnalytics.framework */; };
 		B716A3A4218F5E5B009D407F /* SalesforceSDKCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B716A38A218F5E2D009D407F /* SalesforceSDKCommon.framework */; };
+		B7352CA522761D8400DA2CFF /* SFManagedPreferencesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B7352CA422761D8400DA2CFF /* SFManagedPreferencesTest.m */; };
 		B75233C21F4D390B00040B6E /* SFSDKOAuthClientContext.h in Headers */ = {isa = PBXBuildFile; fileRef = B75233C01F4D390B00040B6E /* SFSDKOAuthClientContext.h */; };
 		B75233C31F4D390B00040B6E /* SFSDKOAuthClientContext.h in Headers */ = {isa = PBXBuildFile; fileRef = B75233C01F4D390B00040B6E /* SFSDKOAuthClientContext.h */; };
 		B75233C41F4D390B00040B6E /* SFSDKOAuthClientContext.m in Sources */ = {isa = PBXBuildFile; fileRef = B75233C11F4D390B00040B6E /* SFSDKOAuthClientContext.m */; };
@@ -1103,6 +1104,7 @@
 		B716A383218F5E2D009D407F /* SalesforceSDKCommon.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceSDKCommon.xcodeproj; path = ../SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj; sourceTree = "<group>"; };
 		B716A38F218F5E37009D407F /* SalesforceAnalytics.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceAnalytics.xcodeproj; path = ../SalesforceAnalytics/SalesforceAnalytics.xcodeproj; sourceTree = "<group>"; };
 		B7282F3F1D8C70E700475F79 /* SalesforceSDKCoreTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SalesforceSDKCoreTestApp.entitlements; sourceTree = "<group>"; };
+		B7352CA422761D8400DA2CFF /* SFManagedPreferencesTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFManagedPreferencesTest.m; path = SalesforceSDKCoreTests/SFManagedPreferencesTest.m; sourceTree = SOURCE_ROOT; };
 		B73BB6F322090DEB0009A7DD /* SFUserAccountIdentity+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SFUserAccountIdentity+Internal.h"; sourceTree = "<group>"; };
 		B75233C01F4D390B00040B6E /* SFSDKOAuthClientContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKOAuthClientContext.h; sourceTree = "<group>"; };
 		B75233C11F4D390B00040B6E /* SFSDKOAuthClientContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKOAuthClientContext.m; sourceTree = "<group>"; };
@@ -1377,6 +1379,7 @@
 				B7E1A50D1F43B0FE007AC36A /* SFSDKWindowManagerTests.m */,
 				B759CD881F8BDBAC0081AA87 /* SDSDKAlertMessageTest.m */,
 				B759CD8A1F8C10DC0081AA87 /* SFSDKErrorManagerTests.m */,
+				B7352CA422761D8400DA2CFF /* SFManagedPreferencesTest.m */,
 			);
 			name = SalesforceSDKCoreTests;
 			path = SalesforceSDKCore;
@@ -2659,6 +2662,7 @@
 				CEB98EDF1F86E7CA0083AB9C /* SFSDKAuthErrorCommandTest.m in Sources */,
 				8263FED31E7336BF0038F694 /* SFSDKAppFeatureMarkersTests.m in Sources */,
 				4F7EB4191BFFC8D700768720 /* SFKeyStoreTests.m in Sources */,
+				B7352CA522761D8400DA2CFF /* SFManagedPreferencesTest.m in Sources */,
 				B759CD8B1F8C10DC0081AA87 /* SFSDKErrorManagerTests.m in Sources */,
 				CEB98EE11F86E7D20083AB9C /* SFSDKAuthResponseCommandTest.m in Sources */,
 				4F7EB41A1BFFC8D700768720 /* SFPasscodeTests.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
@@ -141,9 +141,13 @@ NSString * const kOAuthAppName = @"oauth_app_name";
 
 - (NSString *)oauthCompletionUrl
 {
-    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
-    NSString *redirectUri = [defs objectForKey:kOAuthRedirectUriKey];
-    return redirectUri;
+    if ([SFManagedPreferences sharedPreferences].connectedAppCallbackUri.length > 0 ) {
+        return [SFManagedPreferences sharedPreferences].connectedAppCallbackUri;
+    } else {
+        NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
+        NSString *redirectUri = [defs objectForKey:kOAuthRedirectUriKey];
+        return redirectUri;
+    }
 }
 
 - (void)setOauthCompletionUrl:(NSString *)newRedirectUri
@@ -155,9 +159,13 @@ NSString * const kOAuthAppName = @"oauth_app_name";
 
 - (NSString *)oauthClientId
 {
-    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
-    NSString *clientId = [defs objectForKey:kOAuthClientIdKey];
-    return clientId;
+    if ([SFManagedPreferences sharedPreferences].connectedAppId.length > 0) {
+        return [SFManagedPreferences sharedPreferences].connectedAppId;
+    } else {
+        NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
+        NSString *clientId = [defs objectForKey:kOAuthClientIdKey];
+        return clientId;
+    }
 }
 
 - (void)setOauthClientId:(NSString *)newClientId
@@ -169,8 +177,12 @@ NSString * const kOAuthAppName = @"oauth_app_name";
 
 - (NSString *)idpAppURIScheme
 {
-    NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
-    return [defs stringForKey:kSFIDPKey];
+    if ( [SFManagedPreferences sharedPreferences].idpAppURLScheme.length > 0) {
+        return [SFManagedPreferences sharedPreferences].idpAppURLScheme;
+    } else {
+        NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
+        return [defs stringForKey:kSFIDPKey];
+    }
 }
 
 - (void)setIdpAppURIScheme:(NSString *)appIdentifier
@@ -178,6 +190,10 @@ NSString * const kOAuthAppName = @"oauth_app_name";
     NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
     [defs setObject:appIdentifier forKey:kSFIDPKey];
     [defs synchronize];
+}
+
+- (BOOL)requireBrowserAuthentication {
+    return [SFManagedPreferences sharedPreferences].requireCertificateAuthentication ||  _requireBrowserAuthentication;
 }
 
 - (BOOL)idpEnabled

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFManagedPreferencesTest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFManagedPreferencesTest.m
@@ -1,0 +1,79 @@
+/*
+ SFSDKAuthConfigUtilTests.m
+ SalesforceSDKCoreTests
+ 
+ Created by Raj Rao on 2/28/19.
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#import <XCTest/XCTest.h>
+#import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
+#import <SalesforceSDKCore/SalesforceSDKCore.h>
+
+@interface SFManagedPreferencesTest : XCTestCase
+@property (nonatomic,strong) NSDictionary *managedProps;
+@property (nonatomic,strong) SFUserAccount *prevCurrentUser;
+@end
+static NSException *authException = nil;
+
+@implementation SFManagedPreferencesTest
+
+- (void)setUp {
+    //add  Managed Properties
+    self.prevCurrentUser = [SFUserAccountManager sharedInstance].currentUser;
+    [SFUserAccountManager sharedInstance].currentUser = [[SFUserAccount alloc] init];
+    self.managedProps = @{@"RequireCertAuth":@YES,@"OnlyShowAuthorizedHosts":@YES,
+                          @"ClearClipboardOnBackground":@YES,
+                          @"ManagedAppCallbackURL": @"managed:url",
+                          @"ManagedAppOAuthID" : @"managedappid",
+                          @"IDPAppURLScheme" : @"idp:app:url"};
+    [[NSUserDefaults msdkUserDefaults] setObject:self.managedProps forKey:@"com.apple.configuration.managed"];
+}
+
+- (void)tearDown {
+    //Remove the Managed Properties
+    self.managedProps = nil;
+    [SFUserAccountManager sharedInstance].currentUser = self.prevCurrentUser;
+    [[NSUserDefaults msdkUserDefaults] removeObjectForKey:@"com.apple.configuration.managed"];
+}
+
+- (void)testManagedPreference {
+    
+    XCTAssertNotNil(self.managedProps, @"Dictionary for managed properties should not be nil");
+   
+    XCTAssertTrue([SFManagedPreferences sharedPreferences].requireCertificateAuthentication, @"SFManagedPreferences should have been set");
+    XCTAssertTrue([SFUserAccountManager sharedInstance].useBrowserAuth, @"SFUserAccountManager should have been setup to use SFManagedPreferences settings for Browser");
+    
+    XCTAssertTrue([SFManagedPreferences sharedPreferences].connectedAppCallbackUri, @"SFManagedPreferences connectedAppCallbackUri should have been set");
+   
+    XCTAssertEqualObjects([SFManagedPreferences sharedPreferences].connectedAppCallbackUri,[SFUserAccountManager sharedInstance].oauthCompletionUrl, @"SFUserAccountManager should have been setup to use SFManagedPreferences connectedAppCallbackUri");
+    
+    XCTAssertTrue([SFManagedPreferences sharedPreferences].connectedAppId, @"SFManagedPreferences connectedAppId should have been set");
+    
+    XCTAssertEqualObjects([SFManagedPreferences sharedPreferences].connectedAppId,[SFUserAccountManager sharedInstance].oauthClientId, @"SFUserAccountManager should have been setup to use SFManagedPreferences connectedAppId");
+    
+    XCTAssertTrue([SFManagedPreferences sharedPreferences].idpAppURLScheme, @"SFManagedPreferences idpAppURLScheme should have been set");
+    
+    XCTAssertEqualObjects([SFManagedPreferences sharedPreferences].idpAppURLScheme,[SFUserAccountManager sharedInstance].idpAppURIScheme, @"SFUserAccountManager should have been setup to use SFManagedPreferences connectedAppId");
+    
+}
+@end


### PR DESCRIPTION
MDM configurations were not being fully applied in the initializeSDK model. Since launch is not used anymore Ive moved the handling down into the SFUserAccountManager. It's done lazily now when the properties are accessed. Added a test. 
