### PR TITLE
Add nil check for authInfo

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -1589,11 +1589,16 @@ static int const kSFSDKUserAccountManagerErrorCode = 100;
 
 - (void)notifyUserCancelledOrDismissedAuth:(SFOAuthCredentials *)credentials andAuthInfo:(SFOAuthInfo *)info
  {
-    NSDictionary *userInfo = @{ kSFNotificationUserInfoCredentialsKey:credentials,
-                                kSFNotificationUserInfoAuthTypeKey: info };
+    NSMutableDictionary *userInfo = [NSMutableDictionary new];
+    userInfo[kSFNotificationUserInfoCredentialsKey] = credentials;
+    if (info) {
+        userInfo[kSFNotificationUserInfoAuthTypeKey] = info;
+    }
+
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserCancelledAuth
-                                                        object:self userInfo:userInfo];
-}
+                                                        object:self
+                                                      userInfo:[userInfo copy]];
+ }
 - (void)reload {
     [_accountsLock lock];
 


### PR DESCRIPTION
For #2853

After the first invalid attempt auth info is set to nil and then would refresh but the second invalid attempt is happening before the refresh so auth info is still nil causing the crash. I initially looked into catching it earlier in the cycle but thought it would be more consistent to let it go through and not include the auth info if it didn't exist, let me know if another point would be better