### PR TITLE
Adds Reusable, Generic pipeline

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -218,8 +218,7 @@ extension RestClient {
     /// Reusable, generic Combine Pipeline returning an array of records of a local
     /// model object that conforms to Decodable. This method accepts a query string and defers
     /// to the method above.
-  func records<Record: Decodable>(forQuery query:String, withApiVersion version: String = kSFRestDefaultAPIVersion ) -> AnyPublisher<[Record], Never> {
-    RestClient.shared.apiVersion
+  func records<Record: Decodable>(forQuery query:String, withApiVersion version: String = SFRestDefaultAPIVersion ) -> AnyPublisher<[Record], Never> {
       let request = RestClient.shared.request(forQuery: query, apiVersion: version)
       return self.records(forRequest: request)
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -89,12 +89,12 @@ public struct RestResponse {
 
 extension RestRequest {
   
-  /// Calculated property to determine if this request is a data retrieval request with a SOQL query.
+  /// Calculated property to determine if this request is a data retrieval request with a SOQL or SOSL query.
   /// All such queries will return a JSON decodable QueryResponseWrapper.
   /// Implied contract is that all requests matching both properties here will be decodable via QueryResponseWrapper<Record>
   public var isQueryRequest: Bool {
     get {
-      return self.method == .GET && self.path.lowercased().hasSuffix("query")
+      return self.method == .GET && (self.path.lowercased().hasSuffix("query") || self.path.lowercased().hasSuffix("search"))
     }
   }
   

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -106,7 +106,7 @@ extension RestClient {
     /// This struct requires a Model Object that conforms to Decodable
     /// This model object's properties need to match the Salesforce Schema
     ///   at least in part.
-    struct QueryResponseWrapper<Record: Decodable>: Decodable {
+    struct QueryResponse<Record: Decodable>: Decodable {
       var totalSize: Int
       var done: Bool
       var records: [Record]
@@ -185,7 +185,7 @@ extension RestClient {
               case .success(let response):
                 do {
                   let decoder = JSONDecoder()
-                  let wrapper = try decoder.decode(QueryResponseWrapper<Record>.self, from: response.asData())
+                  let wrapper = try decoder.decode(QueryResponse<Record>.self, from: response.asData())
                   completionBlock(.success(wrapper.records))
                 } catch {
                   completionBlock(.success([Record]()))
@@ -288,7 +288,7 @@ extension RestClient {
         .tryMap({ (response) -> Data in
           response.asData()
         })
-        .decode(type: QueryResponseWrapper<Record>.self, decoder: JSONDecoder())
+        .decode(type: QueryResponse<Record>.self, decoder: JSONDecoder())
         .map({ (record) -> [Record] in
           record.records
         })

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -218,8 +218,9 @@ extension RestClient {
     /// Reusable, generic Combine Pipeline returning an array of records of a local
     /// model object that conforms to Decodable. This method accepts a query string and defers
     /// to the method above.
-    func records<Record: Decodable>(forQuery query:String) -> AnyPublisher<[Record], Never> {
-      let request = RestClient.shared.request(forQuery: query, apiVersion: RestClient.apiVersion)
+  func records<Record: Decodable>(forQuery query:String, withApiVersion version: String = kSFRestDefaultAPIVersion ) -> AnyPublisher<[Record], Never> {
+    RestClient.shared.apiVersion
+      let request = RestClient.shared.request(forQuery: query, apiVersion: version)
       return self.records(forRequest: request)
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientPublisherTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientPublisherTests.swift
@@ -53,6 +53,19 @@ class RestClientPublisherTests: XCTestCase {
         }
     }
     
+    func testRecordsPublisher() {
+      // TODO:  Remove this when iOS 13 becomes the target version.
+      if #available(iOS 13.0, *) {
+        
+        let request = RestClient.shared.request(forQuery: "select name from CONTACT", apiVersion: nil)
+        let publisher: AnyPublisher<RestClient.QueryResponse<TestContact>, Never> = RestClient.shared.records(forRequest: request)
+        
+        let validTest = evaluateResults(publisher: publisher)
+        wait(for: validTest.expectations, timeout: 5)
+        validTest.cancellable?.cancel()
+      }
+    }
+  
     func testCompositePublisher() {
         // TODO:  Remove this when iOS 13 becomes the target version.
         if #available(iOS 13.0, *) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
@@ -26,6 +26,13 @@ import XCTest
 import Foundation
 @testable import SalesforceSDKCore
 
+struct TestContact: Decodable{
+  var id: UUID = UUID()
+  var Id: String?
+  var FirstName: String?
+  var LastName: String?
+}
+
 class RestClientTests: XCTestCase {
 
     var currentUser: UserAccount?
@@ -42,6 +49,23 @@ class RestClientTests: XCTestCase {
     }
 
     
+    func testFetchRecordsNonCombine() {
+      let expectation = XCTestExpectation(description: "queryTest")
+      let request = RestClient.shared.request(forQuery: "select name from CONTACT", apiVersion: nil)
+      
+      var erroredResult: RestClientError?
+      RestClient.shared.fetchRecords(ofModelType: TestContact.self, forRequest: request) { result in
+        switch (result) {
+          case .failure(let error):
+            erroredResult = error
+          default: break
+        }
+        expectation.fulfill()
+      }
+      self.wait(for: [expectation], timeout: 10.0)
+      XCTAssertNil(erroredResult,"Query call should not have failed")
+    }
+  
     func testQuery() {
         let expectation = XCTestExpectation(description: "queryTest")
         let request = RestClient.shared.request(forQuery: "select name from CONTACT", apiVersion: nil)


### PR DESCRIPTION
Includes a re-usable struct representing the JSON structure of a Salesforce Rest Response that includes an array of Salesforce Records.

The output of this pipeline is an array of swift objects hydrated from the Salesforce records.
The Salesforce records are decoded against the inferred type from the pipelines subscriber.