### PR TITLE
Decode using the passed decoder

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -176,15 +176,16 @@ extension RestClient {
     ///
     /// This method relies on the passed parameter ofModelType to infer the generic Record's
     /// concrete type.
-    func fetchRecords<Record: Decodable>(ofModelType: Record.Type, forRequest request: RestRequest,
+    func fetchRecords<Record: Decodable>(ofModelType modelType: Record.Type,
+                                         forRequest request: RestRequest,
+                                         withDecoder decoder: JSONDecoder = .init(),
                                        _ completionBlock: @escaping (Result<QueryResponse<Record>, RestClientError>) -> Void) {
       guard request.isQueryRequest else { return }
       RestClient.shared.send(request: request) { result in
           switch result {
               case .success(let response):
                 do {
-                  let decoder = JSONDecoder()
-                  let wrapper = try decoder.decode(QueryResponse<Record>.self, from: response.asData())
+                  let wrapper = try response.asDecodable(type: QueryResponse<Record>.self, decoder: decoder)
                   completionBlock(.success(wrapper))
                 } catch {
                   completionBlock(.success(QueryResponse<Record>(totalSize: 0, done: true, records: [])))
@@ -213,13 +214,14 @@ extension RestClient {
     ///
     /// This method relies on the passed parameter ofModelType to infer the generic Record's
     /// concrete type.
-    func fetchRecords<Record: Decodable>(ofModelType: Record.Type,
+    func fetchRecords<Record: Decodable>(ofModelType modelType: Record.Type,
                                          forQuery query: String,
                                          withApiVersion version: String = SFRestDefaultAPIVersion,
+                                         withDecoder decoder: JSONDecoder = .init(),
                                          _ completionBlock: @escaping (Result<QueryResponse<Record>, RestClientError>) -> Void) {
         let request = RestClient.shared.request(forQuery: query, apiVersion: version)
         guard request.isQueryRequest else { return }
-        return self.fetchRecords(ofModelType: ofModelType, forRequest: request, completionBlock)
+        return self.fetchRecords(ofModelType: modelType, forRequest: request, withDecoder: decoder, completionBlock)
     }
   
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -76,8 +76,7 @@ public struct RestResponse {
     
     /// Decode the response as  a codable.
     /// - Parameter type: The type to use for decoding.
-    public func asDecodable<T: Decodable>(type: T.Type) throws -> T {
-        let decoder = JSONDecoder()
+    public func asDecodable<T: Decodable>(type: T.Type, decoder: JSONDecoder = .init()) throws -> T {
         do {
             let object = try decoder.decode(type, from: data)
             return object

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -281,7 +281,8 @@ extension RestClient {
     ///   .assign(to: \.contacts, on: self)
     ///
     /// This pipeline infers it's return type from the variable in the assign subscriber.
-    func records<Record: Decodable>(forRequest request:RestRequest ) -> AnyPublisher<QueryResponse<Record>, Never> {
+    func records<Record: Decodable>(forRequest request: RestRequest,
+                                    withDecoder decoder: JSONDecoder = .init()) -> AnyPublisher<QueryResponse<Record>, Never> {
       guard request.isQueryRequest else {
         return Empty(completeImmediately: true).eraseToAnyPublisher()
       }
@@ -289,7 +290,7 @@ extension RestClient {
         .tryMap({ (response) -> Data in
           response.asData()
         })
-        .decode(type: QueryResponse<Record>.self, decoder: JSONDecoder())
+        .decode(type: QueryResponse<Record>.self, decoder: decoder)
         .catch({ _ in
           Just(QueryResponse<Record>(totalSize: 0, done: true, records: []))
         })
@@ -299,8 +300,10 @@ extension RestClient {
     /// Reusable, generic Combine Pipeline returning an array of records of a local
     /// model object that conforms to Decodable. This method accepts a query string and defers
     /// to records<Record:Decodable>(forRequest request: RestRequest) -> AnyPublisher<[Record], Never>
-    func records<Record: Decodable>(forQuery query:String, withApiVersion version: String = SFRestDefaultAPIVersion ) -> AnyPublisher<QueryResponse<Record>, Never> {
+    func records<Record: Decodable>(forQuery query: String,
+                                    withApiVersion version: String = SFRestDefaultAPIVersion,
+                                    withDecoder decoder: JSONDecoder = .init()) -> AnyPublisher<QueryResponse<Record>, Never> {
         let request = RestClient.shared.request(forQuery: query, apiVersion: version)
-        return self.records(forRequest: request)
+        return self.records(forRequest: request, withDecoder: decoder)
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
@@ -409,6 +409,48 @@ class RestClientTests: XCTestCase {
        XCTAssertTrue(resp4["statusCode"] as? Int == 200, "Request processing should have stopped on error")
    }
     
+    func testDecodableResponse() {
+        let expectation = XCTestExpectation(description: "decodableResponseTest")
+        let apiVersion = RestClient.shared.apiVersion
+
+        let query = "select Id from Account limit 5"
+        let request = RestClient.shared.request(forQuery: query, apiVersion: apiVersion)
+        
+        var response: RestResponse?
+        var restClientError: Error?
+
+        RestClient.shared.send(request: request) { result in
+            defer { expectation.fulfill() }
+            switch (result) {
+            case .success(let resp):
+                response = resp
+            case .failure(let error):
+                restClientError = error
+            }
+        }
+        self.wait(for: [expectation], timeout: 20)
+        XCTAssertNil(restClientError, "Error should not have occurred")
+        XCTAssertNotNil(response, "RestResponse should not be nil")
+
+        struct Response: Decodable {
+            struct Record: Decodable {
+                struct Attributes: Decodable {
+                    let type: String
+                    let url: String
+                }
+                
+                let attributes: Attributes
+                let Id: String
+            }
+            
+            let totalSize: Int
+            let done: Bool
+            let records: [Record]
+        }
+        
+        XCTAssertNoThrow(try response?.asDecodable(type: Response.self), "RestResponse should be decodable")
+    }
+
     private func generateRecordName() -> String {
         let timecode = Date.timeIntervalSinceReferenceDate
         return "SwiftTestsiOS\(timecode)"


### PR DESCRIPTION
Hi,

This PR changes that we can pass a decoder to some methods.

```swift
// Decode using the passed decoder
try response.asDecodable(type: Response.self, decoder: decoder)

// Fetch records with the decoder
RestClient.shared.fetchRecords(ofModelType: Record.self, forRequest: request, withDecoder: decoder)

// Create a publisher with the decoder
RestClient.shared.records(forRequest: request, withDecoder: decoder)
```

Ref: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3189#discussion_r415985238

(IMHO, I think it's better to stop grabbing decoding errors in some methods.)