### PR TITLE
Fixes some failing tests & logout issues in tests

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		B7A20FAE1F26C39700D1E4B0 /* SFSDKRootController.h in Headers */ = {isa = PBXBuildFile; fileRef = B7A20FAB1F26C39700D1E4B0 /* SFSDKRootController.h */; };
 		B7A20FAF1F26C39700D1E4B0 /* SFSDKRootController.m in Sources */ = {isa = PBXBuildFile; fileRef = B7A20FAC1F26C39700D1E4B0 /* SFSDKRootController.m */; };
 		B7A20FB01F26C39700D1E4B0 /* SFSDKRootController.m in Sources */ = {isa = PBXBuildFile; fileRef = B7A20FAC1F26C39700D1E4B0 /* SFSDKRootController.m */; };
+		B7A901BE228E4DFB0036D749 /* SFSDKLogoutBlocker.m in Sources */ = {isa = PBXBuildFile; fileRef = B7A901BD228E4DFA0036D749 /* SFSDKLogoutBlocker.m */; };
 		B7BAD70C1FBAB8AA0046629F /* SFSDKStartURLHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B7BAD70A1FBAB8AA0046629F /* SFSDKStartURLHandler.h */; };
 		B7BAD70D1FBAB8AA0046629F /* SFSDKStartURLHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B7BAD70A1FBAB8AA0046629F /* SFSDKStartURLHandler.h */; };
 		B7BAD70E1FBAB8AA0046629F /* SFSDKStartURLHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B7BAD70B1FBAB8AA0046629F /* SFSDKStartURLHandler.m */; };
@@ -1105,6 +1106,7 @@
 		B716A38F218F5E37009D407F /* SalesforceAnalytics.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceAnalytics.xcodeproj; path = ../SalesforceAnalytics/SalesforceAnalytics.xcodeproj; sourceTree = "<group>"; };
 		B7282F3F1D8C70E700475F79 /* SalesforceSDKCoreTestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SalesforceSDKCoreTestApp.entitlements; sourceTree = "<group>"; };
 		B7352CA422761D8400DA2CFF /* SFManagedPreferencesTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFManagedPreferencesTest.m; path = SalesforceSDKCoreTests/SFManagedPreferencesTest.m; sourceTree = SOURCE_ROOT; };
+		B7355248228E84AF001C7759 /* SFSDKLogoutBlocker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SFSDKLogoutBlocker.h; path = SalesforceSDKCoreTests/SFSDKLogoutBlocker.h; sourceTree = SOURCE_ROOT; };
 		B73BB6F322090DEB0009A7DD /* SFUserAccountIdentity+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SFUserAccountIdentity+Internal.h"; sourceTree = "<group>"; };
 		B75233C01F4D390B00040B6E /* SFSDKOAuthClientContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKOAuthClientContext.h; sourceTree = "<group>"; };
 		B75233C11F4D390B00040B6E /* SFSDKOAuthClientContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKOAuthClientContext.m; sourceTree = "<group>"; };
@@ -1139,6 +1141,7 @@
 		B7A20F821F25850E00D1E4B0 /* SFSDKWindowManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKWindowManager.m; sourceTree = "<group>"; };
 		B7A20FAB1F26C39700D1E4B0 /* SFSDKRootController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKRootController.h; sourceTree = "<group>"; };
 		B7A20FAC1F26C39700D1E4B0 /* SFSDKRootController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKRootController.m; sourceTree = "<group>"; };
+		B7A901BD228E4DFA0036D749 /* SFSDKLogoutBlocker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKLogoutBlocker.m; path = SalesforceSDKCoreTests/SFSDKLogoutBlocker.m; sourceTree = SOURCE_ROOT; };
 		B7BAD70A1FBAB8AA0046629F /* SFSDKStartURLHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKStartURLHandler.h; sourceTree = "<group>"; };
 		B7BAD70B1FBAB8AA0046629F /* SFSDKStartURLHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKStartURLHandler.m; sourceTree = "<group>"; };
 		B7C273431F7D7EAA00CE539D /* SFSDKOAuthClientCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKOAuthClientCache.h; sourceTree = "<group>"; };
@@ -1380,6 +1383,8 @@
 				B759CD881F8BDBAC0081AA87 /* SDSDKAlertMessageTest.m */,
 				B759CD8A1F8C10DC0081AA87 /* SFSDKErrorManagerTests.m */,
 				B7352CA422761D8400DA2CFF /* SFManagedPreferencesTest.m */,
+				B7A901BD228E4DFA0036D749 /* SFSDKLogoutBlocker.m */,
+				B7355248228E84AF001C7759 /* SFSDKLogoutBlocker.h */,
 			);
 			name = SalesforceSDKCoreTests;
 			path = SalesforceSDKCore;
@@ -2637,6 +2642,7 @@
 				CEB98EE21F86E7D70083AB9C /* SFSDKIDPAuthInitCommandTest.m in Sources */,
 				B7E1A50E1F43B0FE007AC36A /* SFSDKWindowManagerTests.m in Sources */,
 				4F06AF8A1C49A18E00F70798 /* SalesforceOAuthUnitTests.m in Sources */,
