### PR TITLE
 Added new Async API to switch to new user

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKLoginFlowSelectionViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKLoginFlowSelectionViewController.m
@@ -288,7 +288,7 @@ static CGFloat kSpace = 20.0;
 
 - (void)hostListViewController:(SFSDKLoginHostListViewController *)hostListViewController didChangeLoginHost:(SFSDKLoginHost *)newLoginHost {
     [SFUserAccountManager sharedInstance].loginHost = newLoginHost.host;
-    [[SFUserAccountManager sharedInstance] switchToNewUser];
+    [[SFUserAccountManager sharedInstance] switchToUser:nil];
 }
 
 + (UIImage *)imageFromColor:(UIColor *)color {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserManagementViewController.m
@@ -77,10 +77,12 @@
 
 - (void)actionCreateNewUser
 {
-    [[SFUserAccountManager sharedInstance] loginWithCompletion:^(SFOAuthInfo * authInfo, SFUserAccount * newUser) {
-        [[SFUserAccountManager sharedInstance] switchToUser:newUser];
-    } failure:^(SFOAuthInfo * authInfo, NSError * error) {
-        [SFSDKCoreLogger e:[self class] format:@"Attempt to add new user failed %@",[error localizedDescription]];
+    [[SFUserAccountManager sharedInstance] switchToNewUserWithCompletion:^(NSError * error, SFUserAccount * newUser) {
+        if (error) {
+            [SFSDKCoreLogger e:[self class] format:@"Attempt to add new user failed %@",[error localizedDescription]];
+        } else {
+            [SFSDKCoreLogger d:[self class] format:@"Switch to new User succeeded"];
+        }
     }];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -495,6 +495,12 @@ NS_SWIFT_NAME(UserAccountManager)
 - (void)switchToNewUser NS_SWIFT_NAME(switchToNewUserAccount());
 
 /**
+ Switches to a new user. Sets the current user only if the login succeeds. Completion block is
+ invoked if the login flow completes, or if any errors are encountered during the flow.
+ */
+- (void)switchToNewUserWithCompletion:(void (^)(NSError *, SFUserAccount *))completion NS_SWIFT_NAME(switchToNewUserAccount(_:));
+
+/**
  Switches away from the current user, to the given user account.
  @param userAccount The user to switch to.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -492,7 +492,7 @@ NS_SWIFT_NAME(UserAccountManager)
 /**
  Switches away from the current user, to a new user context.
  */
-- (void)switchToNewUser NS_SWIFT_NAME(switchToNewUserAccount());
+- (void)switchToNewUser NS_SWIFT_NAME(switchToNewUserAccount()) SFSDK_DEPRECATED(7.2, 8.0, "Use switchToNewUserWithCompletion instead.");
 
 /**
  Switches to a new user. Sets the current user only if the login succeeds. Completion block is

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -1505,8 +1505,6 @@ static int const kSFSDKUserAccountManagerErrorCode = 100;
             }
         }];
     }
-    
-    
 }
 
 - (void)switchToUser:(SFUserAccount *)newCurrentUser {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -85,6 +85,8 @@ static NSString *const kErroredClientKey = @"SFErroredOAuthClientKey";
 static NSString * const kSFSPAppFeatureIDPLogin   = @"SP";
 static NSString * const kSFIDPAppFeatureIDPLogin   = @"IP";
 static NSString *const  kOptionsClientKey          = @"clientIdentifier";
+static NSString * const kSFSDKUserAccountManagerErrorDomain = @"com.salesforce.mobilesdk.SFUserAccountManager";
+static int const kSFSDKUserAccountManagerErrorCode = 100;
 
 @interface SFNotificationUserInfo()
 - (instancetype) initWithUser:(SFUserAccount *)user;
@@ -1481,6 +1483,30 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
 - (void)switchToNewUser {
     [SFSDKWebViewStateManager removeSession];
     [self switchToUser:nil];
+}
+
+- (void)switchToNewUserWithCompletion:(void (^)(NSError *error, SFUserAccount * currentAccount))completion {
+    if (!self.currentUser) {
+        NSError *error = [[NSError alloc] initWithDomain:kSFSDKUserAccountManagerErrorDomain
+                                                    code:kSFSDKUserAccountManagerErrorCode
+                                                userInfo:@{
+                                                           NSLocalizedDescriptionKey : @"Cannot switch to new user. No currentUser has been set."
+                                                           }];
+        completion(error,nil);
+    } else {
+        [self loginWithCompletion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
+            [self switchToUser:userAccount];
+            if (completion) {
+                completion(nil, userAccount);
+            }
+        } failure:^(SFOAuthInfo * authInfo, NSError * error) {
+            if (completion) {
+                completion(error,nil);
+            }
+        }];
+    }
+    
+    
 }
 
 - (void)switchToUser:(SFUserAccount *)newCurrentUser {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -302,6 +302,21 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     XCTAssertEqual(self.uam.currentUser, newUser, @"The current user should be set to newUser.");
 }
 
+
+- (void)testSwitchToNewUserNoCurrentUser {
+    NSArray *accounts = [self createAndVerifyUserAccounts:1];
+    SFUserAccount *origUser = accounts[0];
+    self.uam.currentUser = nil;
+    XCTestExpectation *switchExpectation = [self expectationWithDescription:@"testSwitchToNewUserWithCompletionErrorCase"];
+    __block NSError *error = nil;
+    [self.uam switchToNewUserWithCompletion:^(NSError * err, SFUserAccount * account) {
+         error = err;
+        [switchExpectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+    XCTAssertNotNil(error, @"switchToNewUserWithCompletion should not be called without a current user");
+}
+
 - (void)testLoginHostForSwitchToUser {
     NSArray *accounts = [self createAndVerifyUserAccounts:2];
     SFUserAccount *origUser = accounts[0];

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/IDPLoginViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/IDPLoginViewController.swift
@@ -193,6 +193,6 @@ extension IDPLoginViewController: LoginHostDelegate {
     
     func hostListViewController(_ hostListViewController: LoginHostListViewController, didChange newLoginHost: SalesforceLoginHost) {
         UserAccountManager.shared.loginHost = newLoginHost.host
-        UserAccountManager.shared.switchToNewUserAccount()
+        UserAccountManager.shared.switchToNewUser(completion: nil)
     }
 }

--- a/shared/classes/IDPLoginViewController.m
+++ b/shared/classes/IDPLoginViewController.m
@@ -110,7 +110,7 @@
 
 - (void)hostListViewController:(SFSDKLoginHostListViewController *)hostListViewController didChangeLoginHost:(SFSDKLoginHost *)newLoginHost {
     [SFUserAccountManager sharedInstance].loginHost = newLoginHost.host;
-    [[SFUserAccountManager sharedInstance] switchToNewUser];
+    [[SFUserAccountManager sharedInstance] switchToUser:nil];
 }
 
 @end


### PR DESCRIPTION
This PR adds the following.

1. A async api for switchToNewUser. Ensures that current user is not cleared and is set only after the login is completed. Errors out if called without a currentUser. 

2. Deprecated older Sync api. 

Note: Tests are WIP.