### PR TITLE
Adding pragma to upgrade db to sqlcipher 4.x

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -516,13 +516,19 @@ NS_SWIFT_NAME(SmartStore)
 - (BOOL) reIndexSoup:(NSString*)soupName withIndexPaths:(NSArray<NSString*>*)indexPaths NS_SWIFT_NAME(reIndexSoup(named:indexPaths:));
 
 /**
- * Return compile options
+ * Return SQLCipher runtime settings
+ * @return An array with all the compile options used to build SQL Cipher.
+ */
+- (NSArray*) getRuntimeSettings NS_SWIFT_NAME(runtimeSettings());
+
+/**
+ * Return SQLCipher compile options
  * @return An array with all the compile options used to build SQL Cipher.
  */
 - (NSArray *)getCompileOptions NS_SWIFT_NAME(compileOptions());
 
 /**
- * Return sqlcipher version
+ * Return SQLCipher version
  * @return The version of SQL Cipher in use.
  */
 - (NSString *)getSQLCipherVersion NS_SWIFT_NAME(versionOfSQLCipher());

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -2407,6 +2407,11 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
 }
 
 #pragma mark - Misc info methods
+- (NSArray*) getRuntimeSettings
+{
+    return [self queryPragma:@"cipher_settings"];
+}
+
 - (NSArray*) getCompileOptions
 {
     return [self queryPragma:@"compile_options"];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
@@ -199,15 +199,14 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
 
 + (FMDatabase*) unlockDatabase:(FMDatabase*)db key:(NSString*)key salt:(NSString *)salt {
     if ([db open]) {
-        // Using sqlcipher 3.x default settings
-        // => should open 3.x databases without any migration
-        [[db executeQuery:@"PRAGMA cipher_default_compatibility = 3"] close];
         // Using sqlcipher 2.x kdf iter because 3.x default (64000) and 4.x default (256000) are too slow
-        // => should open 2.x databases without any migration
         [[db executeQuery:@"PRAGMA cipher_default_kdf_iter = 4000"] close];
        
         if (key)
            [db setKey:key];
+
+        // Migrating and upgrading an existing database in place (preserving data and schema) if necessary
+        [[db executeQuery:@"PRAGMA cipher_migrate"] close];
         
         if (salt  && [key length] > 0 ){
             [[db executeQuery:@"PRAGMA cipher_plaintext_header_size = 32"] close];

--- a/libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.m
+++ b/libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.m
@@ -98,6 +98,7 @@
     [devInfos addObjectsFromArray:@[
             @"SQLCipher version", [store getSQLCipherVersion],
             @"SQLCipher Compile Options", [[store getCompileOptions] componentsJoinedByString:@", "],
+            @"SQLCipher Runtime Settings", [[store getRuntimeSettings] componentsJoinedByString:@", "],
             @"User Stores", [self safeJoin:[SFSmartStore allStoreNames] separator:@", "],
             @"Global Stores", [self safeJoin:[SFSmartStore allGlobalStoreNames] separator:@", "]
     ]];

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -94,6 +94,22 @@
     XCTAssertTrue([options containsObject:@"ENABLE_JSON1"]);
 }
 
+/**
+ * Test to check runtime settings
+ */
+- (void) testRuntimeSettings
+{
+    NSArray* settings = [self.store getRuntimeSettings];
+    
+    // Make sure run time settings are 4.x settings except for kdf_iter
+    XCTAssertTrue([settings containsObject:@"PRAGMA kdf_iter = 4000;"]);
+    XCTAssertTrue([settings containsObject:@"PRAGMA cipher_page_size = 4096;"]);
+    XCTAssertTrue([settings containsObject:@"PRAGMA cipher_use_hmac = 1;"]);
+    XCTAssertTrue([settings containsObject:@"PRAGMA cipher_plaintext_header_size = 0;"]);
+    XCTAssertTrue([settings containsObject:@"PRAGMA cipher_hmac_algorithm = HMAC_SHA512;"]);
+    XCTAssertTrue([settings containsObject:@"PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA512;"]);
+}
+
 - (void) testSqliteVersion
 {
     NSString* version = [NSString stringWithUTF8String:sqlite3_libversion()];


### PR DESCRIPTION
Now using 4.x settings
Added method + test to check runtime settings (also shown in dev menu)
Tested upgrade with GlobalStoreTester:
- tested 7.0 to 7.2 upgrade: goes from sqlcipher 3.4.2 to 4.2
- tested 7.1 to 7.2 upgrade: goes from sqlcipher 4.0 to 4.2
- tested dowgrades also - they fail as expected  (7.2 -> 7.1 because of db, 7.2 -> 7.0 because of encryption keys)