### PR TITLE
Bug fix for corner case where custom login host is updated with app version updates

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/UIDevice+SFHardware.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/UIDevice+SFHardware.h
@@ -10,7 +10,7 @@
 
 #define IPHONE_1G_NAMESTRING            @"iPhone 1G"
 #define IPHONE_3G_NAMESTRING            @"iPhone 3G"
-#define IPHONE_3GS_NAMESTRING           @"iPhone 3GS" 
+#define IPHONE_3GS_NAMESTRING           @"iPhone 3GS"
 #define IPHONE_4_NAMESTRING             @"iPhone 4"
 #define IPHONE_4S_NAMESTRING            @"iPhone 4S"
 #define IPHONE_5_NAMESTRING             @"iPhone 5"
@@ -18,37 +18,56 @@
 #define IPHONE_5S_NAMESTRING            @"iPhone 5S"
 #define IPHONE_6_NAMESTRING             @"iPhone 6"
 #define IPHONE_6P_NAMESTRING            @"iPhone 6+"
-#define IPHONE_6s_NAMESTRING             @"iPhone 6s"
-#define IPHONE_6sP_NAMESTRING            @"iPhone 6s+"
+#define IPHONE_6s_NAMESTRING            @"iPhone 6s"
+#define IPHONE_6sP_NAMESTRING           @"iPhone 6s+"
 #define IPHONE_SE_NAMESTRING            @"iPhone SE"
-#define IPHONE_7_NAMESTRING            @"iPhone 7"
-#define IPHONE_7P_NAMESTRING            @"iPhone 7P"
+#define IPHONE_7_NAMESTRING             @"iPhone 7"
+#define IPHONE_7P_NAMESTRING            @"iPhone 7+"
+#define IPHONE_8_NAMESTRING             @"iPhone 8"
+#define IPHONE_8P_NAMESTRING            @"iPhone 8+"
+#define IPHONE_X_NAMESTRING             @"iPhone X"
+#define IPHONE_XS_NAMESTRING            @"iPhone XS"
+#define IPHONE_XSMAX_NAMESTRING         @"iPhone XS Max"
+#define IPHONE_XR_NAMESTRING            @"iPhone XR"
+
 #define IPHONE_UNKNOWN_NAMESTRING       @"Unknown iPhone"
 
 #define IPOD_1G_NAMESTRING              @"iPod touch 1G"
 #define IPOD_2G_NAMESTRING              @"iPod touch 2G"
 #define IPOD_3G_NAMESTRING              @"iPod touch 3G"
 #define IPOD_4G_NAMESTRING              @"iPod touch 4G"
+#define IPOD_5G_NAMESTRING              @"iPod Touch 5"
+#define IPOD_6G_NAMESTRING              @"iPod Touch 6"
 #define IPOD_UNKNOWN_NAMESTRING         @"Unknown iPod"
 
 #define IPAD_1G_NAMESTRING              @"iPad 1G"
 #define IPAD_2G_NAMESTRING              @"iPad 2G"
 #define IPAD_3G_NAMESTRING              @"iPad 3G"
 #define IPAD_4G_NAMESTRING              @"iPad 4G"
+#define IPAD_5G_NAMESTRING              @"iPad 5G"
+#define IPAD_6G_NAMESTRING              @"iPad 6G"
 #define IPAD_AIR_1G_NAMESTRING          @"iPad Air 1G"
 #define IPAD_AIR_2G_NAMESTRING          @"iPad Air 2G"
 #define IPAD_PRO_9_7_INCH_NAMESTRING    @"iPad Pro (9.7 inch)"
 #define IPAD_PRO_12_9_INCH_NAMESTRING   @"iPad Pro (12.9 inch)"
+#define IPAD_PRO_12_9_2G_INCH_NAMESTRING   @"iPad Pro (12.9 inch) (2nd generation)"
+#define IPAD_PRO_12_9_3G_INCH_NAMESTRING   @"iPad Pro (12.9 inch) (3rd generation)"
+#define IPAD_PRO_10_5_INCH_NAMESTRING   @"iPad Pro (10.5 inch)"
+#define IPAD_PRO_11_INCH_NAMESTRING     @"iPad Pro (11-inch)"
+
+
 
 #define IPAD_UNKNOWN_NAMESTRING         @"Unknown iPad"
 
 #define IPAD_MINI_1G_NAMESTRING         @"iPad mini 1G"
 #define IPAD_MINI_2G_NAMESTRING         @"iPad mini 2G"
 #define IPAD_MINI_3G_NAMESTRING         @"iPad mini 3G"
+#define IPAD_MINI_4G_NAMESTRING         @"iPad mini 5G"
 
 #define APPLETV_2G_NAMESTRING           @"Apple TV 2G"
 #define APPLETV_3G_NAMESTRING           @"Apple TV 3G"
 #define APPLETV_4G_NAMESTRING           @"Apple TV 4G"
+#define APPLETV_4K_NAMESTRING           @"APPLE TV 4K"
 #define APPLETV_UNKNOWN_NAMESTRING      @"Unknown Apple TV"
 
 #define IOS_FAMILY_UNKNOWN_DEVICE       @"Unknown iOS device"
