### PR TITLE
Deprecate setter for currentUser, loginWithCompletion will set it by default

### DIFF
--- a/SmartStore.podspec
+++ b/SmartStore.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
       smartstore.dependency 'SalesforceSDKCore'
       smartstore.dependency 'FMDB/SQLCipher', '~> 2.7.5'
-      smartstore.dependency 'SQLCipher/fts', '~> 4.0.1'
+      smartstore.dependency 'SQLCipher/fts', '~> 4.2.0'
       smartstore.source_files = 'libs/SmartStore/SmartStore/Classes/**/*.{h,m}', 'libs/SmartStore/SmartStore/SmartStore.h'
       smartstore.public_header_files = 'libs/SmartStore/SmartStore/Classes/SFAlterSoupLongOperation.h', 'libs/SmartStore/SmartStore/Classes/SFQuerySpec.h', 'libs/SmartStore/SmartStore/Classes/SFSDKSmartStoreLogger.h', 'libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.h', 'libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStore.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreInspectorViewController.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreUtils.h', 'libs/SmartStore/SmartStore/Classes/SFSoupIndex.h', 'libs/SmartStore/SmartStore/Classes/SFSoupSpec.h', 'libs/SmartStore/SmartStore/Classes/SFStoreCursor.h', 'libs/SmartStore/SmartStore/SmartStore.h', 'libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.h'
       smartstore.prefix_header_contents = '#import "SFSDKSmartStoreLogger.h"', '#import <SalesforceSDKCore/SalesforceSDKConstants.h>'

--- a/external/ThirdPartyDependencies/sqlcipher/SALESFORCE_README
+++ b/external/ThirdPartyDependencies/sqlcipher/SALESFORCE_README
@@ -3,4 +3,4 @@ Binary in this folder was compiled with FTS support:
 - git checkout sdk
 - ./build_for_sdk.sh
 - copy generated libsqlcipher.a here
-
+- copy sqlite3.h here

--- a/external/ThirdPartyDependencies/sqlcipher/sqlite3.h
+++ b/external/ThirdPartyDependencies/sqlcipher/sqlite3.h
@@ -123,9 +123,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.26.0"
-#define SQLITE_VERSION_NUMBER 3026000
-#define SQLITE_SOURCE_ID      "2018-12-01 12:34:55 bf8c1b2b7a5960c282e543b9c293686dccff272512d08865f4600fb58238alt1"
+#define SQLITE_VERSION        "3.28.0"
+#define SQLITE_VERSION_NUMBER 3028000
+#define SQLITE_SOURCE_ID      "2019-04-16 19:49:53 884b4b7e502b4e991677b53971277adfaf0a04a284f8e483e2553d0f8315alt1"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -189,6 +189,9 @@ SQLITE_API int sqlite3_libversion_number(void);
 #ifndef SQLITE_OMIT_COMPILEOPTION_DIAGS
 SQLITE_API int sqlite3_compileoption_used(const char *zOptName);
 SQLITE_API const char *sqlite3_compileoption_get(int N);
+#else
+# define sqlite3_compileoption_used(X) 0
+# define sqlite3_compileoption_get(X)  ((void*)0)
 #endif
 
 /*
@@ -823,6 +826,15 @@ struct sqlite3_io_methods {
 ** file space based on this hint in order to help writes to the database
 ** file run faster.
 **
+** <li>[[SQLITE_FCNTL_SIZE_LIMIT]]
+** The [SQLITE_FCNTL_SIZE_LIMIT] opcode is used by in-memory VFS that
+** implements [sqlite3_deserialize()] to set an upper bound on the size
+** of the in-memory database.  The argument is a pointer to a [sqlite3_int64].
+** If the integer pointed to is negative, then it is filled in with the
+** current limit.  Otherwise the limit is set to the larger of the value
+** of the integer pointed to and the current database size.  The integer
+** pointed to is set to the new limit.
+**
 ** <li>[[SQLITE_FCNTL_CHUNK_SIZE]]
 ** The [SQLITE_FCNTL_CHUNK_SIZE] opcode is used to request that the VFS
 ** extends and truncates the database file in chunks of a size specified
@@ -1131,6 +1143,7 @@ struct sqlite3_io_methods {
 #define SQLITE_FCNTL_ROLLBACK_ATOMIC_WRITE  33
 #define SQLITE_FCNTL_LOCK_TIMEOUT           34
 #define SQLITE_FCNTL_DATA_VERSION           35
+#define SQLITE_FCNTL_SIZE_LIMIT             36
 
 /* deprecated names */
 #define SQLITE_GET_LOCKPROXYFILE      SQLITE_FCNTL_GET_LOCKPROXYFILE
