### PR TITLE
Fix issue happening with iOS 12 as target

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserAccountPersister.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDefaultUserAccountPersister.m
@@ -244,49 +244,52 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
  @param error On output, contains the error if the method returned NO
  @return YES if the method succeeded, NO otherwise
  */
- - (BOOL)loadUserAccountFromFile:(NSString *)filePath account:(SFUserAccount**)account error:(NSError**)error {
-
-        NSFileManager *manager = [[NSFileManager alloc] init];
-        NSString *reason = @"User account data could not be decrypted. Can't load account.";
-        NSData *encryptedUserAccountData = [manager contentsAtPath:filePath];
-        if (!encryptedUserAccountData) {
-            reason = [NSString stringWithFormat:@"Could not retrieve user account data from '%@'", filePath];
-            if (error) {
-                *error = [NSError errorWithDomain:SFUserAccountManagerErrorDomain
-                                             code:SFUserAccountManagerCannotRetrieveUserData
-                                         userInfo:@{NSLocalizedDescriptionKey: reason}];
-            }
-            [SFSDKCoreLogger d:[self class] format:reason];
-            return NO;
+- (BOOL)loadUserAccountFromFile:(NSString *)filePath account:(SFUserAccount**)account error:(NSError**)error {
+    
+    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSString *reason = @"User account data could not be decrypted. Can't load account.";
+    NSData *encryptedUserAccountData = [manager contentsAtPath:filePath];
+    if (!encryptedUserAccountData) {
+        reason = [NSString stringWithFormat:@"Could not retrieve user account data from '%@'", filePath];
+        if (error) {
+            *error = [NSError errorWithDomain:SFUserAccountManagerErrorDomain
+                                         code:SFUserAccountManagerCannotRetrieveUserData
+                                     userInfo:@{NSLocalizedDescriptionKey: reason}];
         }
-        SFEncryptionKey *encKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:kUserAccountEncryptionKeyLabel autoCreate:YES];
-        NSData *decryptedArchiveData = [encKey decryptData:encryptedUserAccountData];
-        if (!decryptedArchiveData) {
-            if (error) {
-                *error = [NSError errorWithDomain:SFUserAccountManagerErrorDomain
-                                             code:SFUserAccountManagerCannotRetrieveUserData
-                                         userInfo:@{NSLocalizedDescriptionKey: reason}];
-            }
-            [SFSDKCoreLogger w:[self class] format:reason];
-            return NO;
+        [SFSDKCoreLogger d:[self class] format:reason];
+        return NO;
+    }
+    SFEncryptionKey *encKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:kUserAccountEncryptionKeyLabel autoCreate:YES];
+    NSData *decryptedArchiveData = [encKey decryptData:encryptedUserAccountData];
+    if (!decryptedArchiveData) {
+        if (error) {
+            *error = [NSError errorWithDomain:SFUserAccountManagerErrorDomain
+                                         code:SFUserAccountManagerCannotRetrieveUserData
+                                     userInfo:@{NSLocalizedDescriptionKey: reason}];
         }
+        [SFSDKCoreLogger w:[self class] format:reason];
+        return NO;
+    }
+    
+    
+    NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:decryptedArchiveData error:nil];
+    unarchiver.requiresSecureCoding = NO;
+    SFUserAccount *decryptedAccount = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
+    [unarchiver finishDecoding];
 
-        SFUserAccount *decryptedAccount = [NSKeyedUnarchiver unarchivedObjectOfClass:SFUserAccount.class fromData:decryptedArchiveData error:nil];
-
-            // On iOS9, it won't throw an exception, but will return nil instead.
-        if (decryptedAccount) {
-            if (account) {
-                *account = decryptedAccount;
-            }
-            return YES;
-        } else {
-            if (error) {
-                *error = [NSError errorWithDomain:SFUserAccountManagerErrorDomain
-                                             code:SFUserAccountManagerCannotReadDecryptedArchive
-                                         userInfo:@{NSLocalizedDescriptionKey: reason}];
-            }
-            return NO;
+    if (decryptedAccount) {
+        if (account) {
+            *account = decryptedAccount;
         }
+        return YES;
+    } else {
+        if (error) {
+            *error = [NSError errorWithDomain:SFUserAccountManagerErrorDomain
+                                         code:SFUserAccountManagerCannotReadDecryptedArchive
+                                     userInfo:@{NSLocalizedDescriptionKey: reason}];
+        }
+        return NO;
+    }
 }
 
 + (NSString*)userAccountPlistFileForUser:(SFUserAccount*)user {


### PR DESCRIPTION
Archivers defaults to secure coding.
Since the objects we archive don't follow that protocol, we need to pass requiresSecureCoding = NO when archiving/unarchiving.
I missed that one place when I did https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3008.

There was one test failing because of it (testMultipleAccounts).
More importantly, on restart, one had to login again!