### PR TITLE
Adding fallback and nullability markers for API version

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A new SFRestRequest that can be used to fetch this data.
  */
-- (SFRestRequest *)requestForOwnedFilesList:(nullable NSString *)userId page:(NSUInteger)page apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForOwnedFilesList:(nullable NSString *)userId page:(NSUInteger)page apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Build a Request that can fetch a page from the list of files from groups
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A new SFRestRequest that can be used to fetch this data.
  */
-- (SFRestRequest *)requestForFilesInUsersGroups:(nullable NSString *)userId page:(NSUInteger)page apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForFilesInUsersGroups:(nullable NSString *)userId page:(NSUInteger)page apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Build a Request that can fetch a page from the list of files that have
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A new SFRestRequest that can be used to fetch this data.
  */
-- (SFRestRequest *)requestForFilesSharedWithUser:(nullable NSString *)userId page:(NSUInteger)page apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForFilesSharedWithUser:(nullable NSString *)userId page:(NSUInteger)page apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Build a Request that can fetch the file details of a particular version
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A new SFRestRequest that can be used to fetch this data.
  */
-- (SFRestRequest *)requestForFileDetails:(NSString *)sfdcId forVersion:(nullable NSString *)version apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForFileDetails:(NSString *)sfdcId forVersion:(nullable NSString *)version apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Build a request that can fetch the latest file details of one or more
@@ -132,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A new SFRestRequest that can be used to fetch this data
  */
-- (SFRestRequest *)requestForBatchFileDetails:(NSArray<NSString *> *)sfdcIds apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForBatchFileDetails:(NSArray<NSString *> *)sfdcIds apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Build a Request that can fetch the a preview/rendition of a particular
@@ -157,7 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A new SFRestRequest that can be used to fetch this data.
  */
-- (SFRestRequest *)requestForFileRendition:(NSString *)sfdcId version:(nullable NSString *)version renditionType:(NSString *)renditionType page:(NSUInteger)page apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForFileRendition:(NSString *)sfdcId version:(nullable NSString *)version renditionType:(NSString *)renditionType page:(NSUInteger)page apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Builds a request that can fetch the actual binary file contents of this
@@ -178,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A new SFRestRequest that can be used to fetch this data.
  */
-- (SFRestRequest *)requestForFileContents:(NSString *)sfdcId version:(nullable NSString *)version apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForFileContents:(NSString *)sfdcId version:(nullable NSString *)version apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Build a request that can fetch a page from the list of entities that this
@@ -199,7 +199,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A new SFRestRequest that can be used to fetch this data.
  */
-- (SFRestRequest *)requestForFileShares:(NSString *)sfdcId page:(NSUInteger)page apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForFileShares:(NSString *)sfdcId page:(NSUInteger)page apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Build a request that will add a file share for the specified fileId to
@@ -222,7 +222,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A new SFRestRequest that be can used to create this share.
  */
-- (SFRestRequest *)requestForAddFileShare:(NSString *)fileId entityId:(NSString *)entityId shareType:(NSString *)shareType apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForAddFileShare:(NSString *)fileId entityId:(NSString *)entityId shareType:(NSString *)shareType apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Build a request that will delete the specified file share.
@@ -239,7 +239,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A new SFRestRequest that can be used to delete this share.
  */
-- (SFRestRequest *)requestForDeleteFileShare:(NSString *)shareId apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForDeleteFileShare:(NSString *)shareId apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Build a request that can upload a new file to the server, this will
@@ -264,7 +264,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A SFRestRequest that can perform this upload.
  */
-- (SFRestRequest *)requestForUploadFile:(NSData *)data name:(NSString *)name description:(NSString *)description mimeType:(NSString *)mimeType apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForUploadFile:(NSData *)data name:(NSString *)name description:(NSString *)description mimeType:(NSString *)mimeType apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Build a request that can upload a new profile photo to the server
@@ -287,7 +287,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param apiVersion API version.
  * @return A SFRestRequest that can perform this upload.
  */
