### PR TITLE
Ensure that auth failures are processed on main thread

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
@@ -129,17 +129,6 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
 - (void)oauthCoordinatorDidAuthenticate:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)info;
 
 /**
- Sent if authentication fails due to an error. Note: This method is deprecated.  You should use the
- `oauthCoordinator:didFailWithError:authInfo` method instead.
- 
- @param coordinator The SFOAuthCoordinator instance processing this message
- @param error       The error message
- 
- @see SFOAuthCoordinator
- */
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFailWithError:(NSError *)error __attribute__((deprecated));
-
-/**
  Sent if authentication fails due to an error.
  
  @param coordinator The SFOAuthCoordinator instance processing this message.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -291,12 +291,9 @@
     self.authenticating = NO;
     self.advancedAuthState = SFOAuthAdvancedAuthStateNotStarted;
     if ([self.delegate respondsToSelector:@selector(oauthCoordinator:didFailWithError:authInfo:)]) {
-        [self.delegate oauthCoordinator:self didFailWithError:error authInfo:info];
-    } else if ([self.delegate respondsToSelector:@selector(oauthCoordinator:didFailWithError:)]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        [self.delegate oauthCoordinator:self didFailWithError:error];
-#pragma clang diagnostic pop
+        dispatch_async(dispatch_get_main_queue(), ^{
+           [self.delegate oauthCoordinator:self didFailWithError:error authInfo:info];
+        });
     }
     self.authInfo = nil;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKAlertView.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKAlertView.m
@@ -72,14 +72,15 @@
         }];
          [self.controller addAction:actionTwoButton];
     }
-    
-    dispatch_async(dispatch_get_main_queue(), ^{
-        __strong typeof (weakSelf) strongSelf = weakSelf;
-        [strongSelf.window presentWindowAnimated:NO withCompletion:^{
-            UIViewController *controller = strongSelf.window.viewController.presentedViewController?:strongSelf.window.viewController;
-            [controller presentViewController:weakSelf.controller animated:animated completion:completion];
-            }];
-        });
+    __strong typeof (weakSelf) strongSelf = weakSelf;
+    [self.window presentWindowAnimated:NO withCompletion:^{
+        UIViewController *controller =  strongSelf.window.viewController;
+        if (!strongSelf.window.viewController.presentedViewController.isBeingDismissed) {
+            controller = strongSelf.window.viewController.presentedViewController;
+        }
+        [controller presentViewController:strongSelf.controller animated:animated completion:completion];
+     }];
+
 }
 
 - (UIViewController *)blankViewController {


### PR DESCRIPTION
Removes an old deprecated method for error handling. Auth flows typically have a some level of user interactions during failures.  Ensures that failure handling is always  dispatched on main (prior to this in some cases UI handling was being guarded and the other cases (adv. auth) was not). Addl.  removes  unnecessary dispatch_async for alert view presentation, the underlying mechanism dispatches on main thread anyway. cc: @qingqingliu 