### PR TITLE
Added a notification for Refresh flow

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -89,6 +89,11 @@
     if (self.completionBlock) {
         dispatch_async(dispatch_get_main_queue(), ^{
             self.completionBlock(credentials);
+            SFUserAccount *account = [[SFUserAccountManager sharedInstance] accountForCredentials:credentials];
+            NSDictionary *userInfo = @{ kSFNotificationUserInfoAccountKey : account };
+            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationRefreshFlowCompleted
+                                                                object:self
+                                                              userInfo:userInfo];
         });
     }
 }
@@ -110,13 +115,6 @@
     if (info.authType != SFOAuthTypeRefresh) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidLogIn
-                                                                object:nil
-                                                              userInfo:nil];
-        });
-    } else {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            
-            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationRefreshFlowCompleted 
                                                                 object:nil
                                                               userInfo:nil];
         });

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -113,6 +113,13 @@
                                                                 object:nil
                                                               userInfo:nil];
         });
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            
+            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationRefreshFlowCompleted 
+                                                                object:nil
+                                                              userInfo:nil];
+        });
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -91,7 +91,7 @@
             self.completionBlock(credentials);
             SFUserAccount *account = [[SFUserAccountManager sharedInstance] accountForCredentials:credentials];
             NSDictionary *userInfo = @{ kSFNotificationUserInfoAccountKey : account };
-            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationRefreshFlowCompleted
+            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidRefreshToken
                                                                 object:self
                                                               userInfo:userInfo];
         });

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -88,12 +88,12 @@
     [SFSDKCoreLogger i:[self class] format:@"%@ Session was successfully refreshed.", NSStringFromSelector(_cmd)];
     if (self.completionBlock) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            self.completionBlock(credentials);
             SFUserAccount *account = [[SFUserAccountManager sharedInstance] accountForCredentials:credentials];
             NSDictionary *userInfo = @{ kSFNotificationUserInfoAccountKey : account };
             [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidRefreshToken
                                                                 object:self
                                                               userInfo:userInfo];
+            self.completionBlock(credentials);
         });
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -76,7 +76,9 @@ FOUNDATION_EXTERN NSNotificationName kSFNotificationUserDidSwitch NS_SWIFT_NAME(
  */
 FOUNDATION_EXTERN NSNotificationName kSFNotificationOrgDidLogout NS_SWIFT_NAME(UserAccountManager.didLogoutOrg);
 
-FOUNDATION_EXTERN NSNotificationName kSFNotificationRefreshFlowCompleted  NS_SWIFT_NAME(UserAccountManager.refreshFlowCompleted);
+/** Notification sent when a oauth refresh flow succeeds.
+ */
+FOUNDATION_EXTERN NSNotificationName kSFNotificationUserDidRefreshToken  NS_SWIFT_NAME(UserAccountManager.didRefreshToken);
 
 /** Notification sent prior to display of Auth View. In swift access this constant using Notification.Name.SFUserAccountManagerWillShowAuthenticationView
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -76,6 +76,8 @@ FOUNDATION_EXTERN NSNotificationName kSFNotificationUserDidSwitch NS_SWIFT_NAME(
  */
 FOUNDATION_EXTERN NSNotificationName kSFNotificationOrgDidLogout NS_SWIFT_NAME(UserAccountManager.didLogoutOrg);
 
+FOUNDATION_EXTERN NSNotificationName kSFNotificationRefreshFlowCompleted  NS_SWIFT_NAME(UserAccountManager.refreshFlowCompleted);
+
 /** Notification sent prior to display of Auth View. In swift access this constant using Notification.Name.SFUserAccountManagerWillShowAuthenticationView
  */
 FOUNDATION_EXTERN NSNotificationName kSFNotificationUserWillShowAuthView NS_SWIFT_NAME(UserAccountManager.willShowAuthenticationView);

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -46,7 +46,7 @@ NSNotificationName kSFNotificationUserDidLogIn   = @"SFNotificationUserDidLogIn"
 NSNotificationName kSFNotificationUserWillLogout = @"SFNotificationUserWillLogout";
 NSNotificationName kSFNotificationUserDidLogout  = @"SFNotificationUserDidLogout";
 NSNotificationName kSFNotificationOrgDidLogout   = @"SFNotificationOrgDidLogout";
-NSNotificationName kSFNotificationRefreshFlowCompleted   = @"SFNotificationOAuthRefreshFlowCompleted";
+NSNotificationName kSFNotificationUserDidRefreshToken   = @"SFNotificationOAuthUserDidRefreshToken";
 
 NSNotificationName kSFNotificationUserWillSwitch  = @"SFNotificationUserWillSwitch";
 NSNotificationName kSFNotificationUserDidSwitch   = @"SFNotificationUserDidSwitch";
@@ -1427,7 +1427,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
                                                                 object:self
                                                               userInfo:userInfo];
         }  else if (client.context.authInfo.authType == SFOAuthTypeRefresh) {
-            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationRefreshFlowCompleted
+            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidRefreshToken
                                                                 object:self
                                                               userInfo:userInfo];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -46,6 +46,7 @@ NSNotificationName kSFNotificationUserDidLogIn   = @"SFNotificationUserDidLogIn"
 NSNotificationName kSFNotificationUserWillLogout = @"SFNotificationUserWillLogout";
 NSNotificationName kSFNotificationUserDidLogout  = @"SFNotificationUserDidLogout";
 NSNotificationName kSFNotificationOrgDidLogout   = @"SFNotificationOrgDidLogout";