-- (SFRestRequest *)requestForProfilePhotoUpload:(NSData *)data fileName:(NSString *)fileName mimeType:(NSString *)mimeType userId:(NSString *)userId apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForProfilePhotoUpload:(NSData *)data fileName:(NSString *)fileName mimeType:(NSString *)mimeType userId:(NSString *)userId apiVersion:(nullable NSString *)apiVersion;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
@@ -45,7 +45,7 @@
 }
 
 - (SFRestRequest *)requestForOwnedFilesList:(NSString *)userId page:(NSUInteger)page apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/%@", apiVersion,[self communitiesUrlPathIfRequired],  (userId == nil ? ME : userId)];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/%@", [self computeAPIVersion:apiVersion], [self communitiesUrlPathIfRequired],  (userId == nil ? ME : userId)];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (page) params[PAGE] = @(page);
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
@@ -56,7 +56,7 @@
 }
 
 - (SFRestRequest *)requestForFilesInUsersGroups:(NSString *)userId page:(NSUInteger)page apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/%@/filter/groups", apiVersion, [self communitiesUrlPathIfRequired], (userId == nil ? ME : userId)];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/%@/filter/groups", [self computeAPIVersion:apiVersion], [self communitiesUrlPathIfRequired], (userId == nil ? ME : userId)];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (page) params[PAGE] = @(page);
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
@@ -67,7 +67,7 @@
 }
 
 - (SFRestRequest *)requestForFilesSharedWithUser:(NSString *)userId page:(NSUInteger)page apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/%@/filter/sharedwithme", apiVersion, [self communitiesUrlPathIfRequired],(userId == nil ? ME : userId)];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/%@/filter/sharedwithme", [self computeAPIVersion:apiVersion], [self communitiesUrlPathIfRequired],(userId == nil ? ME : userId)];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (page) params[PAGE] = @(page);
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
@@ -78,7 +78,7 @@
 }
 
 - (SFRestRequest *)requestForFileDetails:(NSString *)sfdcId forVersion:(NSString *)version apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@", apiVersion,[self communitiesUrlPathIfRequired], sfdcId];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@", [self computeAPIVersion:apiVersion], [self communitiesUrlPathIfRequired], sfdcId];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (version) params[VERSION] = version;
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
@@ -90,7 +90,7 @@
 
 - (SFRestRequest *)requestForBatchFileDetails:(NSArray *)sfdcIds apiVersion:(NSString *)apiVersion {
     NSString *ids = [sfdcIds componentsJoinedByString:@","];
-    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/batch/%@", apiVersion, [self communitiesUrlPathIfRequired], ids];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/batch/%@", [self computeAPIVersion:apiVersion], [self communitiesUrlPathIfRequired], ids];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
 }
 
@@ -99,7 +99,7 @@
 }
 
 - (SFRestRequest *)requestForFileRendition:(NSString *)sfdcId version:(NSString *)version renditionType:(NSString *)renditionType page:(NSUInteger)page apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@/rendition", apiVersion, [self communitiesUrlPathIfRequired], sfdcId];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@/rendition", [self computeAPIVersion:apiVersion], [self communitiesUrlPathIfRequired], sfdcId];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     params[RENDITION_TYPE] = renditionType;
     if (page) params[PAGE] = @(page);
