### PR TITLE
Enables Adv. Auth for iOS13 & 12, adv auth nav bug & rest client property access

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -38,11 +38,9 @@ public enum RestClientError: Error {
 }
 
 public struct RestResponse {
-    private static let emptyJsonDictionaryArrayResponse = [String: Any]()
-    private static let emptyJsonArrayResponse = [[String: Any]]()
     private static let emptyStringResponse = ""
     private (set) var data: Data
-    private (set) var urlResponse: URLResponse
+    public private (set) var urlResponse: URLResponse
     
     /// Initializes the RestResponse with a Data object and URLResponse
     /// - Parameter data: Response as raw Data

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRootController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRootController.h
@@ -31,10 +31,6 @@
  */
 
 #import "SFSDKRootController.h"
-
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 130000
+#import <AuthenticationServices/AuthenticationServices.h>
 @interface SFSDKAuthRootController : SFSDKRootController <ASWebAuthenticationPresentationContextProviding>
-#else
-@interface SFSDKAuthRootController : SFSDKRootController
-#endif
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRootController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRootController.m
@@ -26,17 +26,9 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
 */
 
 #import "SFSDKAuthRootController.h"
-#import <AuthenticationServices/AuthenticationServices.h>
 
 @implementation SFSDKAuthRootController
-
-/**
-  Implementating  ASWebAuthenticationPresentationContextProviding so that ASWebAuthenticationSession can be started from the window
- */
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 130000
 - (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13.0)) {
-    return self.view.window;
+     return self.view.window;
 }
-#endif
-
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -599,7 +599,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     
     UIViewController *presentedViewController = [SFSDKWindowManager sharedManager].authWindow.viewController.presentedViewController;
     
-    if (presentedViewController) {
+    if (presentedViewController && presentedViewController.isBeingPresented) {
         [presentedViewController dismissViewControllerAnimated:NO completion:^{
             [[SFSDKWindowManager sharedManager].authWindow dismissWindowAnimated:NO withCompletion:^{
                 if (completionBlock) {
@@ -1861,14 +1861,12 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             }];
         }
         else {
-#if __IPHONE_OS_VERSION_MIN_ALLOWED >= 130000
             if (@available(iOS 13.0, *)) {
                 SFSDKAuthRootController* authRootController = [[SFSDKAuthRootController alloc] init];
                 [SFSDKWindowManager sharedManager].authWindow.viewController = authRootController;
                 authRootController.modalPresentationStyle = UIModalPresentationFullScreen;
                 viewHandler.session.presentationContextProvider = (id<ASWebAuthenticationPresentationContextProviding>) [SFSDKWindowManager sharedManager].authWindow.viewController;
             }
-#endif
            [viewHandler.session start];
         }
     };


### PR DESCRIPTION
We do not need the preprocessor checks for min version of iOS. 