+NSNotificationName kSFNotificationRefreshFlowCompleted   = @"SFNotificationOAuthRefreshFlowCompleted";
 
 NSNotificationName kSFNotificationUserWillSwitch  = @"SFNotificationUserWillSwitch";
 NSNotificationName kSFNotificationUserDidSwitch   = @"SFNotificationUserDidSwitch";
@@ -1423,6 +1424,10 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
             [[NSNotificationCenter defaultCenter] postNotification:loggedInNotification];
         } else if (client.context.authInfo.authType != SFOAuthTypeRefresh) {
             [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidLogIn
+                                                                object:self
+                                                              userInfo:userInfo];
+        }  else if (client.context.authInfo.authType == SFOAuthTypeRefresh) {
+            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationRefreshFlowCompleted 
                                                                 object:self
                                                               userInfo:userInfo];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -1427,7 +1427,7 @@ static NSString *const  kOptionsClientKey          = @"clientIdentifier";
                                                                 object:self
                                                               userInfo:userInfo];
         }  else if (client.context.authInfo.authType == SFOAuthTypeRefresh) {
-            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationRefreshFlowCompleted 
+            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationRefreshFlowCompleted
                                                                 object:self
                                                               userInfo:userInfo];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -1435,6 +1435,36 @@ static NSException *authException = nil;
     self.dataCleanupRequired = NO;
 }
 
+// - sets an invalid accessToken
+// - issue a valid REST request
+// - make sure the SDK will:
+//   - do a oauth token exchange to get a new valid accessToken
+//   - fire a notification
+// - make sure the query gets replayed properly (and succeed)
+- (void)testRefreshNotificationWithValidGetRequest {
+    
+    // save invalid token
+    NSString *invalidAccessToken = @"xyz";
+    [self changeOauthTokens:invalidAccessToken refreshToken:nil];
+    
+    [self expectationForNotification:kSFNotificationUserDidRefreshToken object:nil  handler:^BOOL(NSNotification * notification) {
+        return notification.userInfo[kSFNotificationUserInfoAccountKey]!=nil;
+    }];
+    
+    // request (valid)
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForResources];
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    [SFLogger log:[self class] level:SFLogLevelDebug format:@"latest access token: %@", _currentUser.credentials.accessToken];
+    
+    // let's make sure we have another access token
+    NSString *newAccessToken = _currentUser.credentials.accessToken;
+    XCTAssertFalse([newAccessToken isEqualToString:invalidAccessToken], @"access token wasn't refreshed");
+    self.dataCleanupRequired = NO;
+    
+}
+
 - (void)testInvalidAccessTokenWithValidPostRequest {
 
     // save invalid token


### PR DESCRIPTION
Fires kSFNotificationUserDidRefreshToken when the refresh flow completes successfully.

e.g.  usage
``` 
NotificationCenter.default.addObserver(self, selector:  #selector(refreshFlowCompleted(_:)), name: UserAccountManager.didRefreshToken, object: nil)

@objc func refreshFlowCompleted(_ notification: Notification) {
         if let account = notification.userInfo?[UserAccountManager.userInfoAccountKey] as?  UserAccount {
           ... 
           print("Refresh Flow Completed %@",account)
        }
    }

```