### PR TITLE
Avoid returning restrictive supportedInterfaceOrientation that causes crashes.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -247,7 +247,7 @@
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    return UIInterfaceOrientationMaskPortrait;
+    return UIInterfaceOrientationMaskAll;
 }
 
 - (void)layoutWebView {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewController.m
@@ -74,7 +74,7 @@
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-    return UIInterfaceOrientationMaskPortrait;
+    return UIInterfaceOrientationMaskAll;
 }
 
 - (void)setupNavBar

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKRootController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKRootController.m
@@ -85,7 +85,7 @@
     if (topViewController!=nil && topViewController!=self)
         return [topViewController supportedInterfaceOrientations];
     
-    return UIInterfaceOrientationMaskPortrait;
+    return UIInterfaceOrientationMaskAll;
 }
 
 #pragma mark - Helper class methods

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/ActionsPopupController.m
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/ActionsPopupController.m
@@ -54,7 +54,7 @@ NSString *const kActionDbInspector = @"Inspect db";
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
-    return UIInterfaceOrientationMaskPortrait;
+    return UIInterfaceOrientationMaskAll;
 }
 
 #pragma mark - Table view data source


### PR DESCRIPTION
This will avoid crashes when the parent application doesn't support the given orientation.
Should solve this issue:
https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/3060

And is related to this common issue described on StackOverflow:
https://stackoverflow.com/questions/32169216/ios-error-supported-orientations-has-no-common-orientation-with-the-application


Let me know whether I should be concerned with the failing tests, or if this doesn't fit the desired code style.