### PR TITLE
Update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/SalesforceMobileSDK-iOS
   macos:
-    xcode: "10.1.0"
+    xcode: "10.2.1"
   shell: /bin/bash --login -eo pipefail
   environment:
     BASH_ENV: ~/.bashrc
@@ -59,7 +59,7 @@ defaults: &defaults
 
 version: 2
 jobs:
-  test-SalesforceSDKCommon:
+  SalesforceSDKCommon:
     <<: *defaults
     environment:
       - FASTLANE_LANE: "PR lib:SalesforceSDKCommon"
@@ -81,7 +81,7 @@ jobs:
           destination: Static-Analysis
       - run: *codecov
 
-  test-SalesforceAnalytics:
+  SalesforceAnalytics:
     <<: *defaults
     environment:
       - FASTLANE_LANE: "PR lib:SalesforceAnalytics"
@@ -103,7 +103,7 @@ jobs:
           destination: Static-Analysis
       - run: *codecov
 
-  test-SalesforceSDKCore:
+  SalesforceSDKCore:
     <<: *defaults
     environment:
       - FASTLANE_LANE: "PR lib:SalesforceSDKCore"
@@ -125,7 +125,7 @@ jobs:
           destination: Static-Analysis
       - run: *codecov
 
-  test-SmartStore:
+  SmartStore:
     <<: *defaults
     environment:
       - FASTLANE_LANE: "PR lib:SmartStore"
@@ -147,7 +147,7 @@ jobs:
           destination: Static-Analysis
       - run: *codecov
 
-  test-SmartSync:
+  SmartSync:
     <<: *defaults
     environment:
       - FASTLANE_LANE: "PR lib:SmartSync"
@@ -174,34 +174,57 @@ workflows:
 
   build-test-pr:
     jobs:
-      - test-SalesforceSDKCommon:
+      - SalesforceSDKCommon:
           *pr-filter
-      - test-SalesforceAnalytics:
+      - SalesforceAnalytics:
           *pr-filter
-      - test-SalesforceSDKCore:
+      - SalesforceSDKCore:
           *pr-filter
-      - test-SmartStore:
+      - SmartStore:
           *pr-filter
-      - test-SmartSync:
+      - SmartSync:
           *pr-filter
+
   # Cron are on a timezone 8 hours ahead of PST
-  # Build everything at ~9:30pm Sunday/Wednesday Nights
+  # Build everything at ~9:30pm Tuesday/Thursday Nights
   nightly-test-ios11:
     triggers:
       - schedule:
-          cron: "30 5 * * 1,4"
+          cron: "30 5 * * 3,5"
           filters:
             branches:
               only:
                 - dev
     jobs:
-      - test-SalesforceSDKCommon:
+      - SalesforceSDKCommon:
+            context: nightly-test11
+      - SalesforceAnalytics:
+            context: nightly-test11
+      - SalesforceSDKCore:
+            context: nightly-test11
+      - SmartStore:
+            context: nightly-test11
+      - SmartSync:
+            context: nightly-test11
+
+  # Cron are on a timezone 8 hours ahead of PST
+  # Build everything at ~11:30pm Tuesday/Thursday Nights
+  nightly-test-ios12:
+    triggers:
+      - schedule:
+          cron: "30 7 * * 3,5"
+          filters:
+            branches:
+              only:
+                - dev
+    jobs:
+      - SalesforceSDKCommon:
             context: nightly-test
-      - test-SalesforceAnalytics:
+      - SalesforceAnalytics:
             context: nightly-test
-      - test-SalesforceSDKCore:
+      - SalesforceSDKCore:
             context: nightly-test
-      - test-SmartStore:
+      - SmartStore:
             context: nightly-test
-      - test-SmartSync:
+      - SmartSync:
             context: nightly-test

--- a/.circleci/fastlane/Fastfile
+++ b/.circleci/fastlane/Fastfile
@@ -1,7 +1,7 @@
 $git_pr_api = "https://api.github.com/repos/%s/SalesforceMobileSDK-iOS/pulls/%s/files"
 $schemes = ['SalesforceSDKCommon', 'SalesforceAnalytics', 'SalesforceSDKCore', 'SmartStore', 'SmartSync']
-ENV['DEVICE'] = 'iPhone XR' unless ENV.has_key?('DEVICE')
-ENV['IOS_VERSION'] = '12.1' unless ENV.has_key?('IOS_VERSION')
+ENV['DEVICE'] = 'iPhone Xʀ' unless ENV.has_key?('DEVICE')
+ENV['IOS_VERSION'] = '12.2' unless ENV.has_key?('IOS_VERSION')
 
 lane :PR do |options|
   lib_to_test = options[:lib]


### PR DESCRIPTION
- Update to Xcode 10.2.1
- Fix default device for tests
- Separate "nightly" runs for iOS 11 and 12
- Move "nightly" runs to Tuesday/Thursday 
- cleanup job names for readability 