@@ -113,7 +113,7 @@
 }
 
 - (SFRestRequest *)requestForFileContents:(NSString *)sfdcId version:(NSString *)version apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@/content", apiVersion, [self communitiesUrlPathIfRequired], sfdcId];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@/content", [self computeAPIVersion:apiVersion], [self communitiesUrlPathIfRequired], sfdcId];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (version) params[VERSION] = version;
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
@@ -125,7 +125,7 @@
 }
 
 - (SFRestRequest *)requestForFileShares:(NSString *)sfdcId page:(NSUInteger)page apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@/file-shares", apiVersion, [self communitiesUrlPathIfRequired], sfdcId];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/%@/file-shares", [self computeAPIVersion:apiVersion], [self communitiesUrlPathIfRequired], sfdcId];
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     if (page) params[PAGE] = @(page);
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:params];
@@ -136,7 +136,7 @@
 }
 
 - (SFRestRequest *)requestForAddFileShare:(NSString *)fileId entityId:(NSString *)entityId shareType:(NSString *)shareType apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/ContentDocumentLink", apiVersion];
+    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/ContentDocumentLink", [self computeAPIVersion:apiVersion]];
     NSDictionary *params = @{CONTENT_DOCUMENT_ID: fileId, LINKED_ENTITY_ID: entityId, SHARE_TYPE: shareType};
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
     if (params) {
@@ -154,7 +154,7 @@
 }
 
 - (SFRestRequest *)requestForDeleteFileShare:(NSString *)shareId apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/ContentDocumentLink/%@", apiVersion, shareId];
+    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/ContentDocumentLink/%@", [self computeAPIVersion:apiVersion], shareId];
     return [SFRestRequest requestWithMethod:SFRestMethodDELETE path:path queryParams:nil];
 }
 
@@ -163,7 +163,7 @@
 }
 
 - (SFRestRequest *)requestForUploadFile:(NSData *)data name:(NSString *)name description:(NSString *)description mimeType:(NSString *)mimeType apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/me", apiVersion, [self communitiesUrlPathIfRequired]];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/files/users/me", [self computeAPIVersion:apiVersion], [self communitiesUrlPathIfRequired]];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
     NSDictionary *params = @{@"title" : name, @"desc" : description};
     [request addPostFileData:data paramName:FILE_DATA fileName:name mimeType:mimeType params:params];
@@ -175,7 +175,7 @@
 }
 
 - (SFRestRequest *)requestForProfilePhotoUpload:(NSData *)data fileName:(NSString *)fileName mimeType:(NSString *)mimeType userId:(NSString *)userId apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/user-profiles/%@/photo", apiVersion, [self communitiesUrlPathIfRequired], userId];
+    NSString *path = [NSString stringWithFormat:@"/%@/connect%@/user-profiles/%@/photo", [self computeAPIVersion:apiVersion], [self communitiesUrlPathIfRequired], userId];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
     [request addPostFileData:data paramName:FILE_UPLOAD fileName:fileName mimeType:mimeType params:nil];
     return request;
@@ -186,6 +186,10 @@
         return @"";
     }
     return [NSString stringWithFormat:@"/communities/%@", self.user.communityId];
+}
+
+- (NSString *)computeAPIVersion:(NSString *)apiVersion {
+    return (apiVersion != nil ? apiVersion : self.apiVersion);
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Files.m
@@ -28,6 +28,8 @@
 #import "SFRestAPI+Files.h"
 #import "SFRestRequest+Internal.h"
 #import "SFOAuthCredentials.h"
+#import "SFRestAPI+Internal.h"
+
 #define ME @"me"
 #define PAGE @"page"
 #define VERSION @"versionNumber"
@@ -186,10 +188,6 @@
         return @"";
     }
     return [NSString stringWithFormat:@"/communities/%@", self.user.communityId];
