### PR TITLE
Salesforce authentication app store link was taking the user to no wh…

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -22,6 +22,7 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <UIKit/UIKit.h>
 #import <Security/Security.h>
 #import <WebKit/WebKit.h>
 #import "SFOAuthCredentials+Internal.h"
@@ -55,6 +56,9 @@ NSString * const     kSFOAuthErrorDomain                        = @"com.salesfor
 
 static NSString * const kSFOAuthEndPointAuthorize               = @"/services/oauth2/authorize";    // user agent flow
 static NSString * const kSFOAuthEndPointToken                   = @"/services/oauth2/token";        // token refresh flow
+
+// Custom constants
+static NSString * const kSFAppStoreLink   = @"itunes.apple.com";
 
 // Advanced auth constants
 static NSUInteger const kSFOAuthCodeVerifierByteLength          = 128;
@@ -900,7 +904,10 @@ static NSString * const kSFECParameter = @"ec";
     } else if ([self isSPAppRedirectURL:requestUrl]){
         [self handleIDPAuthCodeResponse:url];
         decisionHandler(WKNavigationActionPolicyCancel);
-    }else {
+    } else if ([requestUrl containsString:kSFAppStoreLink]) {
+        decisionHandler(WKNavigationActionPolicyCancel);
+        [[UIApplication sharedApplication] openURL:url];
+    } else {
         decisionHandler(WKNavigationActionPolicyAllow);
     }
 }


### PR DESCRIPTION
When 2 factor authentication is enabled, after logging in, The user gets a web page that asks for salesforce authenticator pass phrase. In the page there is a link to the salesforce authenticator application on the app store. Tapping on that link takes the user to a dead end. 