### PR TITLE
Enhancing LayoutSyncManager to support more fields and use cases

### DIFF
--- a/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.h
+++ b/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.h
@@ -96,6 +96,29 @@ NS_SWIFT_NAME(LayoutSyncManager)
  * @param mode Fetch mode. See SFSDKFetchMode for available modes.
  * @param completionBlock Layout sync completion block.
  */
-- (void)fetchLayoutForObject:(nonnull NSString *)objectType layoutType:(nullable NSString *)layoutType mode:(SFSDKFetchMode)mode completionBlock:(nonnull SFLayoutSyncCompletionBlock)completionBlock;
+- (void)fetchLayoutForObject:(nonnull NSString *)objectType
+                  layoutType:(nullable NSString *)layoutType
+                        mode:(SFSDKFetchMode)mode
+             completionBlock:(nonnull SFLayoutSyncCompletionBlock)completionBlock SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use fetchLayoutForObjectAPIName:objectAPIName:formFactor:layoutType:mode:recordTypeId:syncMode:completionBlock instead.");
+
+/**
+ * Fetches layout data for the specified parameters using the specified sync
+ * mode and triggers the supplied completion block once complete.
+ *
+ * @param objectAPIName Object API name.
+ * @param formFactor Form factor. Could be "Large", "Medium" or "Small". Default value is "Large".
+ * @param layoutType Layout type. Defaults to "Full" if nil is passed in.
+ * @param mode Mode. Could be "Create", "Edit" or "View". Default value is "View".
+ * @param recordTypeId Record type ID. Default will be used if not supplied.
+ * @param syncMode Fetch mode. See SFSDKFetchMode for available modes.
+ * @param completionBlock Layout sync completion block.
+ */
+- (void)fetchLayoutForObjectAPIName:(nonnull NSString *)objectAPIName
+                         formFactor:(nullable NSString *)formFactor
+                         layoutType:(nullable NSString *)layoutType
+                               mode:(nullable NSString *)mode
+                       recordTypeId:(nullable NSString *)recordTypeId
+                           syncMode:(SFSDKFetchMode)syncMode
+                    completionBlock:(nonnull SFLayoutSyncCompletionBlock)completionBlock
 
 @end

--- a/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.h
+++ b/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.h
@@ -123,6 +123,6 @@ NS_SWIFT_NAME(LayoutSyncManager)
                                mode:(nullable NSString *)mode
                        recordTypeId:(nullable NSString *)recordTypeId
                            syncMode:(SFSDKFetchMode)syncMode
-                    completionBlock:(nonnull SFLayoutSyncCompletionBlock)completionBlock
+                    completionBlock:(nonnull SFLayoutSyncCompletionBlock)completionBlock;
 
 @end

--- a/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.h
+++ b/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.h
@@ -35,10 +35,14 @@
 /**
  * Completion block triggered when layout sync completes.
  *
- * @param objectType Object type.
+ * @param objectAPIName Object API name.
+ * @param formFactor Form factor.
+ * @param layoutType Layout type.
+ * @param mode Mode.
+ * @param recordTypeId Record type ID.
  * @param layout Layout.
  */
