### PR TITLE
Move task identifier to local variable to avoid reentrancy issues leading to BTNF

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager+Internal.h
@@ -44,5 +44,6 @@
 @property (nonnull, nonatomic, readwrite, strong) SFSDKEventStoreManager *eventStoreManager;
 @property (nullable, nonatomic, readwrite, strong) SFUserAccount *userAccount;
 @property (nonnull, nonatomic, readwrite, strong) NSMutableArray<SFSDKAnalyticsTransformPublisherPair *> *remotes;
+@property (atomic, readwrite) UIBackgroundTaskIdentifier task;
 
 @end


### PR DESCRIPTION
- In 7.1 the Background Task Identifier was moved from a local variable to a global
- This created a situation wherein if the publishOnAppBackground is called a second time before the first background task is ended, we overwrite the task id, and the original background task is never properly ended
- Apple will then terminate the app due to a Background Task Not Finished.
- This approach, moving it to an atomic property will allow us to gate calls to publishOnBackground so only one instance is active at a time.