### PR TITLE
loadConfigFromFile no longer logs an error if file doesn't exist

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.h
@@ -55,6 +55,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Read config and parse its content (which is expected to be json)
  * @param configFilePath Path of resource file.
+ * @return NSDictionary built from content of tile.
+ */
++ (NSDictionary *)loadConfigFromFile:(NSString *)configFilePath;
+
+
+/**
+ * Read config and parse its content (which is expected to be json)
+ * @param configFilePath Path of resource file.
  * @param error Sets/returns any error that took place when trying to read file.
  * @return NSDictionary built from content of tile.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.h
@@ -55,9 +55,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Read config and parse its content (which is expected to be json)
  * @param configFilePath Path of resource file.
+ * @param error Sets/returns any error that took place when trying to read file.
  * @return NSDictionary built from content of tile.
  */
-+ (NSDictionary *)loadConfigFromFile:(NSString *)configFilePath;
++ (NSDictionary *)loadConfigFromFile:(NSString *)configFilePath error:(NSError**)error;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.m
@@ -72,6 +72,16 @@
     return image;
 }
 
++ (NSDictionary *)loadConfigFromFile:(NSString *)configFilePath {
+    NSError *fileReadError = nil;
+    NSDictionary* jsonDict = [self loadConfigFromFile:configFilePath error:&fileReadError];
+    if (jsonDict == nil) {
+        [SFSDKCoreLogger i:[SFSDKCoreLogger class] format:@"Config at specified path '%@' could not be read: %@", configFilePath, fileReadError];
+        return nil;
+    }
+    return jsonDict;
+}
+
 + (NSDictionary *)loadConfigFromFile:(NSString *)configFilePath error:(NSError**)error
 {
     NSString *fullPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:configFilePath];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKResourceUtils.m
@@ -72,13 +72,11 @@
     return image;
 }
 
-+ (NSDictionary *)loadConfigFromFile:(NSString *)configFilePath
++ (NSDictionary *)loadConfigFromFile:(NSString *)configFilePath error:(NSError**)error
 {
     NSString *fullPath = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:configFilePath];
-    NSError *fileReadError = nil;
-    NSData *fileContents = [NSData dataWithContentsOfFile:fullPath options:NSDataReadingUncached error:&fileReadError];
+    NSData *fileContents = [NSData dataWithContentsOfFile:fullPath options:NSDataReadingUncached error:error];
     if (fileContents == nil) {
-        [SFSDKCoreLogger i:[SFSDKCoreLogger class] format:@"Config at specified path '%@' could not be read: %@", configFilePath, fileReadError];
         return nil;
     }
     NSDictionary *jsonDict = [SFJsonUtils objectFromJSONData:fileContents];

--- a/libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.m
@@ -44,7 +44,7 @@ static NSString *const kStoreConfigIndexes = @"indexes";
 - (nullable id)initWithResourceAtPath:(NSString *)path {
     self = [super init];
     if (self) {
-        NSDictionary *config = [SFSDKResourceUtils loadConfigFromFile:path];
+        NSDictionary *config = [SFSDKResourceUtils loadConfigFromFile:path error:nil];
         self.soupsConfig = config == nil ? nil : config[kStoreConfigSoups];
     }
     return self;

--- a/libs/SmartSync/SmartSync/Classes/Config/SFSDKSyncsConfig.m
+++ b/libs/SmartSync/SmartSync/Classes/Config/SFSDKSyncsConfig.m
@@ -46,7 +46,7 @@ static NSString *const kSyncsConfigTarget = @"target";
 - (nullable id)initWithResourceAtPath:(NSString *)path {
     self = [super init];
     if (self) {
-        NSDictionary *config = [SFSDKResourceUtils loadConfigFromFile:path];
+        NSDictionary *config = [SFSDKResourceUtils loadConfigFromFile:path error:nil];
         self.syncConfigs = config == nil ? nil : config[kSyncsConfigSyncs];
     }
     return self;


### PR DESCRIPTION
It returns the error to the caller - caller that cares should log an error