@@ -1972,6 +1985,17 @@ struct sqlite3_mem_methods {
 ** negative value for this option restores the default behaviour.
 ** This option is only available if SQLite is compiled with the
 ** [SQLITE_ENABLE_SORTER_REFERENCES] compile-time option.
+**
+** [[SQLITE_CONFIG_MEMDB_MAXSIZE]]
+** <dt>SQLITE_CONFIG_MEMDB_MAXSIZE
+** <dd>The SQLITE_CONFIG_MEMDB_MAXSIZE option accepts a single parameter
+** [sqlite3_int64] parameter which is the default maximum size for an in-memory
+** database created using [sqlite3_deserialize()].  This default maximum
+** size can be adjusted up or down for individual databases using the
+** [SQLITE_FCNTL_SIZE_LIMIT] [sqlite3_file_control|file-control].  If this
+** configuration setting is never used, then the default maximum is determined
+** by the [SQLITE_MEMDB_DEFAULT_MAXSIZE] compile-time option.  If that
+** compile-time option is not set, then the default maximum is 1073741824.
 ** </dl>
 */
 #define SQLITE_CONFIG_SINGLETHREAD  1  /* nil */
@@ -2002,6 +2026,7 @@ struct sqlite3_mem_methods {
 #define SQLITE_CONFIG_STMTJRNL_SPILL      26  /* int nByte */
 #define SQLITE_CONFIG_SMALL_MALLOC        27  /* boolean */
 #define SQLITE_CONFIG_SORTERREF_SIZE      28  /* int nByte */
+#define SQLITE_CONFIG_MEMDB_MAXSIZE       29  /* sqlite3_int64 */
 
 /*
 ** CAPI3REF: Database Connection Configuration Options
@@ -2064,8 +2089,8 @@ struct sqlite3_mem_methods {
 **
 ** [[SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER]]
 ** <dt>SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER</dt>
-** <dd> ^This option is used to enable or disable the two-argument
-** version of the [fts3_tokenizer()] function which is part of the
+** <dd> ^This option is used to enable or disable the
+** [fts3_tokenizer()] function which is part of the
 ** [FTS3] full-text search engine extension.
 ** There should be two additional arguments.
 ** The first argument is an integer which is 0 to disable fts3_tokenizer() or
@@ -2177,6 +2202,17 @@ struct sqlite3_mem_methods {
 ** <li> Direct writes to [shadow tables].
 ** </ul>
 ** </dd>
+**
+** [[SQLITE_DBCONFIG_WRITABLE_SCHEMA]] <dt>SQLITE_DBCONFIG_WRITABLE_SCHEMA</dt>
+** <dd>The SQLITE_DBCONFIG_WRITABLE_SCHEMA option activates or deactivates the
+** "writable_schema" flag. This has the same effect and is logically equivalent
+** to setting [PRAGMA writable_schema=ON] or [PRAGMA writable_schema=OFF].
+** The first argument to this setting is an integer which is 0 to disable 
+** the writable_schema, positive to enable writable_schema, or negative to
+** leave the setting unchanged. The second parameter is a pointer to an
+** integer into which is written 0 or 1 to indicate whether the writable_schema
+** is enabled or disabled following this call.
+** </dd>
 ** </dl>
 */
 #define SQLITE_DBCONFIG_MAINDBNAME            1000 /* const char* */
@@ -2190,7 +2226,8 @@ struct sqlite3_mem_methods {
 #define SQLITE_DBCONFIG_TRIGGER_EQP           1008 /* int int* */
 #define SQLITE_DBCONFIG_RESET_DATABASE        1009 /* int int* */
 #define SQLITE_DBCONFIG_DEFENSIVE             1010 /* int int* */
-#define SQLITE_DBCONFIG_MAX                   1010 /* Largest DBCONFIG */
+#define SQLITE_DBCONFIG_WRITABLE_SCHEMA       1011 /* int int* */
+#define SQLITE_DBCONFIG_MAX                   1011 /* Largest DBCONFIG */
 
 /*
 ** CAPI3REF: Enable Or Disable Extended Result Codes
@@ -2347,7 +2384,7 @@ SQLITE_API int sqlite3_changes(sqlite3*);
 ** not. ^Changes to a view that are intercepted by INSTEAD OF triggers 
 ** are not counted.
 **
-** This the [sqlite3_total_changes(D)] interface only reports the number
+** The [sqlite3_total_changes(D)] interface only reports the number
 ** of rows that changed due to SQL statement run against database
 ** connection D.  Any changes by other database connections are ignored.
 ** To detect changes against a database file from other database
@@ -2991,9 +3028,9 @@ SQLITE_API int sqlite3_set_authorizer(
 ** time is in units of nanoseconds, however the current implementation
 ** is only capable of millisecond resolution so the six least significant
 ** digits in the time are meaningless.  Future versions of SQLite
-** might provide greater resolution on the profiler callback.  The
-** sqlite3_profile() function is considered experimental and is
-** subject to change in future versions of SQLite.
+** might provide greater resolution on the profiler callback.  Invoking
+** either [sqlite3_trace()] or [sqlite3_trace_v2()] will cancel the
+** profile callback.
 */
 SQLITE_API SQLITE_DEPRECATED void *sqlite3_trace(sqlite3*,
    void(*xTrace)(void*,const char*), void*);
@@ -3407,6 +3444,8 @@ SQLITE_API int sqlite3_open_v2(
 ** is not a database file pathname pointer that SQLite passed into the xOpen
 ** VFS method, then the behavior of this routine is undefined and probably
 ** undesirable.
+**
+** See the [URI filename] documentation for additional information.
 */
 SQLITE_API const char *sqlite3_uri_parameter(const char *zFilename, const char *zParam);
 SQLITE_API int sqlite3_uri_boolean(const char *zFile, const char *zParam, int bDefault);
@@ -3629,18 +3668,23 @@ SQLITE_API int sqlite3_limit(sqlite3*, int id, int newVal);
 ** deplete the limited store of lookaside memory. Future versions of
 ** SQLite may act on this hint differently.
 **
-** [[SQLITE_PREPARE_NORMALIZE]] ^(<dt>SQLITE_PREPARE_NORMALIZE</dt>
-** <dd>The SQLITE_PREPARE_NORMALIZE flag indicates that a normalized
-** representation of the SQL statement should be calculated and then
-** associated with the prepared statement, which can be obtained via
-** the [sqlite3_normalized_sql()] interface.)^  The semantics used to
-** normalize a SQL statement are unspecified and subject to change.
-** At a minimum, literal values will be replaced with suitable
-** placeholders.
+** [[SQLITE_PREPARE_NORMALIZE]] <dt>SQLITE_PREPARE_NORMALIZE</dt>
+** <dd>The SQLITE_PREPARE_NORMALIZE flag is a no-op. This flag used
+** to be required for any prepared statement that wanted to use the
+** [sqlite3_normalized_sql()] interface.  However, the
+** [sqlite3_normalized_sql()] interface is now available to all
+** prepared statements, regardless of whether or not they use this
+** flag.
+**
+** [[SQLITE_PREPARE_NO_VTAB]] <dt>SQLITE_PREPARE_NO_VTAB</dt>
+** <dd>The SQLITE_PREPARE_NO_VTAB flag causes the SQL compiler
+** to return an error (error code SQLITE_ERROR) if the statement uses
+** any virtual tables.
 ** </dl>
 */
 #define SQLITE_PREPARE_PERSISTENT              0x01
 #define SQLITE_PREPARE_NORMALIZE               0x02
+#define SQLITE_PREPARE_NO_VTAB                 0x04
 
 /*
 ** CAPI3REF: Compiling An SQL Statement
@@ -3866,6 +3910,18 @@ SQLITE_API const char *sqlite3_normalized_sql(sqlite3_stmt *pStmt);
 SQLITE_API int sqlite3_stmt_readonly(sqlite3_stmt *pStmt);
 
 /*
+** CAPI3REF: Query The EXPLAIN Setting For A Prepared Statement
+** METHOD: sqlite3_stmt
+**
+** ^The sqlite3_stmt_isexplain(S) interface returns 1 if the
+** prepared statement S is an EXPLAIN statement, or 2 if the
+** statement S is an EXPLAIN QUERY PLAN.
+** ^The sqlite3_stmt_isexplain(S) interface returns 0 if S is
+** an ordinary statement or a NULL pointer.
+*/
+SQLITE_API int sqlite3_stmt_isexplain(sqlite3_stmt *pStmt);
+
+/*
 ** CAPI3REF: Determine If A Prepared Statement Has Been Reset
 ** METHOD: sqlite3_stmt
 **
@@ -4004,7 +4060,9 @@ typedef struct sqlite3_context sqlite3_context;
 ** ^The fifth argument to the BLOB and string binding interfaces
 ** is a destructor used to dispose of the BLOB or
 ** string after SQLite has finished with it.  ^The destructor is called
-** to dispose of the BLOB or string even if the call to bind API fails.
+** to dispose of the BLOB or string even if the call to the bind API fails,
+** except the destructor is not called if the third parameter is a NULL
+** pointer or the fourth parameter is negative.
 ** ^If the fifth argument is
 ** the special value [SQLITE_STATIC], then SQLite assumes that the
 ** information is in static, unmanaged space and does not need to be freed.
@@ -4921,6 +4979,8 @@ SQLITE_API SQLITE_DEPRECATED int sqlite3_memory_alarm(void(*)(void*,sqlite3_int6
 ** <tr><td><b>sqlite3_value_nochange&nbsp;&nbsp;</b>
 ** <td>&rarr;&nbsp;&nbsp;<td>True if the column is unchanged in an UPDATE
 ** against a virtual table.
+** <tr><td><b>sqlite3_value_frombind&nbsp;&nbsp;</b>
+** <td>&rarr;&nbsp;&nbsp;<td>True if value originated from a [bound parameter]
 ** </table></blockquote>
 **
 ** <b>Details:</b>
@@ -4982,6 +5042,11 @@ SQLITE_API SQLITE_DEPRECATED int sqlite3_memory_alarm(void(*)(void*,sqlite3_int6
 ** than within an [xUpdate] method call for an UPDATE statement, then
 ** the return value is arbitrary and meaningless.
 **
+** ^The sqlite3_value_frombind(X) interface returns non-zero if the
+** value X originated from one of the [sqlite3_bind_int|sqlite3_bind()]
+** interfaces.  ^If X comes from an SQL literal value, or a table column,
+** and expression, then sqlite3_value_frombind(X) returns zero.
+**
 ** Please pay particular attention to the fact that the pointer returned
 ** from [sqlite3_value_blob()], [sqlite3_value_text()], or
 ** [sqlite3_value_text16()] can be invalidated by a subsequent call to
@@ -5027,6 +5092,7 @@ SQLITE_API int sqlite3_value_bytes16(sqlite3_value*);
 SQLITE_API int sqlite3_value_type(sqlite3_value*);
 SQLITE_API int sqlite3_value_numeric_type(sqlite3_value*);
 SQLITE_API int sqlite3_value_nochange(sqlite3_value*);
+SQLITE_API int sqlite3_value_frombind(sqlite3_value*);
 
 /*
 ** CAPI3REF: Finding The Subtype Of SQL Values
@@ -5539,6 +5605,22 @@ SQLITE_API int sqlite3_key_v2(
 ** The code to implement this API is not available in the public release
 ** of SQLite.
 */
+/* BEGIN SQLCIPHER
+   SQLCipher usage note:
+
+   If the current database is plaintext SQLCipher will NOT encrypt it.
+   If the current database is encrypted and pNew==0 or nNew==0, SQLCipher
+   will NOT decrypt it.
+
+   This routine will ONLY work on an already encrypted database in order
+   to change the key.
+
+   Conversion from plaintext-to-encrypted or encrypted-to-plaintext should
+   use an ATTACHed database and the sqlcipher_export() convenience function
+   as per the SQLCipher Documentation.
+
+   END SQLCIPHER
+*/
 SQLITE_API int sqlite3_rekey(
   sqlite3 *db,                   /* Database to be rekeyed */
   const void *pKey, int nKey     /* The new key */
@@ -5762,7 +5844,7 @@ SQLITE_API sqlite3 *sqlite3_db_handle(sqlite3_stmt*);
 ** associated with database N of connection D.  ^The main database file
 ** has the name "main".  If there is no attached database N on the database
 ** connection D, or if database N is a temporary or in-memory database, then
-** a NULL pointer is returned.
+** this function will return either a NULL pointer or an empty string.
 **
 ** ^The filename returned by this function is the output of the
 ** xFullPathname method of the [VFS].  ^In other words, the filename
@@ -9996,7 +10078,7 @@ SQLITE_API int sqlite3changeset_next(sqlite3_changeset_iter *pIter);
 ** sqlite3changeset_next() is called on the iterator or until the 
 ** conflict-handler function returns. If pnCol is not NULL, then *pnCol is 
 ** set to the number of columns in the table affected by the change. If
-** pbIncorrect is not NULL, then *pbIndirect is set to true (1) if the change
+** pbIndirect is not NULL, then *pbIndirect is set to true (1) if the change
 ** is an indirect change, or false (0) otherwise. See the documentation for
 ** [sqlite3session_indirect()] for a description of direct and indirect
 ** changes. Finally, if pOp is not NULL, then *pOp is set to one of 
@@ -10863,7 +10945,7 @@ SQLITE_API int sqlite3rebaser_configure(
 ** in size. This function allocates and populates a buffer with a copy
 ** of the changeset rebased rebased according to the configuration of the
 ** rebaser object passed as the first argument. If successful, (*ppOut)
-** is set to point to the new buffer containing the rebased changset and 
+** is set to point to the new buffer containing the rebased changeset and 
 ** (*pnOut) to its size in bytes and SQLITE_OK returned. It is the
 ** responsibility of the caller to eventually free the new buffer using
 ** sqlite3_free(). Otherwise, if an error occurs, (*ppOut) and (*pnOut)
@@ -11230,12 +11312,8 @@ struct Fts5PhraseIter {
 **
 **   Usually, output parameter *piPhrase is set to the phrase number, *piCol
 **   to the column in which it occurs and *piOff the token offset of the
-**   first token of the phrase. The exception is if the table was created
-**   with the offsets=0 option specified. In this case *piOff is always
-**   set to -1.
-**
-**   Returns SQLITE_OK if successful, or an error code (i.e. SQLITE_NOMEM) 
-**   if an error occurs.
+**   first token of the phrase. Returns SQLITE_OK if successful, or an error
+**   code (i.e. SQLITE_NOMEM) if an error occurs.
 **
 **   This API can be quite slow if used with an FTS5 table created with the
 **   "detail=none" or "detail=column" option. 
@@ -11276,7 +11354,7 @@ struct Fts5PhraseIter {
 **   Save the pointer passed as the second argument as the extension functions 
 **   "auxiliary data". The pointer may then be retrieved by the current or any
 **   future invocation of the same fts5 extension function made as part of
-**   of the same MATCH query using the xGetAuxdata() API.
+**   the same MATCH query using the xGetAuxdata() API.
 **
 **   Each extension function is allocated a single auxiliary data slot for
 **   each FTS query (MATCH expression). If the extension function is invoked 
@@ -11291,7 +11369,7 @@ struct Fts5PhraseIter {
 **   The xDelete callback, if one is specified, is also invoked on the
 **   auxiliary data pointer after the FTS5 query has finished.
 **
-**   If an error (e.g. an OOM condition) occurs within this function, an
+**   If an error (e.g. an OOM condition) occurs within this function,
 **   the auxiliary data is set to NULL and an error code returned. If the
 **   xDelete parameter was not NULL, it is invoked on the auxiliary data
 **   pointer before returning.
@@ -11524,11 +11602,11 @@ struct Fts5ExtensionApi {
 **            the tokenizer substitutes "first" for "1st" and the query works
 **            as expected.
 **
-**       <li> By adding multiple synonyms for a single term to the FTS index.
-**            In this case, when tokenizing query text, the tokenizer may 
-**            provide multiple synonyms for a single term within the document.
-**            FTS5 then queries the index for each synonym individually. For
-**            example, faced with the query:
+**       <li> By querying the index for all synonyms of each query term
+**            separately. In this case, when tokenizing query text, the
+**            tokenizer may provide multiple synonyms for a single term 
+**            within the document. FTS5 then queries the index for each 
+**            synonym individually. For example, faced with the query:
 **
 **   <codeblock>
 **     ... MATCH 'first place'</codeblock>
@@ -11552,7 +11630,7 @@ struct Fts5ExtensionApi {
 **            "place".
 **
 **            This way, even if the tokenizer does not provide synonyms
-**            when tokenizing query text (it should not - to do would be
+**            when tokenizing query text (it should not - to do so would be
 **            inefficient), it doesn't matter if the user queries for 
 **            'first + place' or '1st + place', as there are entries in the
 **            FTS index corresponding to both forms of the first token.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -893,7 +893,6 @@ static NSString * const kSFMobileSDKNativeSwiftDesignator = @"NativeSwift";
     
     SFUserAccountManagerSuccessCallbackBlock successBlock = ^(SFOAuthInfo *authInfo,SFUserAccount *userAccount) {
         [SFSDKCoreLogger i:[self class] format:@"Authentication (%@) succeeded.  Launch completed.", authInfo.authTypeDescription];
-        [SFUserAccountManager sharedInstance].currentUser = userAccount;
         [SFSecurityLockout setupTimer];
         [SFSecurityLockout startActivityMonitoring];
         [self authValidatedToPostAuth:SFSDKLaunchActionAuthenticated];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -237,7 +237,6 @@ static dispatch_once_t pred;
         [SFSDKCoreLogger i:[self class] format:@"No auth credentials found. Authenticating before sending request: %@", request.description];
         [[SFUserAccountManager sharedInstance] loginWithCompletion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
             __strong typeof(weakSelf) strongSelf = weakSelf;
-            [SFUserAccountManager sharedInstance].currentUser = userAccount;
             strongSelf.user = userAccount;
             [strongSelf enqueueRequest:request delegate:delegate shouldRetry:shouldRetry];
         } failure:^(SFOAuthInfo *authInfo, NSError *error) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager+Internal.h
@@ -70,6 +70,8 @@
  */
 @property (nonatomic, assign) BOOL useBrowserAuth;
 
+- (void)setCurrentUserInternal:(SFUserAccount* _Nullable)user;
+
 /**
  Executes the given block for each configured delegate.
  @param block The block to execute for each delegate.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -626,7 +626,7 @@ NS_SWIFT_NAME(UserAccountManager)
  */
 - (SFBiometricUnlockState)biometricUnlockState;
 
-- (void)setCurrentUser:(SFUserAccount * _Nullable)currentUser SFSDK_DEPRECATED(7.2, 8.0, "Use switchToUser instead.");
+- (void)setCurrentUser:(SFUserAccount * _Nullable)currentUser SFSDK_DEPRECATED(7.2, 8.0, "Use switchToUser or  switchToNewUserWithCompletion instead.");
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.h
@@ -626,6 +626,8 @@ NS_SWIFT_NAME(UserAccountManager)
  */
 - (SFBiometricUnlockState)biometricUnlockState;
 
+- (void)setCurrentUser:(SFUserAccount * _Nullable)currentUser SFSDK_DEPRECATED(7.2, 8.0, "Use switchToUser instead.");
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
@@ -68,7 +68,6 @@ static SFOAuthCredentials *credentials = nil;
     NSAssert(![credsData.refreshToken isEqualToString:@"__INSERT_TOKEN_HERE__"],
              @"You need to obtain credentials for your test org and replace test_credentials.json");
     [SalesforceSDKManager initializeSDK];
-   [SFUserAccountManager sharedInstance].currentUser = nil;
     
     // Note: We need to fix this inconsistency for tests in the long run.There should be a clean way to refresh appConfigs for tests. The configs should apply across all components that need the  config.
     SFSDKAppConfig *appconfig  = [[SFSDKAppConfig alloc] init];
@@ -114,8 +113,6 @@ static SFOAuthCredentials *credentials = nil;
          authListener.returnStatus = kTestRequestStatusDidFail;
      }];
     [authListener waitForCompletion];
-    [[SFUserAccountManager sharedInstance] setCurrentUser:user];
-    
     NSAssert([authListener.returnStatus isEqualToString:kTestRequestStatusDidLoad], @"After auth attempt, expected status '%@', got '%@'",
              kTestRequestStatusDidLoad,
              authListener.returnStatus);

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthHelper.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthHelper.m
@@ -38,7 +38,6 @@
 + (void)loginIfRequired:(void (^)(void))completionBlock {
     if (![SFUserAccountManager sharedInstance].currentUser && [SalesforceSDKManager sharedManager].appConfig.shouldAuthenticate) {
         SFUserAccountManagerSuccessCallbackBlock successBlock = ^(SFOAuthInfo *authInfo,SFUserAccount *userAccount) {
-           [SFUserAccountManager sharedInstance].currentUser = userAccount;
            completionBlock();
         };
         

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFManagedPreferencesTest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFManagedPreferencesTest.m
@@ -28,7 +28,7 @@
 #import <XCTest/XCTest.h>
 #import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
 #import <SalesforceSDKCore/SalesforceSDKCore.h>
-
+#import "SFUserAccountManager+Internal.h"
 @interface SFManagedPreferencesTest : XCTestCase
 @property (nonatomic,strong) NSDictionary *managedProps;
 @property (nonatomic,strong) SFUserAccount *prevCurrentUser;
@@ -40,7 +40,7 @@ static NSException *authException = nil;
 - (void)setUp {
     //add  Managed Properties
     self.prevCurrentUser = [SFUserAccountManager sharedInstance].currentUser;
-    [SFUserAccountManager sharedInstance].currentUser = [[SFUserAccount alloc] init];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:[[SFUserAccount alloc] init]];
     self.managedProps = @{@"RequireCertAuth":@YES,@"OnlyShowAuthorizedHosts":@YES,
                           @"ClearClipboardOnBackground":@YES,
                           @"ManagedAppCallbackURL": @"managed:url",
@@ -52,7 +52,7 @@ static NSException *authException = nil;
 - (void)tearDown {
     //Remove the Managed Properties
     self.managedProps = nil;
-    [SFUserAccountManager sharedInstance].currentUser = self.prevCurrentUser;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:self.prevCurrentUser];
     [[NSUserDefaults msdkUserDefaults] removeObjectForKey:@"com.apple.configuration.managed"];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
@@ -49,28 +49,6 @@
     [super tearDown];
 }
 
-- (void)testSuccessfulRefresh {
-    __block NSError *unexpectedRefreshError = nil;
-    __block SFOAuthCredentials *newCreds = nil;
-    XCTestExpectation *refreshAccessTokenExpectation = [self expectationWithDescription:@"Refresh Access Token"];
-    NSString *origAccessToken = self.oauthSessionRefresher.coordinator.credentials.accessToken;
-    self.oauthSessionRefresher.coordinator.credentials.accessToken = nil;
-    [self.oauthSessionRefresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
-        newCreds = updatedCredentials;
-        [refreshAccessTokenExpectation fulfill];
-    } error:^(NSError *refreshError) {
-        unexpectedRefreshError = refreshError;
-        [refreshAccessTokenExpectation fulfill];
-    }];
-    
-    [self waitForExpectationsWithTimeout:2.0 handler:^(NSError *error) {
-        XCTAssertNil(error, @"Error waiting for completion: %@", error);
-        XCTAssertNil(unexpectedRefreshError, @"Should not have received an error refreshing the access token.");
-        XCTAssertNotNil(newCreds.accessToken, @"Should have received a refreshed access token.");
-        self.oauthSessionRefresher.coordinator.credentials.accessToken = origAccessToken;
-    }];
-}
-
 - (void)testBadInputData {
     __block NSError *inputError = nil;
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPreferencesTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPreferencesTests.m
@@ -60,9 +60,8 @@
     user.credentials.identityUrl = [NSURL URLWithString:@"https://login.salesforce.com/id/00D000000000062EA0/005R0000000Dsl0"];
     success = [[SFUserAccountManager sharedInstance] saveAccountForUser:user error:&error];
     XCTAssertNil(error, @"Should be able to update user account");
-    
-    [SFUserAccountManager sharedInstance].currentUser = user;
-
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:user];
+ 
     SFPreferences *prefs = [SFPreferences currentOrgLevelPreferences];
     XCTAssertNotNil(prefs, @"Preferences must exist");
     
@@ -86,8 +85,7 @@
     NSError *error = nil;
     [[SFUserAccountManager sharedInstance] saveAccountForUser:user error:&error];
     XCTAssertNil(error, @"Should be able to create user account");
- 
-    [SFUserAccountManager sharedInstance].currentUser = user;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:user];
     
     SFPreferences *prefs = [SFPreferences currentUserLevelPreferences];
     XCTAssertNotNil(prefs, @"Preferences must exist");
@@ -112,7 +110,7 @@
     NSError *error = nil;
     [[SFUserAccountManager sharedInstance] saveAccountForUser:user error:&error];
     XCTAssertNil(error, @"Should be able to create user account");
-    [SFUserAccountManager sharedInstance].currentUser = user;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:user];
     
     SFPreferences *prefs = [SFPreferences currentCommunityLevelPreferences];
     XCTAssertNotNil(prefs, @"Preferences must exist");

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPushNotificationManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFPushNotificationManagerTests.m
@@ -32,6 +32,7 @@
 #import "SFPreferences.h"
 #import "SFUserAccount+Internal.h"
 #import "SFOAuthCredentials+Internal.h"
+#import "SFUserAccountManager+Internal.h"
 // needs to match what is defined in SFPushNotificationManager
 static NSString* const kSFDeviceSalesforceId = @"deviceSalesforceId";
 
@@ -42,6 +43,7 @@ static NSString* const kSFDeviceSalesforceId = @"deviceSalesforceId";
 @interface SFPushNotificationManagerTests : XCTestCase
 @property (nonatomic, strong) SFPushNotificationManager *manager;
 @property (nonatomic, strong) SFUserAccount *user;
+@property (nonatomic, strong) SFUserAccount *origCurrentUser;
 @end
 
 @implementation SFPushNotificationManagerTests
@@ -54,11 +56,13 @@ static NSString* const kSFDeviceSalesforceId = @"deviceSalesforceId";
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"happy-user" clientId:[SFUserAccountManager sharedInstance].oauthClientId encrypted:YES];
     SFUserAccount *user =[[SFUserAccount alloc] initWithCredentials:credentials];
     user.credentials.identityUrl = [NSURL URLWithString:@"https://login.salesforce.com/id/00D000000000062EA0/005R0000000Dsl0"];
-    [SFUserAccountManager sharedInstance].currentUser = user;
+    self.origCurrentUser = [SFUserAccountManager sharedInstance].currentUser;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:user];
     self.user = user;
 }
 
 - (void)tearDown {
+     [[SFUserAccountManager sharedInstance] setCurrentUserInternal:self.origCurrentUser];
     [super tearDown];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKErrorManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKErrorManagerTests.m
@@ -40,7 +40,7 @@
 
 - (void)tearDown {
     [super tearDown];
-    [SFUserAccountManager sharedInstance].currentUser = _origCurrentUser;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:_origCurrentUser];
 }
 
 - (void)testNetworkError {
@@ -53,8 +53,7 @@
     credentials.organizationId = @"ORG123";
     SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:credentials];
     [[SFUserAccountManager sharedInstance] saveAccountForUser:account error:nil];
-    
-    [SFUserAccountManager sharedInstance].currentUser = account;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:account];
     XCTAssertNotNil(errorManager);
     XCTestExpectation *networkErrorExpectation =  [self expectationWithDescription:@"networkErrorExpectation"];
     NSDictionary *userInfo = [[NSMutableDictionary alloc] init];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerNotificationsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerNotificationsTests.m
@@ -63,7 +63,7 @@ static NSString * const kSFOAuthCommunityUrl = @"sfdc_community_url";
 {
     [self deleteUserAndVerify:_user];
     self.uam.accountPersister = _origAccountPersister;
-    self.uam.currentUser = _origCurrentUser;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:_origCurrentUser];
     [super tearDown];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerPersisterTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerPersisterTests.m
@@ -175,7 +175,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     NSArray *accounts = [self createAndVerifyUserAccounts:2];
     SFUserAccount *origUser = accounts[0];
     SFUserAccount *newUser = accounts[1];
-    self.uam.currentUser = origUser;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:origUser];
     TestUserAccountManagerPersisterDelegate *acctDelegate = [[TestUserAccountManagerPersisterDelegate alloc] init];
     [self.uam switchToUser:newUser];
     XCTAssertEqual(acctDelegate.willSwitchOrigUserAccount, origUser, @"origUser is not equal.");
@@ -189,7 +189,8 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 }
 
 - (void)testSwitchToSameUser {
-    SFUserAccount *newUser = self.uam.currentUser = [self createAndVerifyUserAccounts:1][0];
+    SFUserAccount *newUser = [self createAndVerifyUserAccounts:1][0];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:newUser];
     TestUserAccountManagerPersisterDelegate *acctDelegate = [[TestUserAccountManagerPersisterDelegate alloc] init];
     [self.uam switchToUser:newUser];
     XCTAssertNil(acctDelegate.willSwitchOrigUserAccount, @"No switchToUser action should be taken for same accounts.");

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -123,7 +123,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
         }
     }
     [self.uam clearAllAccountState];
-    self.uam.currentUser = nil;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:nil];
     self.uam.loginHost = nil;
     self.uam.useBrowserAuth = NO;
     self.authViewHandler = [SFUserAccountManager sharedInstance].authViewHandler;
@@ -278,7 +278,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 - (void)testSwitchToNewUser {
     NSArray *accounts = [self createAndVerifyUserAccounts:1];
     SFUserAccount *origUser = accounts[0];
-    self.uam.currentUser = origUser;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:origUser];
     TestUserAccountManagerDelegate *acctDelegate = [[TestUserAccountManagerDelegate alloc] init];
     [self.uam switchToNewUser];
     XCTAssertEqual(acctDelegate.willSwitchOrigUserAccount, origUser, @"origUser is not equal.");
@@ -292,7 +292,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     NSArray *accounts = [self createAndVerifyUserAccounts:2];
     SFUserAccount *origUser = accounts[0];
     SFUserAccount *newUser = accounts[1];
-    self.uam.currentUser = origUser;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:origUser];
     TestUserAccountManagerDelegate *acctDelegate = [[TestUserAccountManagerDelegate alloc] init];
     [self.uam switchToUser:newUser];
     XCTAssertEqual(acctDelegate.willSwitchOrigUserAccount, origUser, @"origUser is not equal.");
