### PR TITLE
Fetch thumbnail url from user account instead of full image

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccount.h
@@ -100,9 +100,6 @@ NS_SWIFT_NAME(UserAccount)
 @property (nonatomic, copy) NSString *userName SFSDK_DEPRECATED(7.1, 8.0, "Use SFUserAccount.idData properties instead");
 
 /** The user's photo. Usually store a thumbnail of the user.
- Note: the consumer of this class must set the photo at least once,
- because this class doesn't fetch it from the server but
- only stores it locally on the disk.
  */
 @property (nonatomic, strong, nullable) UIImage *photo;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -1439,8 +1439,8 @@ static int const kSFSDKUserAccountManagerErrorCode = 100;
 }
 
 - (void)retrieveUserPhotoIfNeeded:(SFUserAccount *)account {
-    if (account.idData.pictureUrl) {
-        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:account.idData.pictureUrl];
+    if (account.idData.thumbnailUrl) {
+        NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:account.idData.thumbnailUrl];
         [request setHTTPMethod:@"GET"];
         [request setValue:[NSString stringWithFormat:kHttpAuthHeaderFormatString, account.credentials.accessToken] forHTTPHeaderField:kHttpHeaderAuthorization];
         SFNetwork *network = [[SFNetwork alloc] initWithEphemeralSession];


### PR DESCRIPTION
The `pictureUrl` is the full sized image that the user uploaded which can have a rectangular aspect ratio. The url has the format `/profilephoto/729R00000000uD6/F"`.

The `thumbnailUrl` is appropriately cropped to have a square aspect ratio, and the format is `/profilephoto/729R00000000uD6/T`.

According to the photo property comment, we should be storing a thumbnail if possible. I also removed the note because MSDK now fetches the photo for us on login.