### PR TITLE
Fixing bug in saveSoupEntryExternally causing externally stored files to be cut-off in some cases

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -865,10 +865,15 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     log(@"1/4 Starting to write to tmp file");
     [outputStream open];
     NSError *error = nil;
-    BOOL success = [NSJSONSerialization writeJSONObject:soupEntry
-                                               toStream:outputStream
-                                                options:0
-                                                  error:&error];
+    
+    // NSJSONSerialization:writeJSONObject returns the number of bytes written
+    // So NSJSONSerialization:writeJSONObject can return a value > 0 while there is an error
+    [NSJSONSerialization writeJSONObject:soupEntry
+                                toStream:outputStream
+                                 options:0
+                                   error:&error];
+    BOOL success = !error;
+
     [outputStream close];
     log(@"2/4 Done writing to tmp file");
 

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -68,6 +68,7 @@ NSString * const kDefaultSmartStoreName   = @"defaultStore";
 NSString * const kSFAppFeatureSmartStoreUser   = @"US";
 NSString * const kSFAppFeatureSmartStoreGlobal   = @"GS";
 NSString * const kSFSmartStoreJSONParseErrorNotification = @"SFSmartStoreJSONParseErrorNotification";
+NSString * const kSFSmartStoreJSONSerializationErrorNotification = @"SFSmartStoreJSONSerializationErrorNotification";
 
 // NSError constants  (TODO: We should move this stuff into a framework where errors can be configurable
 // in a plist, once we start delivering a bundle.
@@ -872,6 +873,11 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
                                 toStream:outputStream
                                  options:0
                                    error:&error];
+    if (error) {
+        [SFSDKSmartStoreLogger e:[self class] format:@"Error serializing JSON in SmartStore in %@", NSStringFromSelector(_cmd)];
+        [SFSmartStore buildEventOnJsonSerializationErrorForUser:self.user fromMethod:NSStringFromSelector(_cmd) error:error];
+    }
+    
     BOOL success = !error;
 
     [outputStream close];
@@ -917,18 +923,28 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     return [SFJsonUtils objectFromJSONString:[self loadExternalSoupEntryAsString:soupEntryId soupTableName:soupTableName]];
 }
 
-+ (void)buildEventOnJsonErrorForUser:(SFUserAccount *)user {
++ (void)buildEventOnJsonParseErrorForUser:(SFUserAccount *)user fromMethod:(NSString*)fromMethod {
     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
     attributes[@"errorCode"] = [NSNumber numberWithInteger:SFJsonUtils.lastError.code];
     attributes[@"errorMessage"] = SFJsonUtils.lastError.localizedDescription;
+    attributes[@"fromMethod"] = fromMethod;
     [SFSDKEventBuilderHelper createAndStoreEvent:@"SmartStoreJSONParseError" userAccount:user className:NSStringFromClass([self class]) attributes:attributes];
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFSmartStoreJSONParseErrorNotification object:self];
+}
+
++ (void)buildEventOnJsonSerializationErrorForUser:(SFUserAccount *)user fromMethod:(NSString*)fromMethod error:(NSError*)error {
+    NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
+    attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
+    attributes[@"errorMessage"] = error.localizedDescription;
+    attributes[@"fromMethod"] = fromMethod;
+    [SFSDKEventBuilderHelper createAndStoreEvent:@"SmartStoreJSONSerializationError" userAccount:user className:NSStringFromClass([self class]) attributes:attributes];
+    [[NSNotificationCenter defaultCenter] postNotificationName:kSFSmartStoreJSONSerializationErrorNotification object:self];
 }
 
 - (BOOL)checkRawJson:(NSString*)rawJson fromMethod:(NSString*)fromMethod {
     if (_jsonSerializationCheckEnabled && [SFJsonUtils objectFromJSONString:rawJson] == nil) {
         [SFSDKSmartStoreLogger e:[self class] format:@"Error parsing JSON in SmartStore in %@", fromMethod];
-        [SFSmartStore buildEventOnJsonErrorForUser:self.user];
+        [SFSmartStore buildEventOnJsonParseErrorForUser:self.user fromMethod:fromMethod];
         return NO;
     } else {
         return YES;

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -873,18 +873,17 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
                                 toStream:outputStream
                                  options:0
                                    error:&error];
+    [outputStream close];
+    
     if (error) {
-        [SFSDKSmartStoreLogger e:[self class] format:@"Error serializing JSON in SmartStore in %@", NSStringFromSelector(_cmd)];
         [SFSmartStore buildEventOnJsonSerializationErrorForUser:self.user fromMethod:NSStringFromSelector(_cmd) error:error];
     }
-    
+
     BOOL success = !error;
-
-    [outputStream close];
-    log(@"2/4 Done writing to tmp file");
-
+    
     // Renaming tmp file by using moveItemAtPath (but first check if destination exists and deletes it if it does)
     if (success) {
+        log(@"2/4 Done writing to tmp file");
         log(@"3/4 Renaming tmp file");
         
         if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
@@ -909,7 +908,6 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
                                   tmpFilePath,
                                   filePath,
                                   error];
-        NSAssert(NO, errorMessage);
         [SFSDKSmartStoreLogger e:[self class] format:errorMessage];
     }
     


### PR DESCRIPTION
When we upsert soup entries that are stored in external files, we use `NSJSONSerialization:writeJSONObject` to write the JSON to a file.
That method can fail if with certain unicode characters. See [corruption tester](https://github.com/wmathurin/CorruptionTester).
`saveSoupEntryExternally` should exit with an error, causing the `upsert` to revert.
Unfoturnately, we were looking at the return value `NSJSONSerialization:writeJSONObject` to decide if an error occurred.
But this method returns the number of bytes written so it could return a non zero value even though it fails to write the entire JSON.
As a result, the file ends up being be cut-off, which causes issues at query time.