### PR TITLE
Using ASWebAuthenticationSession instead of SFAuthenticationSession

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -60,6 +60,10 @@
 		4F16F4C1222A1C53008529FB /* SalesforceAnalytics.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B716A398218F5E37009D407F /* SalesforceAnalytics.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4F16F4C2222A1C5A008529FB /* SalesforceSDKCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B716A38A218F5E2D009D407F /* SalesforceSDKCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4F230BC21BFEABA00030EEFA /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FFE4A001BFE522F00F15E01 /* libz.tbd */; };
+		4F3139652331C5A1007B3705 /* SFSDKAuthRootController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F3139642331C5A1007B3705 /* SFSDKAuthRootController.m */; };
+		4F3139662331C5A1007B3705 /* SFSDKAuthRootController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F3139642331C5A1007B3705 /* SFSDKAuthRootController.m */; };
+		4F3139682331C5C7007B3705 /* SFSDKAuthRootController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F3139672331C5B9007B3705 /* SFSDKAuthRootController.h */; };
+		4F3139692331C5C8007B3705 /* SFSDKAuthRootController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F3139672331C5B9007B3705 /* SFSDKAuthRootController.h */; };
 		4F4055C72232304E00316D91 /* SFSecureEncryptionKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F4055C52232304D00316D91 /* SFSecureEncryptionKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4F4055C82232304E00316D91 /* SFSecureEncryptionKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F4055C62232304E00316D91 /* SFSecureEncryptionKey.m */; };
 		4F4055C92232305F00316D91 /* SFSecureEncryptionKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F4055C52232304D00316D91 /* SFSecureEncryptionKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -892,6 +896,8 @@
 		4F06AF701C49A16A00F70798 /* SFTestSDKManagerFlow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFTestSDKManagerFlow.h; path = SalesforceSDKCoreTests/SFTestSDKManagerFlow.h; sourceTree = SOURCE_ROOT; };
 		4F06AF711C49A16A00F70798 /* SFTestSDKManagerFlow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFTestSDKManagerFlow.m; path = SalesforceSDKCoreTests/SFTestSDKManagerFlow.m; sourceTree = SOURCE_ROOT; };
 		4F06AF721C49A16A00F70798 /* SFUserAccountManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFUserAccountManagerTests.m; path = SalesforceSDKCoreTests/SFUserAccountManagerTests.m; sourceTree = SOURCE_ROOT; };
+		4F3139642331C5A1007B3705 /* SFSDKAuthRootController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKAuthRootController.m; sourceTree = "<group>"; };
+		4F3139672331C5B9007B3705 /* SFSDKAuthRootController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKAuthRootController.h; sourceTree = "<group>"; };
 		4F4055C52232304D00316D91 /* SFSecureEncryptionKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSecureEncryptionKey.h; sourceTree = "<group>"; };
 		4F4055C62232304E00316D91 /* SFSecureEncryptionKey.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSecureEncryptionKey.m; sourceTree = "<group>"; };
 		4F4055CB2232361500316D91 /* SFSecureEncryptionKeyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFSecureEncryptionKeyTests.m; path = SalesforceSDKCoreTests/SFSecureEncryptionKeyTests.m; sourceTree = SOURCE_ROOT; };
@@ -1536,6 +1542,8 @@
 				B70986341F5331A600803FDE /* SFSDKOAuthClientConfig.m */,
 				B7C273431F7D7EAA00CE539D /* SFSDKOAuthClientCache.h */,
 				B7C273441F7D7EAA00CE539D /* SFSDKOAuthClientCache.m */,
+				4F3139672331C5B9007B3705 /* SFSDKAuthRootController.h */,
+				4F3139642331C5A1007B3705 /* SFSDKAuthRootController.m */,
 			);
 			path = OAuth;
 			sourceTree = "<group>";
@@ -2144,6 +2152,7 @@
 				CE4CE3271C0E523B009F6029 /* NSData+SFSDKUtils.h in Headers */,
 				CE4CE3831C0E526A009F6029 /* SFPBKDF2PasscodeProvider.h in Headers */,
 				FDED97271CAA16EB009D80F2 /* SFApplicationHelper.h in Headers */,
