### PR TITLE
JSON check refinements

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -1851,11 +1851,14 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
                 [resultStrings addObject:[((NSNumber*)value) stringValue]];
             }
             else if ([value isKindOfClass:[NSString class]]) {
-                NSMutableString *tmpString = [[NSMutableString alloc] init];
-                [tmpString appendString:@"\""];
-                [tmpString appendString:[self escapeStringValue:((NSString*) value)]];
-                [tmpString appendString:@"\""];
-                [resultStrings addObject:tmpString];
+                NSString *escapedAndQuotedValue = [self escapeStringValueAndQuote:(NSString*) value];
+                if (escapedAndQuotedValue) {
+                    [resultStrings addObject:escapedAndQuotedValue];
+                } else {
+                    // This is a smart query, we can't skip
+                    // If you do select x,y,z, then you expect 3 values per row in the result set
+                    [resultStrings addObject:@"null"];
+                }
             }
         }
     }
@@ -1864,9 +1867,9 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     [resultString appendString:@"]"];
 }
 
--(NSString*) escapeStringValue:(NSString*) raw {
+-(NSString*) escapeStringValueAndQuote:(NSString*) raw {
     NSMutableString* escaped = [NSMutableString new];
-    
+    [escaped appendString:@"\""];
     for (NSUInteger i = 0; i < raw.length; i += 1) {
         unichar c = [raw characterAtIndex:i];
         switch (c) {
@@ -1898,7 +1901,13 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
                 }
         }
     }
-    return [NSString stringWithString:escaped];
+    [escaped appendString:@"\""];
+    
+    if (![self checkRawJson:[NSString stringWithFormat:@"[%@]", escaped] fromMethod:NSStringFromSelector(_cmd)]) {
+        return nil;
+    } else {
+        return [NSString stringWithString:escaped];
+    }
 }
 
 - (NSString *)idsInPredicate:(NSArray *)ids idCol:(NSString*)idCol

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -1841,6 +1841,10 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
                 NSString *loadResult = [self loadExternalSoupEntryAsString:soupEntryId soupTableName:value];
                 if (loadResult) {
                     [resultStrings addObject:loadResult];
+                } else {
+                    // This is a smart query, we can't skip
+                    // If you do select x,y,z, then you expect 3 values per row in the result set
+                    [resultStrings addObject:@"null"];
                 }
             }
             else if ([value isKindOfClass:[NSNumber class]]) {


### PR DESCRIPTION
• If one does a smart query `select a,b,c` all rows should have 3 elements. With json check on, when a bad entry is detected, it is just dropped from the array for that row. It's okay for exact/range/like queries because they return an array of soup entries. But it's not right for smart queries.
• We were only json checking the soup entry, but if an app does a select key, _soup and the key is processed by an escape function (came in at the same time as the optimization), so if somehow it is bad, it will only be picked up by the json check for the whole result set. So I added a json-check for string values.