### PR TITLE
Swift extensions for SmartStore - work in progress

### DIFF
--- a/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
+++ b/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		4F06AFF11C49D53D00F70798 /* SmartStore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE4CE2B91C0E4581009F6029 /* SmartStore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4F51C9F11D35ACE500100D66 /* SFSmartStoreFTSWithExternalStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F51C9F01D35ACE500100D66 /* SFSmartStoreFTSWithExternalStorageTests.m */; };
 		4F5BBB9D23592EBB00E6D619 /* SmartStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5BBB9C23592EBB00E6D619 /* SmartStore.swift */; };
+		4F5BBBB4235E1FD900E6D619 /* SmartStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5BBBB3235E1FD900E6D619 /* SmartStoreTests.swift */; };
 		4F75745222B9A96900528BE2 /* SFSmartSqlCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F75745122B9A96900528BE2 /* SFSmartSqlCache.h */; };
 		4F75745F22B9A99900528BE2 /* SFSmartSqlCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F75745E22B9A99900528BE2 /* SFSmartSqlCache.m */; };
 		4F75747222B9BA9000528BE2 /* SFSmartSqlCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F75747122B9BA9000528BE2 /* SFSmartSqlCacheTests.m */; };
@@ -247,6 +248,7 @@
 		4F230BC31BFEAE430030EEFA /* SmartStore-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SmartStore-Prefix.pch"; path = "SmartStore/SmartStore-Prefix.pch"; sourceTree = SOURCE_ROOT; };
 		4F51C9F01D35ACE500100D66 /* SFSmartStoreFTSWithExternalStorageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSmartStoreFTSWithExternalStorageTests.m; sourceTree = "<group>"; };
 		4F5BBB9C23592EBB00E6D619 /* SmartStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartStore.swift; sourceTree = "<group>"; };
+		4F5BBBB3235E1FD900E6D619 /* SmartStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartStoreTests.swift; sourceTree = "<group>"; };
 		4F75745122B9A96900528BE2 /* SFSmartSqlCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSmartSqlCache.h; sourceTree = "<group>"; };
 		4F75745E22B9A99900528BE2 /* SFSmartSqlCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSmartSqlCache.m; sourceTree = "<group>"; };
 		4F75747122B9BA9000528BE2 /* SFSmartSqlCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSmartSqlCacheTests.m; sourceTree = "<group>"; };
@@ -583,6 +585,7 @@
 				B7352CAC2278F93A00DA2CFF /* SFSmartStoreSharingUpgradeTests.m */,
 				CEAAAE5F195911E600CBBFE9 /* Supporting Files */,
 				4F75747122B9BA9000528BE2 /* SFSmartSqlCacheTests.m */,
+				4F5BBBB3235E1FD900E6D619 /* SmartStoreTests.swift */,
 			);
 			path = SmartStoreTests;
 			sourceTree = "<group>";
@@ -762,6 +765,7 @@
 						LastSwiftMigration = 1100;
 					};
 					CEAAAE54195911E600CBBFE9 = {
+						LastSwiftMigration = 1110;
 						TestTargetID = 4F06AF081C499EB600F70798;
 					};
 				};
@@ -983,6 +987,7 @@
 				4FEE44851BFD5CCC00F09C43 /* SFSmartSqlWithExternalStorageTests.m in Sources */,
 				B7DD6CE61DC178D0004C04F4 /* SFMultipleSmartStoresTests.m in Sources */,
 				4FF4DC671CF51D9300385C2C /* SFQuerySpecTests.m in Sources */,
+				4F5BBBB4235E1FD900E6D619 /* SmartStoreTests.swift in Sources */,
 				4FEE44861BFD5CD200F09C43 /* SFSmartStoreAlterTests.m in Sources */,
 				4F99B53C1CEA81A6007BC4D2 /* SFSmartStoreLoadTests.m in Sources */,
 				4F51C9F11D35ACE500100D66 /* SFSmartStoreFTSWithExternalStorageTests.m in Sources */,