@@ -305,8 +305,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 
 - (void)testSwitchToNewUserNoCurrentUser {
     NSArray *accounts = [self createAndVerifyUserAccounts:1];
-    SFUserAccount *origUser = accounts[0];
-    self.uam.currentUser = nil;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:nil];
     XCTestExpectation *switchExpectation = [self expectationWithDescription:@"testSwitchToNewUserWithCompletionErrorCase"];
     __block NSError *error = nil;
     [self.uam switchToNewUserWithCompletion:^(NSError * err, SFUserAccount * account) {
@@ -324,7 +323,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     SFUserAccount *newUser = accounts[1];
     NSString *testDomain = @"my.test.domain";
     newUser.credentials.domain = testDomain;
-    self.uam.currentUser = origUser;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:origUser];
     TestUserAccountManagerDelegate *acctDelegate = [[TestUserAccountManagerDelegate alloc] init];
     XCTAssertNotEqual(self.uam.loginHost, testDomain, @"The domains should be different before the test.");
     XCTAssertEqual(newUser.credentials.domain, testDomain, @"User domain should have been set in the credentials.");
@@ -339,7 +338,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 
 - (void)testIdentityDataModification {
     NSArray *accounts = [self createAndVerifyUserAccounts:1];
-    self.uam.currentUser = accounts[0];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:accounts[0]];
     SFIdentityData *idData = [self sampleIdentityData];
     [self.uam applyIdData:idData forUser:self.uam.currentUser];
     int origMobileAppPinLength = self.uam.currentUser.idData.mobileAppPinLength;
@@ -683,7 +682,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     //check whether the test config file has never been edited
     NSAssert(![credsData.refreshToken isEqualToString:@"__INSERT_TOKEN_HERE__"],
              @"You need to obtain credentials for your test org and replace test_credentials.json");
-    [SFUserAccountManager sharedInstance].currentUser = nil;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:nil];
     [SFUserAccountManager sharedInstance].oauthClientId = credsData.clientId;
     [SFUserAccountManager sharedInstance].oauthCompletionUrl = credsData.redirectUri;
     [SFUserAccountManager sharedInstance].scopes = [NSSet setWithObjects:@"web", @"api", nil];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
