### PR TITLE
Fixes a large amount of lint warnings for RestApiExplorer

### DIFF
--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -32,13 +32,10 @@ import SalesforceSDKCore
 
 import MobileCoreServices
 
-class AppDelegate : UIResponder, UIApplicationDelegate
-{
+class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
     
-    override
-    init()
-    {
+    override init() {
         
         super.init()
       
@@ -57,8 +54,7 @@ class AppDelegate : UIResponder, UIApplicationDelegate
     
     // MARK: - App delegate lifecycle
     
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
-    {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.main.bounds)
         self.initializeAppViewState()
         
@@ -104,8 +100,7 @@ class AppDelegate : UIResponder, UIApplicationDelegate
         return true
     }
     
-    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data)
-    {
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         //
         // Uncomment the code below to register your device token with the push notification manager
         //
@@ -120,13 +115,11 @@ class AppDelegate : UIResponder, UIApplicationDelegate
         // }
     }
     
-    
-    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error )
-    {
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error ) {
         // Respond to any push notification registration errors here.
     }
     
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         
         // Uncomment following block to enable IDP Login flow
         // return  UserAccountManager.shared.handleIdentityProviderResponse(from: url, with: options)
@@ -134,9 +127,8 @@ class AppDelegate : UIResponder, UIApplicationDelegate
     }
     
     // MARK: - Private methods
