### PR TITLE
Adding API to fetch OpenID token

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -122,17 +122,17 @@
         });
     }
 }
-- (void)oauthCoordinator:(nonnull SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(nonnull SFAuthenticationSession *)session {
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(SFAuthenticationSession *)session {
 
     // Do nothing - doesn't apply to the refresh flow.
 }
 
-- (void)oauthCoordinator:(nonnull SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(nonnull WKWebView *)view {
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(WKWebView *)view {
 
     // Do nothing - doesn't apply to the refresh flow.
 }
 
-- (void)oauthCoordinatorDidCancelBrowserAuthentication:(nonnull SFOAuthCoordinator *)coordinator {
+- (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator {
 
     // Do nothing - doesn't apply to the refresh flow.
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -122,4 +122,19 @@
         });
     }
 }
+- (void)oauthCoordinator:(nonnull SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(nonnull SFAuthenticationSession *)session {
+
+    // Do nothing - doesn't apply to the refresh flow.
+}
+
+- (void)oauthCoordinator:(nonnull SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(nonnull WKWebView *)view {
+
+    // Do nothing - doesn't apply to the refresh flow.
+}
+
+- (void)oauthCoordinatorDidCancelBrowserAuthentication:(nonnull SFOAuthCoordinator *)coordinator {
+
+    // Do nothing - doesn't apply to the refresh flow.
+}
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
@@ -64,35 +64,30 @@ static SFOAuthCredentials *credentials = nil;
               nil != credsData.instanceUrl, @"config credentials are missing! %@",
               dictResponse);
 
-    //check whether the test config file has never been edited
+    // check whether the test config file has never been edited
     NSAssert(![credsData.refreshToken isEqualToString:@"__INSERT_TOKEN_HERE__"],
              @"You need to obtain credentials for your test org and replace test_credentials.json");
     [SalesforceSDKManager initializeSDK];
-    
+
     // Note: We need to fix this inconsistency for tests in the long run.There should be a clean way to refresh appConfigs for tests. The configs should apply across all components that need the  config.
     SFSDKAppConfig *appconfig  = [[SFSDKAppConfig alloc] init];
     appconfig.oauthRedirectURI = credsData.redirectUri;
     appconfig.remoteAccessConsumerKey = credsData.clientId;
-    appconfig.oauthScopes = [NSSet setWithObjects:@"web", @"api", nil];
+    appconfig.oauthScopes = [NSSet setWithObjects:@"web", @"api", @"openid", nil];
     [SalesforceSDKManager sharedManager].appConfig = appconfig;
-   
     [SFUserAccountManager sharedInstance].oauthClientId = credsData.clientId;
     [SFUserAccountManager sharedInstance].oauthCompletionUrl = credsData.redirectUri;
     [SFUserAccountManager sharedInstance].scopes = [NSSet setWithObjects:@"web", @"api", nil];
-
     [SFUserAccountManager sharedInstance].loginHost = credsData.loginHost;
     credentials = [[SFUserAccountManager sharedInstance] newClientCredentials];
     credentials.instanceUrl = [NSURL URLWithString:credsData.instanceUrl];
     credentials.identityUrl = [NSURL URLWithString:credsData.identityUrl];
-
     NSString *communityUrlString = credsData.communityUrl;
     if (communityUrlString.length > 0) {
         credentials.communityUrl = [NSURL URLWithString:communityUrlString];
     }
     credentials.accessToken = credsData.accessToken;
     credentials.refreshToken = credsData.refreshToken;
-   
-    
     return credsData;
 }
 
@@ -108,7 +103,6 @@ static SFOAuthCredentials *credentials = nil;
      completion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
          authListener.returnStatus = kTestRequestStatusDidLoad;
          user = userAccount;
-         
      } failure:^(SFOAuthInfo *authInfo, NSError *error) {
          authListener.lastError = error;
          authListener.returnStatus = kTestRequestStatusDidFail;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface SFSDKOAuthTokenEndpointRequest : NSObject
-@property (nonatomic, copy, nullable) NSString *refreshToken;
+@property (nonatomic, copy) NSString *refreshToken;
 @property (nonatomic, copy, nullable) NSString *userAgentForAuth;
 @property (nonatomic, copy) NSString *redirectURI;
 @property (nonatomic, copy) NSString *clientID;
@@ -91,6 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSDate *issuedAt;
 @property (nonatomic, readonly) NSURL *instanceUrl;
 @property (nonatomic, readonly) NSURL *identityUrl;
+@property (nonatomic, readonly, nullable) NSString *idToken;
 @property (nonatomic, readonly, nullable) NSString *communityId;
 @property (nonatomic, readonly, nullable) NSURL *communityUrl;
 @property (nonatomic, readonly, nullable) NSURL *apiUrl;
@@ -103,6 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol SFSDKOAuthProtocol<NSObject>
 - (void)accessTokenForApprovalCode:(SFSDKOAuthTokenEndpointRequest *)endpointReq completion:(void (^)(SFSDKOAuthTokenEndpointResponse *))completionBlock;
 - (void)accessTokenForRefresh:(SFSDKOAuthTokenEndpointRequest *)endpointReq completion:(void (^)(SFSDKOAuthTokenEndpointResponse *))completionBlock;
+- (void)openIDTokenForRefresh:(SFSDKOAuthTokenEndpointRequest *)endpointReq completion:(void (^)(NSString *))completionBlock;
 @end
 
 @protocol SFSDKOAuthSessionManaging<NSObject>

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -69,7 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property  (nonatomic, readonly) NSError *error;
 @end
 
-
 @interface SFSDKOAuthTokenEndpointRequest : NSObject
 @property (nonatomic, copy, nullable) NSString *refreshToken;
 @property (nonatomic, copy, nullable) NSString *userAgentForAuth;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -27,6 +27,7 @@
  */
 
 #import <Foundation/Foundation.h>
+
 /** SFOAuth default network timeout in seconds.
  */
 extern const NSTimeInterval kSFOAuthDefaultTimeout;
@@ -108,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSURLSession *)createURLSession;
 @end
 
-@interface SFSDKOAuth2 : NSObject<SFSDKOAuthProtocol,SFSDKOAuthSessionManaging>
+@interface SFSDKOAuth2 : NSObject<SFSDKOAuthProtocol, SFSDKOAuthSessionManaging>
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -251,6 +251,15 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     }] resume];
 }
 
