### PR TITLE
Passcode logout button color

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewConfig.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewConfig.h
@@ -89,6 +89,11 @@ NS_SWIFT_NAME(AppLockViewControllerConfig)
 @property (nonatomic, strong, nullable) UIColor * titleTextColor;
 
 /**
+ * Color of the loguot button.
+ */
+@property (nonatomic, strong, nonnull) UIColor * logoutButtonColor;
+
+/**
  * Font used for displaying instructions.
  */
 @property (nonatomic, strong, nullable) UIFont * instructionFont;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewConfig.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewConfig.h
@@ -89,7 +89,7 @@ NS_SWIFT_NAME(AppLockViewControllerConfig)
 @property (nonatomic, strong, nullable) UIColor * titleTextColor;
 
 /**
- * Color of the loguot button.
+ * Color of the logout button on passcode verify screen.
  */
 @property (nonatomic, strong, nonnull) UIColor * logoutButtonColor;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewConfig.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewConfig.m
@@ -48,6 +48,7 @@
         _borderColor = [UIColor passcodeViewBorderColor];
         _instructionTextColor = [UIColor passcodeViewTextColor];
         _titleTextColor = [UIColor passcodeViewTextColor];
+        _logoutButtonColor = _primaryColor;
         _instructionFont = [UIFont systemFontOfSize:14];
         _titleFont = [UIFont systemFontOfSize:18 weight:UIFontWeightBold];
         _buttonFont = [UIFont systemFontOfSize:14 weight:UIFontWeightBold];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeVerifyController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeVerifyController.m
@@ -306,7 +306,7 @@ NSUInteger const kSFMaxNumberofAttempts = 10;
             
             if (![self.navigationItem.leftBarButtonItem isEnabled]) {
                 [self.navigationItem.leftBarButtonItem setEnabled:YES];
-                [self.navigationItem.leftBarButtonItem setTintColor:self.viewConfig.primaryColor];
+                [self.navigationItem.leftBarButtonItem setTintColor:self.viewConfig.logoutButtonColor];
             }
             [self.view setNeedsDisplay];
         }


### PR DESCRIPTION
The logout button shows up only after the user has entered an incorrect password, so depending on what primaryColor is set to it may not be obvious.  Worse even, the user will not see it at all if primaryColor and navBarColor are the same (which was reported by a customer).  