### PR TITLE
Fix deadlock on [SFUserAccountManager sharedInstance]

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFUserAccountManager.m
@@ -146,13 +146,14 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 + (instancetype)sharedInstance {
     static dispatch_once_t pred;
     static SFUserAccountManager *userAccountManager = nil;
+    __block BOOL isFirstRun = NO;
     dispatch_once(&pred, ^{
-		userAccountManager = [[self alloc] init];
-	});
-    static dispatch_once_t pred2;
-    dispatch_once(&pred2, ^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:SFUserAccountManagerDidFinishUserInitNotification object:nil];
+        userAccountManager = [[self alloc] init];
+        isFirstRun = YES;
     });
+    if (isFirstRun) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:SFUserAccountManagerDidFinishUserInitNotification object:nil];
+    };
     return userAccountManager;
 }
 


### PR DESCRIPTION
When the `[SFUserAccountManager sharedInstance]` is created and sends the `SFUserAccountManagerDidFinishUserInitNotification`, if any observer attempts to access the `[SFUserAccountManager sharedInstance]` when the notification is posted, a deadlock is created.

This is because the `dispatch_once` block for posting the notification is still being executed when the `dispatch_once` token is accessed again during the call to access the `[SFUserAccountManager sharedInstance]`.

More information on why this is a problem can be found here:
https://stackoverflow.com/questions/19176219/why-am-i-getting-deadlock-with-dispatch-once

This PR fixes this bug, identified in https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/3111