+- (void)openIDTokenForRefresh:(SFSDKOAuthTokenEndpointRequest *)endpointReq completion:(void (^)(NSString *))completionBlock {
+    [self accessTokenForRefresh:endpointReq completion:^(SFSDKOAuthTokenEndpointResponse *authTokenEndpointResponse) {
+        NSString *idToken = authTokenEndpointResponse.idToken;
+        if (completionBlock) {
+            completionBlock(idToken);
+        }
+    }];
+}
+
 #pragma mark - SFSDKOAuthSessionManaging
 - (NSURLSession *)createURLSession {
     return [[SFNetwork alloc] initWithEphemeralSession].activeSession;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -80,7 +80,6 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
 - (instancetype)initWithError:(NSError *)error {
     if (self = [super init]) {
         _error = [[SFSDKOAuthTokenEndpointErrorResponse alloc] initWithError:error];
-        
     }
     return self;
 }
@@ -254,7 +253,7 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
 
 #pragma mark - SFSDKOAuthSessionManaging
 - (NSURLSession *)createURLSession {
-    return  [[[SFNetwork alloc] initWithEphemeralSession] activeSession];
+    return [[SFNetwork alloc] initWithEphemeralSession].activeSession;
 }
 
 #pragma mark - private
@@ -269,7 +268,6 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
                                                             timeoutInterval:endpointReq.timeout];
     [request setHTTPMethod:kHttpMethodPost];
     [request setValue:kHttpPostContentType forHTTPHeaderField:kHttpHeaderContentType];
