### PR TITLE
Handle invalid values for instrumentation event json.

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Model/SFSDKInstrumentationEvent+Internal.h
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Model/SFSDKInstrumentationEvent+Internal.h
@@ -57,4 +57,11 @@
  */
 - (nonnull instancetype) initWithEventId:(nonnull NSString *) eventId startTime:(NSInteger) startTime endTime:(NSInteger) endTime name:(nonnull NSString *) name attributes:(nullable NSDictionary *) attributes sessionId:(nullable NSString *) sessionId sequenceId:(NSInteger) sequenceId senderId:(nullable NSString *) senderId senderContext:(nullable NSDictionary *) senderContext schemaType:(SFASchemaType) schemaType eventType:(SFAEventType) eventType errorType:(SFAErrorType) errorType deviceAppAttributes:(nonnull SFSDKDeviceAppAttributes *) deviceAppAttributes connectionType:(nonnull NSString *) connectionType senderParentId:(nullable NSString *) senderParentId sessionStartTime:(NSInteger) sessionStartTime page:(nullable NSDictionary *) page previousPage:(nullable NSDictionary *) previousPage marks:(nullable NSDictionary *) marks;
 
+/**
+* Returns a JSON dictionary representation of this event.
+*
+* @return JSON dictionary representation.
+*/
+- (nonnull NSDictionary *) jsonDictionary;
+
 @end

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Model/SFSDKInstrumentationEvent.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Model/SFSDKInstrumentationEvent.m
@@ -183,28 +183,7 @@
 #pragma mark - Public methods
 
 - (NSData *) jsonRepresentation {
-    NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
-    dict[kEventIdKey] = self.eventId;
-    dict[kStartTimeKey] = [NSNumber numberWithInteger:self.startTime];
-    dict[kEndTimeKey] = [NSNumber numberWithInteger:self.endTime];
-    dict[kNameKey] = self.name;
-    dict[kAttributesKey] = self.attributes;
-    dict[kSessionIdKey] = self.sessionId;
-    dict[kSequenceIdKey] = [NSNumber numberWithInteger:self.sequenceId];
-    dict[kSenderIdKey] = self.senderId;
-    dict[kSenderContextKey] = self.senderContext;
-    dict[kSchemaTypeKey] = [self stringValueOfSchemaType:self.schemaType];
-    dict[kEventTypeKey] = [self stringValueOfEventType:self.eventType];
-    dict[kErrorTypeKey] = [self stringValueOfErrorType:self.errorType];
-    if (self.deviceAppAttributes) {
-        dict[kDeviceAppAttributesKey] = [self.deviceAppAttributes jsonRepresentation];
-    }
-    dict[kConnectionTypeKey] = self.connectionType;
-    dict[kSenderParentIdKey] = self.senderParentId;
-    dict[kSessionStartTimeKey] = [NSNumber numberWithInteger:self.sessionStartTime];
-    dict[kPageKey] = self.page;
-    dict[kPreviousPageKey] = self.previousPage;
-    dict[kMarksKey] = self.marks;
+    NSDictionary *dict = [self jsonDictionary];
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict options:0 error:&error];
     return jsonData;
@@ -271,6 +250,32 @@
 }
 
 #pragma mark - Private methods
