### PR TITLE
Update appDisplayName property

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -249,10 +249,11 @@ NS_SWIFT_NAME(SalesforceManager)
  */
 @property (nonatomic, copy) NSString *idpAppURIScheme NS_SWIFT_NAME(identityProviderURLScheme);
 
-/** Use this flag to setup a user friendly display name  for your current app. This value will be used by the identity
- *  provider app on the user selection view.
+/**
+ A user friendly display name for use in UI by the SDK on behalf of the app.  This value will be used on various authentication screens
+ such as biometric enrollment or IDP login. If left unset, this property will fallback to CFBundleDisplayName or CFBundleName depending on what is available.
  */
-@property (nonatomic,copy) NSString *appDisplayName;
+@property (nonatomic,copy) NSString *appDisplayName NS_SWIFT_NAME(appDisplayName);
 
 
 /** Use this flag to indicate if the dev support dialog should be enabled in the APP

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.h
@@ -89,9 +89,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy,nullable) NSString *idpAppURIScheme;
 
-/** Use this property to indicate to provide a user-friendly name for your app. This name will be displayed
- *  in the user selection view of the identity provider app.
- *
+/**
+ A user friendly display name for use in UI by the SDK on behalf of the app.  This value will be used on various authentication screens
+ such as biometric enrollment or IDP login. If left unset, this property will fallback to CFBundleDisplayName or CFBundleName depending on what is available.
+ 
+ This name will be displayed in the user selection view of the identity provider app.
  */
 @property (nonatomic,copy) NSString *appDisplayName;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
@@ -217,7 +217,18 @@ NSString * const kOAuthAppName = @"oauth_app_name";
 - (NSString *)appDisplayName
 {
     NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
-    return [defs stringForKey:kOAuthAppName];
+    NSString *appName = [defs stringForKey:kOAuthAppName];
+    
+    if (appName) {
+        return appName;
+    } else {
+        NSString *bundleDispalyName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+        if(bundleDispalyName) {
+            return bundleDispalyName;
+        } else {
+            return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+        }
+    }
 }
 
 - (void)setAppDisplayName:(NSString *)appDisplayName

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKBiometricViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKBiometricViewController.m
@@ -29,6 +29,7 @@
 #import "SFSDKAppLockViewConfig.h"
 #import "SFSDKResourceUtils.h"
 #import "SFSDKWindowManager.h"
+#import "SalesforceSDKManager.h"
 #import <LocalAuthentication/LocalAuthentication.h>
 
 static CGFloat      const kSFFaceIdIconWidth                   = 36.0f;
@@ -237,7 +238,7 @@ static CGFloat      const kSFBioViewBorderWidth                = 1.0f;
     LAContext *context = [[LAContext alloc] init];
     // Need to evaluate context to for biometricType to be populated
     [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:nil];
-    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+    NSString *appName = [[SalesforceSDKManager sharedManager] appDisplayName];
     NSString *bioInstructions = nil;
     
     switch ([context biometryType]) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
@@ -453,6 +453,23 @@ static NSString* const kTestAppName = @"OverridenAppName";
     XCTAssertTrue([brandedURL containsString:[brandPath substringToIndex:brandPath.length-1]]);
 }
 
+#pragma mark - Dispaly Name Tests
+
+- (void)testDefaultDisplayName {
+    NSString *nilString = nil; //avoids warning from passing nil
+    NSString *bundleName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+    NSString *bundleDisplayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    NSString *matchName = (bundleDisplayName) ? bundleDisplayName : bundleName;
+    [[SalesforceSDKManager sharedManager] setAppDisplayName:nilString];
+    XCTAssertTrue([matchName isEqualToString:[[SalesforceSDKManager sharedManager] appDisplayName]], @"App names should match");
+}
+
+- (void)testSetDisplayName {
+    NSString *appDispalyName = @"unique sdk name";
+    [[SalesforceSDKManager sharedManager] setAppDisplayName:appDispalyName];
+    XCTAssertTrue([appDispalyName isEqualToString:[[SalesforceSDKManager sharedManager] appDisplayName]], @"App names should match");
+}
+
 #pragma mark - Private helpers
 
 - (void)createStandardPostLaunchBlock

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -43,9 +43,10 @@ class AppDelegate : UIResponder, UIApplicationDelegate
         super.init()
       
         SalesforceManager.initializeSDK()
+        SalesforceManager.shared.appDisplayName = "Rest API Explorer"
         
         //Uncomment following block to enable IDP Login flow.
-        // SalesforceSDK.shared().idpAppURIScheme = "sampleidpapp"
+        //SalesforceManager.shared.identityProviderURLScheme = "sampleidpapp"
         AuthHelper.registerBlock(forCurrentUserChangeNotifications: {
             self.resetViewState {
                 self.initializeAppViewState()


### PR DESCRIPTION
Instead of creating a new property I decided to update the existing `appDisplayName` property so it can be used as the SDK's source of truth name for the app for any UI.  Currently it is only used for IDP and Biometric, but this should be the property used for any UI (or external facing messages) going forward.  