-typedef void (^SFLayoutSyncCompletionBlock) (NSString * _Nonnull objectType, SFLayout  * _Nullable layout) NS_SWIFT_NAME(LayoutSyncCompletionBlock);
+typedef void (^SFLayoutSyncCompletionBlock) (NSString * _Nonnull objectAPIName, NSString * _Nullable formFactor, NSString * _Nullable layoutType, NSString * _Nullable mode, NSString * _Nullable recordTypeId, SFLayout * _Nullable layout) NS_SWIFT_NAME(LayoutSyncCompletionBlock);
 
 /**
  * Provides an easy way to fetch layout data using SFLayoutSyncDownTarget.

--- a/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.m
+++ b/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.m
@@ -163,16 +163,16 @@ static NSArray<SFSoupIndex *> *indexSpecs = nil;
           recordTypeId:(NSString *)recordTypeId
        completionBlock:(SFLayoutSyncCompletionBlock)completionBlock
       fallbackOnServer:(BOOL)fallbackOnServer {
-    SFQuerySpec *querySpec = [SFQuerySpec newSmartQuerySpec:[NSString stringWithFormat:kQuery, kSoupName, kSoupName, kSoupName, objectType, formFactor, layoutType, mode, recordTypeId] withPageSize:1];
+    SFQuerySpec *querySpec = [SFQuerySpec newSmartQuerySpec:[NSString stringWithFormat:kQuery, kSoupName, kSoupName, kSoupName, objectAPIName, formFactor, layoutType, mode, recordTypeId] withPageSize:1];
     NSArray *results = [self.smartStore queryWithQuerySpec:querySpec pageIndex:0 error:nil];
     if (!results || results.count == 0) {
         if (fallbackOnServer) {
             [self fetchFromServer:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId completionBlock:completionBlock];
         } else {
-            completionBlock(objectType, nil);
+            completionBlock(objectAPIName, formFactor, layoutType, mode, recordTypeId, nil);
         }
     } else {
-        completionBlock(objectType, [SFLayout fromJSON:results[0][0]]);
+        completionBlock(objectAPIName, formFactor, layoutType, mode, recordTypeId, [SFLayout fromJSON:results[0][0]]);
     }
 }
 

--- a/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.m
+++ b/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.m
@@ -36,7 +36,7 @@
 
 static NSString * const kSoupName = @"sfdcLayouts";
 static NSString * const kSFAppFeatureLayoutSync = @"LY";
-static NSString * const kQuery = @"SELECT {%@:_soup} FROM {%@} WHERE {%@:Id} = '%@-%@'";
+static NSString * const kQuery = @"SELECT {%@:_soup} FROM {%@} WHERE {%@:Id} = '%@-%@-%@-%@-%@'";
 
 @interface SFLayoutSyncManager ()
 
@@ -103,16 +103,29 @@ static NSArray<SFSoupIndex *> *indexSpecs = nil;
     }
 }
 
-- (void)fetchLayoutForObject:(NSString *)objectType layoutType:(NSString *)layoutType mode:(SFSDKFetchMode)mode completionBlock:(SFLayoutSyncCompletionBlock)completionBlock {
-    switch (mode) {
+- (void)fetchLayoutForObject:(NSString *)objectType
+                  layoutType:(NSString *)layoutType
+                        mode:(SFSDKFetchMode)mode
+             completionBlock:(SFLayoutSyncCompletionBlock)completionBlock {
+    [self fetchLayoutForObjectAPIName:objectType formFactor:nil layoutType:layoutType mode:nil recordTypeId:nil syncMode:mode completionBlock:completionBlock];
+}
+
+- (void)fetchLayoutForObjectAPIName:(NSString *)objectAPIName
+                         formFactor:(NSString *)formFactor
+                         layoutType:(NSString *)layoutType
+                               mode:(NSString *)mode
+                       recordTypeId:(NSString *)recordTypeId
+                           syncMode:(SFSDKFetchMode)syncMode
+                    completionBlock:(SFLayoutSyncCompletionBlock)completionBlock {
+    switch (syncMode) {
         case SFSDKFetchModeCacheOnly:
-            [self fetchFromCache:objectType layoutType:layoutType completionBlock:completionBlock fallbackOnServer:NO];
+            [self fetchFromCache:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId completionBlock:completionBlock fallbackOnServer:NO];
             break;
         case SFSDKFetchModeCacheFirst:
-            [self fetchFromCache:objectType layoutType:layoutType completionBlock:completionBlock fallbackOnServer:YES];
+            [self fetchFromCache:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId completionBlock:completionBlock fallbackOnServer:YES];
             break;
         case SFSDKFetchModeServerFirst:
-            [self fetchFromServer:objectType layoutType:layoutType completionBlock:completionBlock];
+            [self fetchFromServer:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId completionBlock:completionBlock];
             break;
     }
 }
@@ -127,23 +140,34 @@ static NSArray<SFSoupIndex *> *indexSpecs = nil;
     return self;
 }
 
-- (void)fetchFromServer:(NSString *)objectType layoutType:(NSString *)layoutType completionBlock:(SFLayoutSyncCompletionBlock)completionBlock {
-    SFLayoutSyncDownTarget *target = [SFLayoutSyncDownTarget newSyncTarget:objectType layoutType:layoutType];
+- (void)fetchFromServer:(NSString *)objectAPIName
+             formFactor:(NSString *)formFactor
+             layoutType:(NSString *)layoutType
+                   mode:(NSString *)mode
+           recordTypeId:(NSString *)recordTypeId
+        completionBlock:(SFLayoutSyncCompletionBlock)completionBlock {
+    SFLayoutSyncDownTarget *target = [SFLayoutSyncDownTarget newSyncTarget:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId];
     __weak typeof (self) weakSelf = self;
     [self.syncManager syncDownWithTarget:target soupName:kSoupName updateBlock:^(SFSyncState *sync) {
         __strong typeof (weakSelf) strongSelf = weakSelf;
         if (sync.status == SFSyncStateStatusDone) {
-            [strongSelf fetchFromCache:objectType layoutType:layoutType completionBlock:completionBlock fallbackOnServer:NO];
+            [strongSelf fetchFromCache:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId completionBlock:completionBlock fallbackOnServer:NO];
         }
     }];
 }
 
-- (void)fetchFromCache:(NSString *)objectType layoutType:(NSString *)layoutType completionBlock:(SFLayoutSyncCompletionBlock)completionBlock fallbackOnServer:(BOOL)fallbackOnServer {
-    SFQuerySpec *querySpec = [SFQuerySpec newSmartQuerySpec:[NSString stringWithFormat:kQuery, kSoupName, kSoupName, kSoupName, objectType, layoutType] withPageSize:1];
+- (void)fetchFromCache:(NSString *)objectAPIName
+            formFactor:(NSString *)formFactor
+            layoutType:(NSString *)layoutType
+                  mode:(NSString *)mode
+          recordTypeId:(NSString *)recordTypeId
+       completionBlock:(SFLayoutSyncCompletionBlock)completionBlock
+      fallbackOnServer:(BOOL)fallbackOnServer {
+    SFQuerySpec *querySpec = [SFQuerySpec newSmartQuerySpec:[NSString stringWithFormat:kQuery, kSoupName, kSoupName, kSoupName, objectType, formFactor, layoutType, mode, recordTypeId] withPageSize:1];
     NSArray *results = [self.smartStore queryWithQuerySpec:querySpec pageIndex:0 error:nil];
     if (!results || results.count == 0) {
         if (fallbackOnServer) {
-            [self fetchFromServer:objectType layoutType:layoutType completionBlock:completionBlock];
+            [self fetchFromServer:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId completionBlock:completionBlock];
         } else {
             completionBlock(objectType, nil);
         }

--- a/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.h
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.h
@@ -30,8 +30,6 @@
 #import <Foundation/Foundation.h>
 #import "SFSyncDownTarget.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
 /**
  * Sync down target for object layouts. This uses the '/ui-api/layout' API to fetch object layouts.
  * The easiest way to use this sync target is through SFLayoutSyncManager.
@@ -39,14 +37,20 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(LayoutSyncDownTarget)
 @interface SFLayoutSyncDownTarget : SFSyncDownTarget
 
-@property (nonatomic, strong, readonly) NSString *objectType;
-@property (nonatomic, strong, readonly) NSString *layoutType;
+@property (nonnull, nonatomic, strong, readonly) NSString *objectAPIName;
+@property (nullable, nonatomic, strong, readonly) NSString *formFactor;
+@property (nullable, nonatomic, strong, readonly) NSString *layoutType;
+@property (nullable, nonatomic, strong, readonly) NSString *mode;
+@property (nullable, nonatomic, strong, readonly) NSString *recordTypeId;
 
 /**
  * Factory method.
  */
-+ (SFLayoutSyncDownTarget *)newSyncTarget:(nonnull NSString *)objectType layoutType:(nullable NSString *)layoutType;
++ (nonnull SFLayoutSyncDownTarget *)newSyncTarget:(nonnull NSString *)objectType layoutType:(nullable NSString *)layoutType SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use newSyncTarget:objectAPIName:formFactor:layoutType:mode:recordTypeId instead.");
+
+/**
+ * Factory method.
+ */
++ (nonnull SFLayoutSyncDownTarget *)newSyncTarget:(nonnull NSString *)objectAPIName formFactor:(nullable NSString *)formFactor layoutType:(nullable NSString *)layoutType mode:(nullable NSString *)mode recordTypeId:(nullable NSString *)recordTypeId;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
@@ -98,26 +98,29 @@ static NSString * const kIDFieldValue = @"%@-%@-%@-%@-%@";
 }
 
 - (void)startFetch:(SFMobileSyncSyncManager *)syncManager
-       maxTimeStamp:(long long)maxTimeStamp
-         errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
-      completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
-    [self startFetch:syncManager maxTimeStamp:maxTimeStamp objectType:self.objectType layoutType:self.layoutType errorBlock:errorBlock completeBlock:completeBlock];
+      maxTimeStamp:(long long)maxTimeStamp
+        errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
+     completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
+    [self startFetch:syncManager maxTimeStamp:maxTimeStamp objectAPIName:self.objectAPIName formFactor:self.formFactor layoutType:self.layoutType mode:self.mode recordTypeId:self.recordTypeId errorBlock:errorBlock completeBlock:completeBlock];
 }
 
 - (void)startFetch:(SFMobileSyncSyncManager *)syncManager
