### PR TITLE
Sync up can now provided a external id field name

### DIFF
--- a/libs/MobileSync/MobileSync/Classes/Target/SFBatchSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFBatchSyncUpTarget.m
@@ -4,7 +4,7 @@
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright notice, this list of conditions
-and the following disclaimer.
+ and the following disclaimer.
  * Redistributions in binary form must reproduce the above copyright notice, this list of
  conditions and the following disclaimer in the documentation and/or other materials provided
  with the distribution.

--- a/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
@@ -92,7 +92,7 @@ static NSString * const kIDFieldValue = @"%@-%@";
          errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
-    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectType:objectType layoutType:layoutType apiVersion:kSFRestDefaultAPIVersion];
+    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectType:objectType layoutType:layoutType apiVersion:nil];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
     } completeBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFMetadataSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFMetadataSyncDownTarget.m
@@ -85,7 +85,7 @@ static NSString * const kSFSyncTargetObjectType = @"sobjectType";
          errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
-    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForDescribeWithObjectType:objectType apiVersion:kSFRestDefaultAPIVersion];
+    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForDescribeWithObjectType:objectType apiVersion:nil];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
     } completeBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFMruSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFMruSyncDownTarget.m
@@ -85,7 +85,7 @@ static NSString * const kSFSyncTargetFieldlist = @"fieldlist";
          errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
-    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForMetadataWithObjectType:self.objectType apiVersion:kSFRestDefaultAPIVersion];
+    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForMetadataWithObjectType:self.objectType apiVersion:nil];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
     } completeBlock:^(NSDictionary* d, NSURLResponse *rawResponse) {
@@ -107,7 +107,7 @@ static NSString * const kSFSyncTargetFieldlist = @"fieldlist";
          errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
-    SFRestRequest * soqlRequest = [[SFRestAPI sharedInstance] requestForQuery:queryRun apiVersion:kSFRestDefaultAPIVersion];
+    SFRestRequest * soqlRequest = [[SFRestAPI sharedInstance] requestForQuery:queryRun apiVersion:nil];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:soqlRequest failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
     } completeBlock:^(NSDictionary * d, NSURLResponse *rawResponse) {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFParentChildrenSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFParentChildrenSyncUpTarget.m
@@ -401,7 +401,7 @@ typedef void (^SFFetchLastModifiedDatesCompleteBlock)(NSDictionary<NSString *, N
         if (isCreate) {
             return nil; // no need to go to server
         } else {
-            return [[SFRestAPI sharedInstance] requestForDeleteWithObjectType:info.sobjectType objectId:id apiVersion:kSFRestDefaultAPIVersion];
+            return [[SFRestAPI sharedInstance] requestForDeleteWithObjectType:info.sobjectType objectId:id apiVersion:nil];
         }
     }
         // Create/update cases
@@ -420,9 +420,9 @@ typedef void (^SFFetchLastModifiedDatesCompleteBlock)(NSDictionary<NSString *, N
         }
 
         if (isCreate) {
-            return [[SFRestAPI sharedInstance] requestForCreateWithObjectType:info.sobjectType fields:fields apiVersion:kSFRestDefaultAPIVersion];
+            return [[SFRestAPI sharedInstance] requestForCreateWithObjectType:info.sobjectType fields:fields apiVersion:nil];
         } else {
-            return [[SFRestAPI sharedInstance] requestForUpdateWithObjectType:info.sobjectType objectId:id fields:fields apiVersion:kSFRestDefaultAPIVersion];
+            return [[SFRestAPI sharedInstance] requestForUpdateWithObjectType:info.sobjectType objectId:id fields:fields apiVersion:nil];
         }
     }
 }
@@ -588,7 +588,7 @@ typedef void (^SFFetchLastModifiedDatesCompleteBlock)(NSDictionary<NSString *, N
     [builder from:self.parentInfo.sobjectType];
     [builder whereClause:[NSString stringWithFormat:@"%@ = '%@'", self.idFieldName, parentId]];
 
-    SFRestRequest * request = [[SFRestAPI sharedInstance] requestForQuery:[builder build] apiVersion:kSFRestDefaultAPIVersion];
+    SFRestRequest * request = [[SFRestAPI sharedInstance] requestForQuery:[builder build] apiVersion:nil];
     return request;
 }
 