@@ -155,7 +155,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
 
 - (void)testOverrideInvalidAiltnAppName
 {
-    [SFUserAccountManager sharedInstance].currentUser = [self createUserAccount];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:[self createUserAccount]];
     [self createStandardPostLaunchBlock];
     [self createTestAppIdentity];
     [self launchAndVerify:YES failMessage:@"Launch attempt should have been successful."];
@@ -187,7 +187,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     XCTAssertNil([SFUserAccountManager sharedInstance].currentUser, @"Current user should be nil.");
     [self createStandardPostLaunchBlock];
     [self createTestAppIdentity];
-    [SFUserAccountManager sharedInstance].currentUser = [self createUserAccount];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:[self createUserAccount]];
     [self launchAndVerify:YES failMessage:@"Launch attempt should have been successful."];
     [self verifyPostLaunchState];
     BOOL userAuthenticatedAtLaunch = ((_postLaunchActions & SFSDKLaunchActionAuthenticated) == SFSDKLaunchActionAuthenticated);
@@ -216,7 +216,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     [SalesforceSDKManager sharedManager].appConfig.shouldAuthenticate = NO;
     [self createStandardPostLaunchBlock];
     [self createTestAppIdentity];
-    [SFUserAccountManager sharedInstance].currentUser = [self createUserAccount];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:[self createUserAccount]];
     [self launchAndVerify:YES failMessage:@"Launch attempt should have been successful."];
     [self verifyPostLaunchState];
     BOOL userAuthenticatedAtLaunch = ((_postLaunchActions & SFSDKLaunchActionAuthenticated) == SFSDKLaunchActionAuthenticated);
