### PR TITLE
fix crash for null string

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSString+SFAdditions.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/NSString+SFAdditions.m
@@ -43,7 +43,7 @@ static inline BOOL IsValidEntityId(NSString *string) {
 @implementation NSString (SFAdditions)
 
 + (BOOL)isEmpty:(nullable NSString *)string {
-    if (nil == string){
+    if (nil == string || string == [NSNull null]){
         return YES;
     }
     string = [string trim];


### PR DESCRIPTION
We've seen many crash on AppCenter and root cause can be traced down here.
`+[NSString(SFAdditions) isEmpty:]
NSString+SFAdditions.m, line 49
SIGABRT: -[NSNull trim]: unrecognized selector sent to instance `

