### PR TITLE
 Handles upgrade scenario for SFSmartStore sharing with app groups

### DIFF
--- a/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
+++ b/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		B716A3D7218F6AD6009D407F /* SalesforceAnalytics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B716A3B2218F6AAC009D407F /* SalesforceAnalytics.framework */; };
 		B716A3D8218F6AD6009D407F /* SalesforceSDKCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B716A3C0218F6AB3009D407F /* SalesforceSDKCommon.framework */; };
 		B716A3D9218F6AD6009D407F /* SalesforceSDKCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B716A3CE218F6ABA009D407F /* SalesforceSDKCore.framework */; };
+		B7352CAD2278F93A00DA2CFF /* SFSmartStoreSharingUpgradeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B7352CAC2278F93A00DA2CFF /* SFSmartStoreSharingUpgradeTests.m */; };
 		B78928412243DE5700BEDED4 /* SFSmartStore+Instrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = B789283F2243DE5700BEDED4 /* SFSmartStore+Instrumentation.h */; };
 		B78928422243DE5700BEDED4 /* SFSmartStore+Instrumentation.h in Headers */ = {isa = PBXBuildFile; fileRef = B789283F2243DE5700BEDED4 /* SFSmartStore+Instrumentation.h */; };
 		B78928432243DE5700BEDED4 /* SFSmartStore+Instrumentation.m in Sources */ = {isa = PBXBuildFile; fileRef = B78928402243DE5700BEDED4 /* SFSmartStore+Instrumentation.m */; };
@@ -384,6 +385,7 @@
 		B716A3B9218F6AB3009D407F /* SalesforceSDKCommon.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceSDKCommon.xcodeproj; path = ../SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj; sourceTree = "<group>"; };
 		B716A3C5218F6ABA009D407F /* SalesforceSDKCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceSDKCore.xcodeproj; path = ../SalesforceSDKCore/SalesforceSDKCore.xcodeproj; sourceTree = "<group>"; };
 		B7282F441D8C713C00475F79 /* SmartStoreTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SmartStoreTestApp.entitlements; sourceTree = "<group>"; };
+		B7352CAC2278F93A00DA2CFF /* SFSmartStoreSharingUpgradeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSmartStoreSharingUpgradeTests.m; sourceTree = "<group>"; };
 		B789283F2243DE5700BEDED4 /* SFSmartStore+Instrumentation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SFSmartStore+Instrumentation.h"; sourceTree = "<group>"; };
 		B78928402243DE5700BEDED4 /* SFSmartStore+Instrumentation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SFSmartStore+Instrumentation.m"; sourceTree = "<group>"; };
 		B7DD6CE41DC178D0004C04F4 /* SFMultipleSmartStoresTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFMultipleSmartStoresTest.h; sourceTree = "<group>"; };
@@ -669,6 +671,7 @@
 				4F96015D1BFD33B30022F021 /* SFSmartStoreTests.h */,
 				4F96015E1BFD33B30022F021 /* SFSmartStoreTests.m */,
 				C03DE7DA1D1B44D000BFA6BD /* SFSmartStoreWithExternalStorageTests.m */,
+				B7352CAC2278F93A00DA2CFF /* SFSmartStoreSharingUpgradeTests.m */,
 				CEAAAE5F195911E600CBBFE9 /* Supporting Files */,
 			);
 			path = SmartStoreTests;
@@ -1158,6 +1161,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B7352CAD2278F93A00DA2CFF /* SFSmartStoreSharingUpgradeTests.m in Sources */,
 				4FEE44891BFD5CDC00F09C43 /* SFSmartStoreTestCase.m in Sources */,
 				4FAB7D811F8D8C3C00226249 /* SFSDKStoreConfigTests.m in Sources */,
 				4FEE44851BFD5CCC00F09C43 /* SFSmartSqlWithExternalStorageTests.m in Sources */,

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -169,6 +169,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
                 _storeUpgradeHasRun = YES;
                 [SFSmartStoreUpgrade updateStoreLocations];
                 [SFSmartStoreUpgrade updateEncryption];