-}
-
-- (NSString *)computeAPIVersion:(NSString *)apiVersion {
-    return (apiVersion != nil ? apiVersion : self.apiVersion);
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Internal.h
@@ -54,6 +54,8 @@
 
 - (void)send:(nonnull SFRestRequest *)request delegate:(nullable id<SFRestDelegate>)delegate shouldRetry:(BOOL)shouldRetry;
 
+- (nonnull NSString *)computeAPIVersion:(nullable NSString *)apiVersion;
+
 + (void)removeSharedInstanceWithUser:(nonnull SFUserAccount *)user;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
@@ -224,7 +224,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see Rest API link: https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_discoveryresource.htm
  */
-- (SFRestRequest *)requestForResources:(NSString *)apiVersion;
+- (SFRestRequest *)requestForResources:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that lists available objects in your org and their
@@ -239,7 +239,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_describeGlobal.htm
  */
-- (SFRestRequest *)requestForDescribeGlobal:(NSString *)apiVersion;
+- (SFRestRequest *)requestForDescribeGlobal:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that describes the individual metadata for the
@@ -256,7 +256,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_basic_info.htm
  */
-- (SFRestRequest *)requestForMetadataWithObjectType:(NSString *)objectType apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForMetadataWithObjectType:(NSString *)objectType apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that completely describes the metadata
@@ -273,7 +273,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_sobject_describe.htm
  */
-- (SFRestRequest *)requestForDescribeWithObjectType:(NSString *)objectType apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForDescribeWithObjectType:(NSString *)objectType apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that provides layout data for the specified object and layout type.
@@ -292,7 +292,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm
  */
-- (SFRestRequest *)requestForLayoutWithObjectType:(nonnull NSString *)objectType layoutType:(nullable NSString *)layoutType apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForLayoutWithObjectType:(nonnull NSString *)objectType layoutType:(nullable NSString *)layoutType apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that retrieves field values for the specified record of the given type.
@@ -320,7 +320,7 @@ NS_SWIFT_NAME(RestClient)
 - (SFRestRequest *)requestForRetrieveWithObjectType:(NSString *)objectType
                                            objectId:(NSString *)objectId
                                           fieldList:(nullable NSString *)fieldList
-                                         apiVersion:(NSString *)apiVersion;
+                                         apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that creates a new record of the given type.
@@ -344,7 +344,7 @@ NS_SWIFT_NAME(RestClient)
  */
 - (SFRestRequest *)requestForCreateWithObjectType:(NSString *)objectType
                                            fields:(nullable NSDictionary<NSString *, id> *)fields
-                                       apiVersion:(NSString *)apiVersion;
+                                       apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that creates or updates record of the given type, based on the 
@@ -378,7 +378,7 @@ NS_SWIFT_NAME(RestClient)
                                   externalIdField:(NSString *)externalIdField
                                        externalId:(nullable NSString *)externalId
                                            fields:(NSDictionary<NSString *, id> *)fields
-                                       apiVersion:(NSString *)apiVersion;
+                                       apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that updates field values on a record of the given type.
@@ -406,7 +406,7 @@ NS_SWIFT_NAME(RestClient)
 - (SFRestRequest *)requestForUpdateWithObjectType:(NSString *)objectType
                                          objectId:(NSString *)objectId
                                            fields:(nullable NSDictionary<NSString *, id> *)fields
-                                       apiVersion:(NSString *)apiVersion;
+                                       apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Same as requestForUpdateWithObjectType:objectId:fields but only executing update
@@ -442,7 +442,7 @@ NS_SWIFT_NAME(RestClient)
                                          objectId:(NSString *)objectId
                                            fields:(nullable NSDictionary<NSString*, id> *)fields
                             ifUnmodifiedSinceDate:(nullable NSDate *) ifUnmodifiedSinceDate
-                                       apiVersion:(NSString *)apiVersion;
+                                       apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that deletes a record of the given type.
@@ -462,7 +462,7 @@ NS_SWIFT_NAME(RestClient)
  */
 - (SFRestRequest *)requestForDeleteWithObjectType:(NSString *)objectType
                                          objectId:(NSString *)objectId
-                                       apiVersion:(NSString *)apiVersion;
+                                       apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that executes the specified SOQL query.
@@ -479,7 +479,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query.htm
  */
-- (SFRestRequest *)requestForQuery:(NSString *)soql apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForQuery:(NSString *)soql apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that executes the specified SOQL query.
@@ -498,7 +498,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_queryall.htm
  */
-- (SFRestRequest *)requestForQueryAll:(NSString *)soql apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForQueryAll:(NSString *)soql apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that executes the specified SOSL search.
@@ -513,7 +513,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_search.htm
  */
-- (SFRestRequest *)requestForSearch:(NSString *)sosl apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForSearch:(NSString *)sosl apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that returns an ordered list of objects in the default global search scope of a logged-in user.
@@ -526,7 +526,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_search_scope_order.htm
  */
-- (SFRestRequest *)requestForSearchScopeAndOrder:(NSString *)apiVersion;
+- (SFRestRequest *)requestForSearchScopeAndOrder:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that contains search result layout information for the objects in the query string.
@@ -543,7 +543,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_search_layouts.htm
  */
-- (SFRestRequest *)requestForSearchResultLayout:(NSString *)objectList apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *)requestForSearchResultLayout:(NSString *)objectList apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that executes a batch of requests.
@@ -560,7 +560,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_batch.htm
  */
