### PR TITLE
Remove flag for push encryption

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.h
@@ -45,12 +45,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nullable, nonatomic, strong) NSDictionary* customPushRegistrationBody;
 
-/**
- * Use this flag to indicate if the notifications should be encrypted. NO by default.
- * This should always be be set to NO for Apex push notifications.
- */
-@property (nonatomic, assign) BOOL encryptionEnabled;
-
 /** The share instance of this class.
  */
 + (SFPushNotificationManager *) sharedInstance;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -66,7 +66,6 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
 #else
         self.isSimulator = NO;
 #endif
-        _encryptionEnabled = NO;
         // Queue for requests
         _queue = [[NSOperationQueue alloc] init];
         
@@ -150,15 +149,11 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
         bodyDict[@"NetworkId"] = communityId;
     }
 
-    // Adds a RSA public key as part of the registration call if encryption is enabled.
-    if (self.encryptionEnabled) {
-        NSString *rsaPublicKey = [self getRSAPublicKey];
-        if (!rsaPublicKey) {
-            [SFSDKCoreLogger e:[self class] format:@"Cannot register for notifications with Salesforce: no RSA key for encrypted notifications"];
-            return NO;
-        }
+    NSString *rsaPublicKey = [self getRSAPublicKey];
+    if (rsaPublicKey) {
         bodyDict[@"RsaPublicKey"] = rsaPublicKey;
     }
+
     [request setCustomRequestBodyDictionary:bodyDict contentType:@"application/json"];
     __weak typeof(self) weakSelf = self;
     [[SFRestAPI sharedInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {


### PR DESCRIPTION
Server will ignore the key if it doesn't support encryption so we don't need to have a flag for it