+                [SFSmartStoreUpgrade updateEncryptionSalt];
             }
         }
         _storeName = name;

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -301,7 +301,7 @@ NSString *const EXPLAIN_ROWS = @"rows";
 
 - (BOOL) openStoreDatabase {
     NSError *openDbError = nil;
-    NSString *salt =  [[self class] encryptionSaltBlock]();
+    NSString *salt =  [[self class]encryptionSaltBlock] ? [[self class] encryptionSaltBlock]() :nil;
     self.storeQueue = [self.dbMgr openStoreQueueWithName:self.storeName key:[[self class] encKey] salt:salt error:&openDbError];
     if (self.storeQueue == nil) {
         [SFSDKSmartStoreLogger e:[self class] format:@"Error opening store '%@': %@", self.storeName, [openDbError localizedDescription]];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
@@ -205,19 +205,16 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
         // Using sqlcipher 2.x kdf iter because 3.x default (64000) and 4.x default (256000) are too slow
         // => should open 2.x databases without any migration
         [[db executeQuery:@"PRAGMA cipher_default_kdf_iter = 4000"] close];
+       
+        [db setKey:key];
         
-        if (key && [key length] > 0 ) {
-           
-            [db setKey:key];
-        
-            if (salt) {
-                [[db executeQuery:@"PRAGMA cipher_plaintext_header_size = 32"] close];
-                NSString *pragma = [NSString stringWithFormat:@"PRAGMA cipher_salt = \"x'%@'\"",salt];
-                [[db executeQuery:pragma] close];
-                sqlite3_exec(db.sqliteHandle, "PRAGMA journal_mode = WAL;",0,0,0);
-            }
-        
+        if (salt  && [key length] > 0 ){
+            [[db executeQuery:@"PRAGMA cipher_plaintext_header_size = 32"] close];
+            NSString *pragma = [NSString stringWithFormat:@"PRAGMA cipher_salt = \"x'%@'\"",salt];
+            [[db executeQuery:pragma] close];
+            sqlite3_exec(db.sqliteHandle, "PRAGMA journal_mode = WAL;",0,0,0);
         }
+            
         
     }
     BOOL accessible = [self verifyDatabaseAccess:db error:nil];
@@ -344,6 +341,14 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
         [manager removeItemAtPath:encDbPath error:nil];
         return db;
     }
+    
+    // Use sqlcipher_export() to move the data from the input DB over to the new one.
+    if (salt) {
+        [[db executeQuery:@"PRAGMA encrypted.cipher_plaintext_header_size = 32"] close];
+        NSString *pragma = [NSString stringWithFormat:@"PRAGMA encrypted.cipher_salt = \"x'%@'\"",salt];
+        [[db executeQuery:pragma] close];
+    }
+    
     FMResultSet *rs = [db executeQuery:@"SELECT sqlcipher_export('encrypted')"];
     if (rs == nil || ![rs next]) {
         [rs close];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
@@ -206,7 +206,8 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
         // => should open 2.x databases without any migration
         [[db executeQuery:@"PRAGMA cipher_default_kdf_iter = 4000"] close];
        
-        [db setKey:key];
+        if (key)
+           [db setKey:key];
         
         if (salt  && [key length] > 0 ){
             [[db executeQuery:@"PRAGMA cipher_plaintext_header_size = 32"] close];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.h
@@ -42,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)updateEncryption;
 
++ (void)updateEncryptionSalt;
+
 /**
  Whether or not a given store for the given user is encrypted based on the key store key.
  @param user The user associated with the store.

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.m
@@ -146,7 +146,7 @@ static NSString * const kKeyStoreHasExternalSalt = @"com.salesforce.smartstore.e
     
     //get Key and new Salt
     NSString *key = [SFSmartStore encKey];
-    NSString *newSalt = [SFSmartStore encryptionSaltBlock]();
+    NSString *newSalt = [SFSmartStore salt];
     
     FMDatabase *originalEncyptedDB = [databaseManager openStoreDatabaseWithName:storeName
                                                                             key:key

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.m
@@ -33,12 +33,14 @@
 #import <SalesforceSDKCore/NSData+SFAdditions.h>
 #import <SalesforceSDKCore/SFPasscodeManager.h>
 #import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
+#import <SalesforceSDKCommon/SFSDKDataSharinghelper.h>
 #import "FMDatabase.h"
 
 static const char *const_key = "H347ergher/32hhj5%hff?Dn@21o";
 static NSString * const kLegacyDefaultPasscodeStoresKey = @"com.salesforce.smartstore.defaultPasscodeStores";
 static NSString * const kLegacyDefaultEncryptionTypeKey = @"com.salesforce.smartstore.defaultEncryptionType";
 static NSString * const kKeyStoreEncryptedStoresKey = @"com.salesforce.smartstore.keyStoreEncryptedStores";
+static NSString * const kKeyStoreHasExternalSalt = @"com.salesforce.smartstore.external.hasExternalSalt";
 
 @implementation SFSmartStoreUpgrade
 
@@ -110,6 +112,138 @@ static NSString * const kKeyStoreEncryptedStoresKey = @"com.salesforce.smartstor
             [SFSmartStore removeSharedStoreWithName:storeName forUser:currentUser];
         }
     }
+}
+
++ (void)updateEncryptionSalt
+{
+    
+    if ( ![SFSDKDatasharingHelper sharedInstance].appGroupEnabled || [[NSUserDefaults msdkUserDefaults] boolForKey:kKeyStoreHasExternalSalt]) {
+        //already migrated or does not need Externalizing of Salt
+        return;
+    }
+    
+    [SFSDKSmartStoreLogger i:[SFSmartStoreUpgrade class] format:@"Updating encryption salt for stores in shared mode."];
+    NSArray *allStoreNames = [[SFSmartStoreDatabaseManager sharedManager] allStoreNames];
+    [SFSDKSmartStoreLogger i:[SFSmartStoreUpgrade class] format:@"Number of stores to update: %d", [allStoreNames count]];
+    SFUserAccount *currentUser = [SFUserAccountManager sharedInstance].currentUser;
+    for (NSString *storeName in allStoreNames) {
+        if (![SFSmartStoreUpgrade updateSaltForStore:storeName user:currentUser]) {
+             [SFSDKSmartStoreLogger e:[SFSmartStoreUpgrade class] format:@"Failed to upgrade store for sharing mode: %@", storeName];
+        }
+    }
+}
+
++ (BOOL)updateSaltForStore:(NSString *)storeName user:(SFUserAccount *)user {
+    
+    SFSmartStoreDatabaseManager *databaseManager = [SFSmartStoreDatabaseManager sharedManagerForUser:user];
+    if (![databaseManager persistentStoreExists:storeName]) {
+        //NEW Database no need for External Salt migration
+        [SFSDKSmartStoreLogger i:[SFSmartStoreUpgrade class] format:@"Store '%@' does not exist on the filesystem. Skipping Externalized Salt based migration is not required. ", storeName];
+        return NO;
+    }
+    
+    NSError *openDbError = nil;
+    
+    //get Key and new Salt
+    NSString *key = [SFSmartStore encKey];
+    NSString *newSalt = [SFSmartStore encryptionSaltBlock]();
+    
+    FMDatabase *originalEncyptedDB = [databaseManager openStoreDatabaseWithName:storeName
+                                                                            key:key
+                                                                           salt:nil
+                                                                          error:&openDbError];
+    if (originalEncyptedDB == nil || openDbError != nil) {
+        [SFSDKSmartStoreLogger e:[SFSmartStoreUpgrade class] format:@"Error opening store '%@' to update encryption: %@", storeName, [openDbError localizedDescription]];
+        return NO;
+    } else if (![[databaseManager class] verifyDatabaseAccess:originalEncyptedDB error:&openDbError]) {
+        [SFSDKSmartStoreLogger e:[SFSmartStoreUpgrade class] format:@"Error reading the content of store '%@' during externalized salt encryption upgrade: %@", storeName, [openDbError  localizedDescription]];
+        [originalEncyptedDB close];
+        return NO;
+    }
+    
+    if ([key length] > 0) {
+        // Unencrypt with previous key.
+        NSString *origDatabasePath = originalEncyptedDB.databasePath;
+        
+        NSString *storePath = [databaseManager fullDbFilePathForStoreName:storeName];
+        NSString *backupStorePath = [NSString stringWithFormat:@"%@_%@",storePath,@"backup"];
+        NSError *backupError = nil;
+        
+        // backup and attempt to copy the reencryopted db with the new key + salt
+        NSFileManager *fileManager = [[NSFileManager alloc] init];
+        NSURL *origDatabaseURL = [NSURL fileURLWithPath:origDatabasePath isDirectory:NO];
+        NSURL *backupDatabaseURL = [NSURL fileURLWithPath:backupStorePath isDirectory:NO];
+        
+        if ([fileManager fileExistsAtPath:backupStorePath]) {
+            [fileManager removeItemAtPath:backupStorePath error:nil];
+        }
+        
+        [fileManager copyItemAtURL:origDatabaseURL toURL:backupDatabaseURL error:&backupError];
+        if (backupError) {
+            [SFSDKSmartStoreLogger e:[SFSmartStoreUpgrade class] format:@"Failed to backup db from '%@' to '%@'", origDatabaseURL, backupDatabaseURL];
+            return NO;
+        }
+        
+        [SFSDKSmartStoreLogger i:[SFSmartStoreUpgrade class] format:@"Migrating db, did backup db first from '%@' to '%@'", origDatabaseURL, backupDatabaseURL];
+        NSError *decryptDbError = nil;
+        
+        //lets decryptDB
+        FMDatabase *decryptedDB = [SFSmartStoreDatabaseManager encryptOrUnencryptDb:originalEncyptedDB name:storeName  path:originalEncyptedDB.databasePath  oldKey:key newKey:nil salt:nil error:&decryptDbError];
+        if (decryptDbError || ![SFSmartStoreDatabaseManager verifyDatabaseAccess:decryptedDB error:&decryptDbError] ) {
+            NSString *errorDesc = [NSString stringWithFormat:@"Migrating db, Failed to decrypt  DB %@:", [decryptedDB lastErrorMessage]];
+            [SFSDKSmartStoreLogger e:[SFSmartStoreUpgrade class] format:@"Migrating db '%@', %@", storePath, errorDesc];
+            NSError *restoreBackupError = nil;
+            [fileManager removeItemAtPath:decryptedDB.databasePath error:nil];
+            [fileManager copyItemAtURL:backupDatabaseURL toURL:origDatabaseURL error:&restoreBackupError];
+            if (restoreBackupError) {
+                [SFSDKSmartStoreLogger e:[SFSmartStoreUpgrade class] format:@"Migrating db at '%@', Could not restore  from backup.", storePath];
+            } else {
+                [SFSDKSmartStoreLogger i:[SFSmartStoreUpgrade class] format:@"Migrating db at '%@', Recovered from backup.", storePath];
+            }
+            return NO;
+        }
+        
+        // Now encrypt with new SALT + KEY
+        NSError *reEncryptDbError = nil;
+        FMDatabase *reEncryptedDB = [SFSmartStoreDatabaseManager encryptOrUnencryptDb:decryptedDB name:storeName  path:decryptedDB.databasePath  oldKey:@"" newKey:key salt:newSalt error:&reEncryptDbError];
+        if (!reEncryptedDB || reEncryptDbError) {
+            NSString *errorDesc = [NSString stringWithFormat:@"Migrating db, Failed to reencrypt DB %@:", [reEncryptedDB lastErrorMessage]];
+            [SFSDKSmartStoreLogger e:[SFSmartStoreUpgrade class] format:@"Migrating db '%@', %@", storePath, errorDesc];
+            [fileManager removeItemAtPath:decryptedDB.databasePath error:nil];
+            
+            NSError *restoreBackupError = nil;
+            [fileManager removeItemAtPath:decryptedDB.databasePath error:nil];
+            [fileManager copyItemAtURL:backupDatabaseURL toURL:origDatabaseURL error:&restoreBackupError];
+            if (restoreBackupError) {
+                [SFSDKSmartStoreLogger e:[SFSmartStoreUpgrade class] format:@"Migrating db at '%@', Could not restore  from backup.", storePath];
+            } else {
+                [SFSDKSmartStoreLogger i:[SFSmartStoreUpgrade class] format:@"Migrating db at '%@', Recovered from backup.", storePath];
+            }
+            return NO;
+        }
+        
+        if (![SFSmartStoreDatabaseManager verifyDatabaseAccess:reEncryptedDB error:&decryptDbError]) {
+            NSString *errorDesc = [NSString stringWithFormat:@"Failed to verify reencrypted  DB %@:", [decryptedDB lastErrorMessage]];
+            [SFSDKSmartStoreLogger e:[SFSmartStoreUpgrade class] format:@"Migrating db at '%@', %@", storePath,errorDesc];
+            [fileManager removeItemAtPath:reEncryptedDB.databasePath error:nil];
+            NSError *restoreBackupError = nil;
+            [fileManager removeItemAtPath:decryptedDB.databasePath error:nil];
+            [fileManager copyItemAtURL:backupDatabaseURL toURL:origDatabaseURL error:&restoreBackupError];
+            if (restoreBackupError) {
+                [SFSDKSmartStoreLogger e:[SFSmartStoreUpgrade class] format:@"Migrating db at '%@', Could not restore from backup.", storePath];
+            } else {
+                [SFSDKSmartStoreLogger i:[SFSmartStoreUpgrade class] format:@"Migrating db at '%@',  Recovered from backup.", storePath];
+            }
+            return NO;
+        }
+        [reEncryptedDB close];
+        [SFSDKSmartStoreLogger i:[SFSmartStoreUpgrade class] format:@"Migrating db '%@',  Migration complete.", storePath];
+        [fileManager removeItemAtPath:backupStorePath error:nil];
+        [SFSDKSmartStoreLogger i:[SFSmartStoreUpgrade class] format:@"Migrating db '%@',  Removed backup.", backupStorePath];
+        [[NSUserDefaults msdkUserDefaults] setBool:YES forKey:kKeyStoreHasExternalSalt];
+        return YES;
+    }
+    return NO;
 }
 
 + (BOOL)updateEncryptionForStore:(NSString *)storeName user:(SFUserAccount *)user

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreSharingUpgradeTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreSharingUpgradeTests.m
@@ -1,0 +1,146 @@
+/*
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
+#import <SalesforceSDKCore/SFKeyStoreManager.h>
+#import <SalesforceSDKCore/NSData+SFAdditions.h>
+#import "SFSmartStoreTestCase.h"
+#import "SFSmartStoreUpgrade.h"
+#import "SFSmartStoreDatabaseManager.h"
+
+#import "sqlite3.h"
+
+#define kTestUpgradeSmartStoreName  @"testSmartStoreUpgrade"
+#define kTestSoupName        @"testSoup"
+
+@interface SFSmartStoreDatabaseManager (Private)
+- (NSString*)fullDbFilePathForStoreName:(NSString*)storeName;
+@end
+
+@interface SFSmartStore (Private)
+@property (nonatomic, class,readwrite) SFSmartStoreEncryptionSaltBlock encryptionSaltBlock;
++ (BOOL)hasPlainTextHeader:(NSString *)storeName user:(SFUserAccount *) user;
++ (void)clearSharedStoreMemoryState;
+@end
+
+@interface SFSmartStoreUpgrade (Private)
++ (BOOL)updateSaltForStore:(NSString *)storeName user:(SFUserAccount *)user;
+@end
+
+@interface SFSmartStoreSharingUpgradeTests : SFSmartStoreTestCase
+@property (nonatomic, strong) SFUserAccount *smartStoreUser;
+@property (nonatomic, strong) SFSmartStore *store;
+@property (nonatomic, strong) SFSmartStore *globalStore;
+@end
+
+@implementation SFSmartStore (Private)
+@dynamic encryptionSaltBlock;
+
++ (BOOL)hasPlainTextHeader:(NSString *)storeName user:(SFUserAccount *) user {
+    //53 51 4c 69 74 65 SQLite marker
+    uint8_t sqlLiteBytes[]  =  {0x53,0x51,0x4c,0x69,0x74,0x65};
+    NSData *sqlLiteHeader = [NSData dataWithBytes:sqlLiteBytes length:6];
+    SFSmartStoreDatabaseManager *databaseManager = [SFSmartStoreDatabaseManager sharedManagerForUser:user];
+
+    if (![databaseManager persistentStoreExists:storeName]) {
+        return NO;
+    }
+    NSString *fullDbFilePath = [databaseManager fullDbFilePathForStoreName:storeName];
+    NSFileHandle *file = [NSFileHandle fileHandleForUpdatingAtPath:fullDbFilePath];
+    [file seekToFileOffset:0];
+    NSData *databuffer = [file readDataOfLength:sqlLiteHeader.length];
+    [file closeFile];
+    return [sqlLiteHeader isEqualToData:databuffer];
+}
+@end
+
+@implementation SFSmartStoreSharingUpgradeTests
+
+- (void) setUp {
+    [super setUp];
+    if ([[SFKeyStoreManager sharedInstance] keyWithLabelExists:kSFSmartStoreEncryptionSaltLabel]) {
+        [[SFKeyStoreManager sharedInstance] removeKeyWithLabel:kSFSmartStoreEncryptionSaltLabel];
+    }
+    [[NSUserDefaults msdkUserDefaults] setBool:NO forKey:@"com.salesforce.smartstore.external.hasExternalSalt"];
+    
+    [SFSDKSmartStoreLogger setLogLevel:SFLogLevelDebug];
+    self.smartStoreUser = [self setUpSmartStoreUser];
+    [SFSmartStore removeSharedStoreWithName:kTestUpgradeSmartStoreName];
+    self.store = [SFSmartStore sharedStoreWithName:kTestUpgradeSmartStoreName];
+    self.store.captureExplainQueryPlan = YES;
+}
+
+- (void) tearDown
+{
+    [SFSmartStore removeSharedStoreWithName:kTestUpgradeSmartStoreName];
+    [self tearDownSmartStoreUser:self.smartStoreUser];
+    self.smartStoreUser = nil;
+    self.store = nil;
+    
+    if ([[SFKeyStoreManager sharedInstance] keyWithLabelExists:kSFSmartStoreEncryptionSaltLabel]) {
+        [[SFKeyStoreManager sharedInstance] removeKeyWithLabel:kSFSmartStoreEncryptionSaltLabel];
+    }
+    [[NSUserDefaults msdkUserDefaults] setBool:NO forKey:@"com.salesforce.smartstore.external.hasExternalSalt"];
+    [super tearDown];
+}
+
+- (void)testUpgrade {
+    //test existence of a datastore with inlined salt
+    SFEncryptionKey *origKey = [SFSmartStore encryptionKeyBlock]();
+    SFSmartStore *store = [SFSmartStore sharedStoreWithName:kTestUpgradeSmartStoreName];
+    XCTAssertNotNil(origKey,@"Database must be setup to have an encKey");
+    XCTAssertNotNil(store,@"Store should not be nil");
+    XCTAssertFalse([SFSmartStore hasPlainTextHeader:store.storeName user:store.user],@"Database must not have plain text header");
+    [self setupSaltBlock];
+    NSString *salt = [SFSmartStore encryptionSaltBlock]();
+    SFEncryptionKey *key = [SFSmartStore encryptionKeyBlock]();
+    XCTAssertNotNil(salt,@"Database must be setup to have a salt");
+    XCTAssertEqualObjects(origKey,key,@"Database must  be setup to have the same encKey");
+    BOOL result = [SFSmartStoreUpgrade updateSaltForStore:store.storeName user:store.user];
+    XCTAssertTrue(result,"Upgrade to using external salt should have worked");
+    XCTAssertTrue([SFSmartStore hasPlainTextHeader:store.storeName user:store.user],@"Database now must  have plain text header");
+    store = [SFSmartStore sharedStoreWithName:kTestUpgradeSmartStoreName];
+    XCTAssertNotNil(store,@"Store should not be nil after upgrade");
+    [self clearSaltBlock];
+    //[SFSmartStore clearSharedStoreMemoryState];
+}
+
+- (void)setupSaltBlock {
+    [SFSmartStore setEncryptionSaltBlock:^NSString * _Nullable{
+            SFEncryptionKey *saltKey = [[SFKeyStoreManager sharedInstance]   retrieveKeyWithLabel:kSFSmartStoreEncryptionSaltLabel autoCreate:YES];
+            NSString *salt = [[saltKey key] md5];
+            return salt;
+    }];
+}
+
+- (void)clearSaltBlock {
+    [SFSmartStore setEncryptionSaltBlock:nil];
+    if ([[SFKeyStoreManager sharedInstance] keyWithLabelExists:kSFSmartStoreEncryptionSaltLabel]) {
+        [[SFKeyStoreManager sharedInstance] removeKeyWithLabel:kSFSmartStoreEncryptionSaltLabel];
+    }
+}
+
+
+@end


### PR DESCRIPTION
Handles upgrade from no app group to app groups enabled mode. This is what this PR does.

1. Upgrade is done only once.  
2. Decrypts Existing DB & Re-encrypt with (new salt + key).
3. Attempt to restore the DB from backup in case of any failure.

Tested both scenarios app group disabled -> enabled and vice versa.