-- (SFRestRequest *) batchRequest:(NSArray<SFRestRequest *> *)requests haltOnError:(BOOL)haltOnError apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *) batchRequest:(NSArray<SFRestRequest *> *)requests haltOnError:(BOOL)haltOnError apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that executes a composite request.
@@ -579,7 +579,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_composite.htm
  */
-- (SFRestRequest *) compositeRequest:(NSArray<SFRestRequest *> *) requests refIds:(NSArray<NSString *> *)refIds allOrNone:(BOOL)allOrNone apiVersion:(NSString *)apiVersion;
+- (SFRestRequest *) compositeRequest:(NSArray<SFRestRequest *> *) requests refIds:(NSArray<NSString *> *)refIds allOrNone:(BOOL)allOrNone apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that executes an sObject tree request.
@@ -596,7 +596,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_sobject_tree.htm
  */
-- (SFRestRequest*) requestForSObjectTree:(NSString *)objectType objectTrees:(NSArray<SFSObjectTree *> *)objectTrees apiVersion:(NSString *)apiVersion;
+- (SFRestRequest*) requestForSObjectTree:(NSString *)objectType objectTrees:(NSArray<SFSObjectTree *> *)objectTrees apiVersion:(nullable NSString *)apiVersion;
 
 ///---------------------------------------------------------------------------------------
 /// @name Other utility methods
@@ -615,7 +615,7 @@ NS_SWIFT_NAME(RestClient)
  * Returns the User-Agent string used by Mobile SDK, adding the qualifier after the app type.
  @param qualifier Optional subtype of native or hybrid Mobile SDK app.
  */
-+ (NSString *)userAgentString:(NSString*)qualifier;
++ (NSString *)userAgentString:(NSString *)qualifier;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -493,7 +493,7 @@ static dispatch_once_t pred;
 }
 
 - (SFRestRequest *)requestForResources:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@", apiVersion];
+    NSString *path = [NSString stringWithFormat:@"/%@", [self computeAPIVersion:apiVersion]];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
 }
 
@@ -502,7 +502,7 @@ static dispatch_once_t pred;
 }
 
 - (SFRestRequest *)requestForDescribeGlobal:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/sobjects", apiVersion];
+    NSString *path = [NSString stringWithFormat:@"/%@/sobjects", [self computeAPIVersion:apiVersion]];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
 }
 
@@ -511,7 +511,7 @@ static dispatch_once_t pred;
 }
 
 - (SFRestRequest *)requestForMetadataWithObjectType:(NSString *)objectType apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@", apiVersion, objectType];
+    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@", [self computeAPIVersion:apiVersion], objectType];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
 }
 
@@ -520,7 +520,7 @@ static dispatch_once_t pred;
 }
 
 - (SFRestRequest *)requestForDescribeWithObjectType:(NSString *)objectType apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@/describe", apiVersion, objectType];
+    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@/describe", [self computeAPIVersion:apiVersion], objectType];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
 }
 