+
+- (NSDictionary *) jsonDictionary {
+    NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
+    dict[kEventIdKey] = self.eventId;
+    dict[kStartTimeKey] = [NSNumber numberWithInteger:self.startTime];
+    dict[kEndTimeKey] = [NSNumber numberWithInteger:self.endTime];
+    dict[kNameKey] = self.name;
+    dict[kAttributesKey] = self.attributes;
+    dict[kSessionIdKey] = self.sessionId;
+    dict[kSequenceIdKey] = [NSNumber numberWithInteger:self.sequenceId];
+    dict[kSenderIdKey] = self.senderId;
+    dict[kSenderContextKey] = self.senderContext;
+    dict[kSchemaTypeKey] = [self stringValueOfSchemaType:self.schemaType];
+    dict[kEventTypeKey] = [self stringValueOfEventType:self.eventType];
+    dict[kErrorTypeKey] = [self stringValueOfErrorType:self.errorType];
+    if (self.deviceAppAttributes) {
+        dict[kDeviceAppAttributesKey] = [self.deviceAppAttributes jsonRepresentation];
+    }
+    dict[kConnectionTypeKey] = self.connectionType;
+    dict[kSenderParentIdKey] = self.senderParentId;
+    dict[kSessionStartTimeKey] = [NSNumber numberWithInteger:self.sessionStartTime];
+    dict[kPageKey] = self.page;
+    dict[kPreviousPageKey] = self.previousPage;
+    dict[kMarksKey] = self.marks;
+    return dict;
+}
 
 - (SFASchemaType) schemaTypeFromString:(NSString *) schemaType {
     SFASchemaType type = SchemaTypeError;

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Model/SFSDKInstrumentationEventBuilder.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Model/SFSDKInstrumentationEventBuilder.m
@@ -79,7 +79,15 @@
     NSInteger curTime = [[NSDate date] timeIntervalSince1970] * 1000;
     self.startTime = (self.startTime == 0) ? curTime : self.startTime;
     self.sessionStartTime = (self.sessionStartTime == 0) ? curTime : self.sessionStartTime;
-    return [[SFSDKInstrumentationEvent alloc] initWithEventId:eventId startTime:self.startTime endTime:self.endTime name:self.name attributes:self.attributes sessionId:self.sessionId sequenceId:sequenceId senderId:self.senderId senderContext:self.senderContext schemaType:self.schemaType eventType:self.eventType errorType:self.errorType deviceAppAttributes:deviceAppAttributes connectionType:[self getConnectionType] senderParentId:self.senderParentId sessionStartTime:self.sessionStartTime page:self.page previousPage:self.previousPage marks:self.marks];
+    
+    SFSDKInstrumentationEvent *event = [[SFSDKInstrumentationEvent alloc] initWithEventId:eventId startTime:self.startTime endTime:self.endTime name:self.name attributes:self.attributes sessionId:self.sessionId sequenceId:sequenceId senderId:self.senderId senderContext:self.senderContext schemaType:self.schemaType eventType:self.eventType errorType:self.errorType deviceAppAttributes:deviceAppAttributes connectionType:[self getConnectionType] senderParentId:self.senderParentId sessionStartTime:self.sessionStartTime page:self.page previousPage:self.previousPage marks:self.marks];
+    
+    if ([NSJSONSerialization isValidJSONObject:[event jsonDictionary]]) {
+        return event;
+    } else {
+        [SFSDKAnalyticsLogger w:[self class] format:@"WARNING: Building event failed! REASON: Invalid JSON properties set!"];
+        return nil;
+    }
 }
 
 - (NSString *) getConnectionType {

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
@@ -75,7 +75,7 @@
 
     // Copies event, to isolate data for I/O.
     SFSDKInstrumentationEvent *eventCopy = [event copy];
-    if (!eventCopy || ![eventCopy jsonRepresentation]) {
+    if (!eventCopy) {
         return;
     }
     if (![self shouldStoreEvent]) {

--- a/libs/SalesforceAnalytics/SalesforceAnalyticsTests/InstrumentationEventBuilderTests.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalyticsTests/InstrumentationEventBuilderTests.m
@@ -98,6 +98,25 @@ static NSString * const kTestSessionId = @"TEST_SESSION_ID";
     XCTAssertEqualObjects(event, nil, @"Event should be nil due to missing mandatory field 'page'");
 }
 
+/**
+ * Test for invalid json properties.
+ */
+- (void) testInvalidJsonProperties {
+    SFSDKInstrumentationEvent *event = [SFSDKInstrumentationEventBuilder buildEventWithBuilderBlock:^(SFSDKInstrumentationEventBuilder *builder) {
+        double curTime = 1000 * [[NSDate date] timeIntervalSince1970];
+        NSString *eventName = [NSString stringWithFormat:kTestEventName, curTime];
+        builder.startTime = curTime;
+        builder.name = eventName;
+        builder.sessionId = kTestSessionId;
+        builder.page =  @{[NSNull null]: @""}; // NSNull is invalid as a key
+        builder.senderId = kTestSenderId;
+        builder.schemaType = SchemaTypeError;
+        builder.eventType = EventTypeSystem;
+        builder.errorType = ErrorTypeWarn;
+    } analyticsManager:self.analyticsManager];
+    XCTAssertEqualObjects(event, nil, @"Event should be nil due to invalid json key of NSNull");
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
 


### PR DESCRIPTION
The SDK can crash if the consumer passes in any invalid keys or values for `NSJSONSerialization`. The Apple docs here suggest checking before calling `dataWithJSONObject`. 
https://developer.apple.com/documentation/foundation/nsjsonserialization/1413636-datawithjsonobject?language=objc#discussion
> If obj will not produce valid JSON, an exception is thrown. This exception is thrown prior to parsing and represents a programming error, not an internal error. You should check whether the input will produce valid JSON before calling this method by using isValidJSONObject:.

This change will ignore events that are invalid instead of crashing.