+				B7A901BE228E4DFB0036D749 /* SFSDKLogoutBlocker.m in Sources */,
 				010A9B5A1CC1A14C002AF4D3 /* SFEncryptDecryptStreamJSONTests.m in Sources */,
 				8214D955205316BA0007349E /* SFSDKSalesforceAnalyticsManagerTests.m in Sources */,
 				4F06AF891C49A18E00F70798 /* NSURL+SFStringUtilsTests.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFRestAPI+Instrumentation.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFRestAPI+Instrumentation.m
@@ -118,7 +118,7 @@
 
 
 + (void)load{
-    if ([SFSDKInstrumentationHelper isEnabled]) {
+    if ([SFSDKInstrumentationHelper isEnabled] && (self == SFRestAPI.self)) {
         [self enableInstrumentation];
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFUserAccountManager+Instrumentation.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFUserAccountManager+Instrumentation.m
@@ -48,7 +48,7 @@
 
 + (void)load{
     
-    if ([SFSDKInstrumentationHelper isEnabled]) {
+    if ([SFSDKInstrumentationHelper isEnabled] && (self == SFUserAccountManager.self)) {
        [self enableInstrumentation];
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
@@ -23,7 +23,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
+#import "SFRestAPI+Internal.h"
 #import "SFRestAPI+Blocks.h"
 #import "SFRestAPI+Files.h"
 #import <objc/runtime.h>
@@ -32,6 +32,7 @@
 // whose address will be used by the objc_setAssociatedObject (no need to have a value).
 static char FailBlockKey;
 static char CompleteBlockKey;
+
 
 @implementation SFRestAPI (Blocks)
 
@@ -58,7 +59,7 @@ static char CompleteBlockKey;
     // Copy blocks into the request instance
     objc_setAssociatedObject(request, &FailBlockKey, failBlock, OBJC_ASSOCIATION_COPY);
     objc_setAssociatedObject(request, &CompleteBlockKey, completeBlock, OBJC_ASSOCIATION_COPY);
-    [self send:request delegate:self];
+    [self send:request delegate:self shouldRetry:self.requiresAuthentication && request.requiresAuthentication];
 }
 
 #pragma mark - various request types

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Internal.h
@@ -53,5 +53,7 @@
 
 - (void)send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate shouldRetry:(BOOL)shouldRetry;
 
++ (void)removeSharedInstanceWithUser:(SFUserAccount *)user;
+
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Internal.h
@@ -38,6 +38,8 @@
  */
 @property (nonatomic, readonly, strong) SFSDKSafeMutableSet *activeRequests;
 
+@property (nonatomic, assign) BOOL requiresAuthentication;
+
 - (void)removeActiveRequestObject:(SFRestRequest *)request;
 
 /**
@@ -47,6 +49,9 @@
  @return YES if we were able to find and timeout the request, NO if the request could not be found
  */
 - (BOOL)forceTimeoutRequest:(SFRestRequest*)req;
+
+
+- (void)send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate shouldRetry:(BOOL)shouldRetry;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -48,7 +48,7 @@ static SFSDKSafeMutableDictionary *sfRestApiList = nil;
 @property (readwrite, assign) BOOL pendingRequestsBeingProcessed;
 @property (nonatomic, strong) SFOAuthSessionRefresher *oauthSessionRefresher;
 @property (nonatomic, strong, readwrite) SFUserAccount *user;
-@property (nonatomic, assign) BOOL requiresAuthentication;
+
 @end
 
 @implementation SFRestAPI

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
@@ -30,7 +30,7 @@
 #import "SFSDKTestRequestListener.h"
 #import "SFSDKTestCredentialsData.h"
 #import "SFOAuthCredentials+Internal.h"
-
+#import "SFSDKAppConfig.h"
 static SFOAuthCredentials *credentials = nil;
 
 @implementation TestSetupUtils
@@ -67,20 +67,33 @@ static SFOAuthCredentials *credentials = nil;
     //check whether the test config file has never been edited
     NSAssert(![credsData.refreshToken isEqualToString:@"__INSERT_TOKEN_HERE__"],
              @"You need to obtain credentials for your test org and replace test_credentials.json");
-    [SFUserAccountManager sharedInstance].currentUser = nil;
+    [SalesforceSDKManager initializeSDK];
+   [SFUserAccountManager sharedInstance].currentUser = nil;
+    
+    // Note: We need to fix this inconsistency for tests in the long run.There should be a clean way to refresh appConfigs for tests. The configs should apply across all components that need the  config.
+    SFSDKAppConfig *appconfig  = [[SFSDKAppConfig alloc] init];
+    appconfig.oauthRedirectURI = credsData.redirectUri;
+    appconfig.remoteAccessConsumerKey = credsData.clientId;
+    appconfig.oauthScopes = [NSSet setWithObjects:@"web", @"api", nil];
+    [SalesforceSDKManager sharedManager].appConfig = appconfig;
+   
     [SFUserAccountManager sharedInstance].oauthClientId = credsData.clientId;
     [SFUserAccountManager sharedInstance].oauthCompletionUrl = credsData.redirectUri;
     [SFUserAccountManager sharedInstance].scopes = [NSSet setWithObjects:@"web", @"api", nil];
+
     [SFUserAccountManager sharedInstance].loginHost = credsData.loginHost;
     credentials = [[SFUserAccountManager sharedInstance] newClientCredentials];
     credentials.instanceUrl = [NSURL URLWithString:credsData.instanceUrl];
     credentials.identityUrl = [NSURL URLWithString:credsData.identityUrl];
+
     NSString *communityUrlString = credsData.communityUrl;
     if (communityUrlString.length > 0) {
         credentials.communityUrl = [NSURL URLWithString:communityUrlString];
     }
     credentials.accessToken = credsData.accessToken;
     credentials.refreshToken = credsData.refreshToken;
+   
+    
     return credsData;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
@@ -22,6 +22,7 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #import <XCTest/XCTest.h>
+#import "SFSDKLogoutBlocker.h"
 #import "SalesforceSDKCoreDefines.h"
 #import "SalesforceSDKManager.h"
 #import "SFOAuthCoordinator.h"
@@ -143,6 +144,13 @@
 
 
 @implementation SFSDKAuthClientTests
