### PR TITLE
idToken is never assigned

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -117,6 +117,10 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     return self.values[kSFOAuthAccessToken];
 }
 
+- (NSString *)idToken {
+    return self.values[kSFOAuthIdToken];
+}
+
 - (NSString *)refreshToken {
     return self.values[kSFOAuthRefreshToken];
 }


### PR DESCRIPTION
idToken is never assigned
SFSDKAuthUtilTests.testOpenIDToken test passes because in swift it returns an empty string while the test is only if it is null.
Issue
#3053 