### PR TITLE
- Fix crash where "Id" is missing from soup dict.

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Target/SFBatchSyncUpTarget.m
+++ b/libs/SmartSync/SmartSync/Classes/Target/SFBatchSyncUpTarget.m
@@ -101,7 +101,7 @@ static NSUInteger const kSFMaxSubRequestsCompositeAPI = 25;
     // Preparing requests
     for (NSMutableDictionary* record in records) {
         NSString *refId;
-        if ([record[self.idFieldName] isEqual:[NSNull null]]) {
+        if (record[self.idFieldName] == nil || [record[self.idFieldName] isEqual:[NSNull null]]) {
             // create local id - needed for refId
             refId = record[self.idFieldName] = [NSString stringWithFormat:@"local_%@", record[SOUP_ENTRY_ID]];
         } else {


### PR DESCRIPTION
Performing a sync up using the new SFBatchSyncUpTarget. Was crashing when records were freshly inserted, not existing records. In this case the record soup dict did not contain the "Id" field. The refId var was having nil assigned, and crashing trying to dereference on line 114.