-    
     if (endpointReq.userAgentForAuth != nil) {
         [request setValue:endpointReq.userAgentForAuth forHTTPHeaderField:kHttpHeaderUserAgent];
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -38,7 +38,6 @@ static NSUInteger const kSFOAuthCodeVerifierByteLength          = 128;
 static NSString * const kSFOAuthCodeVerifierParamName           = @"code_verifier";
 static NSString * const kSFOAuthCodeChallengeParamName          = @"code_challenge";
 static NSString * const kSFOAuthResponseTypeCode                = @"code";
-
 static NSString * const kSFOAuthAccessToken                     = @"access_token";
 static NSString * const kSFOAuthClientId                        = @"client_id";
 static NSString * const kSFOAuthDeviceId                        = @"device_id";
@@ -55,6 +54,7 @@ static NSString * const kSFOAuthId                              = @"id";
 static NSString * const kSFOAuthInstanceUrl                     = @"instance_url";
 static NSString * const kSFOAuthCommunityId                     = @"sfdc_community_id";
 static NSString * const kSFOAuthCommunityUrl                    = @"sfdc_community_url";
+static NSString * const kSFOAuthIdToken                         = @"id_token";
 static NSString * const kSFOAuthIssuedAt                        = @"issued_at";
 static NSString * const kSFOAuthRedirectUri                     = @"redirect_uri";
 static NSString * const kSFOAuthRefreshToken                    = @"refresh_token";
@@ -71,7 +71,6 @@ static NSString * const kSFOAuthResponseClientSecret            = @"client_secre
 
 // OAuth Error Descriptions
 // see https://na1.salesforce.com/help/doc/en/remoteaccess_oauth_refresh_token_flow.htm
-
 static NSString * const kSFOAuthErrorTypeMalformedResponse          = @"malformed_response";
 static NSString * const kSFOAuthErrorTypeAccessDenied               = @"access_denied";
 static NSString * const KSFOAuthErrorTypeInvalidClientId            = @"invalid_client_id"; // invalid_client_id:'client identifier invalid'
@@ -92,9 +91,7 @@ static NSString * const kSFOAuthErrorTypeBrowserLaunchFailed        = @"browser_
 static NSString * const kSFOAuthErrorTypeUnknownAdvancedAuthConfig  = @"unknown_advanced_auth_config";
 static NSString * const kSFOAuthErrorTypeJWTLaunchFailed            = @"jwt_launch_failed";
 static NSString * const kSFOAuthErrorTypeAuthConfig  = @"auth_config";
-
 static NSUInteger kSFOAuthReponseBufferLength                   = 512; // bytes
-
 static NSString * const kHttpMethodPost                         = @"POST";
 static NSString * const kHttpHeaderContentType                  = @"Content-Type";
 static NSString * const kHttpPostContentType                    = @"application/x-www-form-urlencoded";

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthClientTests.m
@@ -41,6 +41,7 @@
 @class SFSDKTestOAuthClient;
 
 @interface SFSDKTestOAuthClient : SFSDKOAuthClient
+
 @property (nonatomic,assign) BOOL isIDPClient;
 @property (nonatomic,assign) BOOL isAdvancedAuthClient;
 @property (nonatomic,assign) BOOL isOAuthClient;
@@ -48,27 +49,23 @@
 @end
 
 @interface SFOAuthCoordinatorTest : SFOAuthCoordinator
+
 @property (nonatomic,assign) BOOL isTestingForErrorCallback;
 @end
-
-
 
 @implementation SFOAuthCoordinatorTest
 
 - (void)beginUserAgentFlow {
-    
     [SFLogger log:[self class] level:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
     if (!self.isTestingForErrorCallback) {
         [self handleUserAgentResponse:[self userAgentSuccessUrl]];
-    }else {
+    } else {
         [self handleUserAgentResponse:[self userAgentErrorUrl]];
     }
-    
 }
 
 - (void)beginTokenEndpointFlow:(SFOAuthTokenEndpointFlow)flowType {
     [SFLogger log:[self class] level:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (!self.isTestingForErrorCallback) {
              [self handleTokenEndpointResponse:[self refreshTokenSuccessData]];
@@ -93,12 +90,11 @@
     });
 }
 
-- (void)handleTokenEndpointResponse:(NSMutableData *) data{
+- (void)handleTokenEndpointResponse:(NSMutableData *) data {
     [SFLogger log:[self class] level:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    
 }
 
-- (NSMutableData *)refreshTokenSuccessData  {
+- (NSMutableData *)refreshTokenSuccessData {
     NSString *successFormatString = @"{\"id\":\"%@\",\"issued_at\":\"%@\",\"instance_url\":\"%@\",\"access_token\":\"%@\"}";
     NSString *successDataString = [NSString stringWithFormat:successFormatString,
                                    self.credentials.redirectUri,
@@ -121,7 +117,7 @@
     return [data mutableCopy];
 }
 
-- (NSURL *)userAgentSuccessUrl{
+- (NSURL *)userAgentSuccessUrl {
     NSString *successFormatString = @"%@#access_token=%@&issued_at=%@&instance_url=%@&id=%@";
     NSString *successUrl = [NSString stringWithFormat:successFormatString,
                             self.credentials.redirectUri,
@@ -133,7 +129,7 @@
     return [NSURL URLWithString:successUrl];
 }
 
-- (NSURL *)userAgentErrorUrl{
+- (NSURL *)userAgentErrorUrl {
     NSString *errorFormatString = @"%@#error=%@&error_description=%@";
     NSString *errorUrl = [NSString stringWithFormat:errorFormatString,
                           self.credentials.redirectUri,
@@ -142,23 +138,24 @@
                           ];
     return [NSURL URLWithString:errorUrl];
 }
-
 @end
 
 @interface TestUserSelectionNavViewController : UINavigationController <SFSDKUserSelectionView>
+
 @property (nonatomic,weak) id<SFSDKUserSelectionViewDelegate> userSelectionDelegate;
 @property (nonatomic,strong) NSDictionary *spAppOptions;
 @end
 
 @implementation TestUserSelectionNavViewController
+
 @dynamic userSelectionDelegate;
 @dynamic spAppOptions;
+
 - (id <SFSDKUserSelectionViewDelegate>)userSelectionDelegate {
     return nil;
 }
 
 - (void)setUserSelectionDelegate:(id <SFSDKUserSelectionViewDelegate>)userSelectionDelegate {
-
 }
 
 - (NSDictionary *)spAppOptions {
@@ -166,24 +163,21 @@
 }
 
 - (void)setSpAppOptions:(NSDictionary *)spAppOptions {
-
 }
 @end
 
-
 @interface TestIDPLoginNavViewController : UINavigationController <SFSDKLoginFlowSelectionView>
+
 @property (weak,nonatomic) id <SFSDKLoginFlowSelectionViewDelegate> selectionFlowDelegate;
 @end
 
 @implementation TestIDPLoginNavViewController
+
 @dynamic selectionFlowDelegate;
 @synthesize appOptions;
-
 @end
 
-
 @interface SFSDKAuthClientTests : XCTestCase
-
 @end
 
 @interface SFSDKTestOAuthClientProvider : NSObject<SFSDKOAuthClientProvider>
@@ -213,10 +207,11 @@
 }
 @end
 
-
 @implementation SFSDKTestOAuthClient
+
 @dynamic coordinator;
 @dynamic idCoordinator;
+
 - (instancetype)initWithConfig:(SFSDKOAuthClientConfig *)config {
     self = [super initWithConfig:config];
     return self;
@@ -226,9 +221,7 @@
 {
     [SFLogger log:[self class] level:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
 }
-
 @end
-
 
 @interface SFSDKAuthClientTests()<SFSDKOAuthClientDelegate,SFSDKOAuthClientSafariViewDelegate>{
     Class<SFSDKOAuthClientProvider> _originalProvider;
@@ -242,12 +235,10 @@
 }
 @end
 
-
 @implementation SFSDKAuthClientTests
 
 + (void)setUp
 {
-    
     [SFSDKLogoutBlocker block];
     [super setUp];
 }
@@ -256,11 +247,9 @@
     [super setUp];
     _originalProvider = SFSDKOAuthClient.clientProvider;
     [SFSDKOAuthClient setClientProvider:SFSDKTestOAuthClientProvider.class];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
 }
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
     [SFSDKOAuthClient setClientProvider:_originalProvider];
     [SFUserAccountManager sharedInstance].idpAppURIScheme = nil;
     [SFUserAccountManager sharedInstance].isIdentityProvider = NO;
@@ -268,72 +257,52 @@
 }
 
 - (void)testFactoryMethodIDP {
-    
    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-
-    
-   SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
-       config.idpAppURIScheme = @"idpApp";
-   }];
-    
-   XCTAssertNotNil(client);
-   XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
-   XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
-   
-   SFSDKTestOAuthClient *testClient = (SFSDKTestOAuthClient *)client;
-   XCTAssertTrue(testClient.isIDPClient,@"Client should be an instance of idp auth");
-    
-}
-
-- (void)testFactoryMethodAdv {
-    
-    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
-    credentials.accessToken = nil;
-    credentials.refreshToken = nil;
-
-    
-    SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
-        config.useBrowserAuth = YES;
+    SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
+        config.idpAppURIScheme = @"idpApp";
     }];
-    
     XCTAssertNotNil(client);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
-    
+    SFSDKTestOAuthClient *testClient = (SFSDKTestOAuthClient *)client;
+    XCTAssertTrue(testClient.isIDPClient,@"Client should be an instance of idp auth");
+}
+
+- (void)testFactoryMethodAdv {
+    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
+    credentials.accessToken = nil;
+    credentials.refreshToken = nil;
+    SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig *config) {
+        config.useBrowserAuth = YES;
+    }];
+    XCTAssertNotNil(client);
+    XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
+    XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     SFSDKTestOAuthClient *testClient = (SFSDKTestOAuthClient *)client;
     XCTAssertTrue(testClient.isAdvancedAuthClient,@"Client should be an instance of idp auth");
-    
 }
 
 - (void)testFactoryMethod {
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-
-    
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
     }];
-    
     XCTAssertNotNil(client);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
-    
     SFSDKTestOAuthClient *testClient = (SFSDKTestOAuthClient *)client;
     XCTAssertTrue(testClient.isOAuthClient,@"Client should be a regular auth client");
-    
 }
 
 - (void)testOAuthCordinatorCreated {
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-
-    
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
     }];
