### PR TITLE
Fixing compilation error in templates

### DIFF
--- a/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.h
+++ b/libs/MobileSync/MobileSync/Classes/Manager/SFLayoutSyncManager.h
@@ -27,6 +27,7 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 #import <SmartStore/SFSmartStore.h>
 #import "SFMobileSyncSyncManager.h"
 #import "SFLayout.h"


### PR DESCRIPTION
Doesn't throw an error in the main repo because it's included in the PCH file.