@@ -240,7 +240,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     [self createStandardPostLaunchBlock];
     [self createTestAppIdentity];
     XCTAssertNil([SFUserAccountManager sharedInstance].currentUser, @"Current user should be nil.");
-    [SFUserAccountManager sharedInstance].currentUser = [self createUserAccount];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:[self createUserAccount]];
     XCTAssertNotNil([SFUserAccountManager sharedInstance].currentUser, @"Current user should not be nil.");
     SFUserAccount *userTo = [self createUserAccount];
     SFUserAccount *userFrom = [SFUserAccountManager sharedInstance].currentUser;
@@ -533,7 +533,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     _origSwitchUserAction = [SalesforceSDKManager sharedManager].switchUserAction; [SalesforceSDKManager sharedManager].switchUserAction = NULL;
     _origPostAppForegroundAction = [SalesforceSDKManager sharedManager].postAppForegroundAction; [SalesforceSDKManager sharedManager].postAppForegroundAction = NULL;
     _origCurrentUser = [SFUserAccountManager sharedInstance].currentUser;
-    [SFUserAccountManager sharedInstance].currentUser = nil;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:nil];
     _postLaunchBlockCalled = NO;
     _postLaunchActions = SFSDKLaunchActionNone;
     _launchErrorBlockCalled = NO;