--- a/libs/MobileSync/MobileSync/Classes/Target/SFRefreshSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFRefreshSyncDownTarget.m
@@ -266,7 +266,7 @@ static NSUInteger const kSFSyncTargetRefreshDefaultCountIdsPerSoql = 500;
                            : @"");
     NSString* whereClause = [NSString stringWithFormat:@"%@ IN ('%@')%@", self.idFieldName, [ids componentsJoinedByString:@"','"], andClause];
     NSString* soql = [[[[SFSDKSoqlBuilder withFieldsArray:fieldlist] from:self.objectType] whereClause:whereClause] build];
-    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:soql apiVersion:kSFRestDefaultAPIVersion];
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:soql apiVersion:nil];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
     } completeBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSoqlSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSoqlSyncDownTarget.m
@@ -122,7 +122,7 @@ static NSString * const kSFSoqlSyncTargetQuery = @"query";
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
     
-    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:queryToRun apiVersion:kSFRestDefaultAPIVersion];
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:queryToRun apiVersion:nil];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
     } completeBlock:^(NSDictionary *responseJson, NSURLResponse *rawResponse) {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSoslSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSoslSyncDownTarget.m
@@ -87,7 +87,7 @@ static NSString * const kSFSoslSyncTargetQuery = @"query";
          errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
-    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearch:queryRun apiVersion:kSFRestDefaultAPIVersion];
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearch:queryRun apiVersion:nil];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
     } completeBlock:^(NSDictionary* d, NSURLResponse *rawResponse) {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
@@ -53,7 +53,7 @@ NSString * const kSyncTargetLastError = @"__last_error__";
 #pragma mark - From/to dictionary
 
 - (instancetype)initWithDict:(NSDictionary *)dict {
-    if (dict == nil) return nil;
+    if (dict == nil) dict = @{};
     
     self = [super init];
     if (self) {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.h
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.h
@@ -27,6 +27,7 @@
 
 extern NSString * _Nonnull const kSFSyncUpTargetCreateFieldlist;
 extern NSString * _Nonnull const kSFSyncUpTargetUpdateFieldlist;
+extern NSString * _Nonnull const kSFSyncUpTargetExternalIdFieldName;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -120,6 +121,11 @@ NS_SWIFT_NAME(SyncUpTarget)
  Update field list (optional)
  */
 @property (nonatomic, strong, readonly) NSArray<NSString*>*  updateFieldlist;
+
+/**
+ External id field name (optional)
+ */
+@property (nonatomic, copy) NSString *externalIdFieldName;
 
 /**
  Creates a new instance of a server target from a serialized dictionary.

--- a/libs/MobileSync/MobileSync/Classes/Util/SFCompositeRequestHelper.m
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFCompositeRequestHelper.m
@@ -36,7 +36,7 @@
              completionBlock:(SFSendCompositeRequestCompleteBlock)completionBlock
                    failBlock:(SFSyncUpTargetErrorBlock)failBlock {
     
-    SFRestRequest *compositeRequest = [[SFRestAPI sharedInstance] compositeRequest:requests refIds:refIds allOrNone:allOrNone apiVersion:kSFRestDefaultAPIVersion];
+    SFRestRequest *compositeRequest = [[SFRestAPI sharedInstance] compositeRequest:requests refIds:refIds allOrNone:allOrNone apiVersion:nil];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:compositeRequest
                                                      failBlock:^(NSError *e, NSURLResponse *rawResponse) {
                                                          failBlock(e);

--- a/libs/MobileSync/MobileSyncTestApp/usersyncs.json
+++ b/libs/MobileSync/MobileSyncTestApp/usersyncs.json
@@ -128,6 +128,9 @@
       "syncType": "syncUp",
       "soupName": "accounts",
       "target": {
+        "idFieldName": "IdX",
+        "modificationDateFieldName": "LastModifiedDateX",
+        "externalIdFieldName": "ExternalIdX"
       },
       "options": {
         "fieldlist": ["Name", "Description"],

--- a/libs/MobileSync/MobileSyncTests/SFSDKSyncsConfigTests.m
+++ b/libs/MobileSync/MobileSyncTests/SFSDKSyncsConfigTests.m
@@ -275,11 +275,15 @@
     
     SFSyncState* sync = [self.syncManager getSyncStatusByName:@"batchSyncUp"];
     XCTAssertEqualObjects(sync.soupName, @"accounts");
+    SFBatchSyncUpTarget* expectedTarget = [[SFBatchSyncUpTarget alloc] initWithCreateFieldlist:nil updateFieldlist:nil];
+    expectedTarget.idFieldName = @"IdX";
+    expectedTarget.modificationDateFieldName = @"LastModifiedDateX";
+    expectedTarget.externalIdFieldName = @"ExternalIdX";
     [self checkStatus:sync
          expectedType:SFSyncStateSyncTypeUp
            expectedId:sync.syncId
          expectedName:@"batchSyncUp"
-       expectedTarget:[[SFBatchSyncUpTarget alloc] initWithCreateFieldlist:nil updateFieldlist:nil]
+       expectedTarget:expectedTarget
       expectedOptions:[SFSyncOptions newSyncOptionsForSyncUp:@[@"Name", @"Description"] mergeMode:SFSyncStateMergeModeOverwrite]
        expectedStatus:SFSyncStateStatusNew
      expectedProgress:0

--- a/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.m
+++ b/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.m
@@ -395,6 +395,7 @@ static NSException *authException = nil;
             XCTAssertTrue([sync.target isKindOfClass:[SFSyncUpTarget class]]);
             XCTAssertEqualObjects(((SFSyncUpTarget*)expectedTarget).createFieldlist, ((SFSyncUpTarget*)sync.target).createFieldlist);
             XCTAssertEqualObjects(((SFSyncUpTarget*)expectedTarget).updateFieldlist, ((SFSyncUpTarget*)sync.target).updateFieldlist);
+            XCTAssertEqualObjects(((SFSyncUpTarget*)expectedTarget).externalIdFieldName, ((SFSyncUpTarget*)sync.target).externalIdFieldName);
         }
     } else {
         XCTAssertNil(sync.target);

--- a/libs/MobileSync/MobileSyncTests/SyncUpTargetTests.m
+++ b/libs/MobileSync/MobileSyncTests/SyncUpTargetTests.m
@@ -623,10 +623,10 @@
     NSMutableDictionary* expectedServerIdToFields = [NSMutableDictionary new];
     expectedServerIdToFields[id1] = @{NAME: name1, DESCRIPTION:idToFields[id1][DESCRIPTION]};
     expectedServerIdToFields[id2] = @{NAME: name2, DESCRIPTION:idToFields[id2][DESCRIPTION]};
-    expectedServerIdToFields[id3] = @{NAME: name3};
+    expectedServerIdToFields[id3] = @{NAME: name3, DESCRIPTION:[NSNull null]};
 
     // Check server
-    [self checkServer:expectedDbIdFields];
+    [self checkServer:expectedServerIdToFields];
 
     // Adding to idToFields so that they get deleted in tearDown
     [idToFields addEntriesFromDictionary:expectedServerIdToFields];

--- a/libs/MobileSync/MobileSyncTests/SyncUpTargetTests.m
+++ b/libs/MobileSync/MobileSyncTests/SyncUpTargetTests.m
@@ -571,6 +571,68 @@
     [self checkServer:idToFieldsRemotelyUpdated];
 }
 
+/**
+ * Create accounts locally but with external id field populated, sync up with external id field name provided, check smartstore and server afterwards
+ */
+-(void) testSyncUpWithExternalId {
+    NSString* externalIdFieldName = @"Id";
+
+    // Create test data
+    [self createTestData];
+    
+    // Creating 3 new names
+    NSString* name1 = [self createAccountName];
+    NSString* name2 = [self createAccountName];
+    NSString* name3 = [self createAccountName];
+
+    // Get id of two records on the server
+    NSArray* allIds = [idToFields allKeys];
+    NSString* id1 = allIds[0];
+    NSString* id2 = allIds[1];
+
+    // Create accounts locally
+    NSArray* localAccounts = [self createAccountsLocally:@[ name1, name2, name3 ]];
+    NSMutableDictionary* localRecord1 = [NSMutableDictionary dictionaryWithDictionary:localAccounts[0]];
+    NSMutableDictionary* localRecord2 = [NSMutableDictionary dictionaryWithDictionary:localAccounts[1]];
+    NSMutableDictionary* localRecord3 = [NSMutableDictionary dictionaryWithDictionary:localAccounts[2]];
+
+    // Update Id field to match and existing id for record 1 and 2
+    localRecord1[externalIdFieldName] = id1;
+    localRecord2[externalIdFieldName] = id2;
+    localRecord3[externalIdFieldName] = nil;
+    [self.store upsertEntries:@[localRecord1, localRecord2, localRecord3] toSoup:ACCOUNTS_SOUP];
+
+    // Sync up with external id field name - NB: only syncing up name field not description
+    SFSyncOptions* options = [SFSyncOptions newSyncOptionsForSyncUp:@[NAME]];
+    [self trySyncUp:3 options:options externalIdFieldName:externalIdFieldName];
+    
+    // Getting id for third record upserted - the one without an valid external id
+    NSString* id3 = [[self getIdToFieldsByName:ACCOUNTS_SOUP fieldNames:@[] nameField:NAME names:@[name3]] allKeys][0];
+     
+    // Expected records locally
+    NSMutableDictionary* expectedDbIdFields = [NSMutableDictionary new];
+    expectedDbIdFields[id1] = @{NAME: name1, DESCRIPTION:localRecord1[DESCRIPTION]};
+    expectedDbIdFields[id2] = @{NAME: name2, DESCRIPTION:localRecord2[DESCRIPTION]};
+    expectedDbIdFields[id3] = @{NAME: name3, DESCRIPTION:localRecord3[DESCRIPTION]};
+
+    // Check db
+    [self checkDbStateFlags:[expectedDbIdFields allKeys] soupName:ACCOUNTS_SOUP expectedLocallyCreated:NO expectedLocallyUpdated:NO expectedLocallyDeleted:NO];
+    [self checkDb:expectedDbIdFields soupName:ACCOUNTS_SOUP];
+
+    // Expected records on server
+    NSMutableDictionary* expectedServerIdToFields = [NSMutableDictionary new];
+    expectedServerIdToFields[id1] = @{NAME: name1, DESCRIPTION:idToFields[id1][DESCRIPTION]};
+    expectedServerIdToFields[id2] = @{NAME: name2, DESCRIPTION:idToFields[id2][DESCRIPTION]};
+    expectedServerIdToFields[id3] = @{NAME: name3};
+
+    // Check server
+    [self checkServer:expectedDbIdFields];
+
+    // Adding to idToFields so that they get deleted in tearDown
+    [idToFields addEntriesFromDictionary:expectedServerIdToFields];
+}
+
+
 #pragma mark - helper methods
 
 -(void) trySyncUpWithLocallyCreatedRecords:(SFSyncStateMergeMode)syncUpMergeMode
@@ -602,9 +664,13 @@
     [self trySyncUp:numberChanges options:defaultOptions];
 }
 
-- (void)trySyncUp:(NSInteger)numberChanges
-          options:(SFSyncOptions *) options {
+- (void)trySyncUp:(NSInteger)numberChanges options:(SFSyncOptions *)options {
+    [self trySyncUp:numberChanges options:options externalIdFieldName:nil];
+}
+
+- (void)trySyncUp:(NSInteger)numberChanges options:(SFSyncOptions *)options externalIdFieldName:(NSString*)externalIdFieldName {
     SFSyncUpTarget *defaultTarget = [self buildSyncUpTarget];
+    defaultTarget.externalIdFieldName = externalIdFieldName;
     [self trySyncUp:numberChanges
       actualChanges:numberChanges
              target:defaultTarget


### PR DESCRIPTION
Locally created records providing an external id are upserted during sync up.

* SyncUpTarget and BatchSyncUpTarget both support the new field
* Added test for SyncUpTarget and BatchSyncUpTarget
* Using the new field in one of the example config and modified config test accordingly

NB:
* ParentChildrenSyncUpTarget does not support it (yet)