### PR TITLE
Fix profile upload params

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.h
@@ -143,6 +143,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (SFRestRequest *) requestForUploadFile:(NSData *)data name:(NSString *)name description:(NSString *)description mimeType:(NSString *)mimeType;
 
+/**
+ * Build a request that can upload a new profile photo to the server
+ *
+ * @param data Data to upload to the server.
+ * @param fileName The name of this file
+ * @param mimeType The mime-type of the file, if known.
+ * @param userId The id of the user to update
+ * @return A SFRestRequest that can perform this upload.
+ */
+- (SFRestRequest *)requestForProfilePhotoUpload:(NSData *)data fileName:(NSString *)fileName mimeType:(NSString *)mimeType userId:(NSString *)userId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
@@ -36,6 +36,7 @@
 #define SHARE_TYPE @"ShareType"
 #define RENDITION_TYPE @"type"
 #define FILE_DATA @"fileData"
+#define FILE_UPLOAD @"fileUpload"
 
 @implementation SFRestAPI (Files)
 
@@ -120,7 +121,17 @@
 - (SFRestRequest *) requestForUploadFile:(NSData *)data name:(NSString *)name description:(NSString *)description mimeType:(NSString *)mimeType {
     NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/me", self.apiVersion,[self communitiesUrlPathIfRequired]];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
-    [request addPostFileData:data paramName:FILE_DATA description:description fileName:name mimeType:mimeType];
+
+    NSDictionary *params = @{@"title" : name, @"desc" : description};
+    [request addPostFileData:data paramName:FILE_DATA fileName:name mimeType:mimeType params:params];
+    return request;
+}
+
+- (SFRestRequest *)requestForProfilePhotoUpload:(NSData *)data fileName:(NSString *)fileName mimeType:(NSString *)mimeType userId:(NSString *)userId {
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/user-profiles/%@/photo", self.apiVersion, [self communitiesUrlPathIfRequired], userId];
+    SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
+
+    [request addPostFileData:data paramName:FILE_UPLOAD fileName:fileName mimeType:mimeType params:nil];
     return request;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -251,6 +251,16 @@ NS_SWIFT_NAME(RestRequest)
 - (void)cancel;
 
 /**
+ * Add file to upload
+ * @param fileData Value of this POST parameter
+ * @param paramName Name of the POST parameter
+ * @param fileName Name of the file
+ * @param mimeType MIME type of the file
+ * @param params File properties (e.g. title, desc, contentSize)
+ */
+- (void)addPostFileData:(NSData *)fileData paramName:(NSString *)paramName fileName:(NSString *)fileName mimeType:(NSString *)mimeType params:(nullable NSDictionary *)params;
+
+/**
  * Add file to upload.
  * @param fileData Value of this POST parameter
  * @param paramName Name of the POST parameter
@@ -258,7 +268,7 @@ NS_SWIFT_NAME(RestRequest)
  * @param fileName Name of the file
  * @param mimeType MIME type of the file
  */
-- (void)addPostFileData:(NSData *)fileData paramName:(NSString*)paramName description:(nullable NSString *)description fileName:(NSString *)fileName mimeType:(NSString *)mimeType;
+- (void)addPostFileData:(NSData *)fileData paramName:(NSString*)paramName description:(nullable NSString *)description fileName:(NSString *)fileName mimeType:(NSString *)mimeType SFSDK_DEPRECATED(7.2, 8.0, "Use addPostFileData:paramName:fileName:mimeType:params instead");
 
 /**
  * Sets a custom request body based on an NSString representation.


### PR DESCRIPTION
`fileUpload` (profile photo upload) vs `fileData` (regular file upload) param types have different valid parameters so I made `addPostFileData` more generic to take given parameters instead of always expecting description and title, and then added a convenience method to build the request for profile photo upload specifically