-    
     XCTAssertNotNil(client);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
@@ -341,7 +310,6 @@
     XCTAssertNotNil(testClient.coordinator,@"coordinator should not be null");
     XCTAssertNotNil(testClient.idCoordinator,@"idCoordinator should not be null");
     XCTAssertNotNil(testClient.config,@"Config should not be null");
-
     XCTAssertNotNil(testClient.context,@"Context should not be null");
     XCTAssertNotNil(testClient.context.credentials,@"Credentials should not be null");
 }
@@ -351,7 +319,6 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-
     SFSDKAuthPreferences *prefs = [[SFSDKAuthPreferences alloc] init];
     [SalesforceSDKManager sharedManager].idpAppURIScheme = @"idpApp";
     [SalesforceSDKManager sharedManager].isIdentityProvider = NO;
@@ -370,13 +337,11 @@
     SFSDKAuthPreferences *prefs = [[SFSDKAuthPreferences alloc] init];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-
     [SalesforceSDKManager sharedManager].isIdentityProvider = YES;
     [SalesforceSDKManager sharedManager].idpAppURIScheme = @"idpApp";
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
         config.isIdentityProvider = prefs.isIdentityProvider;
     }];
-
     XCTAssertNotNil(client);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
@@ -387,61 +352,47 @@
 }
 
 - (void)testSettingOfUserSelectionBlock {
-    
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     SFSDKAuthPreferences *prefs = [[SFSDKAuthPreferences alloc] init];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-
     [SalesforceSDKManager sharedManager].isIdentityProvider = YES;
     [SalesforceSDKManager sharedManager].idpAppURIScheme = @"idpApp";
-    
     [SalesforceSDKManager sharedManager].idpUserSelectionBlock = ^UIViewController<SFSDKUserSelectionView> * {
          TestUserSelectionNavViewController *userSelectionNavViewController = [[TestUserSelectionNavViewController alloc] init];
          return userSelectionNavViewController;
     };
-    
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
         config.isIdentityProvider = prefs.isIdentityProvider;
         config.idpUserSelectionBlock = [SFUserAccountManager sharedInstance].idpUserSelectionAction;
     }];