-       maxTimeStamp:(long long)maxTimeStamp
-           objectType:(NSString *)objectType
-           layoutType:(NSString *)layoutType
-         errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
-      completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
+      maxTimeStamp:(long long)maxTimeStamp
+     objectAPIName:(NSString *)objectAPIName
+        formFactor:(NSString *)formFactor
+        layoutType:(NSString *)layoutType
+              mode:(NSString *)mode
+      recordTypeId:(NSString *)recordTypeId
+        errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
+     completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
-    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectType:objectType layoutType:layoutType apiVersion:nil];
+    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectType:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId apiVersion:nil];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
     } completeBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {
         weakSelf.totalSize = 1;
         NSMutableDictionary *record = [[NSMutableDictionary alloc] initWithDictionary:d];
-        record[kId] = [NSString stringWithFormat:kIDFieldValue, weakSelf.objectType, weakSelf.layoutType];
+        record[kId] = [NSString stringWithFormat:kIDFieldValue, weakSelf.objectAPIName, weakSelf.formFactor, weakSelf.layoutType, weakSelf.mode, weakSelf.recordTypeId];
         NSMutableArray *records = [[NSMutableArray alloc] initWithCapacity:1];
         records[0] = record;
         completeBlock(records);
@@ -125,13 +128,17 @@ static NSString * const kIDFieldValue = @"%@-%@-%@-%@-%@";
 }
 
 - (void)getRemoteIds:(SFMobileSyncSyncManager *)syncManager
-             localIds:(NSArray *)localIds
-           errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
-        completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
+            localIds:(NSArray *)localIds
+          errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
+       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     completeBlock(nil);
 }
 
-- (void)cleanGhosts:(SFMobileSyncSyncManager *)syncManager soupName:(NSString *)soupName syncId:(NSNumber *)syncId errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
+- (void)cleanGhosts:(SFMobileSyncSyncManager *)syncManager
+           soupName:(NSString *)soupName
+             syncId:(NSNumber *)syncId
+         errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
+      completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     completeBlock(nil);
 }
 

--- a/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
@@ -72,11 +72,16 @@ static NSString * const kIDFieldValue = @"%@-%@-%@-%@-%@";
     return self;
 }
 
-+ (SFLayoutSyncDownTarget *)newSyncTarget:(NSString *)objectType layoutType:(NSString *)layoutType {
++ (SFLayoutSyncDownTarget *)newSyncTarget:(NSString *)objectType
+                               layoutType:(NSString *)layoutType {
     return [SFLayoutSyncDownTarget newSyncTarget:objectType formFactor:nil layoutType:layoutType mode:nil recordTypeId:nil];
 }
 
-+ (SFLayoutSyncDownTarget *)newSyncTarget:(NSString *)objectAPIName formFactor:(NSString *)formFactor layoutType:(NSString *)layoutType mode:(NSString *)mode recordTypeId:(NSString *)recordTypeId {
++ (SFLayoutSyncDownTarget *)newSyncTarget:(NSString *)objectAPIName
+                               formFactor:(NSString *)formFactor
+                               layoutType:(NSString *)layoutType
+                                     mode:(NSString *)mode
+                             recordTypeId:(NSString *)recordTypeId {
     SFLayoutSyncDownTarget *syncTarget = [[SFLayoutSyncDownTarget alloc] init];
     syncTarget.queryType = SFSyncDownTargetQueryTypeLayout;
     syncTarget.objectAPIName = objectAPIName;

--- a/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
@@ -114,7 +114,7 @@ static NSString * const kIDFieldValue = @"%@-%@-%@-%@-%@";
         errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
      completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
-    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectType:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId apiVersion:nil];
+    SFRestRequest *request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectAPIName:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId apiVersion:nil];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
     } completeBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
@@ -33,13 +33,19 @@
 #import "SFMobileSyncNetworkUtils.h"
 
 static NSString * const kSFSyncTargetObjectType = @"sobjectType";
+static NSString * const kSFSyncTargetFormFactor = @"formFactor";
 static NSString * const kSFSyncTargetLayoutType = @"layoutType";
-static NSString * const kIDFieldValue = @"%@-%@";
+static NSString * const kSFSyncTargetMode = @"mode";
+static NSString * const kSFSyncTargetRecordTypeId = @"recordTypeId";
+static NSString * const kIDFieldValue = @"%@-%@-%@-%@-%@";
 
 @interface SFLayoutSyncDownTarget ()
 
-@property (nonatomic, strong, readwrite) NSString *objectType;
+@property (nonatomic, strong, readwrite) NSString *objectAPIName;
+@property (nonatomic, strong, readwrite) NSString *formFactor;
 @property (nonatomic, strong, readwrite) NSString *layoutType;
+@property (nonatomic, strong, readwrite) NSString *mode;
+@property (nonatomic, strong, readwrite) NSString *recordTypeId;
 
 @end
 
@@ -49,8 +55,11 @@ static NSString * const kIDFieldValue = @"%@-%@";
     self = [super initWithDict:dict];
     if (self) {
         self.queryType = SFSyncDownTargetQueryTypeLayout;
-        self.objectType = dict[kSFSyncTargetObjectType];
+        self.objectAPIName = dict[kSFSyncTargetObjectType];
+        self.formFactor = dict[kSFSyncTargetFormFactor];
         self.layoutType = dict[kSFSyncTargetLayoutType];
+        self.mode = dict[kSFSyncTargetMode];
+        self.recordTypeId = dict[kSFSyncTargetRecordTypeId];
     }
     return self;
 }
@@ -64,17 +73,27 @@ static NSString * const kIDFieldValue = @"%@-%@";
 }
 
 + (SFLayoutSyncDownTarget *)newSyncTarget:(NSString *)objectType layoutType:(NSString *)layoutType {
+    return [SFLayoutSyncDownTarget newSyncTarget:objectType formFactor:nil layoutType:layoutType mode:nil recordTypeId:nil];
+}
+
++ (SFLayoutSyncDownTarget *)newSyncTarget:(NSString *)objectAPIName formFactor:(NSString *)formFactor layoutType:(NSString *)layoutType mode:(NSString *)mode recordTypeId:(NSString *)recordTypeId {
     SFLayoutSyncDownTarget *syncTarget = [[SFLayoutSyncDownTarget alloc] init];
     syncTarget.queryType = SFSyncDownTargetQueryTypeLayout;
-    syncTarget.objectType = objectType;
+    syncTarget.objectAPIName = objectAPIName;
+    syncTarget.formFactor = formFactor;
     syncTarget.layoutType = layoutType;
+    syncTarget.mode = mode;
+    syncTarget.recordTypeId = recordTypeId;
     return syncTarget;
 }
 
 - (NSMutableDictionary *)asDict {
     NSMutableDictionary *dict = [super asDict];
-    dict[kSFSyncTargetObjectType] = self.objectType;
+    dict[kSFSyncTargetObjectType] = self.objectAPIName;
+    dict[kSFSyncTargetFormFactor] = self.formFactor;
     dict[kSFSyncTargetLayoutType] = self.layoutType;
+    dict[kSFSyncTargetMode] = self.mode;
+    dict[kSFSyncTargetRecordTypeId] = self.recordTypeId;
     return dict;
 }
 