@@ -85,29 +104,47 @@ typedef NS_ENUM(NSUInteger, UIDevicePlatform) {
     UIDeviceSEiPhone,
     UIDevice7iPhone,
     UIDevice7PlusiPhone,
+    UIDevice8iPhone,
+    UIDevice8PlusiPhone,
+    UIDeviceXiPhone,
+    UIDeviceXsiPhone,
+    UIDeviceXsMaxiPhone,
+    UIDeviceXRiPhone,
+    
     
     UIDevice1GiPod,
     UIDevice2GiPod,
     UIDevice3GiPod,
     UIDevice4GiPod,
+    UIDevice5GiPod,
+    UIDevice6GiPod,
     
     UIDevice1GiPad,
     UIDevice2GiPad,
     UIDevice3GiPad,
     UIDevice4GiPad,
+    UIDevice5GiPad,
+    UIDevice6GiPad,
     UIDevice1GiPadAir,
     UIDevice2GiPadAir,
     
     UIDevice1GiPadMini,
     UIDevice2GiPadMini,
     UIDevice3GiPadMini,
+    UIDevice4GiPadMini,
     
     UIDevice97InchiPadPro,
     UIDevice129InchiPadPro,
+    UIDevice2G129InchiPadPro,
+    UIDevice3G129InchiPadPro,
+    UIDevice105InchIpadPro,
+    UIDevice11InchIpadPro,
+    
     
     UIDeviceAppleTV2,
     UIDeviceAppleTV3,
     UIDeviceAppleTV4,
+    UIDeviceAppleTV4k,
     
     UIDeviceUnknowniPhone,
     UIDeviceUnknowniPod,
@@ -185,6 +222,9 @@ typedef NS_ENUM(NSUInteger, UIDeviceFamily) {
 
 /**Returns whether the device has a retina display*/
 - (BOOL) hasRetinaDisplay;
+
+/**Returns whether the device's SOC has a neural engine for core ML tasks*/
+- (BOOL) hasNeuralEngine;
 
 /**Device Family*/
 - (UIDeviceFamily) deviceFamily;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/UIDevice+SFHardware.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/UIDevice+SFHardware.m
@@ -287,86 +287,108 @@
     NSString *platform = [self platform];
     
     // The ever mysterious iFPGA
-    if ([platform isEqualToString:@"iFPGA"])        return UIDeviceIFPGA;
+    if ([platform isEqualToString:@"iFPGA"])            return UIDeviceIFPGA;
     
     // iPhone
-    if ([platform isEqualToString:@"iPhone1,1"])    return UIDevice1GiPhone;
-    if ([platform isEqualToString:@"iPhone1,2"])    return UIDevice3GiPhone;
-    if ([platform hasPrefix:@"iPhone2"])            return UIDevice3GSiPhone;
-    if ([platform hasPrefix:@"iPhone3"])            return UIDevice4iPhone;
-    if ([platform hasPrefix:@"iPhone4"])            return UIDevice4SiPhone;
-
-    if ([platform isEqualToString:@"iPhone5,1"])    return UIDevice5iPhone;
-    if ([platform isEqualToString:@"iPhone5,2"])    return UIDevice5iPhone;
-    if ([platform isEqualToString:@"iPhone5,3"])    return UIDevice5CiPhone;
-    if ([platform isEqualToString:@"iPhone5,4"])    return UIDevice5CiPhone;
-    if ([platform hasPrefix:@"iPhone6"])            return UIDevice5SiPhone;
-    if ([platform isEqualToString:@"iPhone7,1"])    return UIDevice6PlusiPhone;
-    if ([platform isEqualToString:@"iPhone7,2"])    return UIDevice6iPhone;
-    if ([platform isEqualToString:@"iPhone8,1"])    return UIDevice6siPhone;
-    if ([platform isEqualToString:@"iPhone8,2"])    return UIDevice6sPlusiPhone;
-    if ([platform isEqualToString:@"iPhone8,4"])    return UIDeviceSEiPhone;
-    if ([platform isEqualToString:@"iPhone9,1"])    return UIDevice7iPhone;
-    if ([platform isEqualToString:@"iPhone9,2"])    return UIDevice7PlusiPhone;
-    if ([platform isEqualToString:@"iPhone9,3"])    return UIDevice7iPhone;
-    if ([platform isEqualToString:@"iPhone9,4"])    return UIDevice7PlusiPhone;
-    
+    if ([platform isEqualToString:@"iPhone1,1"])        return UIDevice1GiPhone;
+    if ([platform isEqualToString:@"iPhone1,2"])        return UIDevice3GiPhone;
+    if ([platform hasPrefix:@"iPhone2"])                return UIDevice3GSiPhone;
+    if ([platform hasPrefix:@"iPhone3"])                return UIDevice4iPhone;
+    if ([platform hasPrefix:@"iPhone4"])                return UIDevice4SiPhone;
+    if ([platform isEqualToString:@"iPhone5,1"] ||
+        [platform isEqualToString:@"iPhone5,2"])        return UIDevice5iPhone;
+    if ([platform isEqualToString:@"iPhone5,3"] ||
+        [platform isEqualToString:@"iPhone5,4"])        return UIDevice5CiPhone;
+    if ([platform hasPrefix:@"iPhone6"] ||
+        [platform hasPrefix:@"iPhone6,1"] ||
+        [platform hasPrefix:@"iPhone6,2"])              return UIDevice5SiPhone;
+    if ([platform isEqualToString:@"iPhone7,1"])        return UIDevice6PlusiPhone;
+    if ([platform isEqualToString:@"iPhone7,2"])        return UIDevice6iPhone;
+    if ([platform isEqualToString:@"iPhone8,1"])        return UIDevice6siPhone;
+    if ([platform isEqualToString:@"iPhone8,2"])        return UIDevice6sPlusiPhone;
+    if ([platform isEqualToString:@"iPhone8,4"])        return UIDeviceSEiPhone;
+    if ([platform isEqualToString:@"iPhone9,1"] ||
+        [platform hasPrefix:@"iPhone9,3"])              return UIDevice7iPhone;
+    if ([platform isEqualToString:@"iPhone9,2"] ||
+        [platform isEqualToString:@"iPhone9,4"])        return UIDevice7PlusiPhone;
+    if ([platform isEqualToString:@"iPhone10,1"] ||
+        [platform isEqualToString:@"iPhone10,4"])       return UIDevice8iPhone;
+    if ([platform isEqualToString:@"iPhone10,2"] ||
+        [platform isEqualToString:@"iPhone10,5"])       return UIDevice8PlusiPhone;
+    if ([platform isEqualToString:@"iPhone10,3"] ||
+        [platform isEqualToString:@"iPhone10,6"])       return UIDevice8iPhone;
     // iPod
-    if ([platform hasPrefix:@"iPod1"])              return UIDevice1GiPod;
-    if ([platform hasPrefix:@"iPod2"])              return UIDevice2GiPod;
-    if ([platform hasPrefix:@"iPod3"])              return UIDevice3GiPod;
-    if ([platform hasPrefix:@"iPod4"])              return UIDevice4GiPod;
+    if ([platform hasPrefix:@"iPod1"])                  return UIDevice1GiPod;
+    if ([platform hasPrefix:@"iPod2"])                  return UIDevice2GiPod;
+    if ([platform hasPrefix:@"iPod3"])                  return UIDevice3GiPod;
+    if ([platform hasPrefix:@"iPod4"])                  return UIDevice4GiPod;
+    if ([platform hasPrefix:@"iPod5,1"])                return UIDevice5GiPod;
+    if ([platform hasPrefix:@"iPod7,1"])                return UIDevice6GiPod;
+    
     
     // iPad
-    if ([platform isEqualToString:@"iPad1,1"])      return UIDevice1GiPad;
-    
-    if ([platform isEqualToString:@"iPad2,1"])      return UIDevice2GiPad;
-    if ([platform isEqualToString:@"iPad2,2"])      return UIDevice2GiPad;
-    if ([platform isEqualToString:@"iPad2,3"])      return UIDevice2GiPad;
-    if ([platform isEqualToString:@"iPad2,4"])      return UIDevice2GiPad;
-    
-    if ([platform isEqualToString:@"iPad2,5"])      return UIDevice1GiPadMini;
-    if ([platform isEqualToString:@"iPad2,6"])      return UIDevice1GiPadMini;
-    if ([platform isEqualToString:@"iPad2,7"])      return UIDevice1GiPadMini;
-    
-    if ([platform isEqualToString:@"iPad3,1"])      return UIDevice3GiPad;
-    if ([platform isEqualToString:@"iPad3,2"])      return UIDevice3GiPad;
-    if ([platform isEqualToString:@"iPad3,3"])      return UIDevice3GiPad;
-    
-    if ([platform isEqualToString:@"iPad3,4"])      return UIDevice4GiPad;
-    if ([platform isEqualToString:@"iPad3,5"])      return UIDevice4GiPad;
-    if ([platform isEqualToString:@"iPad3,6"])      return UIDevice4GiPad;
-    
-    if ([platform isEqualToString:@"iPad4,1"])      return UIDevice1GiPadAir;
-    if ([platform isEqualToString:@"iPad4,2"])      return UIDevice1GiPadAir;
-    if ([platform isEqualToString:@"iPad4,3"])      return UIDevice1GiPadAir;
-    if ([platform isEqualToString:@"iPad4,4"])      return UIDevice2GiPadMini;
-    if ([platform isEqualToString:@"iPad4,5"])      return UIDevice2GiPadMini;
-    if ([platform isEqualToString:@"iPad4,6"])      return UIDevice2GiPadMini;
-    if ([platform isEqualToString:@"iPad4,7"])      return UIDevice3GiPadMini;
-    if ([platform isEqualToString:@"iPad4,8"])      return UIDevice3GiPadMini;
-    if ([platform isEqualToString:@"iPad4,9"])      return UIDevice3GiPadMini;
-    
-    if ([platform isEqualToString:@"iPad5,3"])      return UIDevice2GiPadAir;
-    if ([platform isEqualToString:@"iPad5,4"])      return UIDevice2GiPadAir;
-    
-    if ([platform isEqualToString:@"iPad6,3"])      return UIDevice97InchiPadPro;
-    if ([platform isEqualToString:@"iPad6,4"])      return UIDevice97InchiPadPro;
-    if ([platform isEqualToString:@"iPad6,7"])      return UIDevice129InchiPadPro;
-    if ([platform isEqualToString:@"iPad6,8"])      return UIDevice129InchiPadPro;
+    if ([platform isEqualToString:@"iPad1,1"])          return UIDevice1GiPad;
+    if ([platform isEqualToString:@"iPad2,1"])          return UIDevice2GiPad;
+    if ([platform isEqualToString:@"iPad2,2"])          return UIDevice2GiPad;
+    if ([platform isEqualToString:@"iPad2,3"])          return UIDevice2GiPad;
+    if ([platform isEqualToString:@"iPad2,4"])          return UIDevice2GiPad;
+    if ([platform isEqualToString:@"iPad2,5"])          return UIDevice1GiPadMini;
+    if ([platform isEqualToString:@"iPad2,6"])          return UIDevice1GiPadMini;
+    if ([platform isEqualToString:@"iPad2,7"])          return UIDevice1GiPadMini;
+    if ([platform isEqualToString:@"iPad3,1"])          return UIDevice3GiPad;
+    if ([platform isEqualToString:@"iPad3,2"])          return UIDevice3GiPad;
+    if ([platform isEqualToString:@"iPad3,3"])          return UIDevice3GiPad;
+    if ([platform isEqualToString:@"iPad3,4"])          return UIDevice4GiPad;
+    if ([platform isEqualToString:@"iPad3,5"])          return UIDevice4GiPad;
+    if ([platform isEqualToString:@"iPad3,6"])          return UIDevice4GiPad;
+    if ([platform isEqualToString:@"iPad4,1"] ||
+        [platform isEqualToString:@"iPad4,2"] ||
+        [platform isEqualToString:@"iPad4,3"])          return UIDevice1GiPadAir;
+    if ([platform isEqualToString:@"iPad4,4"] ||
+        [platform isEqualToString:@"iPad4,5"] ||
+        [platform isEqualToString:@"iPad4,6"])          return UIDevice2GiPadMini;
+    if ([platform isEqualToString:@"iPad4,7"] ||
+        [platform isEqualToString:@"iPad4,8"] ||
+        [platform isEqualToString:@"iPad4,9"])          return UIDevice3GiPadMini;
+    if ([platform isEqualToString:@"iPad5,1"] ||
+        [platform isEqualToString:@"iPad5,2"])          return UIDevice4GiPadMini;
+    if ([platform isEqualToString:@"iPad5,3"] ||
+        [platform isEqualToString:@"iPad5,4"])          return UIDevice2GiPadAir;
+    if ([platform isEqualToString:@"iPad6,3"] ||
+        [platform isEqualToString:@"iPad6,4"])          return UIDevice97InchiPadPro;
+    if ([platform isEqualToString:@"iPad6,7"] ||
+        [platform isEqualToString:@"iPad6,8"])          return UIDevice129InchiPadPro;
+    if ([platform isEqualToString:@"iPad6,11"] ||
+        [platform isEqualToString:@"iPad6,12"])          return UIDevice5GiPad;
+    if ([platform isEqualToString:@"iPad7,1"] ||
+        [platform isEqualToString:@"iPad7,2"])          return UIDevice2G129InchiPadPro;
+    if ([platform isEqualToString:@"iPad7,3"] ||
+        [platform isEqualToString:@"iPad7,4"])          return UIDevice105InchIpadPro;
+    if ([platform isEqualToString:@"iPad7,5"] ||
+        [platform isEqualToString:@"iPad7,6"])          return UIDevice6GiPad;
+    if ([platform isEqualToString:@"iPad8,1"] ||
+        [platform isEqualToString:@"iPad8,2"] ||
+        [platform isEqualToString:@"iPad8,3"] ||
+        [platform isEqualToString:@"iPad8,4"])          return UIDevice11InchIpadPro;
+    if ([platform isEqualToString:@"iPad8,5"] ||
+        [platform isEqualToString:@"iPad8,6"] ||
+        [platform isEqualToString:@"iPad8,7"] ||
+        [platform isEqualToString:@"iPad8,8"])          return UIDevice3G129InchiPadPro;
     
     
     // Apple TV
-    if ([platform hasPrefix:@"AppleTV2"])           return UIDeviceAppleTV2;
-    if ([platform hasPrefix:@"AppleTV3"])           return UIDeviceAppleTV3;
+    if ([platform hasPrefix:@"AppleTV2"])               return UIDeviceAppleTV2;
+    if ([platform hasPrefix:@"AppleTV3"])               return UIDeviceAppleTV3;
+    if ([platform hasPrefix:@"AppleTV5,3"])             return UIDeviceAppleTV4;
+    if ([platform hasPrefix:@"AppleTV6,2"])             return UIDeviceAppleTV4k;
     
     if ([platform hasPrefix:@"iPhone"]) {
         return UIDeviceUnknowniPhone;
     }
     
-    if ([platform hasPrefix:@"iPod"])               return UIDeviceUnknowniPod;
-    if ([platform hasPrefix:@"iPad"])               return UIDeviceUnknowniPad;
-    if ([platform hasPrefix:@"AppleTV"])            return UIDeviceUnknownAppleTV;
+    if ([platform hasPrefix:@"iPod"])                   return UIDeviceUnknowniPod;
+    if ([platform hasPrefix:@"iPad"])                   return UIDeviceUnknowniPad;
+    if ([platform hasPrefix:@"AppleTV"])                return UIDeviceUnknownAppleTV;
     
     // Simulator thanks Jordan Breeding
     if ([platform hasSuffix:@"86"] || [platform isEqual:@"x86_64"])
@@ -382,6 +404,54 @@
     }
     
     return UIDeviceUnknown;
+}
+
+- (BOOL)hasNeuralEngine {
+    
+    if (![UIDevice currentDeviceIsIPad] && ![UIDevice currentDeviceIsIPhone]) {
+        return NO;
+    }
+    
+    UIDevicePlatform platform = [self platformType];
+    switch (platform) {
+        case UIDevice1GiPhone:
+        case UIDevice3GiPhone:
+        case UIDevice3GSiPhone:
+        case UIDevice4iPhone:
+        case UIDevice4SiPhone:
+        case UIDevice5iPhone:
+        case UIDevice5CiPhone:
+        case UIDevice5SiPhone:
+        case UIDevice6PlusiPhone:
+        case UIDevice6iPhone:
+        case UIDevice6siPhone:
+        case UIDevice6sPlusiPhone:
+        case UIDeviceSEiPhone:
+        case UIDevice7iPhone:
+        case UIDevice7PlusiPhone:
+        case UIDevice1GiPad:
+        case UIDevice2GiPad:
+        case UIDevice3GiPad:
+        case UIDevice4GiPad:
+        case UIDevice5GiPad:
+        case UIDevice6GiPad:
+        case UIDevice1GiPadAir:
+        case UIDevice2GiPadAir:
+        case UIDevice1GiPadMini:
+        case UIDevice2GiPadMini:
+        case UIDevice3GiPadMini:
+        case UIDevice4GiPadMini:
+        case UIDevice97InchiPadPro:
+        case UIDevice129InchiPadPro:
+        case UIDevice2G129InchiPadPro:
+        case UIDevice105InchIpadPro:
+        case UIDeviceUnknown:
+        case UIDeviceIFPGA:
+            return NO;
+            
+        default:
+            return YES;
+    }
 }
 
 - (NSString *) platformString
