### PR TITLE
ISO8601 compliance (part 2)

### DIFF
--- a/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncObjectUtils.m
+++ b/libs/SmartSync/SmartSync/Classes/Util/SFSmartSyncObjectUtils.m
@@ -32,8 +32,10 @@ __strong static NSDateFormatter *isoDateFormatter;
 + (void) initialize {
     utcDateFormatter = [NSDateFormatter new];
     isoDateFormatter = [NSDateFormatter new];
+    // See https://developer.apple.com/documentation/foundation/nsdateformatter and https://developer.apple.com/library/archive/qa/qa1480/_index.html
     NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
     [isoDateFormatter setLocale:enUSPOSIXLocale];
+    [isoDateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
     isoDateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 }
 


### PR DESCRIPTION
When working with fixed format dates, such as RFC 3339, you set the dateFormat property to specify a format string.
For most fixed formats, you should also set the locale property to a POSIX locale ("en_US_POSIX"), and set the timeZone property to UTC.
Source: https://developer.apple.com/documentation/foundation/nsdateformatter

This PR is part 2 of https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/2965