@@ -1168,7 +1173,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.salesforce.mobilesdk.SmartStore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-                SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1281,6 +1286,7 @@
 			baseConfigurationReference = 4F96FC501BFD31EF0022F021 /* SmartStore-Test.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SmartStore/SmartStore-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1301,6 +1307,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.salesforce.mobilesdk.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SmartStoreTestApp.app/SmartStoreTestApp";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -1311,6 +1319,7 @@
 			baseConfigurationReference = 4F96FC501BFD31EF0022F021 /* SmartStore-Test.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
+				CLANG_ENABLE_MODULES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "SmartStore/SmartStore-Prefix.pch";
 				INFOPLIST_FILE = "SmartStoreTests/SmartStoreTests-Info.plist";
@@ -1327,6 +1336,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.salesforce.mobilesdk.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SmartStoreTestApp.app/SmartStoreTestApp";
 				WRAPPER_EXTENSION = xctest;
 			};

--- a/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
+++ b/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		4F06AFF01C49D53D00F70798 /* SmartStore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE4CE2B91C0E4581009F6029 /* SmartStore.framework */; };
 		4F06AFF11C49D53D00F70798 /* SmartStore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE4CE2B91C0E4581009F6029 /* SmartStore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4F51C9F11D35ACE500100D66 /* SFSmartStoreFTSWithExternalStorageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F51C9F01D35ACE500100D66 /* SFSmartStoreFTSWithExternalStorageTests.m */; };
+		4F5BBB9D23592EBB00E6D619 /* SmartStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5BBB9C23592EBB00E6D619 /* SmartStore.swift */; };
 		4F75745222B9A96900528BE2 /* SFSmartSqlCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F75745122B9A96900528BE2 /* SFSmartSqlCache.h */; };
 		4F75745F22B9A99900528BE2 /* SFSmartSqlCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F75745E22B9A99900528BE2 /* SFSmartSqlCache.m */; };
 		4F75747222B9BA9000528BE2 /* SFSmartSqlCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F75747122B9BA9000528BE2 /* SFSmartSqlCacheTests.m */; };
