### PR TITLE
Fix not calling the completion block on the metadata fetch failure

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Manager/SFMetadataSyncManager.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFMetadataSyncManager.m
@@ -134,6 +134,8 @@ static NSArray<SFSoupIndex *> *indexSpecs = nil;
         __strong typeof (weakSelf) strongSelf = weakSelf;
         if (sync.status == SFSyncStateStatusDone) {
             [strongSelf fetchFromCache:objectType completionBlock:completionBlock fallbackOnServer:NO];
+        } else if (sync.status == SFSyncStateStatusFailed) {
+            completionBlock(nil);
         }
     }];
 }


### PR DESCRIPTION
The completion block of `SFMetadataSyncManager` `-fetchFromServer:completionBlock:` was never called if the request failed.