-    
     XCTAssertNotNil(client);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     SFSDKTestOAuthClient *testClient = (SFSDKTestOAuthClient *)client;
     XCTAssertTrue(testClient.isIDPClient,@"Client should be a an IDP client when enabled through SDKManager");
-
     XCTAssertNotNil(testClient.config.idpUserSelectionBlock,@"User Selectio nblock should not be nil");
-    
     UIViewController *ctrl = testClient.config.idpUserSelectionBlock();
-    
     XCTAssertTrue([ctrl isKindOfClass:[TestUserSelectionNavViewController class]],@"User Selection block shouldhave been customized");
-
     prefs.isIdentityProvider = NO;
     XCTAssertFalse(prefs.isIdentityProvider,@"Preferences for isIdentityProvider should be set to false");
 }
 
 - (void)testSettingOfLoginFlowSelectionBlock {
-    
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     SFSDKAuthPreferences *prefs = [[SFSDKAuthPreferences alloc] init];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-
     [SalesforceSDKManager sharedManager].isIdentityProvider = YES;
     [SalesforceSDKManager sharedManager].idpAppURIScheme = @"idpApp";
-
     [SalesforceSDKManager sharedManager].idpLoginFlowSelectionBlock = ^UIViewController<SFSDKLoginFlowSelectionView> * {
         TestIDPLoginNavViewController *idpLoginViewController = [[TestIDPLoginNavViewController alloc] init];
         return idpLoginViewController;
     };
-
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
         config.isIdentityProvider = prefs.isIdentityProvider;
         config.idpLoginFlowSelectionBlock = [SFUserAccountManager sharedInstance].idpLoginFlowSelectionAction;
     }];