@@ -403,30 +473,48 @@
         case UIDeviceSEiPhone: return IPHONE_SE_NAMESTRING;
         case UIDevice7iPhone: return IPHONE_7_NAMESTRING;
         case UIDevice7PlusiPhone: return IPHONE_7P_NAMESTRING;
+        case UIDevice8iPhone: return IPHONE_8_NAMESTRING;
+        case UIDevice8PlusiPhone: return IPHONE_8P_NAMESTRING;
+        case UIDeviceXiPhone: return IPHONE_X_NAMESTRING;
+        case UIDeviceXsiPhone: return IPHONE_XS_NAMESTRING;
+        case UIDeviceXsMaxiPhone: return IPHONE_XSMAX_NAMESTRING;
+        case UIDeviceXRiPhone: return IPHONE_XR_NAMESTRING;
+            
         case UIDeviceUnknowniPhone: return IPHONE_UNKNOWN_NAMESTRING;
             
         case UIDevice1GiPod: return IPOD_1G_NAMESTRING;
         case UIDevice2GiPod: return IPOD_2G_NAMESTRING;
         case UIDevice3GiPod: return IPOD_3G_NAMESTRING;
         case UIDevice4GiPod: return IPOD_4G_NAMESTRING;
+        case UIDevice5GiPod: return IPOD_5G_NAMESTRING;
+        case UIDevice6GiPod: return IPOD_6G_NAMESTRING;
         case UIDeviceUnknowniPod: return IPOD_UNKNOWN_NAMESTRING;
             
