### PR TITLE
Deprecation marker for addPostFileData

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -268,7 +268,7 @@ NS_SWIFT_NAME(RestRequest)
  * @param fileName Name of the file
  * @param mimeType MIME type of the file
  */
-- (void)addPostFileData:(NSData *)fileData paramName:(NSString*)paramName description:(nullable NSString *)description fileName:(NSString *)fileName mimeType:(NSString *)mimeType;
+- (void)addPostFileData:(NSData *)fileData paramName:(NSString*)paramName description:(nullable NSString *)description fileName:(NSString *)fileName mimeType:(NSString *)mimeType SFSDK_DEPRECATED(7.2, 8.0, "Use addPostFileData:paramName:fileName:mimeType:params instead");
 
 /**
  * Sets a custom request body based on an NSString representation.


### PR DESCRIPTION
Adding the deprecation marker back in for 7.2 (taken out in #2897)