### PR TITLE
Set's the default presentation mode to full screen for SDK's Auth Controllers

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -705,7 +705,7 @@ static NSString * const kSFMobileSDKNativeSwiftDesignator = @"NativeSwift";
     // If we make the snapshot window the active window now, that's where the SFAuthenticationSession's view controller will end up
     // Then when the application is foregrounded and the snapshot window is dismissed, we will lose the SFAuthenticationSession
     SFSDKWindowContainer* activeWindow = [SFSDKWindowManager sharedManager].activeWindow;
-    if (([activeWindow isAuthWindow]  && ![activeWindow.topViewController isKindOfClass:[SFLoginViewController class]]) ||  [activeWindow isPasscodeWindow]) {
+    if ([activeWindow isAuthWindow] || [activeWindow isPasscodeWindow]) {
         return;
     }
   

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -804,7 +804,7 @@ static NSString * const kSFMobileSDKNativeSwiftDesignator = @"NativeSwift";
     else {
         _snapshotViewController =  [[SnapshotViewController alloc] initWithNibName:nil bundle:nil];
     }
-    
+    _snapshotViewController.modalPresentationStyle = UIModalPresentationFullScreen;
     // Presentation
     __weak typeof (self) weakSelf = self;
     [[SFSDKWindowManager sharedManager].snapshotWindow  presentWindowAnimated:NO withCompletion:^{

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -422,6 +422,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
         hostListViewController.hidesCancelButton = YES;
     
         __weak typeof (self) weakSelf = self;
+        controller.modalPresentationStyle = UIModalPresentationFullScreen;
         [self.authWindow presentWindowAnimated:NO withCompletion:^{
             __strong typeof (weakSelf) strongSelf = weakSelf;
             [strongSelf.authWindow.viewController presentViewController:controller animated:NO completion:nil];
@@ -634,7 +635,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
 
         if (!viewHandler.isAdvancedAuthFlow) {
             UIViewController *controllerToPresent = [[SFSDKNavigationController  alloc]  initWithRootViewController:viewHandler.loginController];
-
+            controllerToPresent.modalPresentationStyle = UIModalPresentationFullScreen;
             [weakSelf.authWindow.viewController presentViewController:controllerToPresent animated:NO completion:^{
                 NSAssert((nil != [viewHandler.loginController.oauthView superview]), @"No superview for oauth web view invoke [super viewDidLayoutSubviews] in the SFLoginViewController subclass");
             }];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -114,6 +114,7 @@ typedef NS_OPTIONS(NSUInteger, SFPasscodePolicy) {
         }];
         
         [SFSecurityLockout setPresentPasscodeViewControllerBlock:^(UIViewController *pvc) {
+            pvc.modalPresentationStyle = UIModalPresentationFullScreen;
             [[SFSDKWindowManager sharedManager].passcodeWindow presentWindowAnimated:NO withCompletion:^{
                 [[SFSDKWindowManager sharedManager].passcodeWindow.viewController  presentViewController:pvc animated:NO completion:nil];
             }];
@@ -711,6 +712,7 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
         SFSDKAppLockViewConfig *displayConfig = (viewConfig) ? viewConfig : self.passcodeViewConfig;
         [[SFSDKWindowManager sharedManager].passcodeWindow presentWindowAnimated:NO withCompletion:^{
             SFSDKAppLockViewController *navController = [[SFSDKAppLockViewController alloc] initWithMode:SFAppLockControllerModeEnableBiometric andViewConfig:displayConfig];
+            navController.modalPresentationStyle = UIModalPresentationFullScreen;
             [[SFSDKWindowManager sharedManager].passcodeWindow.viewController presentViewController:navController animated:NO completion:^{}];
         }];
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+URLHandlers.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+URLHandlers.m
@@ -140,6 +140,7 @@
         UIViewController<SFSDKUserSelectionView> *controller  = authClient.idpUserSelectionBlock();
         controller.spAppOptions = request.allParams;
         controller.userSelectionDelegate = self;
+        controller.modalPresentationStyle = UIModalPresentationFullScreen;
         [authClient.authWindow presentWindowAnimated:NO withCompletion:^{
             [authClient.authWindow.viewController presentViewController:controller animated:NO  completion:nil];
         }];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -562,6 +562,7 @@ static int const kSFSDKUserAccountManagerErrorCode = 100;
     [options setObject:key forKey:kOptionsClientKey];
     controller.appOptions = options;
     [client.authWindow presentWindowAnimated:NO withCompletion:^{
+        client.authWindow.viewController.modalPresentationStyle = UIModalPresentationFullScreen;
         [client.authWindow.viewController presentViewController:controller animated:YES completion:^{
             [[SFSDKOAuthClientCache sharedInstance] addClient:client];
         }];


### PR DESCRIPTION
In iOS 13 the default presentation mode mode for view controllers has changed and  is not  full screen, due to which view controllers can be swiped to be removed from the screen or moved. This fix work is backward compatible with iOS 12 and prior. 