+
++ (void)setUp
+{
+    
+    [SFSDKLogoutBlocker sharedInstance];
+    [super setUp];
+}
 
 - (void)setUp {
     [super setUp];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
@@ -148,7 +148,7 @@
 + (void)setUp
 {
     
-    [SFSDKLogoutBlocker sharedInstance];
+    [SFSDKLogoutBlocker block];
     [super setUp];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLogoutBlocker.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLogoutBlocker.h
@@ -23,5 +23,5 @@
  */
 
 @interface SFSDKLogoutBlocker : NSObject
-+(instancetype)sharedInstance;
++(instancetype)block;
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLogoutBlocker.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLogoutBlocker.h
@@ -1,0 +1,27 @@
+/*
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@interface SFSDKLogoutBlocker : NSObject
++(instancetype)sharedInstance;
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLogoutBlocker.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLogoutBlocker.m
@@ -40,7 +40,7 @@
 @implementation SFSDKLogoutBlocker
 
 
-+ (instancetype)sharedInstance {
++ (instancetype)block {
     static dispatch_once_t pred;
     static SFSDKLogoutBlocker *swizzled = nil;
     dispatch_once(&pred, ^{

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLogoutBlocker.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLogoutBlocker.m
@@ -1,0 +1,123 @@
+/*
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFSDKLogoutBlocker.h"
+#import <objc/runtime.h>
+#import "SFSDKCoreLogger.h"
+#import "SFUserAccountManager+Instrumentation.h"
+#import "SFOAuthCredentials.h"
+
+@interface SFSDKLogoutBlocker()
+- (void)dummy_logout;
+- (void)dummy_logoutUser:(SFUserAccount *)user;
+- (void)dummy_logoutAllUsers;
+- (void)dummy_revokeAccessToken;
+- (void)dummy_revokeRefreshToken;
+- (void)dummy_revoke;
+@end
+
+@implementation SFSDKLogoutBlocker
+
+
++ (instancetype)sharedInstance {
+    static dispatch_once_t pred;
+    static SFSDKLogoutBlocker *swizzled = nil;
+    dispatch_once(&pred, ^{
+        swizzled = [[self alloc] init];
+    });
+    return swizzled;
+}
+
++ (void)load{
+    
+       static dispatch_once_t onceSwizzled;
+        dispatch_once(&onceSwizzled, ^{
+            [SFSDKCoreLogger d:[self class] format:@"Swizzled logout methods for Logout protection."];
+            SEL originalSelector = @selector(logout);
+            SEL swizzledSelector = @selector(dummy_logout);
+            [self swizzleMethod:originalSelector with:swizzledSelector forClass:[SFUserAccountManager class]  isInstanceMethod:YES];
+
+            originalSelector = @selector(logoutAllUsers);
+            swizzledSelector = @selector(dummy_logoutAllUsers);
+            [self swizzleMethod:originalSelector with:swizzledSelector forClass:[SFUserAccountManager class]  isInstanceMethod:YES];
+
+            originalSelector = @selector(logoutUser:);
+            swizzledSelector = @selector(dummy_logoutUser:);
+            [self swizzleMethod:originalSelector with:swizzledSelector forClass:[SFUserAccountManager class]   isInstanceMethod:YES];
+    
+        });
+    
+    
+}
+
+- (void)dummy_logout {
+    
+}
+
+- (void)dummy_logoutUser:(SFUserAccount *)user {
+  
+}
+
+- (void)dummy_logoutAllUsers {
+}
+
+- (void)dummy_revoke {
+}
+
+- (void)dummy_revokeAccessToken {
+}
+
+- (void)dummy_revokeRefreshToken{
+}
+
+
++ (void)swizzleMethod:(SEL)originalSelector with:(SEL)swizzledSelector forClass:(Class)clazz isInstanceMethod:(BOOL)isInstanceMethod {
+    
+    Method originalMethod;
+    Method swizzledMethod;
+    
+    if (isInstanceMethod) {
+        originalMethod = class_getInstanceMethod(clazz, originalSelector);
+        swizzledMethod = class_getInstanceMethod(self, swizzledSelector);
+    } else {
+        originalMethod = class_getClassMethod(clazz, originalSelector);
+        swizzledMethod = class_getClassMethod(self, swizzledSelector);
+    }
+    
+    BOOL didAddMethod =
+    class_addMethod(clazz,
+                    originalSelector,
+                    method_getImplementation(swizzledMethod),
+                    method_getTypeEncoding(swizzledMethod));
+    
+    if (didAddMethod) {
+        class_replaceMethod(clazz,
+                            swizzledSelector,
+                            method_getImplementation(originalMethod),
+                            method_getTypeEncoding(originalMethod));
+    } else {
+        method_exchangeImplementations(originalMethod, swizzledMethod);
+    }
+}
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -101,7 +101,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 
 + (void)setUp
 {
-    [SFSDKLogoutBlocker sharedInstance];
+    [SFSDKLogoutBlocker block];
     [super setUp];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -25,6 +25,7 @@
 #import <XCTest/XCTest.h>
 #import <SalesforceSDKCommon/SFJsonUtils.h>
 #import <SalesforceSDKCore/SalesforceSDKCore.h>
+#import "SFSDKLogoutBlocker.h"
 #import "SFSDKAuthViewHandler.h"
 #import "SFUserAccountManager+Internal.h"
 #import "SFDefaultUserAccountPersister.h"
@@ -97,6 +98,12 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 @end
 
 @implementation SFUserAccountManagerTests
+
++ (void)setUp
+{
+    [SFSDKLogoutBlocker sharedInstance];
+    [super setUp];
+}
 
 - (void)setUp {
     [super setUp];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
@@ -48,7 +48,7 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
 + (void)setUp
 {
     
-    [SFSDKLogoutBlocker sharedInstance];
+    [SFSDKLogoutBlocker block];
     [super setUp];
 }
 - (void)setUp {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
@@ -21,7 +21,7 @@
  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
+#import "SFSDKLogoutBlocker.h"
 #import "SFOAuthCoordinator.h"
 #import "SFOAuthCredentials.h"
 #import "SFOAuthKeychainCredentials.h"
@@ -45,6 +45,12 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
 
 @implementation SalesforceOAuthUnitTests
 
++ (void)setUp
+{
+    
+    [SFSDKLogoutBlocker sharedInstance];
+    [super setUp];
+}
 - (void)setUp {
     [super setUp];
     // Set-up code here.

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -103,7 +103,7 @@ static NSException *authException = nil;
 + (void)setUp
 {
     @try {
-        [SFSDKLogoutBlocker sharedInstance];
+        [SFSDKLogoutBlocker block];
         [TestSetupUtils populateAuthCredentialsFromConfigFileForClass:[self class]];
         [TestSetupUtils synchronousAuthRefresh];
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -29,6 +29,7 @@
 #import "SFNativeRestRequestListener.h"
 #import "SFUserAccount+Internal.h"
 #import "SFOAuthCredentials+Internal.h"
+#import "SFUserAccountManager+Internal.h"
  // Constants only used in the tests below
 #define ENTITY_PREFIX_NAME @"RestClientTestsiOS"
 #define ACCOUNT @"Account"
@@ -56,6 +57,7 @@
     SFUserAccount *_currentUser;
 }
 @property (nonatomic, strong) XCTestExpectation *currentExpectation;
+@property (assign) BOOL dataCleanupRequired;
 
 @end
 
@@ -118,7 +120,7 @@ static NSException *authException = nil;
     if (authException) {
         XCTFail(@"Setting up authentication failed: %@", authException);
     }
-    
+    _dataCleanupRequired = YES;
     // Set-up code here.
     _currentUser = [SFUserAccountManager sharedInstance].currentUser;
     [super setUp];
@@ -127,7 +129,9 @@ static NSException *authException = nil;
 - (void)tearDown
 {
     // Tear-down code here.
-    [self cleanup];
+    if (self.dataCleanupRequired) {
+        [self cleanup];
+    }
     [[SFRestAPI sharedGlobalInstance] cleanup];
     [[SFRestAPI sharedInstance] cleanup];
     [NSThread sleepForTimeInterval:0.1];  // Some test runs were failing, saying the run didn't complete.  This seems to fix that.
@@ -188,6 +192,7 @@ static NSException *authException = nil;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForVersions];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // Using an unauthenticated client to make authenicated requests should result in an assertin failure.
@@ -210,6 +215,7 @@ static NSException *authException = nil;
     [self waitForExpectations:@[assertExpectation] timeout:30];
     [[[NSThread currentThread] threadDictionary] setValue:nil
                                                    forKey:NSAssertionHandlerKey];
+    self.dataCleanupRequired = NO;
    
 }
 
@@ -221,6 +227,7 @@ static NSException *authException = nil;
     [[SFRestAPI sharedInstance] send:request delegate:listener];
     [listener waitForCompletion];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // simple: make sure fully-defined paths in the request are honored too.
@@ -230,6 +237,7 @@ static NSException *authException = nil;
     [SFLogger log:[self class] level:SFLogLevelDebug format:@"request.path: %@", request.path];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // simple: make sure that user-defined endpoints are respected
@@ -238,6 +246,7 @@ static NSException *authException = nil;
     [request setEndpoint:@"/my/custom/endpoint"];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidFail, @"request should have failed");
+    self.dataCleanupRequired = NO;
 }
 
 // simple: just invoke requestForUserInfo
@@ -245,6 +254,7 @@ static NSException *authException = nil;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForUserInfo];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // simple: just invoke requestForResources
@@ -252,6 +262,7 @@ static NSException *authException = nil;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForResources];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // simple: just invoke requestForDescribeGlobal
@@ -259,6 +270,7 @@ static NSException *authException = nil;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForDescribeGlobal];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // simple: just invoke requestForDescribeGlobal, force a cancel & timeout
@@ -269,6 +281,7 @@ static NSException *authException = nil;
     [[SFRestAPI sharedInstance] cancelAllRequests];
     [listener waitForCompletion];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidCancel, @"request should have been cancelled");
+    self.dataCleanupRequired = NO;
 
 }
 
@@ -283,6 +296,7 @@ static NSException *authException = nil;
     
     [listener waitForCompletion];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidTimeout, @"request should have timed out");
+    self.dataCleanupRequired = NO;
  }
 
 // simple: just invoke requestForMetadataWithObjectType:@"Contact"
@@ -290,6 +304,7 @@ static NSException *authException = nil;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForMetadataWithObjectType:CONTACT];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // simple: just invoke requestForDescribeWithObjectType:@"Contact"
@@ -297,6 +312,7 @@ static NSException *authException = nil;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForDescribeWithObjectType:CONTACT];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // simple: just invoke requestForLayoutWithObjectType:@"Contact" without layoutType.
@@ -304,6 +320,7 @@ static NSException *authException = nil;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectType:CONTACT layoutType:nil];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // simple: just invoke requestForLayoutWithObjectType:@"Contact" with layoutType:@"Compact".
@@ -318,6 +335,7 @@ static NSException *authException = nil;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearchScopeAndOrder];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // simple: just invoke requestForSearchResultLayout:@"Account"
@@ -325,6 +343,7 @@ static NSException *authException = nil;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearchResultLayout:ACCOUNT];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // attempt to create a Contact with none of the required fields (should fail)
@@ -654,6 +673,7 @@ static NSException *authException = nil;
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidFail , @"request was supposed to fail");
     XCTAssertEqual(listener.lastError.code, 400, @"invalid code");
+    self.dataCleanupRequired = NO;
 }
 
 // issue invalid retrieve and test for errors
@@ -666,6 +686,7 @@ static NSException *authException = nil;
     listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidFail, @"request was supposed to fail");
     XCTAssertEqual(listener.lastError.code, 404, @"invalid code");
+    self.dataCleanupRequired = NO;
 }
 
  // Test for batch request
@@ -868,6 +889,7 @@ static NSException *authException = nil;
     request = [[SFRestAPI sharedInstance] requestForOwnedFilesList:_currentUser.credentials.userId page:0];
     listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 - (void)testOwnedFilesListWithCommunity {
@@ -886,6 +908,7 @@ static NSException *authException = nil;
     NSURLRequest *urlRequest = [request prepareRequestForSend:account];
     NSRange range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
     XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
+    self.dataCleanupRequired = NO;
 }
 
 - (void)testOwnedFilesListWithCommunityWithHeaders {
@@ -922,6 +945,7 @@ static NSException *authException = nil;
     request = [[SFRestAPI sharedInstance] requestForFilesInUsersGroups:_currentUser.credentials.userId page:0];
     listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // test url for  testFilesInUsersGroupsWithCommunity
@@ -941,6 +965,7 @@ static NSException *authException = nil;
     NSURLRequest *urlRequest = [request prepareRequestForSend:account];
     NSRange range = [[[urlRequest URL] absoluteString] rangeOfString:@"connect/communities/COMMUNITYID/"];
     XCTAssertTrue(range.location!= NSNotFound && range.length > 0 , "The URL must have communities path");
+    self.dataCleanupRequired = NO;
 }
 
 // simple: just invoke requestForFilesSharedWithUser
@@ -954,6 +979,7 @@ static NSException *authException = nil;
     request = [[SFRestAPI sharedInstance] requestForFilesSharedWithUser:_currentUser.credentials.userId page:0];
     listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 
@@ -1368,6 +1394,7 @@ static NSException *authException = nil;
     // let's make sure we have another access token
     NSString *newAccessToken = _currentUser.credentials.accessToken;
     XCTAssertFalse([newAccessToken isEqualToString:invalidAccessToken], @"access token wasn't refreshed");
+    self.dataCleanupRequired = NO;
 }
 
 - (void)testInvalidAccessTokenWithValidPostRequest {
@@ -1392,6 +1419,7 @@ static NSException *authException = nil;
     request = [[SFRestAPI sharedInstance] requestForDeleteWithObjectType:CONTACT objectId:contactId];
     listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
 }
 
 // - sets an invalid accessToken
@@ -1413,6 +1441,7 @@ static NSException *authException = nil;
     
     // let's make sure we have another access token
     NSString *newAccessToken = _currentUser.credentials.accessToken;
+    self.dataCleanupRequired = NO;
     XCTAssertFalse([newAccessToken isEqualToString:invalidAccessToken], @"access token wasn't refreshed");
 }
 
@@ -1436,6 +1465,7 @@ static NSException *authException = nil;
     XCTAssertFalse(completionTimedOut);
     XCTAssertEqual(0, [SFRestAPI sharedInstance].activeRequests.count, @"Active requests queue should be empty.");
     _currentUser.credentials.instanceUrl = origInstanceUrl;
+    self.dataCleanupRequired = NO;
 }
 
 // - sets an invalid accessToken
@@ -1443,35 +1473,30 @@ static NSException *authException = nil;
 // - issue a valid REST request
 // - ensure all requests are failed with the proper error
 - (void)testInvalidAccessAndRefreshToken {
-
-    // save valid tokens and current user
-    NSString *origAccessToken = _currentUser.credentials.accessToken;
-    NSString *origRefreshToken = _currentUser.credentials.refreshToken;
-    SFOAuthCredentials *origCreds = [_currentUser.credentials copy];
     
-    // set invalid tokens
-    NSString *invalidAccessToken = @"xyz";
-    NSString *invalidRefreshToken = @"xyz";
-    [self changeOauthTokens:invalidAccessToken refreshToken:invalidRefreshToken];
+    SFUserAccount *fakeUser = [self createNewUser];
+    XCTAssertNotNil(fakeUser,"User should have been created");
+    fakeUser.credentials.accessToken = @"xyz";
+    fakeUser.credentials.refreshToken = @"xyz";
+    
+    SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:fakeUser];
+    XCTAssertNotNil(restAPI,"SFRestAPI instance for fake user should have been created");
+    
     @try {
-
         // request (valid)
-        SFRestRequest* request = [[SFRestAPI sharedInstance] requestForResources];
-        SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+        SFRestRequest* request = [restAPI requestForResources];
+        SFNativeRestRequestListener *listener = [self sendSyncRequest:request usingInstance:restAPI];
         XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidFail, @"request should have failed");
         XCTAssertEqualObjects(listener.lastError.domain, kSFOAuthErrorDomain, @"invalid domain");
         XCTAssertEqual(listener.lastError.code, kSFOAuthErrorInvalidGrant, @"invalid code");
         XCTAssertNotNil(listener.lastError.userInfo);
     }
     @finally {
-        origCreds.accessToken = origAccessToken;
-        origCreds.refreshToken = origRefreshToken;
-        _currentUser.credentials = origCreds;
-        [_currentUser transitionToLoginState:SFUserAccountLoginStateLoggedIn];
-        [[SFUserAccountManager sharedInstance] saveAccountForUser:_currentUser error:nil];
-        [SFUserAccountManager sharedInstance].currentUser = _currentUser;
+        self.dataCleanupRequired = NO;
+        XCTAssertTrue([self deleteUser:fakeUser],"Should have successfully deleted fake user");
     }
 }
+
 
 // - set an invalid access token (simulate expired)
 // - make multiple simultaneous requests
@@ -1480,45 +1505,59 @@ static NSException *authException = nil;
 // - ensure that all requests eventually succeed
 //
 -(void)testInvalidAccessToken_MultipleRequests {
-
+    
     // save invalid token
     NSString *invalidAccessToken = @"xyz";
     [self changeOauthTokens:invalidAccessToken refreshToken:nil];
     
     // request (valid)
     SFRestRequest* request0 = [[SFRestAPI sharedInstance] requestForDescribeGlobal];
-    SFNativeRestRequestListener *listener0 = [[SFNativeRestRequestListener alloc] initWithRequest:request0];
     SFRestRequest* request1 = [[SFRestAPI sharedInstance] requestForDescribeGlobal];
-    SFNativeRestRequestListener *listener1 = [[SFNativeRestRequestListener alloc] initWithRequest:request1];
     SFRestRequest* request2 = [[SFRestAPI sharedInstance] requestForDescribeGlobal];
-    SFNativeRestRequestListener *listener2 = [[SFNativeRestRequestListener alloc] initWithRequest:request2];
     SFRestRequest* request3 = [[SFRestAPI sharedInstance] requestForDescribeGlobal];
-    SFNativeRestRequestListener *listener3 = [[SFNativeRestRequestListener alloc] initWithRequest:request3];
     SFRestRequest* request4 = [[SFRestAPI sharedInstance] requestForDescribeGlobal];
-    SFNativeRestRequestListener *listener4 = [[SFNativeRestRequestListener alloc] initWithRequest:request4];
+    XCTestExpectation *expectation0 = [self expectationWithDescription:@"request1"];
+    XCTestExpectation *expectation1 = [self expectationWithDescription:@"request1"];
+    XCTestExpectation *expectation2 = [self expectationWithDescription:@"request2"];
+    XCTestExpectation *expectation3 = [self expectationWithDescription:@"request3"];
+    XCTestExpectation *expectation4 = [self expectationWithDescription:@"request4"];
+    __block BOOL error = NO;
     
-    //send multiple requests, all of which should fail with "unauthorized" initially,
-    //but then be replayed after an access token refresh
-    [[SFRestAPI sharedInstance] send:request0 delegate:listener0];
-    [[SFRestAPI sharedInstance] send:request1 delegate:listener1];
-    [[SFRestAPI sharedInstance] send:request2 delegate:listener2];
-    [[SFRestAPI sharedInstance] send:request3 delegate:listener3];
-    [[SFRestAPI sharedInstance] send:request4 delegate:listener4];
+    [[SFRestAPI sharedInstance] sendRESTRequest:request0 failBlock:^(NSError *  e, NSURLResponse * _Nullable rawResponse) {
+        error = YES;
+    } completeBlock:^(id response, NSURLResponse *  rawResponse) {
+        [expectation0 fulfill];
+    }];
     
-    //wait for requests to complete in some arbitrary order
-    [listener4 waitForCompletion];
-    [listener1 waitForCompletion];
-    [listener3 waitForCompletion];
-    [listener2 waitForCompletion];
-    [listener0 waitForCompletion];
-    XCTAssertEqualObjects(listener0.returnStatus, kTestRequestStatusDidLoad, @"request0 failed");
-    XCTAssertEqualObjects(listener1.returnStatus, kTestRequestStatusDidLoad, @"request1 failed");
-    XCTAssertEqualObjects(listener2.returnStatus, kTestRequestStatusDidLoad, @"request2 failed");
-    XCTAssertEqualObjects(listener3.returnStatus, kTestRequestStatusDidLoad, @"request3 failed");
-    XCTAssertEqualObjects(listener4.returnStatus, kTestRequestStatusDidLoad, @"request4 failed");
+    [[SFRestAPI sharedInstance] sendRESTRequest:request1 failBlock:^(NSError *  e, NSURLResponse * _Nullable rawResponse) {
+        error = YES;
+    } completeBlock:^(id response, NSURLResponse *  rawResponse) {
+        [expectation1 fulfill];
+    }];
     
+    [[SFRestAPI sharedInstance] sendRESTRequest:request2 failBlock:^(NSError *  e, NSURLResponse *  rawResponse) {
+        error = YES;
+    } completeBlock:^(id response, NSURLResponse * rawResponse) {
+        [expectation2 fulfill];
+    }];
+    
+    [[SFRestAPI sharedInstance] sendRESTRequest:request3 failBlock:^(NSError *  e, NSURLResponse * _Nullable rawResponse) {
+       error = YES;
+    } completeBlock:^(id response, NSURLResponse *  rawResponse) {
+         [expectation3 fulfill];
+    }];
+    
+    [[SFRestAPI sharedInstance] sendRESTRequest:request4 failBlock:^(NSError *  e, NSURLResponse * _Nullable rawResponse) {
+        error = YES;
+    } completeBlock:^(id response, NSURLResponse *  rawResponse) {
+        [expectation4 fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation0, expectation1,expectation2,expectation3,expectation4] timeout:10.0];
+    XCTAssertFalse(error,@"All pending Requests should not have had errors");
     // let's make sure we have a new access token
     NSString *newAccessToken = _currentUser.credentials.accessToken;
+    self.dataCleanupRequired = NO;
     XCTAssertFalse([newAccessToken isEqualToString:invalidAccessToken], @"access token wasn't refreshed");
 }
 
@@ -1528,71 +1567,68 @@ static NSException *authException = nil;
 // - make sure the token exchange failed
 // - ensure all requests are failed with the proper error code
 - (void)testInvalidAccessAndRefreshToken_MultipleRequests {
-
-    // save valid tokens and current user
-    NSString *origAccessToken = _currentUser.credentials.accessToken;
-    NSString *origRefreshToken = _currentUser.credentials.refreshToken;
-    SFOAuthCredentials *origCreds = [_currentUser.credentials copy];
     
-    // set invalid tokens
-    NSString *invalidAccessToken = @"xyz";
-    NSString *invalidRefreshToken = @"xyz";
-    [self changeOauthTokens:invalidAccessToken refreshToken:invalidRefreshToken];
+    SFUserAccount *fakeUser = [self createNewUser];
+    XCTAssertNotNil(fakeUser,@"User should not be nil ");
+    fakeUser.credentials.accessToken = @"xyz";
+    fakeUser.credentials.refreshToken = @"xyz";
     @try {
-
         // request (valid)
-        SFRestRequest* request0 = [[SFRestAPI sharedInstance] requestForDescribeGlobal];
-        SFNativeRestRequestListener *listener0 = [[SFNativeRestRequestListener alloc] initWithRequest:request0];
-        SFRestRequest* request1 = [[SFRestAPI sharedInstance] requestForDescribeGlobal];
-        SFNativeRestRequestListener *listener1 = [[SFNativeRestRequestListener alloc] initWithRequest:request1];
-        SFRestRequest* request2 = [[SFRestAPI sharedInstance] requestForDescribeGlobal];
-        SFNativeRestRequestListener *listener2 = [[SFNativeRestRequestListener alloc] initWithRequest:request2];
-        SFRestRequest* request3 = [[SFRestAPI sharedInstance] requestForDescribeGlobal];
-        SFNativeRestRequestListener *listener3 = [[SFNativeRestRequestListener alloc] initWithRequest:request3];
-        SFRestRequest* request4 = [[SFRestAPI sharedInstance] requestForDescribeGlobal];
-        SFNativeRestRequestListener *listener4 = [[SFNativeRestRequestListener alloc] initWithRequest:request4];
+        SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:fakeUser];
+        XCTAssertNotNil(restAPI,@"SFRestAPI instance should not be nil");
+        SFRestRequest* request0 = [restAPI requestForDescribeGlobal];
+        XCTestExpectation *expectation0 = [self expectationWithDescription:@"request1"];
+        XCTestExpectation *expectation1 = [self expectationWithDescription:@"request2"];
+        XCTestExpectation *expectation2 = [self expectationWithDescription:@"request3"];
+        XCTestExpectation *expectation3 = [self expectationWithDescription:@"request4"];
+        XCTestExpectation *expectation4 = [self expectationWithDescription:@"request5"];
         
-        //send multiple requests, all of which should fail with "unauthorized"
-        [[SFRestAPI sharedInstance] send:request0 delegate:listener0];
-        [[SFRestAPI sharedInstance] send:request1 delegate:listener1];
-        [[SFRestAPI sharedInstance] send:request2 delegate:listener2];
-        [[SFRestAPI sharedInstance] send:request3 delegate:listener3];
-        [[SFRestAPI sharedInstance] send:request4 delegate:listener4];
+        SFRestRequest* request1 = [restAPI requestForDescribeGlobal];
+        SFRestRequest* request2 = [restAPI requestForDescribeGlobal];
+        SFRestRequest* request3 = [restAPI requestForDescribeGlobal];
+        SFRestRequest* request4 = [restAPI requestForDescribeGlobal];
         
-        //wait for requests to complete in some arbitrary order
-        [listener4 waitForCompletion];
-        [listener1 waitForCompletion];
-        [listener3 waitForCompletion];
-        [listener2 waitForCompletion];
-        [listener0 waitForCompletion];
-        XCTAssertEqualObjects(listener0.returnStatus, kTestRequestStatusDidFail, @"request0 should have failed");
-        XCTAssertEqualObjects(listener0.lastError.domain, kSFOAuthErrorDomain, @"invalid error domain");
-        XCTAssertEqual(listener0.lastError.code, kSFOAuthErrorInvalidGrant, @"invalid error code");
-        XCTAssertNotNil(listener0.lastError.userInfo,@"userInfo should not be nil");
-        XCTAssertEqualObjects(listener1.returnStatus, kTestRequestStatusDidFail, @"request1 should have failed");
-        XCTAssertEqualObjects(listener1.lastError.domain, kSFOAuthErrorDomain, @"invalid  error domain");
-        XCTAssertEqual(listener1.lastError.code, kSFOAuthErrorInvalidGrant, @"invalid error code");
-        XCTAssertNotNil(listener1.lastError.userInfo,@"userInfo should not be nil");
-        XCTAssertEqualObjects(listener2.returnStatus, kTestRequestStatusDidFail, @"request2 should have failed");
-        XCTAssertEqualObjects(listener2.lastError.domain, kSFOAuthErrorDomain, @"invalid  error domain");
-        XCTAssertEqual(listener2.lastError.code, kSFOAuthErrorInvalidGrant, @"invalid error code");
-        XCTAssertNotNil(listener2.lastError.userInfo,@"userInfo should not be nil");
-        XCTAssertEqualObjects(listener3.returnStatus, kTestRequestStatusDidFail, @"request3 should have failed");
-        XCTAssertEqualObjects(listener3.lastError.domain, kSFOAuthErrorDomain, @"invalid  error domain");
-        XCTAssertEqual(listener3.lastError.code, kSFOAuthErrorInvalidGrant, @"invalid error code");
-        XCTAssertNotNil(listener3.lastError.userInfo,@"userInfo should not be nil");
-        XCTAssertEqualObjects(listener4.returnStatus, kTestRequestStatusDidFail, @"request4 should have failed");
-        XCTAssertEqualObjects(listener4.lastError.domain, kSFOAuthErrorDomain, @"invalid  error domain");
-        XCTAssertEqual(listener4.lastError.code, kSFOAuthErrorInvalidGrant, @"invalid error code");
-        XCTAssertNotNil(listener4.lastError.userInfo,@"userInfo should not be nil");
+        [restAPI sendRESTRequest:request0 failBlock:^(NSError *  e, NSURLResponse *rawResponse) {
+            [expectation0 fulfill];
+            XCTAssertEqualObjects(e.domain, kSFOAuthErrorDomain, @"invalid error domain");
+        } completeBlock:^(id  response, NSURLResponse * rawResponse) {
+            
+        }];
+        
+        [restAPI sendRESTRequest:request1 failBlock:^(NSError *  e, NSURLResponse *rawResponse) {
+            [expectation1 fulfill];
+            XCTAssertEqualObjects(e.domain, kSFOAuthErrorDomain, @"invalid error domain");
+        } completeBlock:^(id response, NSURLResponse * rawResponse) {
+            
+        }];
+        
+        [restAPI sendRESTRequest:request2 failBlock:^(NSError *  e, NSURLResponse *rawResponse) {
+            [expectation2 fulfill];
+            XCTAssertEqualObjects(e.domain, kSFOAuthErrorDomain, @"invalid error domain");
+        } completeBlock:^(id response, NSURLResponse *  rawResponse) {
+            
+        }];
+        
+        [restAPI sendRESTRequest:request3 failBlock:^(NSError *  e, NSURLResponse *rawResponse) {
+            [expectation3 fulfill];
+            XCTAssertEqualObjects(e.domain, kSFOAuthErrorDomain, @"invalid error domain");
+        } completeBlock:^(id response, NSURLResponse *  rawResponse) {
+            
+        }];
+        
+        [restAPI sendRESTRequest:request4 failBlock:^(NSError *  e, NSURLResponse *rawResponse) {
+            [expectation4 fulfill];
+            XCTAssertEqualObjects(e.domain, kSFOAuthErrorDomain, @"invalid error domain");
+        } completeBlock:^(id response, NSURLResponse *  rawResponse) {
+            
+        }];
+        [self waitForExpectations:@[expectation0,expectation1,expectation2,expectation3,expectation4] timeout:10.0];
+        
     }
     @finally {
-        origCreds.accessToken = origAccessToken;
-        origCreds.refreshToken = origRefreshToken;
-        _currentUser.credentials = origCreds;
-        [_currentUser transitionToLoginState:SFUserAccountLoginStateLoggedIn];
-        [[SFUserAccountManager sharedInstance] saveAccountForUser:_currentUser error:nil];
-        [SFUserAccountManager sharedInstance].currentUser = _currentUser;
+        [self deleteUser:fakeUser];
+        // no need for cleanup routine here since we dont create any records, adds unneccesary latency to the tests.
+        self.dataCleanupRequired = NO;
     }
 }
 
@@ -2120,5 +2156,42 @@ static NSException *authException = nil;
     creds.instanceUrl = instanceUrl;
     return creds;
 }
+
+- (SFUserAccount *)createNewUser {
+    SFOAuthCredentials *credentials = [[SFUserAccountManager sharedInstance] newClientCredentials];
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:credentials];
+    [account transitionToLoginState:SFUserAccountLoginStateLoggedIn];
+    NSString *userId = [self generateRandomId:15];
+    NSString *orgId = [self generateRandomId:18];
+    account.credentials.userId = userId;
+    account.credentials.organizationId = orgId;
+    
+    credentials.instanceUrl = [SFUserAccountManager sharedInstance].currentUser.credentials.instanceUrl;
+    NSError *error = nil;
+    BOOL result = [[SFUserAccountManager sharedInstance] saveAccountForUser:account error:&error];
+    return result?account:nil;
+}
+
+- (BOOL)deleteUser:(SFUserAccount *)user {
+    NSError *error = nil;
+    [SFRestAPI removeSharedInstanceWithUser:user];
+    BOOL result = [[SFUserAccountManager sharedInstance] deleteAccountForUser:user error:&error];
+    return result;
+}
+
+- (NSString *) generateRandomId:(NSInteger)len {
+    
+    NSString *alphabet  = @"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXZY0123456789";
+    NSMutableString *s = [NSMutableString stringWithCapacity:20];
+    for (NSUInteger i = 0U; i < len; i++) {
+        u_int32_t r = arc4random() % [alphabet length];
+        unichar c = [alphabet characterAtIndex:r];
+        [s appendFormat:@"%C", c];
+    }
+    
+    return s;
+}
+
+
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -21,7 +21,7 @@
  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
+#import "SFSDKLogoutBlocker.h"
 #import "SalesforceRestAPITests.h"
 #import <SalesforceSDKCore/SalesforceSDKCore.h>
 #import "SFRestAPI+Internal.h"
@@ -103,6 +103,7 @@ static NSException *authException = nil;
 + (void)setUp
 {
     @try {
+        [SFSDKLogoutBlocker sharedInstance];
         [TestSetupUtils populateAuthCredentialsFromConfigFileForClass:[self class]];
         [TestSetupUtils synchronousAuthRefresh];
     }

--- a/libs/SmartStore/SmartStore/Classes/Instrumentation/SFSmartStore+Instrumentation.m
+++ b/libs/SmartStore/SmartStore/Classes/Instrumentation/SFSmartStore+Instrumentation.m
@@ -51,7 +51,7 @@
 
 
 + (void)load{
-    if ([SFSDKInstrumentationHelper isEnabled]) {
+    if ([SFSDKInstrumentationHelper isEnabled] && (self == SFSmartStore.self)) {
         [self enableInstrumentation];
     }
 }

--- a/libs/SmartSync/SmartSync/Classes/Instrumentation/SFSmartSyncSyncManager+Instrumentation.m
+++ b/libs/SmartSync/SmartSync/Classes/Instrumentation/SFSmartSyncSyncManager+Instrumentation.m
@@ -46,7 +46,7 @@
 
 
 + (void)load{
-    if ([SFSDKInstrumentationHelper isEnabled]) {
+    if ([SFSDKInstrumentationHelper isEnabled]  && (self == SFSmartSyncSyncManager.self)) {
         [self enableInstrumentation];
     }
 }


### PR DESCRIPTION
Prevents logout from occurring during tests. Fixes the failing tests for multiple access token/refresh token requests. Logout is modeled as a synchronous call, but in true nature it encompasses usage of async calls (fire & forget). So as tests proceed further swapping out of invalid tokens with valid tokens can inadvertently run the revocation for a valid token. The swizzled methods are no-op methods for logout preventing such scenarios from occurring.  