@@ -556,7 +556,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     [SalesforceSDKManager sharedManager].postLogoutAction = _origPostLogoutAction;
     [SalesforceSDKManager sharedManager].switchUserAction = _origSwitchUserAction;
     [SalesforceSDKManager sharedManager].postAppForegroundAction = _origPostAppForegroundAction;
-    [SFUserAccountManager sharedInstance].currentUser = _origCurrentUser;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:_origCurrentUser];
     SalesforceSDKManager.ailtnAppName = _origAppName;
     SFSDKWebViewStateManager.sharedProcessPool = _origProcessPool;
     [SalesforceSDKManager sharedManager].brandLoginPath = _origBrandLoginPath;
@@ -565,7 +565,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
 - (void)compareAiltnAppNames:(NSString *)expectedAppName
 {
     SFUserAccount *prevCurrentUser = [SFUserAccountManager sharedInstance].currentUser;
-    [SFUserAccountManager sharedInstance].currentUser = [self createUserAccount];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:[self createUserAccount]];
     SFSDKSalesforceAnalyticsManager *analyticsManager = [SFSDKSalesforceAnalyticsManager sharedInstanceWithUser:[SFUserAccountManager sharedInstance].currentUser];
     XCTAssertNotNil(analyticsManager, @"SFSDKSalesforceAnalyticsManager instance should not be nil");
     SFSDKDeviceAppAttributes *deviceAttributes = analyticsManager.analyticsManager.deviceAttributes;