@@ -532,7 +532,7 @@ static dispatch_once_t pred;
     NSDictionary *queryParams = (layoutType ?
                                  @{@"layoutType": layoutType}
                                  : nil);
-    NSString *path = [NSString stringWithFormat:@"/%@/ui-api/layout/%@", apiVersion, objectType];
+    NSString *path = [NSString stringWithFormat:@"/%@/ui-api/layout/%@", [self computeAPIVersion:apiVersion], objectType];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:queryParams];
 }
 
@@ -549,7 +549,7 @@ static dispatch_once_t pred;
     NSDictionary *queryParams = (fieldList ?
                                  @{@"fields": fieldList}
                                  : nil);
-    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@/%@", apiVersion, objectType, objectId];
+    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@/%@", [self computeAPIVersion:apiVersion], objectType, objectId];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:queryParams];
 }
 
@@ -561,7 +561,7 @@ static dispatch_once_t pred;
 - (SFRestRequest *)requestForCreateWithObjectType:(NSString *)objectType
                                            fields:(NSDictionary *)fields
                                        apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@", apiVersion, objectType];
+    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@", [self computeAPIVersion:apiVersion], objectType];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
     return [self addBodyForPostRequest:fields request:request];
 }
@@ -576,7 +576,7 @@ static dispatch_once_t pred;
                                          objectId:(NSString *)objectId
                                            fields:(NSDictionary *)fields
                                        apiVersion:(NSString *)apiVersion {
-    return [self requestForUpdateWithObjectType:objectType objectId:objectId fields:fields ifUnmodifiedSinceDate:nil apiVersion:apiVersion];
+    return [self requestForUpdateWithObjectType:objectType objectId:objectId fields:fields ifUnmodifiedSinceDate:nil apiVersion:[self computeAPIVersion:apiVersion]];
 }
 
 - (SFRestRequest *)requestForUpdateWithObjectType:(NSString *)objectType
@@ -591,7 +591,7 @@ static dispatch_once_t pred;
                                            fields:(NSDictionary *)fields
                             ifUnmodifiedSinceDate:(NSDate *)ifUnmodifiedSinceDate
                                        apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@/%@", apiVersion, objectType, objectId];
+    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@/%@", [self computeAPIVersion:apiVersion], objectType, objectId];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPATCH path:path queryParams:nil];
     request = [self addBodyForPostRequest:fields request:request];
     if (ifUnmodifiedSinceDate) {
@@ -613,7 +613,7 @@ static dispatch_once_t pred;
                                            fields:(NSDictionary *)fields
                                        apiVersion:(NSString *)apiVersion {
     NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@/%@/%@",
-                      apiVersion,
+                      [self computeAPIVersion:apiVersion],
                       objectType,
                       externalIdField,
                       externalId == nil ? @"" : externalId];
@@ -630,7 +630,7 @@ static dispatch_once_t pred;
 - (SFRestRequest *)requestForDeleteWithObjectType:(NSString *)objectType
                                          objectId:(NSString *)objectId
                                        apiVersion:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@/%@", apiVersion, objectType, objectId];
+    NSString *path = [NSString stringWithFormat:@"/%@/sobjects/%@/%@", [self computeAPIVersion:apiVersion], objectType, objectId];
     return [SFRestRequest requestWithMethod:SFRestMethodDELETE path:path queryParams:nil];
 }
 
@@ -643,7 +643,7 @@ static dispatch_once_t pred;
     if (soql) {
         queryParams = @{@"q": soql};
     }
-    NSString *path = [NSString stringWithFormat:@"/%@/query", apiVersion];
+    NSString *path = [NSString stringWithFormat:@"/%@/query", [self computeAPIVersion:apiVersion]];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:queryParams];
 }
 
@@ -656,7 +656,7 @@ static dispatch_once_t pred;
     if (soql) {
         queryParams = @{@"q": soql};
     }
