### PR TITLE
Enforcing sync isoformatter locale for date to be ISO8601 compliant

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncObjectUtils.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncObjectUtils.m
@@ -32,6 +32,8 @@ __strong static NSDateFormatter *isoDateFormatter;
 + (void) initialize {
     utcDateFormatter = [NSDateFormatter new];
     isoDateFormatter = [NSDateFormatter new];
+    NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+    [isoDateFormatter setLocale:enUSPOSIXLocale];
     isoDateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 }
 


### PR DESCRIPTION
This commit addresses forcedotcom/SalesforceMobileSDK-iOS#2964