-    
     XCTAssertNotNil(client);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
@@ -452,39 +403,30 @@
 }
 
 - (void)testOAuthClientDidBeginCallback {
-    
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
         config.delegate = self;
     }];
-    
     XCTAssertNotNil(client);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     SFOAuthCoordinatorTest *testCoordinator = [[SFOAuthCoordinatorTest alloc] initWithCredentials:credentials];
     client.coordinator = testCoordinator;
     client.coordinator.delegate = (id<SFOAuthCoordinatorDelegate>)client;
-    
     SFSDKTestOAuthClient *testClient = (SFSDKTestOAuthClient *)client;
-   
     _willBeginExpectation = [self expectationWithDescription:@"willStartAuth"];
     [testClient refreshCredentials];
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
-
 }
 
 - (void)testOAuthClientDidFinishCallback {
-
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
-
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
         config.delegate = self;
     }];
-
     XCTAssertNotNil(client);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     SFOAuthCoordinatorTest *testCoordinator = [[SFOAuthCoordinatorTest alloc] initWithCredentials:credentials];
@@ -494,13 +436,11 @@
     _currentClient = testClient;
     _willBeginExpectation = [self expectationWithDescription:@"willStartAuth"];
     _didFinishExpectation = [self expectationWithDescription:@"willFinish"];