-    NSString *path = [NSString stringWithFormat:@"/%@/queryAll", apiVersion];
+    NSString *path = [NSString stringWithFormat:@"/%@/queryAll", [self computeAPIVersion:apiVersion]];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:queryParams];
 }
 
@@ -669,7 +669,7 @@ static dispatch_once_t pred;
     if (sosl) {
         queryParams = @{@"q": sosl};
     }
-    NSString *path = [NSString stringWithFormat:@"/%@/search", apiVersion];
+    NSString *path = [NSString stringWithFormat:@"/%@/search", [self computeAPIVersion:apiVersion]];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:queryParams];
 }
 
@@ -678,7 +678,7 @@ static dispatch_once_t pred;
 }
 
 - (SFRestRequest *)requestForSearchScopeAndOrder:(NSString *)apiVersion {
-    NSString *path = [NSString stringWithFormat:@"/%@/search/scopeOrder", apiVersion];
+    NSString *path = [NSString stringWithFormat:@"/%@/search/scopeOrder", [self computeAPIVersion:apiVersion]];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
 }
 
@@ -688,7 +688,7 @@ static dispatch_once_t pred;
 
 - (SFRestRequest *)requestForSearchResultLayout:(NSString *)objectList apiVersion:(NSString *)apiVersion {
     NSDictionary *queryParams = @{@"q": objectList};
-    NSString *path = [NSString stringWithFormat:@"/%@/search/layout", apiVersion];
+    NSString *path = [NSString stringWithFormat:@"/%@/search/layout", [self computeAPIVersion:apiVersion]];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:queryParams];
 }
 
@@ -717,7 +717,7 @@ static dispatch_once_t pred;
     NSMutableDictionary<NSString *, id> *batchRequestJson = [NSMutableDictionary new];
     batchRequestJson[@"batchRequests"] = requestsArrayJson;
     batchRequestJson[@"haltOnError"] = [NSNumber numberWithBool:haltOnError];
-    NSString *path = [NSString stringWithFormat:@"/%@/composite/batch", apiVersion];
+    NSString *path = [NSString stringWithFormat:@"/%@/composite/batch", [self computeAPIVersion:apiVersion]];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
     return [self addBodyForPostRequest:batchRequestJson request:request];
 }
@@ -750,7 +750,7 @@ static dispatch_once_t pred;
     NSMutableDictionary<NSString *, id> *compositeRequestJson = [NSMutableDictionary new];
     compositeRequestJson[@"compositeRequest"] = requestsArrayJson;
     compositeRequestJson[@"allOrNone"] = [NSNumber numberWithBool:allOrNone];
-    NSString *path = [NSString stringWithFormat:@"/%@/composite", apiVersion];
+    NSString *path = [NSString stringWithFormat:@"/%@/composite", [self computeAPIVersion:apiVersion]];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
     return [self addBodyForPostRequest:compositeRequestJson request:request];
 }
@@ -765,7 +765,7 @@ static dispatch_once_t pred;
         [jsonTrees addObject:[objectTree asJSON]];
     }
     NSDictionary<NSString *, id> * requestJson = @{@"records": jsonTrees};
-    NSString *path = [NSString stringWithFormat:@"/%@/composite/tree/%@", apiVersion, objectType];
+    NSString *path = [NSString stringWithFormat:@"/%@/composite/tree/%@", [self computeAPIVersion:apiVersion], objectType];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
     return [self addBodyForPostRequest:requestJson request:request];
 }
@@ -817,6 +817,10 @@ static dispatch_once_t pred;
         [sfRestApi cleanup];
     }
     [[self class] removeSharedInstanceWithUser:user];
+}
+
+- (NSString *)computeAPIVersion:(NSString *)apiVersion {
+    return (apiVersion != nil ? apiVersion : self.apiVersion);
 }
 
 @end


### PR DESCRIPTION
This PR:
- Adds nullability markers for `apiVersion`.
- Falls back on the default API version, if `apiVersion` is not supplied.