-        case UIDevice1GiPad : return IPAD_1G_NAMESTRING;
-        case UIDevice2GiPad : return IPAD_2G_NAMESTRING;
-        case UIDevice3GiPad : return IPAD_3G_NAMESTRING;
-        case UIDevice4GiPad : return IPAD_4G_NAMESTRING;
+        case UIDevice1GiPad: return IPAD_1G_NAMESTRING;
+        case UIDevice2GiPad: return IPAD_2G_NAMESTRING;
+        case UIDevice3GiPad: return IPAD_3G_NAMESTRING;
+        case UIDevice4GiPad: return IPAD_4G_NAMESTRING;
+        case UIDevice5GiPad: return IPAD_5G_NAMESTRING;
+        case UIDevice6GiPad: return IPAD_6G_NAMESTRING;
         case UIDevice1GiPadAir: return IPAD_AIR_1G_NAMESTRING;
         case UIDevice2GiPadAir: return IPAD_AIR_2G_NAMESTRING;
         case UIDevice1GiPadMini: return  IPAD_MINI_1G_NAMESTRING;
         case UIDevice2GiPadMini: return  IPAD_MINI_2G_NAMESTRING;
         case UIDevice3GiPadMini: return  IPAD_MINI_3G_NAMESTRING;
+        case UIDevice4GiPadMini: return IPAD_MINI_4G_NAMESTRING;
         case UIDevice97InchiPadPro: return  IPAD_PRO_9_7_INCH_NAMESTRING;
         case UIDevice129InchiPadPro: return  IPAD_PRO_12_9_INCH_NAMESTRING;