@@ -245,6 +246,7 @@
 		4F06AF1C1C499EB600F70798 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4F230BC31BFEAE430030EEFA /* SmartStore-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SmartStore-Prefix.pch"; path = "SmartStore/SmartStore-Prefix.pch"; sourceTree = SOURCE_ROOT; };
 		4F51C9F01D35ACE500100D66 /* SFSmartStoreFTSWithExternalStorageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSmartStoreFTSWithExternalStorageTests.m; sourceTree = "<group>"; };
+		4F5BBB9C23592EBB00E6D619 /* SmartStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartStore.swift; sourceTree = "<group>"; };
 		4F75745122B9A96900528BE2 /* SFSmartSqlCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSmartSqlCache.h; sourceTree = "<group>"; };
 		4F75745E22B9A99900528BE2 /* SFSmartSqlCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSmartSqlCache.m; sourceTree = "<group>"; };
 		4F75747122B9BA9000528BE2 /* SFSmartSqlCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSmartSqlCacheTests.m; sourceTree = "<group>"; };
@@ -414,6 +416,14 @@
 				4F06AF0C1C499EB600F70798 /* main.m */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		4F5BBB9323592E9600E6D619 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				4F5BBB9C23592EBB00E6D619 /* SmartStore.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		828917791C52B6E2002F9981 /* fmdb */ = {
@@ -589,6 +599,7 @@
 		CEF50A79196B3EB60076264C /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				4F5BBB9323592E9600E6D619 /* Extensions */,
 				B789278D2242B2AD00BEDED4 /* Instrumentation */,
 				828917791C52B6E2002F9981 /* fmdb */,
 				CE682C7E1F01B5E3003C43C0 /* SFSDKSmartStoreLogger.h */,
@@ -748,6 +759,7 @@
 					};
 					CE4CE2B81C0E4581009F6029 = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 1100;
 					};
 					CEAAAE54195911E600CBBFE9 = {
 						TestTargetID = 4F06AF081C499EB600F70798;
@@ -956,6 +968,7 @@
 				CE4CE40E1C0E59DA009F6029 /* SFQuerySpec.m in Sources */,
 				CE4CE41D1C0E59DA009F6029 /* SFSmartStoreUtils.m in Sources */,
 				FDCEC343F565157E01DA4FCC /* SFSDKStoreConfig.m in Sources */,
+				4F5BBB9D23592EBB00E6D619 /* SmartStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1118,6 +1131,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.salesforce.mobilesdk.SmartStore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1151,6 +1168,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.salesforce.mobilesdk.SmartStore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+                SWIFT_INSTALL_OBJC_HEADER = NO;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/libs/SmartStore/SmartStore/Classes/Extensions/SmartStore.swift
+++ b/libs/SmartStore/SmartStore/Classes/Extensions/SmartStore.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/*
+ SmartStire.swift
+ SalesforceSDKCore
+ 
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+import Combine
+
+struct Constants {
+    static let PAGE_SIZE: UInt = 65536
+}
+
+/**
+  Error used by Combine friendly query:smartSql method in SmartStore extension below
+ */
+public enum QueryError: Error {
+    case error(_ error: Error?)
+    case unknown
+}
+
+/**
+SmartStore extension
+*/
+extension SmartStore {
+    /**
+      Runs a query and return a Result<>
+      @param smartSql:String the query smart sql
+      @return a Result<[Any], QueryError>
+    */
+    func query(_ smartSql: String) -> Result<[Any], QueryError> {
+        let querySpec = QuerySpec.buildSmartQuerySpec(smartSql: smartSql, pageSize: Constants.PAGE_SIZE)!
+        
+        do {
+            let results = try self.query(using: querySpec, startingFromPageIndex: 0)
+            return .success(results)
+        } catch let error {
+            return .failure(.error(error))
+        }
+    }
+}
+
+/**
+SmartStore extension for iOS 13 and above
+*/
+@available(iOS 13.0, watchOS 6.0, *)
+extension SmartStore {
+    
+    /**
+        Runs a query and return a Future<> publisher to consume the result
+        @param smartSql:String the query smart sql
+        @return a Future<[Any], QueryError> publisher
+     */
+    func publisher(_ smartSql: String) -> Future<[Any], QueryError> {
+        Future<[Any], QueryError> { promise in
+            let result = self.query(smartSql)
+            switch result {
+                case .success(let results):
+                    promise(.success(results))
+                case .failure(let error):
+                    promise(.failure(error))
+            }
+        }
+    }
+    
+}

--- a/libs/SmartStore/SmartStore/Classes/Extensions/SmartStore.swift
+++ b/libs/SmartStore/SmartStore/Classes/Extensions/SmartStore.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /*
- SmartStire.swift
+ SmartStore.swift
  SalesforceSDKCore
  
  Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.

--- a/libs/SmartStore/SmartStore/Classes/Extensions/SmartStore.swift
+++ b/libs/SmartStore/SmartStore/Classes/Extensions/SmartStore.swift
@@ -35,7 +35,7 @@ struct Constants {
 }
 
 /**
-  Enum for errors
+ Enum for errors
  */
 public enum SmartStoreError: Error {
     case error(_ error: Error?)
@@ -43,16 +43,16 @@ public enum SmartStoreError: Error {
 }
 
 /**
-SmartStore extension
-*/
+ SmartStore extension
+ */
 extension SmartStore {
     /**
-      Register a soup and returns a Result<>
-      @param soupName: name of the soups
-      @param indexPaths: array of paths to index
-      @return a Result<Bool, SmartStoreError>
-    */
-    func registerSoup(_ soupName: String, indexPaths: [String]) throws -> Result<Bool, SmartStoreError> {
+     Register a soup and returns a Result<>
+     @param withName: name of the soups
+     @param withIndexPaths: array of paths to index
+     @return a Result<Bool, SmartStoreError>
+     */
+    func registerSoup(withName soupName: String, withIndexPaths indexPaths: [String]) -> Result<Bool, SmartStoreError> {
         let soupIndexes:[SoupIndex] = indexPaths.map({ SoupIndex(path:$0, indexType:kSoupIndexTypeJSON1, columnName:nil)! })
         do {
             try self.registerSoup(withName: soupName, withIndices: soupIndexes)
@@ -63,10 +63,10 @@ extension SmartStore {
     }
     
     /**
-      Runs a query and return a Result<>
-      @param smartSql:String the query smart sql
-      @return a Result<[Any], SmartStoreError>
-    */
+     Runs a query and return a Result<>
+     @param smartSql:String the query smart sql
+     @return a Result<[Any], SmartStoreError>
+     */
     func query(_ smartSql: String) -> Result<[Any], SmartStoreError> {
         let querySpec = QuerySpec.buildSmartQuerySpec(smartSql: smartSql, pageSize: Constants.PAGE_SIZE)!
         
@@ -80,24 +80,24 @@ extension SmartStore {
 }
 
 /**
-SmartStore extension for iOS 13 and above
-*/
+ SmartStore extension for iOS 13 and above
+ */
 @available(iOS 13.0, watchOS 6.0, *)
 extension SmartStore {
     
     /**
-        Runs a query and return a Future<> publisher to consume the result
-        @param smartSql:String the query smart sql
-        @return a Future<[Any], SmartStoreError> publisher
+     Runs a query and return a Future<> publisher to consume the result
+     @param smartSql:String the query smart sql
+     @return a Future<[Any], SmartStoreError> publisher
      */
     func publisher(_ smartSql: String) -> Future<[Any], SmartStoreError> {
         Future<[Any], SmartStoreError> { promise in
             let result = self.query(smartSql)
             switch result {
-                case .success(let results):
-                    promise(.success(results))
-                case .failure(let error):
-                    promise(.failure(error))
+            case .success(let results):
+                promise(.success(results))
+            case .failure(let error):
+                promise(.failure(error))
             }
         }
     }

--- a/libs/SmartStore/SmartStore/Classes/Extensions/SmartStore.swift
+++ b/libs/SmartStore/SmartStore/Classes/Extensions/SmartStore.swift
@@ -35,9 +35,9 @@ struct Constants {
 }
 
 /**
-  Error used by Combine friendly query:smartSql method in SmartStore extension below
+  Enum for errors
  */
-public enum QueryError: Error {
+public enum SmartStoreError: Error {
     case error(_ error: Error?)
     case unknown
 }
@@ -47,11 +47,27 @@ SmartStore extension
 */
 extension SmartStore {
     /**
+      Register a soup and returns a Result<>
+      @param soupName: name of the soups
+      @param indexPaths: array of paths to index
+      @return a Result<Bool, SmartStoreError>
+    */
+    func registerSoup(_ soupName: String, indexPaths: [String]) throws -> Result<Bool, SmartStoreError> {
+        let soupIndexes:[SoupIndex] = indexPaths.map({ SoupIndex(path:$0, indexType:kSoupIndexTypeJSON1, columnName:nil)! })
+        do {
+            try self.registerSoup(withName: soupName, withIndices: soupIndexes)
+            return .success(true)
+        } catch let error {
+            return .failure(.error(error))
+        }
+    }
+    
+    /**
       Runs a query and return a Result<>
       @param smartSql:String the query smart sql
-      @return a Result<[Any], QueryError>
+      @return a Result<[Any], SmartStoreError>
     */
-    func query(_ smartSql: String) -> Result<[Any], QueryError> {
+    func query(_ smartSql: String) -> Result<[Any], SmartStoreError> {
         let querySpec = QuerySpec.buildSmartQuerySpec(smartSql: smartSql, pageSize: Constants.PAGE_SIZE)!
         
         do {
@@ -72,10 +88,10 @@ extension SmartStore {
     /**
         Runs a query and return a Future<> publisher to consume the result
         @param smartSql:String the query smart sql
-        @return a Future<[Any], QueryError> publisher
+        @return a Future<[Any], SmartStoreError> publisher
      */
-    func publisher(_ smartSql: String) -> Future<[Any], QueryError> {
-        Future<[Any], QueryError> { promise in
+    func publisher(_ smartSql: String) -> Future<[Any], SmartStoreError> {
+        Future<[Any], SmartStoreError> { promise in
             let result = self.query(smartSql)
             switch result {
                 case .success(let results):

--- a/libs/SmartStore/SmartStoreTests/SmartStoreTests.swift
+++ b/libs/SmartStore/SmartStoreTests/SmartStoreTests.swift
@@ -1,0 +1,79 @@
+/*
+ SmartStoreTests.swift
+ Test for Swift SmarStore extensions
+ 
+ Copyright (c) 2019-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+import Foundation
+@testable import SmartStore
+
+class SmartStoreTests: XCTestCase {
+    
+    var store:SmartStore = SmartStore.sharedGlobal(withName: SmartStore.defaultStoreName)
+
+    override func tearDown() {
+        store.removeAllSoups()
+    }
+
+    func testRegisterSoup() {
+        let result = store.registerSoup(withName: "MyTestSoup", withIndexPaths: ["key", "owner"])
+        switch(result) {
+        case .success(let val): XCTAssertTrue(val)
+        case .failure(_): XCTFail("registerSoup should not have failed")
+        }
+    }
+
+    func testBadRegisterSoup() {
+        let result = store.registerSoup(withName: "", withIndexPaths: ["key", "owner"])
+        switch(result) {
+        case .success(_): XCTFail("registerSoup should have failed")
+        case .failure(let error): XCTAssertNotNil(error)
+        }
+    }
+
+    func testQuery() {
+        _ = store.registerSoup(withName: "MyTestSoup", withIndexPaths: ["key", "owner"])
+        store.upsert(entries: [["key":"key1", "owner":"owner1"],
+                               ["key":"key2", "owner":"owner2"],
+                               ["key":"key3", "owner":"owner1"]], forSoupNamed: "MyTestSoup")
+        let result = store.query("select {MyTestSoup:key} from {MyTestSoup} where {MyTestSoup:owner} = 'owner1' order by {MyTestSoup:key}")
+        switch (result) {
+        case .success(let val):
+            let arr = val as! [[String]]
+            XCTAssertEqual(arr, [["key1"], ["key3"]])
+        case .failure(_): XCTFail("query should not have failed")
+        }
+    }
+
+    func testBadQuery() {
+        _ = store.registerSoup(withName: "MyTestSoup", withIndexPaths: ["key", "owner"])
+        let result = store.query("select {MyTestSoup:date} from {MyTestSoup}")
+        switch (result) {
+        case .success(_): XCTFail("query should have failed")
+        case .failure(let error): XCTAssertNotNil(error)
+        }
+    }
+
+}

--- a/libs/SmartStore/SmartStoreTests/SmartStoreTests.swift
+++ b/libs/SmartStore/SmartStoreTests/SmartStoreTests.swift
@@ -31,14 +31,20 @@ import Foundation
 
 class SmartStoreTests: XCTestCase {
     
-    var store:SmartStore = SmartStore.sharedGlobal(withName: SmartStore.defaultStoreName)
+    let testStoreName = "SmartStoreTestsGlobalStore"
+    
+    var store:SmartStore?
 
+    override func setUp() {
+        store = SmartStore.sharedGlobal(withName: testStoreName)
+    }
+    
     override func tearDown() {
-        store.removeAllSoups()
+        SmartStore.removeSharedGlobal(withName: testStoreName)
     }
 
     func testRegisterSoup() {
-        let result = store.registerSoup(withName: "MyTestSoup", withIndexPaths: ["key", "owner"])
+        let result = store!.registerSoup(withName: "MyTestSoup", withIndexPaths: ["key", "owner"])
         switch(result) {
         case .success(let val): XCTAssertTrue(val)
         case .failure(_): XCTFail("registerSoup should not have failed")
@@ -46,7 +52,7 @@ class SmartStoreTests: XCTestCase {
     }
 
     func testBadRegisterSoup() {
-        let result = store.registerSoup(withName: "", withIndexPaths: ["key", "owner"])
+        let result = store!.registerSoup(withName: "", withIndexPaths: ["key", "owner"])
         switch(result) {
         case .success(_): XCTFail("registerSoup should have failed")
         case .failure(let error): XCTAssertNotNil(error)
@@ -54,11 +60,11 @@ class SmartStoreTests: XCTestCase {
     }
 
     func testQuery() {
-        _ = store.registerSoup(withName: "MyTestSoup", withIndexPaths: ["key", "owner"])
-        store.upsert(entries: [["key":"key1", "owner":"owner1"],
+        _ = store!.registerSoup(withName: "MyTestSoup", withIndexPaths: ["key", "owner"])
+        store!.upsert(entries: [["key":"key1", "owner":"owner1"],
                                ["key":"key2", "owner":"owner2"],
                                ["key":"key3", "owner":"owner1"]], forSoupNamed: "MyTestSoup")
-        let result = store.query("select {MyTestSoup:key} from {MyTestSoup} where {MyTestSoup:owner} = 'owner1' order by {MyTestSoup:key}")
+        let result = store!.query("select {MyTestSoup:key} from {MyTestSoup} where {MyTestSoup:owner} = 'owner1' order by {MyTestSoup:key}")
         switch (result) {
         case .success(let val):
             let arr = val as! [[String]]
@@ -68,8 +74,8 @@ class SmartStoreTests: XCTestCase {
     }
 
     func testBadQuery() {
-        _ = store.registerSoup(withName: "MyTestSoup", withIndexPaths: ["key", "owner"])
-        let result = store.query("select {MyTestSoup:date} from {MyTestSoup}")
+        _ = store!.registerSoup(withName: "MyTestSoup", withIndexPaths: ["key", "owner"])
+        let result = store!.query("select {MyTestSoup:date} from {MyTestSoup}")
         switch (result) {
         case .success(_): XCTFail("query should have failed")
         case .failure(let error): XCTAssertNotNil(error)


### PR DESCRIPTION
We have decent swift interfaces already (through NS_SWIFT_NAME) and all SmartStore operations are synchronous. So not a lot to do here.

However I simplified two operations:
1) soup registration: simply takes a name and an array of paths. No need for SoupSpec or IndexSpec (we want to phase out external storage and non-json indexing).

2) query: simply takes smartsql and return Result<> or Future<> (on iOS 13). No need for QuerySpec. Also no need for page size or page index since that can be expressed inside the smartsql.