@@ -575,7 +575,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
      NSError *error = nil;
     [[SFUserAccountManager sharedInstance] deleteAccountForUser:[SFUserAccountManager sharedInstance].currentUser error:&error];
     XCTAssertNil(error, @"SalesforceSDKManagerTests for ailtn could not delete created user");
-    [SFUserAccountManager sharedInstance].currentUser = prevCurrentUser;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:prevCurrentUser];
 }
 
 @end

--- a/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
@@ -44,6 +44,10 @@
 - (void)setCurrentUserInternal:(SFUserAccount *)userAccount;
 @end
 
+@interface SFUserAccountManager()
+- (void)setCurrentUserInternal:(SFUserAccount *)userAccount;
+@end
+
 @implementation SFMultipleSmartStoresTests
 
 #pragma mark - setup and teardown

--- a/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFMultipleSmartStoresTests.m
@@ -40,6 +40,10 @@
 
 @end
 
+@interface SFUserAccountManager()
+- (void)setCurrentUserInternal:(SFUserAccount *)userAccount;
+@end
+
 @implementation SFMultipleSmartStoresTests
 
 #pragma mark - setup and teardown
@@ -111,7 +115,7 @@
     [user transitionToLoginState:SFUserAccountLoginStateLoggedIn];
     [[SFUserAccountManager sharedInstance] saveAccountForUser:user error:&error];
      XCTAssertNil(error);
-    [SFUserAccountManager sharedInstance].currentUser = user;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal: user];
     return user;
 }
 
@@ -120,7 +124,7 @@
     [SFSmartStore removeAllGlobalStores];
     [SFSmartStore removeAllStores];
     [[SFUserAccountManager sharedInstance] deleteAccountForUser:user error:nil];
-    [SFUserAccountManager sharedInstance].currentUser = nil;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal: nil];
 }
 
 @end

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
@@ -40,6 +40,10 @@
 
 @end
 
+@interface SFUserAccountManager()
+- (void)setCurrentUserInternal:(SFUserAccount *)userAccount;
+@end
+
 @implementation SFSmartSqlTests
 
 #pragma mark - setup and teardown
