### PR TITLE
Change the return type to the type used for decoding

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -76,7 +76,7 @@ public struct RestResponse {
     
     /// Decode the response as  a codable.
     /// - Parameter type: The type to use for decoding.
-    public func asDecodable<T: Decodable>(type: T.Type) throws -> Decodable? {
+    public func asDecodable<T: Decodable>(type: T.Type) throws -> T {
         let decoder = JSONDecoder()
         do {
             let object = try decoder.decode(type, from: data)


### PR DESCRIPTION
Hi,

I think it would be more convenient to change the return type of `RestResponse.asDecodable(type:)` to the type used for decoding.

```swift
// I expect `foo` to be `Foo` but now it is `Decodable?`
let foo = try response.asDecodable(type: Foo.self)
```