+        case UIDevice2G129InchiPadPro: return IPAD_PRO_12_9_2G_INCH_NAMESTRING;
+        case UIDevice3G129InchiPadPro: return IPAD_PRO_12_9_3G_INCH_NAMESTRING;
+        case UIDevice105InchIpadPro: return IPAD_PRO_10_5_INCH_NAMESTRING;
+        case UIDevice11InchIpadPro: return IPAD_PRO_11_INCH_NAMESTRING;
+            
         case UIDeviceUnknowniPad : return IPAD_UNKNOWN_NAMESTRING;
             
-        case UIDeviceAppleTV2 : return APPLETV_2G_NAMESTRING;
-        case UIDeviceAppleTV3 : return APPLETV_3G_NAMESTRING;
-        case UIDeviceAppleTV4 : return APPLETV_4G_NAMESTRING;
+        case UIDeviceAppleTV2: return APPLETV_2G_NAMESTRING;
+        case UIDeviceAppleTV3: return APPLETV_3G_NAMESTRING;
+        case UIDeviceAppleTV4: return APPLETV_4G_NAMESTRING;
+        case UIDeviceAppleTV4k: return APPLETV_4K_NAMESTRING;
         case UIDeviceUnknownAppleTV: return APPLETV_UNKNOWN_NAMESTRING;
             
         case UIDeviceSimulator: return SIMULATOR_NAMESTRING;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostStorage.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostStorage.m