+				4F3139682331C5C7007B3705 /* SFSDKAuthRootController.h in Headers */,
 				B78A238B21014FCA00B19AB3 /* SFSDKAuthHelper.h in Headers */,
 				B773CCF61F8200BD00D2D1B2 /* SFSDKIDPInitCommand.h in Headers */,
 				CE4CE3671C0E526A009F6029 /* SFDefaultUserManagementListViewController.h in Headers */,
@@ -2377,6 +2386,7 @@
 				CEA882D71C18FB8E008D871B /* SFAuthErrorHandlerList.h in Headers */,
 				CEA882D51C18FB8E008D871B /* SFAuthErrorHandler.h in Headers */,
 				CEA882EB1C18FB8E008D871B /* SFKeyStoreKey.h in Headers */,
+				4F3139692331C5C8007B3705 /* SFSDKAuthRootController.h in Headers */,
 				E1C80D171C5C365D001B3A21 /* SFLoginViewController.h in Headers */,
 				B7E3911B2209EB1300D61D4D /* SFSDKViewUtils.h in Headers */,
 				CEA882B11C18FB28008D871B /* SFIdentityCoordinator+Internal.h in Headers */,
@@ -2833,6 +2843,7 @@
 				B7E8A2A61E7369DB007C0D92 /* SFDefaultUserAccountPersister.m in Sources */,
 				B7A20FAF1F26C39700D1E4B0 /* SFSDKRootController.m in Sources */,
 				CE50CE921DD3DD1F00F1297B /* SFSDKEventBuilderHelper.m in Sources */,
+				4F3139652331C5A1007B3705 /* SFSDKAuthRootController.m in Sources */,
 				CE4CE3A61C0E5279009F6029 /* SFDirectoryManager.m in Sources */,
 				A3161D062181104000437BD2 /* SFSDKAppLockViewController.m in Sources */,
 				B7C274561F81507100CE539D /* SFSDKAuthResponseCommand.m in Sources */,
@@ -2921,6 +2932,7 @@
 				B70986381F5331A600803FDE /* SFSDKOAuthClientConfig.m in Sources */,
 				E1C80D281C5C366F001B3A21 /* SFSDKLoginHost.m in Sources */,
 				CEA8829E1C18FAAB008D871B /* UIScreen+SFAdditions.m in Sources */,
+				4F3139662331C5A1007B3705 /* SFSDKAuthRootController.m in Sources */,
 				CEA882F41C18FB8E008D871B /* SFPasscodeManager.m in Sources */,
 				B7C274081F7EF2D700CE539D /* SFSDKIDPConstants.m in Sources */,
 				B7FB26EC1F78098C00FB25A2 /* SFSDKAdvancedAuthURLHandler.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -719,9 +719,9 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
     // Don't present snapshot during advanced authentication or Passcode Presentation
     // ==============================================================================
     // During advanced authentication, application is briefly backgrounded then foregrounded
-    // The SFAuthenticationSession's view controller is pushed into the key window
-    // If we make the snapshot window the active window now, that's where the SFAuthenticationSession's view controller will end up
-    // Then when the application is foregrounded and the snapshot window is dismissed, we will lose the SFAuthenticationSession
+    // The ASWebAuthenticationSession's view controller is pushed into the key window
+    // If we make the snapshot window the active window now, that's where the ASWebAuthenticationSession's view controller will end up
+    // Then when the application is foregrounded and the snapshot window is dismissed, we will lose the ASWebAuthenticationSession
     SFSDKWindowContainer* activeWindow = [SFSDKWindowManager sharedManager].activeWindow;
     if ([activeWindow isAuthWindow] || [activeWindow isPasscodeWindow]) {
         return;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
@@ -22,7 +22,7 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <SafariServices/SafariServices.h>
+#import <AuthenticationServices/AuthenticationServices.h>
 #import <Security/Security.h>
 #import <UIKit/UIKit.h>
 #import <WebKit/WebKit.h>
@@ -210,14 +210,14 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
  */
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(WKWebView *)view;
 
