### PR TITLE
Only load SFDCOAuthLoginHost when there aren't MDM hosts

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostStorage.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostStorage.m
@@ -91,10 +91,8 @@ static NSString * const SFSDKLoginHostNameKey = @"SalesforceLoginHostNameKey";
             if (managedPreferences.onlyShowAuthorizedHosts) {
                 return self;
             }
-        }
-
-        // Load from info.plist.
-        if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"SFDCOAuthLoginHost"]) {
+        } else if ([[NSBundle mainBundle] objectForInfoDictionaryKey:@"SFDCOAuthLoginHost"]) {
+            // Load from info.plist.
             NSString *customHost = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"SFDCOAuthLoginHost"];
 
             /*


### PR DESCRIPTION
This matches the Android behavior, too