@@ -64,11 +64,13 @@ static NSString * const SFSDKLoginHostNameKey = @"SalesforceLoginHostNameKey";
     if (self) {
         self.loginHostList = [NSMutableArray array];
         SFManagedPreferences *managedPreferences = [SFManagedPreferences sharedPreferences];
+        SFSDKLoginHost *production = [SFSDKLoginHost hostWithName:[SFSDKResourceUtils localizedString:@"LOGIN_SERVER_PRODUCTION"] host:@"login.salesforce.com" deletable:NO];
+        SFSDKLoginHost *sandbox = [SFSDKLoginHost hostWithName:[SFSDKResourceUtils localizedString:@"LOGIN_SERVER_SANDBOX"] host:@"test.salesforce.com" deletable:NO];
 
         // Add the Production and Sandbox login hosts, unless an MDM policy explicitly forbids this.
         if (!(managedPreferences.hasManagedPreferences && managedPreferences.onlyShowAuthorizedHosts)) {
-            [self.loginHostList addObject:[SFSDKLoginHost hostWithName:[SFSDKResourceUtils localizedString:@"LOGIN_SERVER_PRODUCTION"] host:@"login.salesforce.com" deletable:NO]];
-            [self.loginHostList addObject:[SFSDKLoginHost hostWithName:[SFSDKResourceUtils localizedString:@"LOGIN_SERVER_SANDBOX"] host:@"test.salesforce.com" deletable:NO]];
+            [self.loginHostList addObject:production];
+            [self.loginHostList addObject:sandbox];
         }
 
         // Load from managed preferences (e.g. MDM).
@@ -78,7 +80,7 @@ static NSString * const SFSDKLoginHostNameKey = @"SalesforceLoginHostNameKey";
              * If there are any existing login hosts, remove them as MDM should take
              * highest priority and only the hosts enforced by MDM should be in the list.
              */
-            if([self.loginHostList count] > 0) {
+            if ([self.loginHostList count] > 0) {
                 [self removeAllLoginHosts];
             }
             NSArray *hostLabels = managedPreferences.loginHostLabels;
@@ -86,18 +88,26 @@ static NSString * const SFSDKLoginHostNameKey = @"SalesforceLoginHostNameKey";
                 NSString *hostLabel = hostLabels.count > idx ? hostLabels[idx] : loginHost;
                 [self.loginHostList addObject:[SFSDKLoginHost hostWithName:hostLabel host:loginHost deletable:NO]];
             }];
-            
-            if(managedPreferences.onlyShowAuthorizedHosts)
+            if (managedPreferences.onlyShowAuthorizedHosts) {
                 return self;
+            }
         }
-        
+
         // Load from info.plist.
-        if([[NSBundle mainBundle] objectForInfoDictionaryKey:@"SFDCOAuthLoginHost"]) {
+        if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"SFDCOAuthLoginHost"]) {
             NSString *customHost = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"SFDCOAuthLoginHost"];
 
-            // Add the login host from info.plist only if it is not already added.
-            if(![self loginHostForHostAddress:customHost]) {
-                [self.loginHostList addObject:[SFSDKLoginHost hostWithName:customHost host:customHost deletable:NO]];
+            /*
+             * Add the login host from info.plist if it doesn't exist already.
+             * This also handles the case where the custom host configured
+             * was changed between version updates of the application.
+             */
+            if (![self loginHostForHostAddress:customHost]) {
+                [self.loginHostList removeAllObjects];
+                [self.loginHostList addObject:production];
+                [self.loginHostList addObject:sandbox];
+                SFSDKLoginHost *customLoginHost = [SFSDKLoginHost hostWithName:customHost host:customHost deletable:NO];
+                [self.loginHostList addObject:customLoginHost];
             }
         }
 