--- a/libs/MobileSync/MobileSyncTestApp/usersyncs.json
+++ b/libs/MobileSync/MobileSyncTestApp/usersyncs.json
@@ -58,7 +58,9 @@
       "target": {
         "type":"layout",
         "sobjectType": "Account",
-        "layoutType": "Compact"
+        "formFactor": "Medium",
+        "layoutType": "Compact",
+        "mode": "Edit"
       },
       "options": {
         "mergeMode":"OVERWRITE"

--- a/libs/MobileSync/MobileSyncTests/SFLayoutSyncManagerTests.m
+++ b/libs/MobileSync/MobileSyncTests/SFLayoutSyncManagerTests.m
@@ -32,9 +32,11 @@
 #import "SFMobileSyncSyncManager.h"
 #import <SmartStore/SFQuerySpec.h>
 
+static NSString * const kMedium = @"Medium";
 static NSString * const kCompact = @"Compact";
+static NSString * const kEdit = @"Edit";
 static NSString * const kSoupName = @"sfdcLayouts";
-static NSString * const kQuery = @"SELECT {%@:_soup} FROM {%@} WHERE {%@:Id} = '%@-%@'";
+static NSString * const kQuery = @"SELECT {%@:_soup} FROM {%@} WHERE {%@:Id} = '%@-%@-%@-%@-%@'";
 
 @interface SFLayoutSyncManagerTests : SyncManagerTestCase
 
@@ -61,20 +63,28 @@ static NSString * const kQuery = @"SELECT {%@:_soup} FROM {%@} WHERE {%@:Id} = '
  */
 - (void)testFetchLayoutInCacheOnlyMode {
     XCTestExpectation *fetchLayoutServerFirst = [self expectationWithDescription:@"fetchLayoutServerFirst"];
-    [self.layoutSyncManager fetchLayoutForObject:kAccount layoutType:kCompact mode:SFSDKFetchModeServerFirst completionBlock:^(NSString *objectType, SFLayout *layout) {
+    [self.layoutSyncManager fetchLayoutForObjectAPIName:kAccount formFactor:kMedium layoutType:kCompact mode:kEdit recordTypeId:nil syncMode:SFSDKFetchModeServerFirst completionBlock:^(NSString *objectAPIName, NSString *formFactor, NSString *layoutType, NSString *mode, NSString *recordTypeId, SFLayout *layout) {
         [fetchLayoutServerFirst fulfill];
     }];
     [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    __block NSString *objType = nil;
-    __block SFLayout *layoutData = nil;
+    __block NSString *objectAPINameBlock = nil;
+    __block NSString *formFactorBlock = nil;
+    __block NSString *layoutTypeBlock = nil;
+    __block NSString *modeBlock = nil;
+    __block NSString *recordTypeIdBlock = nil;
+    __block SFLayout *layoutBlock = nil;
     XCTestExpectation *fetchLayoutCacheOnly = [self expectationWithDescription:@"fetchLayoutCacheOnly"];
-    [self.layoutSyncManager fetchLayoutForObject:kAccount layoutType:kCompact mode:SFSDKFetchModeCacheOnly completionBlock:^(NSString *objectType, SFLayout *layout) {
-        objType = objectType;
-        layoutData = layout;
+    [self.layoutSyncManager fetchLayoutForObjectAPIName:kAccount formFactor:kMedium layoutType:kCompact mode:kEdit recordTypeId:nil syncMode:SFSDKFetchModeCacheOnly completionBlock:^(NSString *objectAPIName, NSString *formFactor, NSString *layoutType, NSString *mode, NSString *recordTypeId, SFLayout *layout) {
+        objectAPINameBlock = objectAPIName;
+        formFactorBlock = formFactor;
+        layoutTypeBlock = layoutType;
+        modeBlock = mode;
+        recordTypeIdBlock = recordTypeId;
+        layoutBlock = layout;
         [fetchLayoutCacheOnly fulfill];
     }];
     [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [self validateResult:objType layout:layoutData];
+    [self validateResult:objectAPINameBlock formFactor:formFactorBlock layoutType:layoutTypeBlock mode:modeBlock recordTypeId:recordTypeIdBlock layout:layoutBlock];
 }
 
 /**
@@ -82,85 +92,128 @@ static NSString * const kQuery = @"SELECT {%@:_soup} FROM {%@} WHERE {%@:Id} = '
  */
 - (void)testFetchLayoutInCacheFirstModeWithCacheData {
     XCTestExpectation *fetchLayoutServerFirst = [self expectationWithDescription:@"fetchLayoutServerFirst"];
-    [self.layoutSyncManager fetchLayoutForObject:kAccount layoutType:kCompact mode:SFSDKFetchModeServerFirst completionBlock:^(NSString *objectType, SFLayout *layout) {
+    [self.layoutSyncManager fetchLayoutForObjectAPIName:kAccount formFactor:kMedium layoutType:kCompact mode:kEdit recordTypeId:nil syncMode:SFSDKFetchModeServerFirst completionBlock:^(NSString *objectAPIName, NSString *formFactor, NSString *layoutType, NSString *mode, NSString *recordTypeId, SFLayout *layout) {
         [fetchLayoutServerFirst fulfill];
     }];
     [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    __block NSString *objType = nil;
-    __block SFLayout *layoutData = nil;
+    __block NSString *objectAPINameBlock = nil;
+    __block NSString *formFactorBlock = nil;
+    __block NSString *layoutTypeBlock = nil;
+    __block NSString *modeBlock = nil;
+    __block NSString *recordTypeIdBlock = nil;
+    __block SFLayout *layoutBlock = nil;
     XCTestExpectation *fetchLayoutCacheFirst = [self expectationWithDescription:@"fetchLayoutCacheFirst"];
-    [self.layoutSyncManager fetchLayoutForObject:kAccount layoutType:kCompact mode:SFSDKFetchModeCacheFirst completionBlock:^(NSString *objectType, SFLayout *layout) {
-        objType = objectType;
-        layoutData = layout;
+    [self.layoutSyncManager fetchLayoutForObjectAPIName:kAccount formFactor:kMedium layoutType:kCompact mode:kEdit recordTypeId:nil syncMode:SFSDKFetchModeCacheFirst completionBlock:^(NSString *objectAPIName, NSString *formFactor, NSString *layoutType, NSString *mode, NSString *recordTypeId, SFLayout *layout) {
+        objectAPINameBlock = objectAPIName;
+        formFactorBlock = formFactor;
+        layoutTypeBlock = layoutType;
+        modeBlock = mode;
+        recordTypeIdBlock = recordTypeId;
+        layoutBlock = layout;
         [fetchLayoutCacheFirst fulfill];
     }];
     [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [self validateResult:objType layout:layoutData];
+    [self validateResult:objectAPINameBlock formFactor:formFactorBlock layoutType:layoutTypeBlock mode:modeBlock recordTypeId:recordTypeIdBlock layout:layoutBlock];
 }
 
 /**
  * Test for fetching layout in SFSDKFetchModeCacheFirst mode with an empty cache.
  */
 - (void)testFetchLayoutInCacheFirstModeWithoutCacheData {
-    __block NSString *objType = nil;
-    __block SFLayout *layoutData = nil;
+    __block NSString *objectAPINameBlock = nil;
+    __block NSString *formFactorBlock = nil;
+    __block NSString *layoutTypeBlock = nil;
+    __block NSString *modeBlock = nil;
+    __block NSString *recordTypeIdBlock = nil;
+    __block SFLayout *layoutBlock = nil;
     XCTestExpectation *fetchLayoutCacheFirst = [self expectationWithDescription:@"fetchLayoutCacheFirst"];
-    [self.layoutSyncManager fetchLayoutForObject:kAccount layoutType:kCompact mode:SFSDKFetchModeCacheFirst completionBlock:^(NSString *objectType, SFLayout *layout) {
-        objType = objectType;
-        layoutData = layout;
+    [self.layoutSyncManager fetchLayoutForObjectAPIName:kAccount formFactor:kMedium layoutType:kCompact mode:kEdit recordTypeId:nil syncMode:SFSDKFetchModeCacheFirst completionBlock:^(NSString *objectAPIName, NSString *formFactor, NSString *layoutType, NSString *mode, NSString *recordTypeId, SFLayout *layout) {
+        objectAPINameBlock = objectAPIName;
+        formFactorBlock = formFactor;
+        layoutTypeBlock = layoutType;
+        modeBlock = mode;
+        recordTypeIdBlock = recordTypeId;
+        layoutBlock = layout;
         [fetchLayoutCacheFirst fulfill];
     }];
     [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [self validateResult:objType layout:layoutData];
+    [self validateResult:objectAPINameBlock formFactor:formFactorBlock layoutType:layoutTypeBlock mode:modeBlock recordTypeId:recordTypeIdBlock layout:layoutBlock];
 }
 
 /**
  * Test for fetching layout in SFSDKFetchModeServerFirst mode.
  */
 - (void)testFetchLayoutInServerFirstMode {
-    __block NSString *objType = nil;
-    __block SFLayout *layoutData = nil;
+    __block NSString *objectAPINameBlock = nil;
+    __block NSString *formFactorBlock = nil;
+    __block NSString *layoutTypeBlock = nil;
+    __block NSString *modeBlock = nil;
+    __block NSString *recordTypeIdBlock = nil;
+    __block SFLayout *layoutBlock = nil;
     XCTestExpectation *fetchLayoutServerFirst = [self expectationWithDescription:@"fetchLayoutServerFirst"];
-    [self.layoutSyncManager fetchLayoutForObject:kAccount layoutType:kCompact mode:SFSDKFetchModeServerFirst completionBlock:^(NSString *objectType, SFLayout *layout) {
-        objType = objectType;
-        layoutData = layout;
+    [self.layoutSyncManager fetchLayoutForObjectAPIName:kAccount formFactor:kMedium layoutType:kCompact mode:kEdit recordTypeId:nil syncMode:SFSDKFetchModeServerFirst completionBlock:^(NSString *objectAPIName, NSString *formFactor, NSString *layoutType, NSString *mode, NSString *recordTypeId, SFLayout *layout) {
+        objectAPINameBlock = objectAPIName;
+        formFactorBlock = formFactor;
+        layoutTypeBlock = layoutType;
+        modeBlock = mode;
+        recordTypeIdBlock = recordTypeId;
+        layoutBlock = layout;
         [fetchLayoutServerFirst fulfill];
     }];
     [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [self validateResult:objType layout:layoutData];
+    [self validateResult:objectAPINameBlock formFactor:formFactorBlock layoutType:layoutTypeBlock mode:modeBlock recordTypeId:recordTypeIdBlock layout:layoutBlock];
 }
 
 /**
  * Test for fetching layout multiple times and ensuring only 1 row is created.
  */
 - (void)testFetchLayoutMultipleTimes {
-    __block NSString *objType = nil;
-    __block SFLayout *layoutData = nil;
+    __block NSString *objectAPINameBlock = nil;
+    __block NSString *formFactorBlock = nil;
+    __block NSString *layoutTypeBlock = nil;
+    __block NSString *modeBlock = nil;
+    __block NSString *recordTypeIdBlock = nil;
+    __block SFLayout *layoutBlock = nil;
     XCTestExpectation *fetchLayoutOne = [self expectationWithDescription:@"fetchLayoutOne"];
-    [self.layoutSyncManager fetchLayoutForObject:kAccount layoutType:kCompact mode:SFSDKFetchModeServerFirst completionBlock:^(NSString *objectType, SFLayout *layout) {
-        objType = objectType;
-        layoutData = layout;
+    [self.layoutSyncManager fetchLayoutForObjectAPIName:kAccount formFactor:kMedium layoutType:kCompact mode:kEdit recordTypeId:nil syncMode:SFSDKFetchModeServerFirst completionBlock:^(NSString *objectAPIName, NSString *formFactor, NSString *layoutType, NSString *mode, NSString *recordTypeId, SFLayout *layout) {
+        objectAPINameBlock = objectAPIName;
+        formFactorBlock = formFactor;
+        layoutTypeBlock = layoutType;
+        modeBlock = mode;
+        recordTypeIdBlock = recordTypeId;
+        layoutBlock = layout;
         [fetchLayoutOne fulfill];
     }];
     [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [self validateResult:objType layout:layoutData];
+    [self validateResult:objectAPINameBlock formFactor:formFactorBlock layoutType:layoutTypeBlock mode:modeBlock recordTypeId:recordTypeIdBlock layout:layoutBlock];
     XCTestExpectation *fetchLayoutTwo = [self expectationWithDescription:@"fetchLayoutTwo"];
-    [self.layoutSyncManager fetchLayoutForObject:kAccount layoutType:kCompact mode:SFSDKFetchModeServerFirst completionBlock:^(NSString *objectType, SFLayout *layout) {
-        objType = objectType;
-        layoutData = layout;
+    [self.layoutSyncManager fetchLayoutForObjectAPIName:kAccount formFactor:kMedium layoutType:kCompact mode:kEdit recordTypeId:nil syncMode:SFSDKFetchModeServerFirst completionBlock:^(NSString *objectAPIName, NSString *formFactor, NSString *layoutType, NSString *mode, NSString *recordTypeId, SFLayout *layout) {
+        objectAPINameBlock = objectAPIName;
+        formFactorBlock = formFactor;
+        layoutTypeBlock = layoutType;
+        modeBlock = mode;
+        recordTypeIdBlock = recordTypeId;
+        layoutBlock = layout;
         [fetchLayoutTwo fulfill];
     }];
     [self waitForExpectationsWithTimeout:30.0 handler:nil];
-    [self validateResult:objType layout:layoutData];
-    SFQuerySpec *querySpec = [SFQuerySpec newSmartQuerySpec:[NSString stringWithFormat:kQuery, kSoupName, kSoupName, kSoupName, kAccount, kCompact] withPageSize:2];
+    [self validateResult:objectAPINameBlock formFactor:formFactorBlock layoutType:layoutTypeBlock mode:modeBlock recordTypeId:recordTypeIdBlock layout:layoutBlock];
+    SFQuerySpec *querySpec = [SFQuerySpec newSmartQuerySpec:[NSString stringWithFormat:kQuery, kSoupName, kSoupName, kSoupName, kAccount, kMedium, kCompact, kEdit, nil] withPageSize:2];
     long numRows = [[self.layoutSyncManager.smartStore countWithQuerySpec:querySpec error:nil] longValue];
     XCTAssertEqual(numRows, 1, "Number of rows should be 1");
 }
 
-- (void)validateResult:(NSString *)objectType layout:(SFLayout *)layout {
-    XCTAssertEqual(objectType, kAccount, @"Object types should match");
+- (void)validateResult:(NSString *)objectAPIName
+            formFactor:(NSString *)formFactor
+            layoutType:(NSString *)layoutType
+                  mode:(NSString *)mode
+          recordTypeId:(NSString *)recordTypeId
+                layout:(SFLayout *)layout {
+    XCTAssertEqual(objectAPIName, kAccount, @"Object types should match");
+    XCTAssertEqualObjects(formFactor, kMedium, @"Form factors should match");
     XCTAssertNotEqualObjects(layout, nil, @"Layout data should not be nil");
     XCTAssertEqualObjects(layout.layoutType, kCompact, @"Layout types should match");
+    XCTAssertEqualObjects(mode, kEdit, @"Modes should match");
     XCTAssertNotEqualObjects(layout.rawData, nil, @"Layout raw data should not be nil");
     XCTAssertNotEqualObjects(layout.sections, nil, @"Layout sections should not be nil");
     XCTAssertTrue(layout.sections.count > 0, @"Number of layout sections should be 1 or more");

--- a/libs/MobileSync/MobileSyncTests/SFSDKSyncsConfigTests.m
+++ b/libs/MobileSync/MobileSyncTests/SFSDKSyncsConfigTests.m
@@ -199,7 +199,11 @@
            expectedId:sync.syncId
          expectedName:@"layoutSyncDown"
        expectedTarget:[SFLayoutSyncDownTarget
-                       newSyncTarget:@"Account" layoutType:@"Compact"]
+                       newSyncTarget:@"Account"
+                       formFactor:@"Medium"
+                       layoutType:@"Compact"
+                       mode:@"Edit"
+                       recordTypeId:nil]
       expectedOptions:[SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeOverwrite]
        expectedStatus:SFSyncStateStatusNew
      expectedProgress:0

--- a/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.m
+++ b/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.m
@@ -360,7 +360,7 @@ static NSException *authException = nil;
                 XCTAssertEqualObjects(((SFMetadataSyncDownTarget*)expectedTarget).objectType, ((SFMetadataSyncDownTarget*)sync.target).objectType);
             } else if (expectedQueryType == SFSyncDownTargetQueryTypeLayout) {
                 XCTAssertTrue([sync.target isKindOfClass:[SFLayoutSyncDownTarget class]]);
-                XCTAssertEqualObjects(((SFLayoutSyncDownTarget*)expectedTarget).objectType, ((SFLayoutSyncDownTarget*)sync.target).objectType);
+                XCTAssertEqualObjects(((SFLayoutSyncDownTarget*)expectedTarget).objectAPIName, ((SFLayoutSyncDownTarget*)sync.target).objectAPIName);
                 XCTAssertEqualObjects(((SFLayoutSyncDownTarget*)expectedTarget).layoutType, ((SFLayoutSyncDownTarget*)sync.target).layoutType);
             } else if (expectedQueryType == SFSyncDownTargetQueryTypeParentChildren) {
                 XCTAssertTrue([sync.target isKindOfClass:[SFParentChildrenSyncDownTarget class]]);

--- a/libs/MobileSync/MobileSyncTests/SyncManagerTests.m
+++ b/libs/MobileSync/MobileSyncTests/SyncManagerTests.m
@@ -416,7 +416,7 @@
                             [[SFSoupIndex alloc] initWithPath:@"Id" indexType:kSoupIndexTypeString columnName:nil]
                             ];
     [self.store registerSoup:ACCOUNTS_SOUP withIndexSpecs:indexSpecs error:nil];
-    [self trySyncDown:SFSyncStateMergeModeOverwrite target:[SFLayoutSyncDownTarget newSyncTarget:ACCOUNT_TYPE layoutType:@"Compact"] soupName:ACCOUNTS_SOUP totalSize:1 numberFetches:1];
+    [self trySyncDown:SFSyncStateMergeModeOverwrite target:[SFLayoutSyncDownTarget newSyncTarget:ACCOUNT_TYPE formFactor:@"Medium" layoutType:@"Compact" mode:@"Edit" recordTypeId:nil] soupName:ACCOUNTS_SOUP totalSize:1 numberFetches:1];
     NSString* smartSql = @"SELECT {accounts:_soup} FROM {accounts}";
     SFQuerySpec* querySpec = [SFQuerySpec newSmartQuerySpec:smartSql withPageSize:1];
     NSArray *rows = [self.store queryWithQuerySpec:querySpec pageIndex:0 error:nil];
@@ -425,6 +425,8 @@
     XCTAssertNotNil(layout, @"Layout should not be nil");
     NSString *layoutType = layout[@"layoutType"];
     XCTAssertEqualObjects(layoutType, @"Compact", @"Layout type should be Compact");
+    NSString *mode = layout[@"mode"];
+    XCTAssertEqualObjects(mode, @"Edit", @"Mode should be Edit");
 }
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.h
@@ -132,6 +132,26 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
                                     completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
+ * Returns an `SFRestRequest` object that provides layout data for the specified parameters.
+ * @param objectAPIName Object API name.
+ * @param formFactor Form factor. Could be "Large", "Medium" or "Small". Default value is "Large".
+ * @param layoutType Layout type. Could be "Compact" or "Full". Default value is "Full".
+ * @param mode Mode. Could be "Create", "Edit" or "View". Default value is "View".
+ * @param recordTypeId Record type ID. Default will be used if not supplied.
+ * @param failBlock Failure block.
+ * @param completeBlock Completion block.
+ * @see https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm
+ */
+- (SFRestRequest *) performLayoutWithObjectAPIName:(NSString *)objectAPIName
+                                        formFactor:(NSString *)formFactor
+                                        layoutType:(NSString *)layoutType
+                                              mode:(NSString *)mode
+                                      recordTypeId:(NSString *)recordTypeId
+                                         failBlock:(SFRestFailBlock)failBlock
+                                     completeBlock:(SFRestDictionaryResponseBlock)completeBlock
+                                        NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");;
+
+/**
  * Executes a metadata describe on a single sObject.
  * @param objectType the API name of the object to describe.
  * @param failBlock the block to be executed when the request fails (timeout, cancel, or error)

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
@@ -160,8 +160,8 @@ static char CompleteBlockKey;
     return request;
 }
 
-- (SFRestRequest *) performLayoutWithObjectType:(NSString *)objectType layoutType:(NSString *)layoutType failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestDictionaryResponseBlock)completeBlock {
-    SFRestRequest *request = [self requestForLayoutWithObjectType:objectType layoutType:layoutType apiVersion:self.apiVersion];
+- (SFRestRequest *) performLayoutWithObjectAPIName:(NSString *)objectAPIName formFactor:(NSString *)formFactor layoutType:(NSString *)layoutType mode:(NSString *)mode recordTypeId:(NSString *)recordTypeId failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestDictionaryResponseBlock)completeBlock {
+    SFRestRequest *request = [self requestForLayoutWithObjectAPIName:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode apiVersion:self.apiVersion];
     [self sendRESTRequest:request
                 failBlock:failBlock
             completeBlock:completeBlock];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
@@ -161,7 +161,7 @@ static char CompleteBlockKey;
 }
 
 - (SFRestRequest *) performLayoutWithObjectAPIName:(NSString *)objectAPIName formFactor:(NSString *)formFactor layoutType:(NSString *)layoutType mode:(NSString *)mode recordTypeId:(NSString *)recordTypeId failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestDictionaryResponseBlock)completeBlock {
-    SFRestRequest *request = [self requestForLayoutWithObjectAPIName:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode apiVersion:self.apiVersion];
+    SFRestRequest *request = [self requestForLayoutWithObjectAPIName:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId apiVersion:self.apiVersion];
     [self sendRESTRequest:request
                 failBlock:failBlock
             completeBlock:completeBlock];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
@@ -254,7 +254,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm
  */
-- (SFRestRequest *)requestForLayoutWithObjectType:(nonnull NSString *)objectType layoutType:(nullable NSString *)layoutType apiVersion:(nullable NSString *)apiVersion SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use requestForLayoutWithObjectAPIName:objectAPIName:formFactor:layoutType:mode:recordTypeId instead.");
+- (SFRestRequest *)requestForLayoutWithObjectType:(nonnull NSString *)objectType layoutType:(nullable NSString *)layoutType apiVersion:(nullable NSString *)apiVersion SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use requestForLayoutWithObjectAPIName:objectAPIName:formFactor:layoutType:mode:recordTypeId:apiVersion instead.");
 
 /**
  * Returns an `SFRestRequest` object that provides layout data for the specified parameters.
@@ -266,7 +266,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm
  */
-- (SFRestRequest *)requestForLayoutWithObjectAPIName:(NSString *)objectAPIName formFactor:(NSString *)formFactor layoutType:(NSString *)layoutType mode:(NSString *)mode apiVersion:(NSString *)apiVersion recordTypeId:(NSString *)recordTypeId;
+- (SFRestRequest *)requestForLayoutWithObjectAPIName:(nonnull NSString *)objectAPIName formFactor:(nullable NSString *)formFactor layoutType:(nullable NSString *)layoutType mode:(nullable NSString *)mode recordTypeId:(nullable NSString *)recordTypeId apiVersion:(nullable NSString *)apiVersion;
 
 /**
  * Returns an `SFRestRequest` object that retrieves field values for the specified record of the given type.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
@@ -257,6 +257,18 @@ NS_SWIFT_NAME(RestClient)
 - (SFRestRequest *)requestForLayoutWithObjectType:(nonnull NSString *)objectType layoutType:(nullable NSString *)layoutType apiVersion:(nullable NSString *)apiVersion;
 
 /**
+ * Returns an `SFRestRequest` object that provides layout data for the specified parameters.
+ * @param objectAPIName Object API name.
+ * @param formFactor Form factor. Could be "Large", "Medium" or "Small". Default value is "Large".
+ * @param layoutType Layout type. Could be "Compact" or "Full". Default value is "Full".
+ * @param mode Mode. Could be "Create", "Edit" or "View". Default value is "View".
+ * @param recordTypeId Record type ID. Default will be used if not supplied.
+ * @param apiVersion API version.
+ * @see https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm
+ */
+- (SFRestRequest *)requestForLayoutWithObjectAPIName:(NSString *)objectAPIName formFactor:(NSString *)formFactor layoutType:(NSString *)layoutType mode:(NSString *)mode apiVersion:(NSString *)apiVersion recordTypeId:(NSString *)recordTypeId;
+
+/**
  * Returns an `SFRestRequest` object that retrieves field values for the specified record of the given type.
  * @param objectType Type of a Salesforce object. Example: "Account".
  * @param objectId Requested record's object ID.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
@@ -254,7 +254,7 @@ NS_SWIFT_NAME(RestClient)
  * @param apiVersion API version.
  * @see https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm
  */
-- (SFRestRequest *)requestForLayoutWithObjectType:(nonnull NSString *)objectType layoutType:(nullable NSString *)layoutType apiVersion:(nullable NSString *)apiVersion;
+- (SFRestRequest *)requestForLayoutWithObjectType:(nonnull NSString *)objectType layoutType:(nullable NSString *)layoutType apiVersion:(nullable NSString *)apiVersion SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use requestForLayoutWithObjectAPIName:objectAPIName:formFactor:layoutType:mode:recordTypeId instead.");
 
 /**
  * Returns an `SFRestRequest` object that provides layout data for the specified parameters.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -529,10 +529,10 @@ static dispatch_once_t pred;
 }
 
 - (SFRestRequest *)requestForLayoutWithObjectType:(NSString *)objectType layoutType:(NSString *)layoutType apiVersion:(NSString *)apiVersion {
-    return [self requestForLayoutWithObjectAPIName:objectType formFactor:nil layoutType:layoutType mode:nil apiVersion:apiVersion recordTypeId:nil];
+    return [self requestForLayoutWithObjectAPIName:objectType formFactor:nil layoutType:layoutType mode:nil recordTypeId:nil apiVersion:apiVersion];
 }
 
-- (SFRestRequest *)requestForLayoutWithObjectAPIName:(NSString *)objectAPIName formFactor:(NSString *)formFactor layoutType:(NSString *)layoutType mode:(NSString *)mode apiVersion:(NSString *)apiVersion recordTypeId:(NSString *)recordTypeId {
+- (SFRestRequest *)requestForLayoutWithObjectAPIName:(NSString *)objectAPIName formFactor:(NSString *)formFactor layoutType:(NSString *)layoutType mode:(NSString *)mode recordTypeId:(NSString *)recordTypeId apiVersion:(NSString *)apiVersion {
     NSMutableDictionary *queryParams = [[NSMutableDictionary alloc] init];
     if (formFactor) {
         queryParams[@"formFactor"] = formFactor;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -529,10 +529,24 @@ static dispatch_once_t pred;
 }
 
 - (SFRestRequest *)requestForLayoutWithObjectType:(NSString *)objectType layoutType:(NSString *)layoutType apiVersion:(NSString *)apiVersion {
-    NSDictionary *queryParams = (layoutType ?
-                                 @{@"layoutType": layoutType}
-                                 : nil);
-    NSString *path = [NSString stringWithFormat:@"/%@/ui-api/layout/%@", [self computeAPIVersion:apiVersion], objectType];
+    return [self requestForLayoutWithObjectAPIName:objectType formFactor:nil layoutType:layoutType mode:nil apiVersion:apiVersion recordTypeId:nil];
+}
+
+- (SFRestRequest *)requestForLayoutWithObjectAPIName:(NSString *)objectAPIName formFactor:(NSString *)formFactor layoutType:(NSString *)layoutType mode:(NSString *)mode apiVersion:(NSString *)apiVersion recordTypeId:(NSString *)recordTypeId {
+    NSMutableDictionary *queryParams = [[NSMutableDictionary alloc] init];
+    if (formFactor) {
+        queryParams[@"formFactor"] = formFactor;
+    }
+    if (layoutType) {
+        queryParams[@"layoutType"] = layoutType;
+    }
+    if (mode) {
+        queryParams[@"mode"] = mode;
+    }
+    if (recordTypeId) {
+        queryParams[@"recordTypeId"] = recordTypeId;
+    }
+    NSString *path = [NSString stringWithFormat:@"/%@/ui-api/layout/%@", [self computeAPIVersion:apiVersion], objectAPIName];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:queryParams];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -371,13 +371,6 @@ static NSException *authException = nil;
     self.dataCleanupRequired = NO;
 }
 
-// simple: just invoke requestForLayoutWithObjectType:@"Contact" with recordTypeId:@"Test".
-- (void)testGetLayoutWithObjectAPINameWithRecordTypeId {
-    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectAPIName:CONTACT formFactor:nil layoutType:nil mode:nil recordTypeId:@"Test" apiVersion:kSFRestDefaultAPIVersion];
-    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
-    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
-}
-
 // simple: just invoke requestForSearchScopeAndOrder
 - (void)testGetSearchScopeAndOrder {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearchScopeAndOrder:kSFRestDefaultAPIVersion];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -319,16 +319,61 @@ static NSException *authException = nil;
 }
 
 // simple: just invoke requestForLayoutWithObjectType:@"Contact" without layoutType.
-- (void)testGetLayoutWithObjectTypeWithoutLayoutType {
-    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectType:CONTACT layoutType:nil apiVersion:kSFRestDefaultAPIVersion];
+- (void)testGetLayoutWithObjectAPINameWithoutFormFactor {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectAPIName:CONTACT formFactor:nil layoutType:nil mode:nil recordTypeId:nil apiVersion:kSFRestDefaultAPIVersion];
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
+}
+
+// simple: just invoke requestForLayoutWithObjectType:@"Contact" with formFactor:@"Medium".
+- (void)testGetLayoutWithObjectAPINameWithFormFactor {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectAPIName:CONTACT formFactor:@"Medium" layoutType:nil mode:nil recordTypeId:nil apiVersion:kSFRestDefaultAPIVersion];
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+}
+
+// simple: just invoke requestForLayoutWithObjectType:@"Contact" without layoutType.
+- (void)testGetLayoutWithObjectAPINameWithoutLayoutType {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectAPIName:CONTACT formFactor:nil layoutType:nil mode:nil recordTypeId:nil apiVersion:kSFRestDefaultAPIVersion];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
     self.dataCleanupRequired = NO;
 }
 
 // simple: just invoke requestForLayoutWithObjectType:@"Contact" with layoutType:@"Compact".
-- (void)testGetLayoutWithObjectTypeWithLayoutType {
-    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectType:CONTACT layoutType:@"Compact" apiVersion:kSFRestDefaultAPIVersion];
+- (void)testGetLayoutWithObjectAPINameWithLayoutType {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectAPIName:CONTACT formFactor:nil layoutType:@"Compact" mode:nil recordTypeId:nil apiVersion:kSFRestDefaultAPIVersion];
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+}
+
+// simple: just invoke requestForLayoutWithObjectType:@"Contact" without mode.
+- (void)testGetLayoutWithObjectAPINameWithoutMode {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectAPIName:CONTACT formFactor:nil layoutType:nil mode:nil recordTypeId:nil apiVersion:kSFRestDefaultAPIVersion];
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
+}
+
+// simple: just invoke requestForLayoutWithObjectType:@"Contact" with mode:@"Edit".
+- (void)testGetLayoutWithObjectAPINameWithMode {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectAPIName:CONTACT formFactor:nil layoutType:nil mode:@"Edit" recordTypeId:nil apiVersion:kSFRestDefaultAPIVersion];
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+}
+
+// simple: just invoke requestForLayoutWithObjectType:@"Contact" without recordTypeId.
+- (void)testGetLayoutWithObjectAPINameWithoutRecordTypeId {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectAPIName:CONTACT formFactor:nil layoutType:nil mode:nil recordTypeId:nil apiVersion:kSFRestDefaultAPIVersion];
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    self.dataCleanupRequired = NO;
+}
+
+// simple: just invoke requestForLayoutWithObjectType:@"Contact" with recordTypeId:@"Test".
+- (void)testGetLayoutWithObjectAPINameWithRecordTypeId {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectAPIName:CONTACT formFactor:nil layoutType:nil mode:nil recordTypeId:@"Test" apiVersion:kSFRestDefaultAPIVersion];
     SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
 }


### PR DESCRIPTION
- Details [here](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/3157).
- This should now support everything listed under `UI API` [here](https://developer.salesforce.com/docs/atlas.en-us.uiapi.meta/uiapi/ui_api_resources_record_layout.htm).
- Added new tests for all the new functionality/fields.
- Same as equivalent Android PR [here](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2045).