-/** Sent after SFAuthenticationSession was initialized with authentication URL.
+/** Sent after ASWebAuthenticationSession was initialized with authentication URL.
  
  @param coordinator The SFOAuthCoordinator instance processing this message
- @param session     The SFAuthenticationSession instance that will be used to conduct the authentication workflow
+ @param session     The ASWebAuthenticationSession instance that will be used to conduct the authentication workflow
  
  @see SFOAuthCoordinator
  */
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(SFAuthenticationSession *)session;
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(ASWebAuthenticationSession *)session;
 
 /**
  Sent to notify the delegate that a browser authentication flow was cancelled out of by the user.
@@ -297,7 +297,7 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
 /**
  Auth session through which the user will input OAuth credentials for the user-agent flow OAuth process.
  */
-@property (nonatomic, readonly, null_unspecified) SFAuthenticationSession *authSession;
+@property (nonatomic, readonly, null_unspecified) ASWebAuthenticationSession *authSession;
 
 /**
  The user agent string that will be used for authentication.  While this property will persist throughout

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -365,7 +365,7 @@
     [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureSafariBrowserForLogin];
     __weak typeof(self) weakSelf = self;
     
-    _authSession = [[SFAuthenticationSession alloc] initWithURL:nativeBrowserUrl callbackURLScheme:nil completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable error) {
+    _authSession = [[ASWebAuthenticationSession alloc] initWithURL:nativeBrowserUrl callbackURLScheme:nil completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!error && [[SFSDKURLHandlerManager sharedInstance] canHandleRequest:callbackURL options:nil]) {
             [[SFSDKURLHandlerManager sharedInstance] processRequest:callbackURL  options:nil];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -122,7 +122,7 @@
         });
     }
 }
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(SFAuthenticationSession *)session {
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(ASWebAuthenticationSession *)session {
 
     // Do nothing - doesn't apply to the refresh flow.
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRootController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRootController.h
@@ -1,0 +1,37 @@
+/*
+ SFSDKAuthRootController.h
+ SalesforceSDKCore
+ 
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+  Sub class of SFSDKRootViewController used in the auth window
+  Implements the ASWebAuthenticationPresentationContextProviding on iOS 13
+ */
+
+#import "SFSDKRootController.h"
+
+@interface SFSDKAuthRootController : SFSDKRootController
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRootController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRootController.m
@@ -1,0 +1,40 @@
+/*
+SFSDKAuthRootController.m
+SalesforceSDKCore
+
+Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
+
+Redistribution and use of this software in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this list of
+conditions and the following disclaimer in the documentation and/or other materials provided
+with the distribution.
+* Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+endorse or promote products derived from this software without specific prior written
+permission of salesforce.com, inc.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#import "SFSDKAuthRootController.h"
+#import <AuthenticationServices/AuthenticationServices.h>
+
+@implementation SFSDKAuthRootController
+
+/**
+  Implementating  ASWebAuthenticationPresentationContextProviding so that ASWebAuthenticationSession can be started from the window
+ */
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13.0)) {
+    return self.view.window;
+}
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthViewHandler.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthViewHandler.h
@@ -28,7 +28,7 @@
  */
 #import <Foundation/Foundation.h>
 @class WKWebView;
-@class SFAuthenticationSession;
+@class ASWebAuthenticationSession;
 @class SFSDKAuthViewHolder;
 @class SFLoginViewController;
 NS_ASSUME_NONNULL_BEGIN
@@ -49,7 +49,7 @@ NS_SWIFT_NAME(AuthViewHolder)
 
 @property (nonatomic,weak) SFLoginViewController *loginController;
 
-@property (nonatomic,weak,nullable) SFAuthenticationSession *session;
+@property (nonatomic,weak,nullable) ASWebAuthenticationSession *session;
 
 @property (nonatomic,assign) BOOL isAdvancedAuthFlow;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.h