@@ -47,7 +51,7 @@
 - (void) setUp
 {
     [super setUp];
-    [SFUserAccountManager sharedInstance].currentUser = [self createUserAccount];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal: [self createUserAccount]];
     self.store = [SFSmartStore sharedStoreWithName:kTestStore user:[SFUserAccountManager sharedInstance].currentUser];
     
     // Employees soup

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlWithExternalStorageTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlWithExternalStorageTests.m
@@ -32,6 +32,9 @@
 @interface SFUserAccountManager()
 - (void)setCurrentUserInternal:(SFUserAccount *)userAccount;
 @end
+@interface SFUserAccountManager()
+- (void)setCurrentUserInternal:(SFUserAccount *)userAccount;
+@end
 
 @interface SFSmartSqlWithExternalStorageTests : SFSmartSqlTests
 

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlWithExternalStorageTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlWithExternalStorageTests.m
@@ -29,6 +29,9 @@
 #import <SalesforceSDKCommon/SFJsonUtils.h>
 #import "SFSoupSpec.h"
 #import "SFSmartSqlTests.h"
+@interface SFUserAccountManager()
+- (void)setCurrentUserInternal:(SFUserAccount *)userAccount;
+@end
 
 @interface SFSmartSqlWithExternalStorageTests : SFSmartSqlTests
 
@@ -40,7 +43,7 @@
 
 - (void)setUp {
     NSArray *features = @[kSoupFeatureExternalStorage];
-    [SFUserAccountManager sharedInstance].currentUser = [super createUserAccount];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:[super createUserAccount]];
     self.store = [SFSmartStore sharedStoreWithName:kTestStore user:[SFUserAccountManager sharedInstance].currentUser];
     
     // Employees soup

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTestCase.m
@@ -32,6 +32,11 @@
 @property (nonatomic, readwrite, nullable) NSURL *identityUrl;
 
 @end
+
+@interface SFUserAccountManager()
+- (void)setCurrentUserInternal:(SFUserAccount *)userAccount;
+@end
+
 @implementation SFSmartStoreTestCase
 
 #pragma mark - helper methods for comparing json
@@ -351,7 +356,7 @@
     NSError *error = nil;
     [[SFUserAccountManager sharedInstance] saveAccountForUser:user error:&error];
     XCTAssertNil(error);
-    [SFUserAccountManager sharedInstance].currentUser = user;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:user];
     
     return user;
 }
@@ -359,7 +364,7 @@
 - (void)tearDownSmartStoreUser:(SFUserAccount*)user
 {
     [[SFUserAccountManager sharedInstance] deleteAccountForUser:user error:nil];
-    [SFUserAccountManager sharedInstance].currentUser = nil;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:nil];
 }
 
 

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -97,13 +97,13 @@
 - (void) testSqliteVersion
 {
     NSString* version = [NSString stringWithUTF8String:sqlite3_libversion()];
-    XCTAssertEqualObjects(version, @"3.26.0");
+    XCTAssertEqualObjects(version, @"3.28.0");
 }
 
 - (void) testSqlCipherVersion
 {
     NSString* version = [self.store getSQLCipherVersion];
-    XCTAssertEqualObjects(version, @"4.0.1 community");
+    XCTAssertEqualObjects(version, @"4.2.0 community");
 }
 
 /**

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/IDPLoginViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/IDPLoginViewController.swift
@@ -193,6 +193,8 @@ extension IDPLoginViewController: LoginHostDelegate {
     
     func hostListViewController(_ hostListViewController: LoginHostListViewController, didChange newLoginHost: SalesforceLoginHost) {
         UserAccountManager.shared.loginHost = newLoginHost.host
-        UserAccountManager.shared.switchToNewUser(completion: nil)
+        UserAccountManager.shared.switchToNewUserAccount { (error, userAccount) in
+            
+        }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -31,29 +31,16 @@ The Salesforce Mobile SDK for iOS requires iOS 11.0 or greater.  The install.sh 
 Introduction
 ==
 
-### What's New in 7.1
+### What's New in 7.2
 
-**SmartSync Data Framework Updates**
-- SmartSync Data Framework now supports a batch sync up target that uses the Salesforce Composite API for uploading groups of up to 25 records per call.
-- New methods allow native apps to stop and restart in-flight sync operations. To reflect the new sync state, we’ve added a stopped sync status.
-- Swift `syncUp` and `syncDown` methods that take a sync name, both `reSync` methods, and the legacy `cleanResyncGhosts` method now can throw exceptions.
-- We’ve updated iOS methods to make error handling more consistent between platforms.
-- You can now call `cleanResyncGhosts` with a sync name.
+**SmartStore Updates**
+- Using NSCache for SmartStore statement caches
 
-**Security Updates**
-- Mobile SDK for iOS raises its master key security to use Secure Enclave on devices that support it. We’ve also strengthened our master key encryption to use a 256-bit elliptic curve cryptography (ECC) private key.
-
-**Miscellaneous Changes**
-- We’ve improved support for using biometric input to supply application passcodes.
-- We’ve improved support for sending unauthenticated REST requests to external endpoints. Mobile SDK now provides a shared global instance of its REST client. This REST client doesn’t require OAuth authentication and is unaware of the concept of user. Native apps can use it to send custom unauthenticated requests to non-Salesforce endpoints before or after the user logs in to Salesforce.
-- For profiling how Mobile SDK operations affect an app’s runtime performance, we’ve added signposts to Mobile SDK libraries.
-
-**Tool and Version Updates**
-- We’ve updated our Swift template app to Swift version 5.0 and Xcode version 10.2.
-- We've updated SQLCipher to version 4.0.1
+**Version Updates**
+- SQLCipher: 4.2.0
 
 **Deprecation**
-- For a list of deprecated methods, see “About Sync Task Errors” in the [*Mobile SDK Development Guide*](https://developer.salesforce.com/docs/atlas.en-us.mobile_sdk.meta/mobile_sdk/)
+- TBD
 
 Check http://developer.force.com/mobilesdk for additional articles and tutorials.
 


### PR DESCRIPTION
This PR does the following

1.  Deprecates setter for currentUser. The alternative now is to use switchUser or switchToNewUserWithCompletion.
2. SFUserAccountManager's loginWithCompletion will set the current user. Ensures that currentUser is set before successBlock is invoked.
3. Fixed tests to use internal setter for currentUser (dummy users). 