@@ -105,8 +115,7 @@ static NSString * const SFSDKLoginHostNameKey = @"SalesforceLoginHostNameKey";
         NSArray *persistedList = [[NSUserDefaults msdkUserDefaults] objectForKey:SFSDKLoginHostList];
         if (persistedList) {
             for (NSDictionary *dic in persistedList) {
-                [self.loginHostList addObject:[SFSDKLoginHost hostWithName:[dic objectForKey:SFSDKLoginHostNameKey]
-                                                                      host:[dic objectForKey:SFSDKLoginHostKey]
+                [self.loginHostList addObject:[SFSDKLoginHost hostWithName:[dic objectForKey:SFSDKLoginHostNameKey] host:[dic objectForKey:SFSDKLoginHostKey]
                                                                  deletable:YES]];
             }
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostStorage.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostStorage.m
@@ -187,4 +187,3 @@ static NSString * const SFSDKLoginHostNameKey = @"SalesforceLoginHostNameKey";
 }
 
 @end
-

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
@@ -30,6 +30,7 @@
 #import "SFSDKAuthPreferences.h"
 #import "SFManagedPreferences.h"
 #import "SFSDKLoginHostStorage.h"
+#import "SFSDKLoginHost.h"
 #import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
 
 static NSString * const kSFLoginHostChangedNotification = @"kSFLoginHostChanged";
@@ -59,11 +60,17 @@ NSString * const kOAuthAppName = @"oauth_app_name";
 
 @implementation SFSDKAuthPreferences
 
-- (void)setLoginHost:(NSString*)host {
+- (void)setLoginHost:(NSString *)host {
     NSString *oldLoginHost = [self loginHost];
     if (nil == host) {
         [[NSUserDefaults msdkUserDefaults] removeObjectForKey:kSFUserAccountOAuthLoginHost];
     } else {
+
+        // Persists the login host if it doesn't exist already.
+        if ([[SFSDKLoginHostStorage sharedInstance] loginHostForHostAddress:host] == nil) {
+            SFSDKLoginHost *loginHost = [SFSDKLoginHost hostWithName:host host:host deletable:YES];
+            [[SFSDKLoginHostStorage sharedInstance] addLoginHost:loginHost];
+        }
         [[NSUserDefaults msdkUserDefaults] setObject:host forKey:kSFUserAccountOAuthLoginHost];
     }
     [[NSUserDefaults msdkUserDefaults] synchronize];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
@@ -40,13 +40,13 @@ static NSString * const kSFUserAccountOAuthLoginHostDefault = @"login.salesforce
 static NSString * const kSFUserAccountOAuthLoginHost = @"SFDCOAuthLoginHost";
 
 // The key for storing the persisted OAuth scopes.
-static NSString * const  kOAuthScopesKey = @"oauth_scopes";
+static NSString * const kOAuthScopesKey = @"oauth_scopes";
 
 // The key for storing the persisted OAuth client ID.
-static NSString * const  kOAuthClientIdKey = @"oauth_client_id";
+static NSString * const kOAuthClientIdKey = @"oauth_client_id";
 
 // The key for storing the persisted OAuth redirect URI.
-static NSString * const  kOAuthRedirectUriKey = @"oauth_redirect_uri";
+static NSString * const kOAuthRedirectUriKey = @"oauth_redirect_uri";
 
 // The key for storing the persisted IDP app identifier
 NSString * const kSFIDPKey = @"SFDCIdp";
@@ -187,7 +187,7 @@ NSString * const kOAuthAppName = @"oauth_app_name";
 }
 
 - (BOOL)requireBrowserAuthentication {
-    return [SFManagedPreferences sharedPreferences].requireCertificateAuthentication ||  _requireBrowserAuthentication;
+    return [SFManagedPreferences sharedPreferences].requireCertificateAuthentication || _requireBrowserAuthentication;
 }
 
 - (BOOL)idpEnabled
@@ -215,9 +215,9 @@ NSString * const kOAuthAppName = @"oauth_app_name";
     if (appName) {
         return appName;
     } else {
-        NSString *bundleDispalyName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-        if (bundleDispalyName) {
-            return bundleDispalyName;
+        NSString *bundleDisplayName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+        if (bundleDisplayName) {
+            return bundleDisplayName;
         } else {
             return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
         }
@@ -230,4 +230,5 @@ NSString * const kOAuthAppName = @"oauth_app_name";
     [defs setObject:appDisplayName forKey:kOAuthAppName];
     [defs synchronize];
 }
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
@@ -40,14 +40,14 @@ static NSString * const kSFOAuthEndPointAuthConfiguration = @"/.well-known/auth-
 
 + (void)getMyDomainAuthConfig:(MyDomainAuthConfigBlock)authConfigBlock loginDomain:(NSString *)loginDomain {
     NSString *orgConfigUrl = [NSString stringWithFormat:@"https://%@%@", loginDomain, kSFOAuthEndPointAuthConfiguration];
-    [SFSDKCoreLogger d:[self class] format:@"%@ Advanced authentication configured. Retrieving auth configuration from %@", NSStringFromSelector(_cmd), orgConfigUrl];
+    [SFSDKCoreLogger i:[self class] format:@"%@ Advanced authentication configured. Retrieving auth configuration from %@", NSStringFromSelector(_cmd), orgConfigUrl];
     NSMutableURLRequest *orgConfigRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:orgConfigUrl]];
     SFNetwork *network = [[SFNetwork alloc] initWithEphemeralSession];
     __weak __typeof(self) weakSelf = self;
     [network sendRequest:orgConfigRequest dataResponseBlock:^(NSData *data, NSURLResponse *response, NSError *error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (error) {
-            [SFSDKCoreLogger d:[strongSelf class] format:@"Org config request failed with error: Error Code: %ld, Description: %@", (long) error.code, error.localizedDescription];
+            [SFSDKCoreLogger w:[strongSelf class] format:@"Org config request failed with error: Error Code: %ld, Description: %@", (long) error.code, error.localizedDescription];
             authConfigBlock(nil, error);
             return;
         }
@@ -58,7 +58,7 @@ static NSString * const kSFOAuthEndPointAuthConfiguration = @"/.well-known/auth-
 
             // Checks if the server returned any data.
             if (data == nil) {
-                [SFSDKCoreLogger d:[strongSelf class] format:@"No org auth config data returned from %@", orgConfigUrl];
+                [SFSDKCoreLogger w:[strongSelf class] format:@"No org auth config data returned from %@", orgConfigUrl];
                 authConfigBlock(nil, nil);
                 return;
             }
@@ -67,17 +67,17 @@ static NSString * const kSFOAuthEndPointAuthConfiguration = @"/.well-known/auth-
             NSDictionary *configDict = [SFJsonUtils objectFromJSONData:data];
             if (configDict == nil) {
                 NSError *jsonParseError = [SFJsonUtils lastError];
-                [SFSDKCoreLogger d:[strongSelf class] format:@"Could not parse org auth config response from %@: %@", orgConfigUrl, [jsonParseError localizedDescription]];
+                [SFSDKCoreLogger e:[strongSelf class] format:@"Could not parse org auth config response from %@: %@", orgConfigUrl, [jsonParseError localizedDescription]];
                 authConfigBlock(nil, jsonParseError);
                 return;
             }
 
             // Passes the retrieved auth config back.
-            [SFSDKCoreLogger d:[strongSelf class] format:@"Successfully retrieved org auth config data from %@", orgConfigUrl];
+            [SFSDKCoreLogger i:[strongSelf class] format:@"Successfully retrieved org auth config data from %@", orgConfigUrl];
             SFOAuthOrgAuthConfiguration *orgAuthConfig = [[SFOAuthOrgAuthConfiguration alloc] initWithConfigDict:configDict];
             authConfigBlock(orgAuthConfig, nil);
         } else {
-            [SFSDKCoreLogger d:[strongSelf class] format:@"Org config request failed with error: Status Code: %ld", statusCode];
+            [SFSDKCoreLogger w:[strongSelf class] format:@"Org config request failed with error: Status Code: %ld", statusCode];
             authConfigBlock(nil, nil);
         }
     }];

--- a/libs/SmartSync/SmartSync/Classes/Manager/SFAdvancedSyncUpTask.m
+++ b/libs/SmartSync/SmartSync/Classes/Manager/SFAdvancedSyncUpTask.m
@@ -64,7 +64,9 @@
             else {
                 // Server date is newer than the local date.  Skip this update.
                 [SFSDKSmartSyncLogger d:[strongSelf class] format:@"syncUpMultipleEntries: Record not synced since client does not have the latest from server:%@", record];
-                [strongSelf syncUpMultipleEntries:sync recordIds:recordIds index:i+1 batch:batch];
+                // Calling addToSyncUpBatchAndProcessIfNeeded with nil for record - we don't want to add the current record to the batch
+                // but we do want the batch to be processed if needed
+                [strongSelf addToSyncUpBatchAndProcessIfNeeded:sync recordIds:recordIds index:i record:nil batch:batch];
             }
         }];
     } else {
@@ -81,8 +83,10 @@
     SFSyncUpTarget<SFAdvancedSyncUpTarget>* advancedTarget = (SFSyncUpTarget<SFAdvancedSyncUpTarget>*) sync.target;
     NSUInteger maxBatchSize = advancedTarget.maxBatchSize;
     
-    // Add record to batch
-    [batch addObject:record];
+    // Add record to batch unless nil
+    if (record) {
+        [batch addObject:record];
+    }
     
     // Process batch if max batch size reached or at the end of recordIds
     if (batch.count == maxBatchSize || i == recordIds.count - 1) {

--- a/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.m
+++ b/libs/SmartSync/SmartSyncTests/SyncManagerTestCase.m
@@ -95,7 +95,7 @@ static NSException *authException = nil;
 }
 
 - (NSString*)createRecordName:(NSString*)objectType {
-    return [NSString stringWithFormat:@"SyncManagerTestCase_%@_%08d", objectType, arc4random_uniform(100000000)];
+    return [NSString stringWithFormat:@"SyncTest_%@_%lu%03d", objectType, (NSUInteger)([[NSDate date] timeIntervalSince1970]*1000), arc4random_uniform(1000)];
 }
 
 - (NSString*) createAccountName {


### PR DESCRIPTION
If a custom host is configured though the app's `plist`, and that custom host value is changed with a new version of the app, our code would hold on to the old custom host value. The app would have to be uninstalled and reinstalled to recover. This is because we use `NSUserDefaults` to store the host selection value and a different persistent store for all hosts. This PR addresses that bug by ensuring they are in sync. It also fixes some log levels. Tested using `SmartSyncExplorer`.