-    func initializeAppViewState()
-    {
-        if (!Thread.isMainThread) {
+    func initializeAppViewState() {
+        if !Thread.isMainThread {
             DispatchQueue.main.async {
                 self.initializeAppViewState()
             }
@@ -147,15 +139,13 @@ class AppDelegate : UIResponder, UIApplicationDelegate
         self.window!.makeKeyAndVisible()
     }
     
-    func setupRootViewController()
-    {
+    func setupRootViewController() {
         let rootVC = RootViewController(nibName: nil, bundle: nil)
         let navVC = UINavigationController(rootViewController: rootVC)
         self.window!.rootViewController = navVC
     }
     
-    func resetViewState(_ postResetBlock: @escaping () -> ())
-    {
+    func resetViewState(_ postResetBlock: @escaping () -> Void ) {
         if let rootViewController = self.window!.rootViewController {
             if let _ = rootViewController.presentedViewController {
                 rootViewController.dismiss(animated: false, completion: postResetBlock)
@@ -183,10 +173,9 @@ class AppDelegate : UIResponder, UIApplicationDelegate
         if let community = creds.communityUrl {
             config["community_url"] = community.absoluteString
         }
-        
+    
         let configJSON = SFJsonUtils.jsonRepresentation(config)
         let board = UIPasteboard.general
         board.setValue(configJSON, forPasteboardType: kUTTypeUTF8PlainText as String)
     }
 }
-

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Helpers/UIColors+helper.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Helpers/UIColors+helper.swift
@@ -31,51 +31,36 @@ import UIKit
 
 extension UIColor {
     
-    class var appDarkBlue:UIColor {
-        get {
-            return UIColor(displayP3Red: 20.0/255.0, green: 50.0/255.0, blue: 92.0/255.0, alpha: 1.0)
-        }
+    class var appDarkBlue: UIColor {
+        return UIColor(displayP3Red: 20.0/255.0, green: 50.0/255.0, blue: 92.0/255.0, alpha: 1.0)
+    }
+
+    class var appTextBlue: UIColor {
+       return UIColor(displayP3Red: 84.0/255.0, green: 105.0/255.0, blue: 141.0/255.0, alpha: 1.0)
+    }
+
+    class var appTextFieldBlue: UIColor {
+        return UIColor(displayP3Red: 42.0/255.0, green: 66.0/255.0, blue: 108.0/255.0, alpha: 1.0)
+
+    }
+
+    class var appTextFieldBorder: UIColor {
+       return UIColor(displayP3Red: 168.0/255.0, green: 183.0/255.0, blue: 199.0/255.0, alpha: 1.0)
     }
     
-    class var appTextBlue:UIColor {
-        get {
-            return UIColor(displayP3Red: 84.0/255.0, green: 105.0/255.0, blue: 141.0/255.0, alpha: 1.0)
-        }
+    class var appViewBorder: UIColor {
+        return UIColor(displayP3Red: 224.0/255.0, green: 229.0/255.0, blue: 238.0/255.0, alpha: 1.0)
+    }
+
+    class var appButton: UIColor {
+        return UIColor(displayP3Red: 0.0/255.0, green: 112.0/255.0, blue: 210.0/255.0, alpha: 1.0)
+    }
+
+    class var appContentBackground: UIColor {
+        return UIColor(displayP3Red: 224.0/255.0, green: 229.0/255.0, blue: 238.0/255.0, alpha: 1.0)
     }
     
-    class var appTextFieldBlue:UIColor {
-        get {
-            return UIColor(displayP3Red: 42.0/255.0, green: 66.0/255.0, blue: 108.0/255.0, alpha: 1.0)
-        }
-    }
-    
-    class var appTextFieldBorder:UIColor {
-        get {
-            return UIColor(displayP3Red: 168.0/255.0, green: 183.0/255.0, blue: 199.0/255.0, alpha: 1.0)
-        }
-    }
-    
-    class var appViewBorder:UIColor {
-        get {
-            return UIColor(displayP3Red: 224.0/255.0, green: 229.0/255.0, blue: 238.0/255.0, alpha: 1.0)
-        }
-    }
-    
-    class var appButton:UIColor {
-        get {
-            return UIColor(displayP3Red: 0.0/255.0, green: 112.0/255.0, blue: 210.0/255.0, alpha: 1.0)
-        }
-    }
-    
-    class var appContentBackground:UIColor {
-        get {
-            return UIColor(displayP3Red: 224.0/255.0, green: 229.0/255.0, blue: 238.0/255.0, alpha: 1.0)
-        }
-    }
-    
-    class var appTextViewYellowBackground:UIColor {
-        get {
-            return UIColor(displayP3Red: 250.0/255.0, green: 255.0/255.0, blue: 189.0/255.0, alpha: 1.0)
-        }
+    class var appTextViewYellowBackground: UIColor {
+        return UIColor(displayP3Red: 250.0/255.0, green: 255.0/255.0, blue: 189.0/255.0, alpha: 1.0)
     }
 }

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Helpers/UIFont+helper.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Helpers/UIFont+helper.swift
@@ -30,15 +30,15 @@
 import UIKit
 
 extension UIFont {
-    class func appRegularFont(_ size:CGFloat) -> UIFont? {
+    class func appRegularFont(_ size: CGFloat) -> UIFont? {
         return UIFont.systemFont(ofSize: size, weight: .regular)
     }
     
-    class func appBoldFont(_ size:CGFloat) -> UIFont? {
+    class func appBoldFont(_ size: CGFloat) -> UIFont? {
         return UIFont.boldSystemFont(ofSize: size)
     }
     
-    class func appLightFont(_ size:CGFloat) -> UIFont? {
+    class func appLightFont(_ size: CGFloat) -> UIFont? {
         return UIFont.systemFont(ofSize: size, weight: .light)
     }
 }

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Model/Actions.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Model/Actions.swift
@@ -60,7 +60,7 @@ enum ActionType {
 }
 
 struct Action {
-    let type:ActionType
-    let method:String
-    let objectTypes:String?
+    let type: ActionType
+    let method: String
+    let objectTypes: String?
 }

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/ActionsTableViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/ActionsTableViewController.swift
@@ -30,43 +30,42 @@
 import UIKit
 
 protocol ActionTableViewDelegate: class {
-    func userDidSelectAction(_ action:Action)
+    func userDidSelectAction(_ action: Action)
 }
 
 class ActionTableViewController: UIViewController {
-    weak var delegate:ActionTableViewDelegate?
-    let actions:[Action]
+    weak var delegate: ActionTableViewDelegate?
+    let actions: [Action]
     fileprivate var tableView = UITableView(frame: .zero, style: .plain)
     
     init() {
-        let versions = Action(type: ActionType.versions, method: "versions", objectTypes:nil)
-        let resources = Action(type: ActionType.resources, method: "resources", objectTypes:nil)
-        let describeGlobal = Action(type: ActionType.describeGlobal, method: "describeGlobal", objectTypes:nil)
-        let metadata = Action(type: ActionType.metadataWithObjectType, method: "metadataWithObjectType", objectTypes:"objectType")
-        let describe = Action(type: ActionType.describeWithObjectType, method: "describeWithObjectType:", objectTypes:"objectType")
-        let retrieve = Action(type: ActionType.retrieveWithObjectType, method: "retrieveWithObjectType:objectId:fieldList", objectTypes:"objectType, objectId, fieldList")
-        let create = Action(type: ActionType.createWithObjectType, method: "createWithObjectType:fields", objectTypes:"objectType, fields")
-        let upsert = Action(type: ActionType.upsertWithObjectType, method: "upsertWithObjectType:externalField:externalId:fields", objectTypes:"objectType, externalField, externalId, fields")
-        let update = Action(type: ActionType.updateWithObjectType, method: "updateWithObjectType:externalField:externalId:fields", objectTypes:"objectType, objectId, fields")
+        let versions = Action(type: ActionType.versions, method: "versions", objectTypes: nil)
+        let resources = Action(type: ActionType.resources, method: "resources", objectTypes: nil)
+        let describeGlobal = Action(type: ActionType.describeGlobal, method: "describeGlobal", objectTypes: nil)
+        let metadata = Action(type: ActionType.metadataWithObjectType, method: "metadataWithObjectType", objectTypes: "objectType")
+        let describe = Action(type: ActionType.describeWithObjectType, method: "describeWithObjectType:", objectTypes: "objectType")
+        let retrieve = Action(type: ActionType.retrieveWithObjectType, method: "retrieveWithObjectType:objectId:fieldList", objectTypes: "objectType, objectId, fieldList")
+        let create = Action(type: ActionType.createWithObjectType, method: "createWithObjectType:fields", objectTypes: "objectType, fields")
+        let upsert = Action(type: ActionType.upsertWithObjectType, method: "upsertWithObjectType:externalField:externalId:fields", objectTypes: "objectType, externalField, externalId, fields")
+        let update = Action(type: ActionType.updateWithObjectType, method: "updateWithObjectType:externalField:externalId:fields", objectTypes: "objectType, objectId, fields")
         let delete = Action(type: ActionType.deleteWithObjectType, method: "deleteWithObjectType:objectId", objectTypes:"objectType, objectId")
-        let query = Action(type: ActionType.query, method: "query:", objectTypes:"query")
-        let search = Action(type: ActionType.search, method: "search:", objectTypes:"search")
-        let searchScope = Action(type: ActionType.searchScopeAndOrder, method: "searchScopeAndOrder:", objectTypes:nil)
-        let searchResultLayout = Action(type: ActionType.searchResultLayout, method: "searchResultLayout:", objectTypes:"objectList")
-        let ownedFiles = Action(type: ActionType.ownedFilesList, method: "ownedFilesList:page", objectTypes:"userId, page")
-        let filesInUserGroups = Action(type: ActionType.filesInUserGroups, method: "filesInUserGroups:page", objectTypes:"userId, page")
-        let filesShared = Action(type: ActionType.filesSharedWithUser, method: "filesSharedWithUser:page", objectTypes:"userId, page")
-        let fileDetails = Action(type: ActionType.fileDetails, method: "fileDetails:forVersions", objectTypes:"objectId, version")
-        let batchFileDetails = Action(type: ActionType.batchFileDetails, method: "batchFileDetails:", objectTypes:"objectIdList")
-        let fileShares = Action(type: ActionType.fileShares, method: "fileShares:page", objectTypes:"objectId, page")
-        let addFileShare = Action(type: ActionType.addFileShare, method: "addFileShare:entityId:shareType", objectTypes:"objectId, entityId, sharedType")
-        let deleteFileShare = Action(type: ActionType.deleteFileShare, method: "deleteFileShares:", objectTypes:"objectId")
-        let currentUserInfo = Action(type: ActionType.currentUserInfo, method: "current user info", objectTypes:nil)
-        let enableBiometric = Action(type: ActionType.enableBiometric, method: "Enable Touch/Face Id", objectTypes:nil)
-        let logout = Action(type: ActionType.logout, method: "logout", objectTypes:nil)
-        let switchUser = Action(type: ActionType.switchUser, method: "switch user", objectTypes:nil)
-        let exportCredentials = Action(type: ActionType.exportCredentials, method: "Export Credentials to pasteboard", objectTypes:nil)
-        
+        let query = Action(type: ActionType.query, method: "query:", objectTypes: "query")
+        let search = Action(type: ActionType.search, method: "search:", objectTypes: "search")
+        let searchScope = Action(type: ActionType.searchScopeAndOrder, method: "searchScopeAndOrder:", objectTypes: nil)
+        let searchResultLayout = Action(type: ActionType.searchResultLayout, method: "searchResultLayout:", objectTypes: "objectList")
+        let ownedFiles = Action(type: ActionType.ownedFilesList, method: "ownedFilesList:page", objectTypes: "userId, page")
+        let filesInUserGroups = Action(type: ActionType.filesInUserGroups, method: "filesInUserGroups:page", objectTypes: "userId, page")
+        let filesShared = Action(type: ActionType.filesSharedWithUser, method: "filesSharedWithUser:page", objectTypes: "userId, page")
+        let fileDetails = Action(type: ActionType.fileDetails, method: "fileDetails:forVersions", objectTypes: "objectId, version")
+        let batchFileDetails = Action(type: ActionType.batchFileDetails, method: "batchFileDetails:", objectTypes: "objectIdList")
+        let fileShares = Action(type: ActionType.fileShares, method: "fileShares:page", objectTypes: "objectId, page")
+        let addFileShare = Action(type: ActionType.addFileShare, method: "addFileShare:entityId:shareType", objectTypes: "objectId, entityId, sharedType")
+        let deleteFileShare = Action(type: ActionType.deleteFileShare, method: "deleteFileShares:", objectTypes: "objectId")
+        let currentUserInfo = Action(type: ActionType.currentUserInfo, method: "current user info", objectTypes: nil)
+        let enableBiometric = Action(type: ActionType.enableBiometric, method: "Enable Touch/Face Id", objectTypes: nil)
+        let logout = Action(type: ActionType.logout, method: "logout", objectTypes: nil)
+        let switchUser = Action(type: ActionType.switchUser, method: "switch user", objectTypes: nil)
+        let exportCredentials = Action(type: ActionType.exportCredentials, method: "Export Credentials to pasteboard", objectTypes: nil)
         
         self.actions = [versions, resources, describeGlobal, metadata, describe, retrieve, create, upsert, update, delete, query, search, searchScope, searchResultLayout, ownedFiles, filesInUserGroups, filesShared, fileDetails, batchFileDetails, fileShares, addFileShare, deleteFileShare, currentUserInfo, enableBiometric, logout, switchUser, exportCredentials]
         
@@ -97,9 +96,9 @@ class ActionTableViewController: UIViewController {
 
 extension ActionTableViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if let d = self.delegate {
+        if let del = self.delegate {
             let action = self.actions[indexPath.row]
-            d.userDidSelectAction(action)
+            del.userDidSelectAction(action)
         }
     }
     
@@ -111,12 +110,15 @@ extension ActionTableViewController: UITableViewDelegate {
 extension ActionTableViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let action = self.actions[indexPath.row]
-        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath) as! ActionTableViewCell
-        cell.actionLabel.text = action.method
-        if let types = action.objectTypes {
-            cell.objectLabel.text = "params: " + types
-        } else {
-            cell.objectLabel.text = "no params"
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        
+        if let actionCell = cell as? ActionTableViewCell {
+            actionCell.actionLabel.text = action.method
+            if let types = action.objectTypes {
+                actionCell.objectLabel.text = "params: " + types
+            } else {
+                actionCell.objectLabel.text = "no params"
+            }
         }
         return cell
     }

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/IDPLoginNavViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/IDPLoginNavViewController.swift
@@ -31,9 +31,9 @@ import UIKit
 import SalesforceSDKCore.SFSDKLoginFlowSelectionView
 
 class IDPLoginNavViewController: UINavigationController, SFSDKLoginFlowSelectionView {
-    weak var selectionFlowDelegate:SFSDKLoginFlowSelectionViewDelegate?
-    var appOptions:[AnyHashable: Any]!
-    
+    weak var selectionFlowDelegate: SFSDKLoginFlowSelectionViewDelegate?
+    var appOptions: [AnyHashable: Any]!
+
     override func viewDidLoad() {
         super.viewDidLoad()
         let controller = IDPLoginViewController(nibName: nil, bundle: nil)
@@ -44,14 +44,14 @@ class IDPLoginNavViewController: UINavigationController, SFSDKLoginFlowSelection
 
 extension IDPLoginNavViewController: IDPLoginViewControllerDelegate {
     func loginUsingIDP() {
-        if let d = self.selectionFlowDelegate {
-            d.loginFlowSelectionIDPSelected(self, options: self.appOptions)
+        if let delegate = self.selectionFlowDelegate {
+            delegate.loginFlowSelectionIDPSelected(self, options: self.appOptions)
         }
     }
-    
+
     func loginUsingApp() {
-        if let d = self.selectionFlowDelegate {
-            d.loginFlowSelectionLocalLoginSelected(self, options: self.appOptions)
+        if let delegate = self.selectionFlowDelegate {
+            delegate.loginFlowSelectionLocalLoginSelected(self, options: self.appOptions)
         }
     }
 }

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/IDPLoginViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/IDPLoginViewController.swift
@@ -40,24 +40,20 @@ import SalesforceSDKCore.SFSDKLoginHost
 
 class IDPLoginViewController: UIViewController {
 
-    weak var loginSelectionDelegate:IDPLoginViewControllerDelegate?
-    fileprivate var loginHostViewController:LoginHostListViewController?
-    fileprivate lazy var loginHostListViewController:LoginHostListViewController = {
-        let l = LoginHostListViewController(style: .plain)
-        l.delegate = self
-        return l
+    weak var loginSelectionDelegate: IDPLoginViewControllerDelegate?
+    fileprivate var loginHostViewController: LoginHostListViewController?
+    fileprivate lazy var loginHostListViewController: LoginHostListViewController = {
+        let loginHostCtrl = LoginHostListViewController(style: .plain)
+        loginHostCtrl.delegate = self
+        return loginHostCtrl
     }()
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        get {
-            return .lightContent
-        }
+        return .lightContent
     }
     
     override var prefersStatusBarHidden: Bool {
-        get {
-            return false
-        }
+        return false
     }
     
     override func viewDidLoad() {
@@ -120,20 +116,20 @@ class IDPLoginViewController: UIViewController {
         selectLabel.topAnchor.constraint(equalTo: container.topAnchor).isActive = true
         selectLabel.centerXAnchor.constraint(equalTo: container.centerXAnchor).isActive = true
         
-        idpLabel.topAnchor.constraint(equalTo: selectLabel.bottomAnchor, constant:60).isActive = true
+        idpLabel.topAnchor.constraint(equalTo: selectLabel.bottomAnchor, constant: 60).isActive = true
         idpLabel.leftAnchor.constraint(equalTo: container.leftAnchor).isActive = true
         idpLabel.rightAnchor.constraint(equalTo: container.rightAnchor).isActive = true
         
-        idpButton.topAnchor.constraint(equalTo: idpLabel.bottomAnchor, constant:14).isActive = true
+        idpButton.topAnchor.constraint(equalTo: idpLabel.bottomAnchor, constant: 14).isActive = true
         idpButton.leftAnchor.constraint(equalTo: container.leftAnchor).isActive = true
         idpButton.rightAnchor.constraint(equalTo: container.rightAnchor).isActive = true
         idpButton.heightAnchor.constraint(equalToConstant: 50.0).isActive = true
         
-        appLabel.topAnchor.constraint(equalTo: idpButton.bottomAnchor, constant:60).isActive = true
+        appLabel.topAnchor.constraint(equalTo: idpButton.bottomAnchor, constant: 60).isActive = true
         appLabel.leftAnchor.constraint(equalTo: container.leftAnchor).isActive = true
         appLabel.rightAnchor.constraint(equalTo: container.rightAnchor).isActive = true
         
-        appButton.topAnchor.constraint(equalTo: appLabel.bottomAnchor, constant:14).isActive = true
+        appButton.topAnchor.constraint(equalTo: appLabel.bottomAnchor, constant: 14).isActive = true
         appButton.leftAnchor.constraint(equalTo: container.leftAnchor).isActive = true
         appButton.rightAnchor.constraint(equalTo: container.rightAnchor).isActive = true
         appButton.heightAnchor.constraint(equalToConstant: 50.0).isActive = true
@@ -153,13 +149,13 @@ class IDPLoginViewController: UIViewController {
     }
     
     @objc func loginIDPAction() {
-        guard let d = self.loginSelectionDelegate else {return}
-        d.loginUsingIDP?()
+        guard let delegate = self.loginSelectionDelegate else {return}
+        delegate.loginUsingIDP?()
     }
     
     @objc func loginLocalAction() {
-        guard let d = self.loginSelectionDelegate else {return}
-        d.loginUsingApp?()
+        guard let delegate = self.loginSelectionDelegate else {return}
+        delegate.loginUsingApp?()
     }
     
     func showHostListView() {
@@ -168,7 +164,7 @@ class IDPLoginViewController: UIViewController {
         self.present(navController, animated: true, completion: nil)
     }
     
-    func hideHostListView(_ animated:Bool) {
+    func hideHostListView(_ animated: Bool) {
         self.dismiss(animated: animated, completion: nil)
     }
     
@@ -193,7 +189,7 @@ extension IDPLoginViewController: LoginHostDelegate {
     
     func hostListViewController(_ hostListViewController: LoginHostListViewController, didChange newLoginHost: SalesforceLoginHost) {
         UserAccountManager.shared.loginHost = newLoginHost.host
-        UserAccountManager.shared.switchToNewUserAccount { (error, userAccount) in
+        UserAccountManager.shared.switchToNewUserAccount { _, _ in
             
         }
     }

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/InitialViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/InitialViewController.swift
@@ -54,6 +54,4 @@ class InitialViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
 
-
 }
-

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/RootViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/RootViewController.swift
@@ -1,9 +1,9 @@
 /*
  RootViewController.swift
  RestAPIExplorerSwift
-
+ 
  Created by Nicholas McDonald on 1/8/18.
-
+ 
  Copyright (c) 2018-present, salesforce.com, inc. All rights reserved.
  
  Redistribution and use of this software in source and binary forms, with or without modification,
@@ -32,12 +32,12 @@ import SalesforceSDKCore
 import LocalAuthentication
 
 struct ContentSection {
-    var title:String {
+    var title: String {
         didSet {
             self.titleLabel.text = title
         }
     }
-    var attributedTitle:NSAttributedString? {
+    var attributedTitle: NSAttributedString? {
         didSet {
             self.titleLabel.attributedText = attributedTitle
         }
@@ -45,69 +45,70 @@ struct ContentSection {
     var contentView = UIView()
     var container = UIView()
     private let titleLabel = UILabel()
-    
-    static let horizontalSpace:CGFloat = 18.0
-    static let interItemVerticalSpace:CGFloat = 4.0
-    static let topSpace:CGFloat = 8.0
-    static let bottomSpace:CGFloat = 12.0
-    static let horizontalMargin:CGFloat = 20.0
-    static let verticalMargin:CGFloat = 16.0
-    static let titleMargin:CGFloat = 8.0
-    
-    init(_ title:String) {
+
+    static let horizontalSpace: CGFloat = 18.0
+    static let interItemVerticalSpace: CGFloat = 4.0
+    static let topSpace: CGFloat = 8.0
+    static let bottomSpace: CGFloat = 12.0
+    static let horizontalMargin: CGFloat = 20.0
+    static let verticalMargin: CGFloat = 16.0
+    static let titleMargin: CGFloat = 8.0
+
+    init(_ title: String) {
         self.contentView.translatesAutoresizingMaskIntoConstraints = false
         self.container.translatesAutoresizingMaskIntoConstraints = false
-        
+
         self.titleLabel.translatesAutoresizingMaskIntoConstraints = false
         self.titleLabel.font = UIFont.appRegularFont(20)
         self.titleLabel.text = title
         self.titleLabel.textColor = UIColor.appDarkBlue
         self.container.addSubview(self.titleLabel)
-        self.titleLabel.leftAnchor.constraint(equalTo: self.container.leftAnchor, constant:ContentSection.horizontalMargin).isActive = true
-        self.titleLabel.rightAnchor.constraint(equalTo: self.container.rightAnchor, constant:-ContentSection.horizontalMargin).isActive = true
-        self.titleLabel.topAnchor.constraint(equalTo: self.container.topAnchor, constant:ContentSection.titleMargin).isActive = true
+        self.titleLabel.leftAnchor.constraint(equalTo: self.container.leftAnchor, constant: ContentSection.horizontalMargin).isActive = true
+ 
+        self.titleLabel.rightAnchor.constraint(equalTo: self.container.rightAnchor, constant: -ContentSection.horizontalMargin).isActive = true
+        self.titleLabel.topAnchor.constraint(equalTo: self.container.topAnchor, constant: ContentSection.titleMargin).isActive = true
         
         self.container.addSubview(self.contentView)
-        self.contentView.leftAnchor.constraint(equalTo: self.container.leftAnchor, constant:ContentSection.horizontalMargin).isActive = true
+        self.contentView.leftAnchor.constraint(equalTo: self.container.leftAnchor, constant: ContentSection.horizontalMargin).isActive = true
         self.contentView.topAnchor.constraint(equalTo: self.titleLabel.bottomAnchor).isActive = true
-        self.contentView.rightAnchor.constraint(equalTo: self.container.rightAnchor, constant:-ContentSection.horizontalMargin).isActive = true
-        self.contentView.bottomAnchor.constraint(equalTo: self.container.bottomAnchor, constant:-ContentSection.verticalMargin).isActive = true
+        self.contentView.rightAnchor.constraint(equalTo: self.container.rightAnchor, constant: -ContentSection.horizontalMargin).isActive = true
+        self.contentView.bottomAnchor.constraint(equalTo: self.container.bottomAnchor, constant: -ContentSection.verticalMargin).isActive = true
         
         self.title = title
     }
 }
 
 class RootViewController: UIViewController {
-    weak var presentedActions:ActionTableViewController?
-    weak var logoutAlert:UIAlertController?
+    weak var presentedActions: ActionTableViewController?
+    weak var logoutAlert: UIAlertController?
     
     fileprivate let paramSection = ContentSection("Parameters for action based query")
     fileprivate let querySection = ContentSection("Manual query")
     fileprivate var responseSection = ContentSection("Response for...")
     
-    fileprivate var objectTypeTextField:UITextField!
-    fileprivate var objectIdTextField:UITextField!
-    fileprivate var externalIdTextField:UITextField!
-    fileprivate var searchTextField:UITextField!
-    fileprivate var queryTextField:UITextField!
-    fileprivate var externalFieldIdTextField:UITextField!
-    fileprivate var fieldListTextField:UITextField!
-    fileprivate var fieldsTextView:UITextView!
-    fileprivate var objectListTextField:UITextField!
-    fileprivate var userIdTextField:UITextField!
-    fileprivate var pageTextField:UITextField!
-    fileprivate var versionTextField:UITextField!
-    fileprivate var objectIdListTextField:UITextField!
-    fileprivate var entityIdTextField:UITextField!
-    fileprivate var shareTypeTextField:UITextField!
-    fileprivate var manualQueryTextField:UITextField!
-    fileprivate var paramsTextView:UITextView!
-    fileprivate var methodControl:UISegmentedControl!
-    fileprivate var responseForLabel:UILabel!
-    fileprivate var responseForTextView:UITextView!
+    fileprivate var objectTypeTextField: UITextField!
+    fileprivate var objectIdTextField: UITextField!
+    fileprivate var externalIdTextField: UITextField!
+    fileprivate var searchTextField: UITextField!
+    fileprivate var queryTextField: UITextField!
+    fileprivate var externalFieldIdTextField: UITextField!
+    fileprivate var fieldListTextField: UITextField!
+    fileprivate var fieldsTextView: UITextView!
+    fileprivate var objectListTextField: UITextField!
+    fileprivate var userIdTextField: UITextField!
+    fileprivate var pageTextField: UITextField!
+    fileprivate var versionTextField: UITextField!
+    fileprivate var objectIdListTextField: UITextField!
+    fileprivate var entityIdTextField: UITextField!
+    fileprivate var shareTypeTextField: UITextField!
+    fileprivate var manualQueryTextField: UITextField!
+    fileprivate var paramsTextView: UITextView!
+    fileprivate var methodControl: UISegmentedControl!
+    fileprivate var responseForLabel: UILabel!
+    fileprivate var responseForTextView: UITextView!
     
-    fileprivate var responseContractedTopConstraint:NSLayoutConstraint!
-    fileprivate var responseExpandedTopConstraint:NSLayoutConstraint!
+    fileprivate var responseContractedTopConstraint: NSLayoutConstraint!
+    fileprivate var responseExpandedTopConstraint: NSLayoutConstraint!
     
     fileprivate var fullName: String {
         if let currentAccount = UserAccountManager.shared.currentUserAccount, let id =  currentAccount.idData  {
@@ -121,15 +122,11 @@ class RootViewController: UIViewController {
     }
     
     override var prefersStatusBarHidden: Bool {
-        get {
-            return false
-        }
+        return false
     }
     
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        get {
-            return .lightContent
-        }
+        return .lightContent
     }
     
     override func viewDidLoad() {
@@ -147,7 +144,7 @@ class RootViewController: UIViewController {
         guard let font = UIFont.appRegularFont(20) else {
             return
         }
-       self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white, NSAttributedString.Key.font: font]
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white, NSAttributedString.Key.font: font]
         self.title = "RestAPI Explorer"
         
         guard let leftImage = UIImage(named: "list")?.withRenderingMode(.alwaysOriginal), let _ = UIImage(named: "search")?.withRenderingMode(.alwaysOriginal) else {
@@ -174,7 +171,6 @@ class RootViewController: UIViewController {
         self.view.addSubview(querybar)
         self.view.addSubview(responseContent)
         
-        
         var topAnchor = self.view.topAnchor
         var bottomAnchor = self.view.bottomAnchor
         var rightAnchor = self.view.rightAnchor
@@ -186,7 +182,7 @@ class RootViewController: UIViewController {
             leftAnchor = self.view.safeAreaLayoutGuide.leftAnchor
         }
         
-       // let safe = self.view.safeAreaLayoutGuide
+        // let safe = self.view.safeAreaLayoutGuide
         paramContent.topAnchor.constraint(equalTo: topAnchor).isActive = true
         paramContent.leftAnchor.constraint(equalTo: leftAnchor).isActive = true
         paramContent.rightAnchor.constraint(equalTo: rightAnchor).isActive = true
@@ -220,7 +216,7 @@ class RootViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
     
-    @objc func didPressLeftNavButton(_ sender:UIBarButtonItem) {
+    @objc func didPressLeftNavButton(_ sender: UIBarButtonItem) {
         let actions = ActionTableViewController()
         actions.delegate = self
         self.presentedActions = actions
@@ -346,10 +342,10 @@ class RootViewController: UIViewController {
         
         // top row
         objType.0.leftAnchor.constraint(equalTo: content.leftAnchor).isActive = true
-        objType.0.topAnchor.constraint(equalTo: content.topAnchor, constant:ContentSection.topSpace).isActive = true
-        objId.0.leftAnchor.constraint(equalTo: objType.0.rightAnchor, constant:ContentSection.horizontalSpace).isActive = true
+        objType.0.topAnchor.constraint(equalTo: content.topAnchor, constant: ContentSection.topSpace).isActive = true
+        objId.0.leftAnchor.constraint(equalTo: objType.0.rightAnchor, constant: ContentSection.horizontalSpace).isActive = true
         objId.0.topAnchor.constraint(equalTo: objType.0.topAnchor).isActive = true
-        extId.0.leftAnchor.constraint(equalTo: objId.0.rightAnchor, constant:ContentSection.horizontalSpace).isActive = true
+        extId.0.leftAnchor.constraint(equalTo: objId.0.rightAnchor, constant: ContentSection.horizontalSpace).isActive = true
         extId.0.topAnchor.constraint(equalTo: objType.0.topAnchor).isActive = true
         extId.0.rightAnchor.constraint(equalTo: content.rightAnchor).isActive = true
         objId.0.widthAnchor.constraint(equalTo: objType.0.widthAnchor).isActive = true
@@ -359,10 +355,10 @@ class RootViewController: UIViewController {
         
         // second row
         search.0.leftAnchor.constraint(equalTo: content.leftAnchor).isActive = true
-        search.0.topAnchor.constraint(equalTo: objType.0.bottomAnchor, constant:ContentSection.interItemVerticalSpace).isActive = true
-        query.0.leftAnchor.constraint(equalTo: search.0.rightAnchor, constant:ContentSection.horizontalSpace).isActive = true
+        search.0.topAnchor.constraint(equalTo: objType.0.bottomAnchor, constant: ContentSection.interItemVerticalSpace).isActive = true
+        query.0.leftAnchor.constraint(equalTo: search.0.rightAnchor, constant: ContentSection.horizontalSpace).isActive = true
         query.0.topAnchor.constraint(equalTo: search.0.topAnchor).isActive = true
-        extFieldId.0.leftAnchor.constraint(equalTo: query.0.rightAnchor, constant:ContentSection.horizontalSpace).isActive = true
+        extFieldId.0.leftAnchor.constraint(equalTo: query.0.rightAnchor, constant: ContentSection.horizontalSpace).isActive = true
         extFieldId.0.topAnchor.constraint(equalTo: search.0.topAnchor).isActive = true
         extFieldId.0.rightAnchor.constraint(equalTo: content.rightAnchor).isActive = true
         query.0.widthAnchor.constraint(equalTo: search.0.widthAnchor).isActive = true
@@ -373,13 +369,13 @@ class RootViewController: UIViewController {
         
         // third and fourth row
         fieldList.0.leftAnchor.constraint(equalTo: content.leftAnchor).isActive = true
-        fieldList.0.topAnchor.constraint(equalTo: search.0.bottomAnchor, constant:ContentSection.interItemVerticalSpace).isActive = true
-        fields.0.leftAnchor.constraint(equalTo: fieldList.0.rightAnchor, constant:ContentSection.horizontalSpace).isActive = true
+        fieldList.0.topAnchor.constraint(equalTo: search.0.bottomAnchor, constant: ContentSection.interItemVerticalSpace).isActive = true
+        fields.0.leftAnchor.constraint(equalTo: fieldList.0.rightAnchor, constant: ContentSection.horizontalSpace).isActive = true
         fields.0.topAnchor.constraint(equalTo: fieldList.0.topAnchor).isActive = true
         fields.0.rightAnchor.constraint(equalTo: content.rightAnchor).isActive = true
         fields.0.bottomAnchor.constraint(equalTo: objList.0.bottomAnchor).isActive = true
         objList.0.leftAnchor.constraint(equalTo: content.leftAnchor).isActive = true
-        objList.0.topAnchor.constraint(equalTo: fieldList.0.bottomAnchor, constant:ContentSection.interItemVerticalSpace).isActive = true
+        objList.0.topAnchor.constraint(equalTo: fieldList.0.bottomAnchor, constant: ContentSection.interItemVerticalSpace).isActive = true
         fieldList.0.widthAnchor.constraint(equalTo: search.0.widthAnchor).isActive = true
         objList.0.widthAnchor.constraint(equalTo: search.0.widthAnchor).isActive = true
         fieldList.0.heightAnchor.constraint(equalTo: objType.0.heightAnchor).isActive = true
@@ -387,10 +383,10 @@ class RootViewController: UIViewController {
         
         // sixth row
         userId.0.leftAnchor.constraint(equalTo: content.leftAnchor).isActive = true
-        userId.0.topAnchor.constraint(equalTo: objList.0.bottomAnchor, constant:ContentSection.interItemVerticalSpace).isActive = true
-        page.0.leftAnchor.constraint(equalTo: userId.0.rightAnchor, constant:ContentSection.horizontalSpace).isActive = true
+        userId.0.topAnchor.constraint(equalTo: objList.0.bottomAnchor, constant: ContentSection.interItemVerticalSpace).isActive = true
+        page.0.leftAnchor.constraint(equalTo: userId.0.rightAnchor, constant: ContentSection.horizontalSpace).isActive = true
         page.0.topAnchor.constraint(equalTo: userId.0.topAnchor).isActive = true
-        version.0.leftAnchor.constraint(equalTo: page.0.rightAnchor, constant:ContentSection.horizontalSpace).isActive = true
+        version.0.leftAnchor.constraint(equalTo: page.0.rightAnchor, constant: ContentSection.horizontalSpace).isActive = true
         version.0.topAnchor.constraint(equalTo: userId.0.topAnchor).isActive = true
         version.0.rightAnchor.constraint(equalTo: content.rightAnchor).isActive = true
         page.0.widthAnchor.constraint(equalTo: search.0.widthAnchor).isActive = true
@@ -401,11 +397,11 @@ class RootViewController: UIViewController {
         
         // seventh row
         objIdList.0.leftAnchor.constraint(equalTo: content.leftAnchor).isActive = true
-        objIdList.0.topAnchor.constraint(equalTo: userId.0.bottomAnchor, constant:ContentSection.interItemVerticalSpace).isActive = true
+        objIdList.0.topAnchor.constraint(equalTo: userId.0.bottomAnchor, constant: ContentSection.interItemVerticalSpace).isActive = true
         objIdList.0.bottomAnchor.constraint(equalTo: content.bottomAnchor).isActive = true
-        entityId.0.leftAnchor.constraint(equalTo: objIdList.0.rightAnchor, constant:ContentSection.horizontalSpace).isActive = true
+        entityId.0.leftAnchor.constraint(equalTo: objIdList.0.rightAnchor, constant: ContentSection.horizontalSpace).isActive = true
         entityId.0.topAnchor.constraint(equalTo: objIdList.0.topAnchor).isActive = true
-        shareType.0.leftAnchor.constraint(equalTo: entityId.0.rightAnchor, constant:ContentSection.horizontalSpace).isActive = true
+        shareType.0.leftAnchor.constraint(equalTo: entityId.0.rightAnchor, constant: ContentSection.horizontalSpace).isActive = true
         shareType.0.topAnchor.constraint(equalTo: objIdList.0.topAnchor).isActive = true
         shareType.0.rightAnchor.constraint(equalTo: content.rightAnchor).isActive = true
         entityId.0.widthAnchor.constraint(equalTo: objIdList.0.widthAnchor).isActive = true
@@ -510,13 +506,13 @@ class RootViewController: UIViewController {
         
         let expandButton = UIButton(type: .custom)
         expandButton.translatesAutoresizingMaskIntoConstraints = false
-        expandButton.setImage(UIImage(named:"up"), for: .normal)
+        expandButton.setImage(UIImage(named: "up"), for: .normal)
         expandButton.addTarget(self, action: #selector(userDidTapExpandButton(_:)), for: .touchUpInside)
         
         self.responseSection.container.addSubview(expandButton)
         
         expandButton.centerXAnchor.constraint(equalTo: self.responseSection.container.centerXAnchor).isActive = true
-        expandButton.topAnchor.constraint(equalTo: self.responseSection.container.topAnchor, constant:-10).isActive = true
+        expandButton.topAnchor.constraint(equalTo: self.responseSection.container.topAnchor, constant: -10).isActive = true
         expandButton.widthAnchor.constraint(equalToConstant: 100.0).isActive = true
         expandButton.heightAnchor.constraint(equalToConstant: 40.0).isActive = true
         
@@ -533,21 +529,20 @@ class RootViewController: UIViewController {
         
         textView.leftAnchor.constraint(equalTo: content.leftAnchor).isActive = true
         textView.rightAnchor.constraint(equalTo: content.rightAnchor).isActive = true
-        textView.topAnchor.constraint(equalTo: content.topAnchor, constant:ContentSection.topSpace).isActive = true
+        textView.topAnchor.constraint(equalTo: content.topAnchor, constant: ContentSection.topSpace).isActive = true
         textView.bottomAnchor.constraint(equalTo: content.bottomAnchor).isActive = true
-        
         
         self.responseForTextView = textView
         
         return self.responseSection.container
     }
     
-    @objc func userDidTapQueryButton(_ sender:UIButton) {
+    @objc func userDidTapQueryButton(_ sender: UIButton) {
         print("handle tapped query button")
         self.view.endEditing(true)
         guard let path = self.manualQueryTextField.text, let method = RestRequest.Method(rawValue: self.methodControl.selectedSegmentIndex) else {return}
         
-        var queryParams:[String: Any]?
+        var queryParams: [String: Any]?
         if let params = self.paramsTextView.text {
             queryParams = SFJsonUtils.object(fromJSONString: params) as? [String: Any]
         }
@@ -557,14 +552,14 @@ class RootViewController: UIViewController {
             DispatchQueue.main.async { [weak self] in
                 self?.updateUI(request, response: nil, error: nil)
             }
-        } , onSuccess: { [weak self] (reponse, urlResponse) in
+        }, onSuccess: { [weak self] (reponse, urlResponse) in
             DispatchQueue.main.async {
                 self?.updateUI(request, response: reponse, error: nil)
             }
         })
     }
     
-    @objc func userDidTapExpandButton(_ sender:UIButton) {
+    @objc func userDidTapExpandButton(_ sender: UIButton) {
         UIView.animate(withDuration: 0.35, delay: 0.0, usingSpringWithDamping: 0.8, initialSpringVelocity: 0.3, options: .curveEaseIn, animations: {
             if self.responseContractedTopConstraint.isActive {
                 self.responseContractedTopConstraint.isActive = false
@@ -576,21 +571,21 @@ class RootViewController: UIViewController {
                 self.responseContractedTopConstraint.isActive = true
             }
             self.view.layoutIfNeeded()
-        }) { (completed) in
+        }) { _ in
             self.view.layoutIfNeeded()
         }
     }
-
-    func showMissingFieldError(_ reason:String?) {
-        guard let r = reason else {return}
-        self.showAlert("Missing Fields", message: "You need to fill out the following field(s): \(r)")
+    
+    func showMissingFieldError(_ reason: String?) {
+        guard let rsn = reason else {return}
+        self.showAlert("Missing Fields", message: "You need to fill out the following field(s): \(rsn)")
     }
     
-    func showAlert(_ title:String, message:String) {
+    func showAlert(_ title: String, message: String) {
         let alert = UIAlertController(title: title,
                                       message: message,
                                       preferredStyle: .alert)
-        let cancel = UIAlertAction(title: "Ok", style: .default) { (action) in
+        let cancel = UIAlertAction(title: "Ok", style: .default) { _ in
             self.presentedViewController?.dismiss(animated: true, completion: nil)
         }
         alert.addAction(cancel)
@@ -602,10 +597,10 @@ class RootViewController: UIViewController {
                                       message: "Are you sure you want to log out?",
                                       preferredStyle: .alert)
         
-        let logout = UIAlertAction(title: "Logout", style: .default) { (action) in
+        let logout = UIAlertAction(title: "Logout", style: .default) { _ in
             UserAccountManager.shared.logout()
         }
-        let cancel = UIAlertAction(title: "Cancel", style: .cancel) { (action) in
+        let cancel = UIAlertAction(title: "Cancel", style: .cancel) { _ in
             self.presentedViewController?.dismiss(animated: true, completion: nil)
         }
         alert.addAction(cancel)
@@ -625,8 +620,8 @@ class RootViewController: UIViewController {
     }
     
     func dismissPopover() {
-        if let p = self.presentedActions {
-            p.dismiss(animated: true, completion: nil)
+        if let pAction = self.presentedActions {
+            pAction.dismiss(animated: true, completion: nil)
         }
     }
     
@@ -635,17 +630,17 @@ class RootViewController: UIViewController {
             appDelegate.exportTestingCredentials()
         }
     }
-
-    func updateUI(_ forRequest:RestRequest, response: Any? , error:Error?) {
+    
+    func updateUI(_ forRequest: RestRequest, response: Any?, error: Error?) {
         self.manualQueryTextField.text = forRequest.path
         self.paramsTextView.text = SFJsonUtils.jsonRepresentation(forRequest.queryParams as Any)
         self.methodControl.selectedSegmentIndex = forRequest.method.rawValue
         
         guard let largeFont = UIFont.appRegularFont(20), let regFont = UIFont.appRegularFont(14) else {return}
-        let titleAttribs:[NSAttributedString.Key: Any] = [NSAttributedString.Key.font : largeFont,
-                                                         NSAttributedString.Key.foregroundColor: UIColor.appDarkBlue]
-        let descriptionAttribs:[NSAttributedString.Key: Any] = [NSAttributedString.Key.font: regFont,
-                                                               NSAttributedString.Key.foregroundColor: UIColor.appTextFieldBlue]
+        let titleAttribs: [NSAttributedString.Key: Any] = [NSAttributedString.Key.font: largeFont,
+                                                          NSAttributedString.Key.foregroundColor: UIColor.appDarkBlue]
+        let descriptionAttribs: [NSAttributedString.Key: Any] = [NSAttributedString.Key.font: regFont,
+                                                                NSAttributedString.Key.foregroundColor: UIColor.appTextFieldBlue]
         
         let attributedString = NSMutableAttributedString(string: "Response for: ", attributes: titleAttribs)
         
@@ -654,19 +649,19 @@ class RootViewController: UIViewController {
         attributedString.append(descriptionString)
         self.responseSection.attributedTitle = attributedString
         
-        if let r = response {
-            let jsonData = try? JSONSerialization.data(withJSONObject: r, options: .prettyPrinted)
+        if let resp = response {
+            let jsonData = try? JSONSerialization.data(withJSONObject: resp, options: .prettyPrinted)
             if let jsonObj = jsonData {
                 let jsonString = String(data: jsonObj, encoding: .utf8)
                 self.responseForTextView.setContentOffset(CGPoint.zero, animated: false)
                 self.responseForTextView.text = jsonString
             }
         }
-      
-        if let e = error {
-            self.responseForTextView.text = e.localizedDescription
+        
+        if let err = error {
+            self.responseForTextView.text = err.localizedDescription
         }
-            
+        
     }
 }
 
@@ -685,172 +680,171 @@ extension RootViewController: ActionTableViewDelegate {
         let objectId = self.objectIdTextField.text
         let fieldList = self.fieldListTextField.text
         let objectList = self.objectListTextField.text
-        let fields = SFJsonUtils.object(fromJSONString: self.fieldsTextView.text) as? [String:Any]
+        let fields = SFJsonUtils.object(fromJSONString: self.fieldsTextView.text) as? [String: Any]
         let search = self.searchTextField.text
         let query = self.queryTextField.text
         let externalId = self.externalIdTextField.text
         let externalFieldId = self.externalFieldIdTextField.text
         let userId = self.userIdTextField.text
         let page = UInt(self.pageTextField.text ?? "")
-        let version = self.versionTextField.text
         let objectIdList = self.objectIdListTextField.text?.components(separatedBy: ",")
         let entityId = self.entityIdTextField.text
         let shareType = self.shareTypeTextField.text
         let restApi = RestClient.shared
-      
+        
         switch action.type {
-                    case .versions:
-                        request = restApi.requestForVersions()
-                    case .resources:
-                        request =  restApi.request(forResources: SFRestDefaultAPIVersion)
-                    case .describeGlobal:
-                        request = restApi.request(forDescribeGlobal: SFRestDefaultAPIVersion)
-                    case .metadataWithObjectType:
-                        guard let objType = objectType else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.requestForMetadata(withObjectType: objType, apiVersion: SFRestDefaultAPIVersion)
-                    case .describeWithObjectType:
-                        guard let objType = objectType else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.requestForDescribe(withObjectType: objType, apiVersion: SFRestDefaultAPIVersion)
-                     case .retrieveWithObjectType:
-                        guard let objType = objectType , let objId = objectId, let fList = fieldList else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.requestForRetrieve(withObjectType: objType, objectId: objId, fieldList: fList, apiVersion: SFRestDefaultAPIVersion)
-                    case .createWithObjectType:
-                        guard let objType = objectType, let f = fields else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.requestForCreate(withObjectType: objType, fields: f, apiVersion: SFRestDefaultAPIVersion)
-                    case .upsertWithObjectType:
-                        guard let objType = objectType, let extFId = externalFieldId, let extId = externalId, let f = fields else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request =  restApi.requestForUpsert(withObjectType: objType, externalIdField: extFId, externalId: extId, fields: f, apiVersion: SFRestDefaultAPIVersion)
-                   case .updateWithObjectType:
-                        guard let objType = objectType, let objId = objectId, let f = fields else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.requestForUpdate(withObjectType: objType, objectId: objId, fields: f, apiVersion: SFRestDefaultAPIVersion)
-                   case .deleteWithObjectType:
-                        guard let objType = objectType, let objId = objectId else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.requestForDelete(withObjectType: objType, objectId: objId, apiVersion: SFRestDefaultAPIVersion)
-                   case .query:
-                        guard let q = query else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.request(forQuery: q, apiVersion: SFRestDefaultAPIVersion)
-                    case .search:
-                        guard let s = search else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.request(forSearch: s, apiVersion: SFRestDefaultAPIVersion)
-                    case .searchScopeAndOrder:
-                        request = restApi.request(forSearchScopeAndOrder: SFRestDefaultAPIVersion)
-                    case .searchResultLayout:
-                        guard let objList = objectList else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.request(forSearchResultLayout: objList, apiVersion: SFRestDefaultAPIVersion)
-                    case .ownedFilesList:
-                        guard let uId = userId, let p = page else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.request(forOwnedFilesList: uId, page: p, apiVersion: SFRestDefaultAPIVersion)
-                    case .filesInUserGroups:
-                        guard let uId = userId, let p = page else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.requestForFiles(inUsersGroups: uId, page: p, apiVersion: SFRestDefaultAPIVersion)
-                    case .filesSharedWithUser:
-                        guard let uId = userId, let p = page else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.requestForFilesShared(withUser: uId, page: p, apiVersion: SFRestDefaultAPIVersion)
-                    case .fileDetails:
-                        guard let objId = objectId, let _ = version else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.request(forFileDetails: objId, forVersion: objId, apiVersion: SFRestDefaultAPIVersion)
-                    case .batchFileDetails:
-                        guard let objIdList = objectIdList else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.request(forBatchFileDetails: objIdList, apiVersion: SFRestDefaultAPIVersion)
-                    case .fileShares:
-                        guard let objId = objectId, let p = page else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.request(forFileShares: objId, page: p, apiVersion: SFRestDefaultAPIVersion)
-           
-                    case .addFileShare:
-                        guard let objId = objectId, let eId = entityId, let sType = shareType else {
-                            self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.request(forAddFileShare: objId, entityId: eId, shareType: sType, apiVersion: SFRestDefaultAPIVersion)
-                    case .deleteFileShare:
-                        guard let objId = objectId else {
-                        self.showMissingFieldError(objectTypes)
-                            return
-                        }
-                        request = restApi.request(forDeleteFileShare: objId, apiVersion: SFRestDefaultAPIVersion)
-                    case .currentUserInfo:
-                        guard let currentAccount = UserAccountManager.shared.currentUserAccount else {return}
-                        guard let idData = currentAccount.idData else {return}
-                        var userInfoString = "Name: " + self.fullName
-                        userInfoString = userInfoString + "\nID: " + idData.username
-                        userInfoString = userInfoString + "\nEmail: " + idData.email
-                        self.showAlert("User Info", message:userInfoString)
-                        return
-                    case .enableBiometric:
-                        // Uncomment this code to find the current state of biometric unlock
-                        //UserAccountManager.shared.biometricUnlockState()
-                        
-                        UserAccountManager.shared.presentBiometricEnrollment(nil)
-                        return
-                    case .logout:
-                        self.presentedViewController?.dismiss(animated: true, completion: nil)
-                        self.createLogoutActionSheet()
-                        return
-                    case .switchUser:
-                        let umvc = SalesforceUserManagementViewController.init(completionBlock: { (action) in
-                            self.dismiss(animated: true, completion: nil)
-                        })
-                        self.present(umvc, animated: true, completion: nil)
-                        return
-                    case .exportCredentials:
-                        self.exportTestingCredentials()
-                        return
+        case .versions:
+            request = restApi.requestForVersions()
+        case .resources:
+            request =  restApi.request(forResources: SFRestDefaultAPIVersion)
+        case .describeGlobal:
+            request = restApi.request(forDescribeGlobal: SFRestDefaultAPIVersion)
+        case .metadataWithObjectType:
+            guard let objType = objectType else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.requestForMetadata(withObjectType: objType, apiVersion: SFRestDefaultAPIVersion)
+        case .describeWithObjectType:
+            guard let objType = objectType else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.requestForDescribe(withObjectType: objType, apiVersion: SFRestDefaultAPIVersion)
+        case .retrieveWithObjectType:
+            guard let objType = objectType, let objId = objectId, let fList = fieldList else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.requestForRetrieve(withObjectType: objType, objectId: objId, fieldList: fList, apiVersion: SFRestDefaultAPIVersion)
+        case .createWithObjectType:
+            guard let objType = objectType, let flds = fields else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.requestForCreate(withObjectType: objType, fields: flds, apiVersion: SFRestDefaultAPIVersion)
+        case .upsertWithObjectType:
+            guard let objType = objectType, let extFId = externalFieldId, let extId = externalId, let flds = fields else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request =  restApi.requestForUpsert(withObjectType: objType, externalIdField: extFId, externalId: extId, fields: flds, apiVersion: SFRestDefaultAPIVersion)
+        case .updateWithObjectType:
+            guard let objType = objectType, let objId = objectId, let flds = fields else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.requestForUpdate(withObjectType: objType, objectId: objId, fields: flds, apiVersion: SFRestDefaultAPIVersion)
+        case .deleteWithObjectType:
+            guard let objType = objectType, let objId = objectId else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.requestForDelete(withObjectType: objType, objectId: objId, apiVersion: SFRestDefaultAPIVersion)
+        case .query:
+            guard let qry = query else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.request(forQuery: qry, apiVersion: SFRestDefaultAPIVersion)
+        case .search:
+            guard let srch = search else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.request(forSearch: srch, apiVersion: SFRestDefaultAPIVersion)
+        case .searchScopeAndOrder:
+            request = restApi.request(forSearchScopeAndOrder: SFRestDefaultAPIVersion)
+        case .searchResultLayout:
+            guard let objList = objectList else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.request(forSearchResultLayout: objList, apiVersion: SFRestDefaultAPIVersion)
+        case .ownedFilesList:
+            guard let uId = userId, let pge = page else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.request(forOwnedFilesList: uId, page: pge, apiVersion: SFRestDefaultAPIVersion)
+        case .filesInUserGroups:
+            guard let uId = userId, let pge = page else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.requestForFiles(inUsersGroups: uId, page: pge, apiVersion: SFRestDefaultAPIVersion)
+        case .filesSharedWithUser:
+            guard let uId = userId, let pge = page else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.requestForFilesShared(withUser: uId, page: pge, apiVersion: SFRestDefaultAPIVersion)
+        case .fileDetails:
+            guard let objId = objectId else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.request(forFileDetails: objId, forVersion: objId, apiVersion: SFRestDefaultAPIVersion)
+        case .batchFileDetails:
+            guard let objIdList = objectIdList else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.request(forBatchFileDetails: objIdList, apiVersion: SFRestDefaultAPIVersion)
+        case .fileShares:
+            guard let objId = objectId, let pge = page else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.request(forFileShares: objId, page: pge, apiVersion: SFRestDefaultAPIVersion)
+            
+        case .addFileShare:
+            guard let objId = objectId, let eId = entityId, let sType = shareType else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.request(forAddFileShare: objId, entityId: eId, shareType: sType, apiVersion: SFRestDefaultAPIVersion)
+        case .deleteFileShare:
+            guard let objId = objectId else {
+                self.showMissingFieldError(objectTypes)
+                return
+            }
+            request = restApi.request(forDeleteFileShare: objId, apiVersion: SFRestDefaultAPIVersion)
+        case .currentUserInfo:
+            guard let currentAccount = UserAccountManager.shared.currentUserAccount else {return}
+            guard let idData = currentAccount.idData else {return}
+            var userInfoString = "Name: " + self.fullName
+            userInfoString += "\nID: " + idData.username
+            userInfoString += "\nEmail: " + idData.email
+            self.showAlert("User Info", message: userInfoString)
+            return
+        case .enableBiometric:
+            // Uncomment this code to find the current state of biometric unlock
+            //UserAccountManager.shared.biometricUnlockState()
+            
+            UserAccountManager.shared.presentBiometricEnrollment(nil)
+            return
+        case .logout:
+            self.presentedViewController?.dismiss(animated: true, completion: nil)
+            self.createLogoutActionSheet()
+            return
+        case .switchUser:
+            let umvc = SalesforceUserManagementViewController.init(completionBlock: { _ in
+                self.dismiss(animated: true, completion: nil)
+            })
+            self.present(umvc, animated: true, completion: nil)
+            return
+        case .exportCredentials:
+            self.exportTestingCredentials()
+            return
             
         }
         
-        restApi.send(request: request!, onFailure: { (error, urlResponse) in
+        restApi.send(request: request!, onFailure: { (error, _) in
             DispatchQueue.main.async { [weak self] in
                 self?.updateUI(request!, response: nil, error: error)
             }
-        } , onSuccess: { [weak self] (reponse, urlResponse) in
+        }, onSuccess: { [weak self] (reponse, _) in
             DispatchQueue.main.async {
                 self?.updateUI(request!, response: reponse, error: nil)
             }


### PR DESCRIPTION
Similar to template swift code fixes. Resolves a lot of swift lint issues. The length of function and class  still remains the same, so will still see those lint warnings.  The only other warning that you will see  is the presence of an empty line in code. The rest of the warnings have been resolved. We can perhaps revisit and reduce the size of the code for RootViewController for 8.0 in terms of loc.