### PR TITLE
Update CircleCI XCode image to 11.5.

### DIFF
--- a/.circleci/Gemfile.lock
+++ b/.circleci/Gemfile.lock
@@ -197,4 +197,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   1.16.6
+   2.0.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,12 @@ executors:
   mac:
     working_directory: ~/SalesforceMobileSDK-iOS
     macos:
-      xcode: 11.3.1
+      xcode: 11.5.0
     shell: /bin/bash --login -eo pipefail
     environment:
       BASH_ENV: ~/.bashrc
       FASTLANE_SKIP_UPDATE_CHECK: "true"
-      CHRUBY_VER: 2.6.5
+      CHRUBY_VER: 2.7.1
 
 version: 2.1
 jobs:
@@ -21,7 +21,7 @@ jobs:
         default: "iPhone 11"
       ios:
         type: string
-        default: "13.3"
+        default: "13.5"
       nightly-test:
         type: boolean
         default: false


### PR DESCRIPTION
FYI: CircleCI no longer denotes beta builds in the tag to their XCode images (e.g. 11.5.0-beta1) so today tag 11.5.0 gives us beta1 but will give us beta2 and eventually stable with no changes to the config.