-
     [client refreshCredentials];
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
 }
 
 - (void)testOAuthClientErrorCallback {
-
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.redirectUri = @"sample://callback";
     credentials.accessToken = nil;
@@ -524,22 +464,18 @@
 }
 
 - (void)testOAuthClientRefreshFlowCallback {
-    
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = @"MY_ACCESS_TOKEN";
     credentials.refreshToken = @"MY_REFRESH_TOKEN";
-    
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
         config.delegate = self;
     }];
-    
     XCTAssertNotNil(client);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     SFSDKTestOAuthClient *testClient = (SFSDKTestOAuthClient *)client;
     _currentClient = testClient;
     _willBeginExpectation = [self expectationWithDescription:@"willStartAuth"];
     _refreshFlowExpectation = [self expectationWithDescription:@"willTrigerRefreshFlow"];
-    
     [client refreshCredentials];
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
 }
@@ -548,11 +484,9 @@
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = @"MY_ACCESS_TOKEN";
     credentials.refreshToken = @"MY_REFRESH_TOKEN";
-   
     SFSDKOAuthClient *client = [SFSDKOAuthClient clientWithCredentials:credentials  configBlock:^(SFSDKOAuthClientConfig * config) {
         config.delegate = self;
     }];
-    
     XCTAssertNotNil(client);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     SFSDKTestOAuthClient *testClient = (SFSDKTestOAuthClient *)client;
@@ -564,7 +498,6 @@
 }
 
 - (void)testOAuthClientNativeBrowserCallback {
-   
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:@"testId" clientId:@"testId" encrypted:NO];
     credentials.accessToken = nil;
     credentials.refreshToken = nil;
@@ -574,7 +507,6 @@
         config.safariViewDelegate = self;
         config.useBrowserAuth = [SFUserAccountManager sharedInstance].useBrowserAuth;
     }];
-   
     XCTAssertNotNil(client);
     XCTAssertTrue([client isKindOfClass:[SFSDKTestOAuthClient class]]);
     SFOAuthCoordinatorTest *testCoordinator = [[SFOAuthCoordinatorTest alloc] initWithCredentials:credentials];
@@ -582,10 +514,8 @@
     client.coordinator.delegate = (id<SFOAuthCoordinatorDelegate>)client;
     SFSDKTestOAuthClient *testClient = (SFSDKTestOAuthClient *)client;
     _currentClient = testClient;
-    
     _willBeginExpectation = [self expectationWithDescription:@"willStartAuth"];
     _didFinishExpectation = [self expectationWithDescription:@"finishedAuth"];
-    
     [client refreshCredentials];
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
 }
@@ -613,25 +543,15 @@
    [_refreshFlowExpectation fulfill];
 }
 
-
 - (void)authClientWillRevokeCredentials:(SFSDKOAuthClient *)client {
     [_willRevokeExpectation fulfill];
-
 }
 
 - (void)authClientDidRevokeCredentials:(SFSDKOAuthClient *)client {
     [_didRevokeExpectation fulfill];
-
 }
 
 - (void)authClient:(SFSDKOAuthClient * _Nonnull)client displayMessage:(nonnull SFSDKAlertMessage *)message {
 }
-
-
-
-
-
-
-
 
 @end


### PR DESCRIPTION
This PR adds a new API to fetch OpenID token. Using this API requires an OpenID token to be configured on the connected app. It also needs the "openid" scope to be added on the client and the server.

Equivalent PR on Android is [here](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/1969).