### PR TITLE
Ensure task is removed from active syncs

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Manager/SFSyncTask.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFSyncTask.m
@@ -62,6 +62,10 @@ NSInteger const kSyncManagerUnchanged = -1;
     return self;
 }
 
+- (void)dealloc {
+    [self.syncManager removeFromActiveSyncs: self];
+}
+
 - (BOOL) shouldStop {
     if (![self.syncManager checkAcceptingSyncs:nil]) {
         self.sync.status = SFSyncStateStatusStopped;


### PR DESCRIPTION
Ensure the task has been removed from the active syncs list. See https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/2884

The task is added to the active syncs list in the init(), and usually removed in the updateSync() method, however the SFCleanSyncGhostsTask overrides updateSync() causing the task to be left in the list, and the subsequent attempt to do a sync down fails.