@@ -167,7 +167,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)authClient:(SFSDKOAuthClient *)client willBeginBrowserAuthentication:(SFOAuthBrowserFlowCallbackBlock)callbackBlock;
 
-- (void)authClient:(SFSDKOAuthClient *)client didBeginAuthenticationWithSession:(SFAuthenticationSession *)session;
+- (void)authClient:(SFSDKOAuthClient *)client didBeginAuthenticationWithSession:(ASWebAuthenticationSession *)session;
 
 /**
  Called when a browser flow authentication is cancelled.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -396,7 +396,7 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
 
 }
 
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(SFAuthenticationSession *)session {
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(ASWebAuthenticationSession *)session {
     [SFSDKCoreLogger d:[self class] format:@"oauthCoordinator:didBeginAuthenticationWithSession:"];
     if ([self.config.safariViewDelegate respondsToSelector:@selector(authClient:didBeginAuthenticationWithSession:)]) {
         [self.config.safariViewDelegate authClient:self didBeginAuthenticationWithSession:session];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKOAuthClient.m
@@ -41,6 +41,7 @@
 #import "SFSecurityLockout.h"
 #import "SFSDKIDPAuthClient.h"
 #import "SFOAuthCredentials+Internal.h"
+#import "SFSDKAuthRootController.h"
 
 // Auth error handler name constants
 static NSString * const kSFInvalidCredentialsAuthErrorHandler = @"InvalidCredentialsErrorHandler";
@@ -636,17 +637,22 @@ static Class<SFSDKOAuthClientProvider> _clientProvider = nil;
     
     __weak typeof(self) weakSelf = self;
     void (^presentViewBlock)(void) = ^void() {
-
+        __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!viewHandler.isAdvancedAuthFlow) {
             UIViewController *controllerToPresent = [[SFSDKNavigationController  alloc]  initWithRootViewController:viewHandler.loginController];
             controllerToPresent.modalPresentationStyle = UIModalPresentationFullScreen;
-            [weakSelf.authWindow.viewController presentViewController:controllerToPresent animated:NO completion:^{
+            [strongSelf.authWindow.viewController presentViewController:controllerToPresent animated:NO completion:^{
                 NSAssert((nil != [viewHandler.loginController.oauthView superview]), @"No superview for oauth web view invoke [super viewDidLayoutSubviews] in the SFLoginViewController subclass");
             }];
         }
         else {
+            if (@available(iOS 13.0, *)) {
+                SFSDKAuthRootController* authRootController = [[SFSDKAuthRootController alloc] init];
+                strongSelf.authWindow.viewController = authRootController;
+                authRootController.modalPresentationStyle = UIModalPresentationFullScreen;
+                viewHandler.session.presentationContextProvider = (id<ASWebAuthenticationPresentationContextProviding>) authRootController;
+            }
             [viewHandler.session start];
-            // FIXME what if it returns NO
         }
     };
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserAccountPersister.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserAccountPersister.m
@@ -200,7 +200,7 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
     }
 
     // Serialize the user account data.
-    NSData *archiveData = [NSKeyedArchiver archivedDataWithRootObject:userAccount];
+    NSData *archiveData = [NSKeyedArchiver archivedDataWithRootObject:userAccount requiringSecureCoding:NO error:nil];
     if (!archiveData) {
         NSString *reason = [NSString stringWithFormat:@"Could not archive user account data to save it.  %@",filePath];
         [SFSDKCoreLogger w:[self class] format:reason];
@@ -271,7 +271,7 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
             return NO;
         }
 
-        SFUserAccount *decryptedAccount = [NSKeyedUnarchiver unarchiveObjectWithData:decryptedArchiveData];
+        SFUserAccount *decryptedAccount = [NSKeyedUnarchiver unarchivedObjectOfClass:SFUserAccount.class fromData:decryptedArchiveData error:nil];
 
             // On iOS9, it won't throw an exception, but will return nil instead.
         if (decryptedAccount) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
@@ -114,7 +114,7 @@ NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
     NSAssert(NO, @"User Agent flow not supported in this class.");
 }
 
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(SFAuthenticationSession *)session {
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(ASWebAuthenticationSession *)session {
     NSAssert(NO, @"Web Server flow not supported in this class.");
 }
 - (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlowCoordinatorDelegate.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthTestFlowCoordinatorDelegate.m
@@ -27,7 +27,7 @@
 
 static NSString * const kWebNotSupportedExceptionName = @"com.salesforce.oauth.tests.WebNotSupported";
 static NSString * const kWebNotSupportedReasonFormat  = @"%@ WKWebView transactions not supported in unit test framework.";
-static NSString * const kSFAuthenticationSessionNotSupportedReasonFormat  = @"%@ SFAuthenticationSession transactions not supported in unit test framework.";
+static NSString * const kASWebAuthenticationSessionNotSupportedReasonFormat  = @"%@ ASWebAuthenticationSession transactions not supported in unit test framework.";
 
 @implementation SFOAuthTestFlowCoordinatorDelegate
 
@@ -90,15 +90,15 @@ static NSString * const kSFAuthenticationSessionNotSupportedReasonFormat  = @"%@
     return self.isNetworkAvailable;
 }
 
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(SFAuthenticationSession *)session {
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(ASWebAuthenticationSession *)session {
     [SFLogger log:[self class] level:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    NSString *reason = [NSString stringWithFormat:kSFAuthenticationSessionNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
-    @throw [NSException exceptionWithName:kSFAuthenticationSessionNotSupportedReasonFormat reason:reason userInfo:nil];
+    NSString *reason = [NSString stringWithFormat:kASWebAuthenticationSessionNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
+    @throw [NSException exceptionWithName:kASWebAuthenticationSessionNotSupportedReasonFormat reason:reason userInfo:nil];
 }
 - (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator {
     [SFLogger log:[self class] level:SFLogLevelDebug format:@"%@ called.", NSStringFromSelector(_cmd)];
-    NSString *reason = [NSString stringWithFormat:kSFAuthenticationSessionNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
-    @throw [NSException exceptionWithName:kSFAuthenticationSessionNotSupportedReasonFormat reason:reason userInfo:nil];
+    NSString *reason = [NSString stringWithFormat:kASWebAuthenticationSessionNotSupportedReasonFormat, NSStringFromSelector(_cmd)];
+    @throw [NSException exceptionWithName:kASWebAuthenticationSessionNotSupportedReasonFormat reason:reason userInfo:nil];
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTestsCoordinatorDelegate.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTestsCoordinatorDelegate.m
@@ -39,15 +39,15 @@
     XCTFail(@"user agent authentication flow should not begin");
 }
 
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(SFAuthenticationSession *)session {
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(ASWebAuthenticationSession *)session {
 
-    // SFAuthenticationSession auth flow is not supported in unit test framework.
-    XCTFail(@"SFAuthenticationSession auth flow is not supported in unit test framework");
+    // ASWebAuthenticationSession auth flow is not supported in unit test framework.
+    XCTFail(@"ASWebAuthenticationSession auth flow is not supported in unit test framework");
 }
 - (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator {
 
-    // SFAuthenticationSession auth flow is not supported in unit test framework.
-    XCTFail(@"SFAuthenticationSession auth flow is not supported in unit test framework");
+    // ASWebAuthenticationSession auth flow is not supported in unit test framework.
+    XCTFail(@"ASWebAuthenticationSession auth flow is not supported in unit test framework");
 }
 
 @end

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Info.plist
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Info.plist
@@ -34,9 +34,9 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSFaceIDUsageDescription</key>
-	<string>"Use FaceID"</string>
+	<string>&quot;Use FaceID&quot;</string>
 	<key>SFDCOAuthLoginHost</key>
-	<string>sdk.cs1.my.salesforce.com</string>
+	<string>mobilesdk.my.salesforce.com</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
On iOS 13, a presentation need to be provided, so there is a new view controller `SFSDKAuthRootController`  being used in the auth window which implements 
```objective-c
- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session
```