### PR TITLE
Use appropriate RestAPI instance for when no user is set

### DIFF
--- a/libs/MobileSync/MobileSync/Classes/Util/SFMobileSyncNetworkUtils.m
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFMobileSyncNetworkUtils.m
@@ -24,6 +24,7 @@
 
 #import "SFMobileSyncNetworkUtils.h"
 #import <SalesforceSDKCore/SFRestRequest.h>
+#import "SFUserAccountManager.h"
 
 // For user agent
 NSString * const kUserAgent = @"User-Agent";

--- a/libs/MobileSync/MobileSync/Classes/Util/SFMobileSyncNetworkUtils.m
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFMobileSyncNetworkUtils.m
@@ -34,7 +34,11 @@ NSString * const kMobileSync = @"MobileSync";
 + (void)sendRequestWithMobileSyncUserAgent:(SFRestRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestResponseBlock)completeBlock {
     [SFSDKMobileSyncLogger d:[self class] format:@"sendRequestWithMobileSyncUserAgent:request:%@", request];
     [request setHeaderValue:[SFRestAPI userAgentString:kMobileSync] forHeaderName:kUserAgent];
-    [[SFRestAPI sharedInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    
+    SFUserAccount *user = [SFUserAccountManager sharedInstance].currentUser;
+    SFRestAPI *restApiInstance = (!user) ? [SFRestAPI sharedGlobalInstance] : [SFRestAPI sharedInstance];
+    
+    [restApiInstance sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         [SFSDKMobileSyncLogger e:[self class] format:@"sendRequestWithMobileSyncUserAgent:error:%ld:%@", (long) e.code, e.domain];
         failBlock(e, rawResponse);
     } completeBlock:^(id response, NSURLResponse *rawResponse) {

--- a/libs/MobileSync/MobileSync/Classes/Util/SFMobileSyncNetworkUtils.m
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFMobileSyncNetworkUtils.m
@@ -24,7 +24,7 @@
 
 #import "SFMobileSyncNetworkUtils.h"
 #import <SalesforceSDKCore/SFRestRequest.h>
-#import "SFUserAccountManager.h"
+#import <SalesforceSDKCore/SFUserAccountManager.h>
 
 // For user agent
 NSString * const kUserAgent = @"User-Agent";


### PR DESCRIPTION
Check if a user is currently set and based on that determine whether to use `sharedGlobalInstance` or `sharedInstance`