### PR TITLE
Make dateTime fields decodable as Date

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -77,7 +77,11 @@ public struct RestResponse {
     /// Decode the response as  a codable.
     /// - Parameter type: The type to use for decoding.
     public func asDecodable<T: Decodable>(type: T.Type) throws -> Decodable? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+        
         let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
         do {
             let object = try decoder.decode(type, from: data)
             return object

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
@@ -409,6 +409,48 @@ class RestClientTests: XCTestCase {
        XCTAssertTrue(resp4["statusCode"] as? Int == 200, "Request processing should have stopped on error")
    }
     
+    func testDecodableResponse() {
+        let expectation = XCTestExpectation(description: "decodableResponseTest")
+        let apiVersion = RestClient.shared.apiVersion
+
+        let query = "select Id from Account limit 5"
+        let request = RestClient.shared.request(forQuery: query, apiVersion: apiVersion)
+        
+        var response: RestResponse?
+        var restClientError: Error?
+
+        RestClient.shared.send(request: request) { result in
+            defer { expectation.fulfill() }
+            switch (result) {
+            case .success(let resp):
+                response = resp
+            case .failure(let error):
+                restClientError = error
+            }
+        }
+        self.wait(for: [expectation], timeout: 20)
+        XCTAssertNil(restClientError, "Error should not have occurred")
+        XCTAssertNotNil(response, "RestResponse should not be nil")
+
+        struct Response: Decodable {
+            struct Record: Decodable {
+                struct Attributes: Decodable {
+                    let type: String
+                    let url: String
+                }
+                
+                let attributes: Attributes
+                let Id: String
+            }
+            
+            let totalSize: Int
+            let done: Bool
+            let records: [Record]
+        }
+        
+        XCTAssertNoThrow(try response?.asDecodable(type: Response.self), "RestResponse should be decodable")
+    }
+
     private func generateRecordName() -> String {
         let timecode = Date.timeIntervalSinceReferenceDate
         return "SwiftTestsiOS\(timecode)"

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
@@ -413,7 +413,7 @@ class RestClientTests: XCTestCase {
         let expectation = XCTestExpectation(description: "decodableResponseTest")
         let apiVersion = RestClient.shared.apiVersion
 
-        let query = "select Id from Account limit 5"
+        let query = "select Id, CreatedDate from Account limit 5"
         let request = RestClient.shared.request(forQuery: query, apiVersion: apiVersion)
         
         var response: RestResponse?
@@ -441,6 +441,7 @@ class RestClientTests: XCTestCase {
                 
                 let attributes: Attributes
                 let Id: String
+                let CreatedDate: Date
             }
             
             let totalSize: Int


### PR DESCRIPTION
Hi,

As the title suggests this PR makes dateTime fields decodable as `Date`.

```swift
struct Response: Decodable {
    struct Record: Decodable {
        struct Attributes: Decodable {
            let type: String
            let url: String
        }

        let attributes: Attributes
        let Id: String
        let CreatedDate: Date // Decode as `Date` instead of `String`
    }

    let totalSize: Int
    let done: Bool
    let records: [Record]
}

try response.asDecodable(type: Response.self)
```