### PR TITLE
Weakify self reference for background task.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -316,8 +316,9 @@ UIBackgroundTaskIdentifier task;
         return;
     }
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        __block typeof(self) weakSelf = self;
         task = [[SFApplicationHelper sharedApplication] beginBackgroundTaskWithName:NSStringFromClass([self class]) expirationHandler:^{
-            [self cleanupBackgroundTask];
+            [weakSelf cleanupBackgroundTask];
         }];
         [self publishAllEvents];
     });


### PR DESCRIPTION
Apple's doc doesn't describe how the expiration handler is cleaned up when the task ends so this is just to be safe.  