### PR TITLE
Refactoring of REST API Library and Simplification of Callbacks

### DIFF
--- a/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFLayoutSyncDownTarget.m
@@ -120,9 +120,9 @@ static NSString * const kIDFieldValue = @"%@-%@-%@-%@-%@";
      completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
     SFRestRequest *request = [[SFRestAPI sharedInstance] requestForLayoutWithObjectAPIName:objectAPIName formFactor:formFactor layoutType:layoutType mode:mode recordTypeId:recordTypeId apiVersion:nil];
-    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
-    } completeBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {
+    } successBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {
         weakSelf.totalSize = 1;
         NSMutableDictionary *record = [[NSMutableDictionary alloc] initWithDictionary:d];
         record[kId] = [NSString stringWithFormat:kIDFieldValue, weakSelf.objectAPIName, weakSelf.formFactor, weakSelf.layoutType, weakSelf.mode, weakSelf.recordTypeId];

--- a/libs/MobileSync/MobileSync/Classes/Target/SFMetadataSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFMetadataSyncDownTarget.m
@@ -86,9 +86,9 @@ static NSString * const kSFSyncTargetObjectType = @"sobjectType";
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
     SFRestRequest *request = [[SFRestAPI sharedInstance] requestForDescribeWithObjectType:objectType apiVersion:nil];
-    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
-    } completeBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {
+    } successBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {
         weakSelf.totalSize = 1;
         NSMutableDictionary *record = [[NSMutableDictionary alloc] initWithDictionary:d];
         record[kId] = weakSelf.objectType;

--- a/libs/MobileSync/MobileSync/Classes/Target/SFMruSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFMruSyncDownTarget.m
@@ -86,9 +86,9 @@ static NSString * const kSFSyncTargetFieldlist = @"fieldlist";
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
     SFRestRequest *request = [[SFRestAPI sharedInstance] requestForMetadataWithObjectType:self.objectType apiVersion:nil];
-    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
-    } completeBlock:^(NSDictionary* d, NSURLResponse *rawResponse) {
+    } successBlock:^(NSDictionary* d, NSURLResponse *rawResponse) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         NSArray* recentItems = [strongSelf pluck:d[kRecentItems] key:strongSelf.idFieldName];
         NSString* inPredicate = [@[ strongSelf.idFieldName, @" IN ('", [recentItems componentsJoinedByString:@"', '"], @"')"]
@@ -108,9 +108,9 @@ static NSString * const kSFSyncTargetFieldlist = @"fieldlist";
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
     SFRestRequest * soqlRequest = [[SFRestAPI sharedInstance] requestForQuery:queryRun apiVersion:nil];
-    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:soqlRequest failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:soqlRequest failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
-    } completeBlock:^(NSDictionary * d, NSURLResponse *rawResponse) {
+    } successBlock:^(NSDictionary * d, NSURLResponse *rawResponse) {
         weakSelf.totalSize = [d[kResponseTotalSize] integerValue];
         completeBlock(d[kResponseRecords]);
     }];

--- a/libs/MobileSync/MobileSync/Classes/Target/SFParentChildrenSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFParentChildrenSyncUpTarget.m
@@ -249,10 +249,10 @@ typedef void (^SFFetchLastModifiedDatesCompleteBlock)(NSDictionary<NSString *, N
     NSString* parentId = record[self.idFieldName];
     SFRestRequest* lastModRequest = [self getRequestForTimestamps:parentId];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:lastModRequest
-                                                     failBlock:^(NSError *error, NSURLResponse *rawResponse) {
+                                                     failureBlock:^(id response, NSError *error, NSURLResponse *rawResponse) {
                                                          completionBlock(nil);
                                                      }
-                                                 completeBlock:^(id lastModResponse, NSURLResponse *rawResponse) {
+                                                 successBlock:^(id lastModResponse, NSURLResponse *rawResponse) {
                                                      NSMutableDictionary<NSString *, NSString *> * idToRemoteTimestamps = nil;
                                                      id rows = lastModResponse[kResponseRecords];
                                                      if (rows && rows != [NSNull null] && [rows count] > 0) {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFRefreshSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFRefreshSyncDownTarget.m
@@ -259,7 +259,6 @@ static NSUInteger const kSFSyncTargetRefreshDefaultCountIdsPerSoql = 500;
             maxTimeStamp:(long long)maxTimeStamp
               errorBlock:(SFSyncDownTargetFetchErrorBlock)errorBlock
            completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
-
     NSString* maxTimeStampStr = [SFMobileSyncObjectUtils getIsoStringFromMillis:maxTimeStamp];
     NSString* andClause = (maxTimeStamp > 0
                            ? [NSString stringWithFormat:@" AND %@ > %@", self.modificationDateFieldName, maxTimeStampStr]
@@ -267,9 +266,9 @@ static NSUInteger const kSFSyncTargetRefreshDefaultCountIdsPerSoql = 500;
     NSString* whereClause = [NSString stringWithFormat:@"%@ IN ('%@')%@", self.idFieldName, [ids componentsJoinedByString:@"','"], andClause];
     NSString* soql = [[[[SFSDKSoqlBuilder withFieldsArray:fieldlist] from:self.objectType] whereClause:whereClause] build];
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:soql apiVersion:nil];
-    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
-    } completeBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {
+    } successBlock:^(NSDictionary *d, NSURLResponse *rawResponse) {
         completeBlock(d[kResponseRecords]);
     }];
 }

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSoqlSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSoqlSyncDownTarget.m
@@ -123,9 +123,9 @@ static NSString * const kSFSoqlSyncTargetQuery = @"query";
     __weak typeof(self) weakSelf = self;
     
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:queryToRun apiVersion:nil];
-    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
-    } completeBlock:^(NSDictionary *responseJson, NSURLResponse *rawResponse) {
+    } successBlock:^(NSDictionary *responseJson, NSURLResponse *rawResponse) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         strongSelf.totalSize = [responseJson[kResponseTotalSize] integerValue];
         strongSelf.nextRecordsUrl = responseJson[kResponseNextRecordsUrl];
@@ -139,9 +139,9 @@ static NSString * const kSFSoqlSyncTargetQuery = @"query";
     if (self.nextRecordsUrl) {
         __weak typeof(self) weakSelf = self;
         SFRestRequest* request = [SFRestRequest requestWithMethod:SFRestMethodGET path:self.nextRecordsUrl queryParams:nil];
-        [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+        [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
             errorBlock(e);
-        } completeBlock:^(NSDictionary *responseJson, NSURLResponse *rawResponse) {
+        } successBlock:^(NSDictionary *responseJson, NSURLResponse *rawResponse) {
             __strong typeof(weakSelf) strongSelf = weakSelf;
             strongSelf.nextRecordsUrl = responseJson[kResponseNextRecordsUrl];
             completeBlock([strongSelf getRecordsFromResponse:responseJson]);

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSoslSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSoslSyncDownTarget.m
@@ -88,9 +88,9 @@ static NSString * const kSFSoslSyncTargetQuery = @"query";
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSearch:queryRun apiVersion:nil];
-    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
-    } completeBlock:^(NSDictionary* d, NSURLResponse *rawResponse) {
+    } successBlock:^(NSDictionary* d, NSURLResponse *rawResponse) {
         weakSelf.totalSize = [d[kResponseSearchRecords] count];
         completeBlock(d[kResponseSearchRecords]);
     }];

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
@@ -276,10 +276,10 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
        completionBlock:(SFSyncUpTargetCompleteBlock)completionBlock
              failBlock:(SFSyncUpTargetErrorBlock)failBlock
 {
-    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         self.lastError = e.description;
         failBlock(e);
-    } completeBlock:^(NSDictionary* d, NSURLResponse *rawResponse) {
+    } successBlock:^(NSDictionary* d, NSURLResponse *rawResponse) {
         completionBlock(d);
     }];
 }
@@ -296,12 +296,11 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
                                    fieldList:self.modificationDateFieldName
                                   apiVersion:nil];
 
-    [SFMobileSyncNetworkUtils
-            sendRequestWithMobileSyncUserAgent:request
-                                    failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request
+                                    failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
                                         completeBlock([[SFRecordModDate alloc] initWithTimestamp:nil isDeleted:e.code == 404]);
                                     }
-                                completeBlock:^(id response, NSURLResponse *rawResponse) {
+                                successBlock:^(id response, NSURLResponse *rawResponse) {
                                     completeBlock([[SFRecordModDate alloc] initWithTimestamp:response[self.modificationDateFieldName] isDeleted:FALSE]);
                                 }
     ];

--- a/libs/MobileSync/MobileSync/Classes/Util/SFCompositeRequestHelper.m
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFCompositeRequestHelper.m
@@ -35,13 +35,12 @@
                     requests:(NSArray<SFRestRequest *> *)requests
              completionBlock:(SFSendCompositeRequestCompleteBlock)completionBlock
                    failBlock:(SFSyncUpTargetErrorBlock)failBlock {
-    
     SFRestRequest *compositeRequest = [[SFRestAPI sharedInstance] compositeRequest:requests refIds:refIds allOrNone:allOrNone apiVersion:nil];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:compositeRequest
-                                                     failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+                                                     failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
                                                          failBlock(e);
                                                      }
-                                                 completeBlock:^(id response, NSURLResponse *rawResponse) {
+                                                 successBlock:^(id response, NSURLResponse *rawResponse) {
                                                      SFSDKCompositeResponse* compositeResponse = [[SFSDKCompositeResponse alloc] initWith:response];
                                                      NSMutableDictionary *refIdToResponses = [NSMutableDictionary new];
                                                      for (SFSDKCompositeSubResponse *response in compositeResponse.subResponses) {

--- a/libs/MobileSync/MobileSync/Classes/Util/SFMobileSyncNetworkUtils.h
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFMobileSyncNetworkUtils.h
@@ -41,7 +41,16 @@ NS_SWIFT_NAME(NetworkUtils)
  @param failBlock The block to call if the request fails.
  @param completeBlock The block to call if the request succeeds.
  */
-+ (void)sendRequestWithMobileSyncUserAgent:(SFRestRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestResponseBlock)completeBlock;
++ (void)sendRequestWithMobileSyncUserAgent:(SFRestRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestResponseBlock)completeBlock SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use sendRequestWithMobileSyncUserAgent:request:failureBlock:successBlock instead.");
+
+/**
+ * Sends a REST request, after applying the MobileSync user agent string.
+ *
+ * @param request The request to send.
+ * @param failureBlock The block to call if the request fails.
+ * @param successBlock The block to call if the request succeeds.
+ */
++ (void)sendRequestWithMobileSyncUserAgent:(SFRestRequest *)request failureBlock:(SFRestRequestFailBlock)failureBlock successBlock:(SFRestResponseBlock)successBlock;
 
 @end
 

--- a/libs/MobileSync/MobileSync/Classes/Util/SFMobileSyncNetworkUtils.m
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFMobileSyncNetworkUtils.m
@@ -26,7 +26,7 @@
 #import <SalesforceSDKCore/SFRestRequest.h>
 #import <SalesforceSDKCore/SFUserAccountManager.h>
 
-// For user agent
+// For user agent.
 NSString * const kUserAgent = @"User-Agent";
 NSString * const kMobileSync = @"MobileSync";
 
@@ -35,16 +35,28 @@ NSString * const kMobileSync = @"MobileSync";
 + (void)sendRequestWithMobileSyncUserAgent:(SFRestRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestResponseBlock)completeBlock {
     [SFSDKMobileSyncLogger d:[self class] format:@"sendRequestWithMobileSyncUserAgent:request:%@", request];
     [request setHeaderValue:[SFRestAPI userAgentString:kMobileSync] forHeaderName:kUserAgent];
-    
     SFUserAccount *user = [SFUserAccountManager sharedInstance].currentUser;
     SFRestAPI *restApiInstance = (!user) ? [SFRestAPI sharedGlobalInstance] : [SFRestAPI sharedInstance];
-    
     [restApiInstance sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
         [SFSDKMobileSyncLogger e:[self class] format:@"sendRequestWithMobileSyncUserAgent:error:%ld:%@", (long) e.code, e.domain];
         failBlock(e, rawResponse);
     } completeBlock:^(id response, NSURLResponse *rawResponse) {
         [SFSDKMobileSyncLogger d:[self class] format:@"sendRequestWithMobileSyncUserAgent:response:%@", response];
         completeBlock(response, rawResponse);
+    }];
+}
+
++ (void)sendRequestWithMobileSyncUserAgent:(SFRestRequest *)request failureBlock:(SFRestRequestFailBlock)failureBlock successBlock:(SFRestResponseBlock)successBlock {
+    [SFSDKMobileSyncLogger d:[self class] format:@"sendRequestWithMobileSyncUserAgent:request:%@", request];
+    [request setHeaderValue:[SFRestAPI userAgentString:kMobileSync] forHeaderName:kUserAgent];
+    SFUserAccount *user = [SFUserAccountManager sharedInstance].currentUser;
+    SFRestAPI *restApiInstance = (!user) ? [SFRestAPI sharedGlobalInstance] : [SFRestAPI sharedInstance];
+    [restApiInstance sendRequest:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
+        [SFSDKMobileSyncLogger e:[self class] format:@"sendRequestWithMobileSyncUserAgent:error:%ld:%@", (long) e.code, e.domain];
+        failureBlock(response, e, rawResponse);
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
+        [SFSDKMobileSyncLogger d:[self class] format:@"sendRequestWithMobileSyncUserAgent:response:%@", response];
+        successBlock(response, rawResponse);
     }];
 }
 

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Util/SFJsonUtils.m
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Util/SFJsonUtils.m
@@ -70,14 +70,14 @@ static NSError *sLastError = nil;
     return [SFJsonUtils JSONRepresentation:obj options:options];
 }
 
-+ (NSString*)JSONRepresentation:(id)obj options:(NSJSONWritingOptions)options {
++ (NSString *)JSONRepresentation:(id)obj options:(NSJSONWritingOptions)options {
     NSString *result = nil;
-    
-    NSData *jsonData = [self JSONDataRepresentation:obj options:options];
-    if (nil != jsonData) {
-          result = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    if (obj) {
+        NSData *jsonData = [self JSONDataRepresentation:obj options:options];
+        if (nil != jsonData) {
+            result = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        }
     }
-    
     return result;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAILTNPublisher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAILTNPublisher.m
@@ -65,12 +65,12 @@ static NSString* const kRestApiSuffix = @"connect/proxy/app-analytics-logging";
     [request setCustomRequestBodyData:postData contentType:@"application/json"];
     [request setHeaderValue:@"gzip" forHeaderName:@"Content-Encoding"];
     [request setHeaderValue:[NSString stringWithFormat:@"%lu", (unsigned long)[postData length]] forHeaderName:@"Content-Length"];
-    [[SFRestAPI sharedInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [[SFRestAPI sharedInstance] sendRequest:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         if (e) {
             [SFSDKCoreLogger e:[self class] format:@"Upload failed %ld %@", (long)[e code], [e localizedDescription]];
         }
         publishCompleteBlock(NO, e);
-    } completeBlock:^(id response, NSURLResponse *rawResponse) {
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
         publishCompleteBlock(YES, nil);
     }];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -116,10 +116,10 @@ extension RestClient {
     /// - Parameter completionBlock: `Result` block that handles the server's response.
     public func send(request: RestRequest, _ completionBlock: @escaping (Result<RestResponse, RestClientError>) -> Void) {
         request.parseResponse = false
-        __send(request, fail: { (error, urlResponse) in
+        __send(request, failureBlock: { (rawResponse, error, urlResponse) in
             let apiError = RestClientError.apiInvocationFailed(underlyingError: error ?? RestClientError.apiResponseIsEmpty, urlResponse: urlResponse)
             completionBlock(Result.failure(apiError))
-        }, complete: { (rawResponse, urlResponse) in
+        }, successBlock: { (rawResponse, urlResponse) in
             if let data = rawResponse as? Data,
                 let urlResponse = urlResponse {
                 let result = RestResponse(data: data, urlResponse: urlResponse)
@@ -136,10 +136,10 @@ extension RestClient {
     /// - See   [Composite](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_composite.htm).
     public func send(compositeRequest: CompositeRequest, _ completionBlock: @escaping (Result<CompositeResponse, RestClientError>) -> Void) {
         compositeRequest.parseResponse = false
-        __sendCompositeRESTRequest(compositeRequest, fail: { (error, urlResponse) in
+        __send(compositeRequest, failureBlock: { (response, error, urlResponse) in
             let apiError = RestClientError.apiInvocationFailed(underlyingError: error ?? RestClientError.apiResponseIsEmpty, urlResponse: urlResponse)
             completionBlock(Result.failure(apiError))
-        }, complete: { (response, _) in
+        }, successBlock: { (response, _) in
             completionBlock(Result.success(response))
         })
     }
@@ -150,10 +150,10 @@ extension RestClient {
     /// - See   [Batch](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_batch.htm).
     public func send(batchRequest: BatchRequest, _ completionBlock: @escaping (Result<BatchResponse, RestClientError>) -> Void ) {
         batchRequest.parseResponse = false
-        __sendBatchRESTRequest(batchRequest, fail: { (error, urlResponse) in
+        __send(batchRequest, failureBlock: { (response, error, urlResponse) in
             let apiError = RestClientError.apiInvocationFailed(underlyingError: error ?? RestClientError.apiResponseIsEmpty, urlResponse: urlResponse)
             completionBlock(Result.failure(apiError))
-        }, complete: { (response, _) in
+        }, successBlock: { (response, _) in
             completionBlock(Result.success(response))
         })
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFRestAPI+Instrumentation.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFRestAPI+Instrumentation.h
@@ -30,7 +30,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SFRestAPI(Instrumentation) <SFRestDelegate>
+@interface SFRestAPI(Instrumentation) <SFRestDelegate, SFRestRequestDelegate>
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFRestAPI+Instrumentation.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFRestAPI+Instrumentation.m
@@ -170,7 +170,7 @@
         SEL swizzledSelector = @selector(instr_send:delegate:);
         [SFSDKInstrumentationHelper swizzleMethod:originalSelector with:swizzledSelector forClass:class isInstanceMethod:YES];
         originalSelector = @selector(send:requestDelegate:);
-        swizzledSelector = @selector(instr_send:requestDelegate:);
+        swizzledSelector = @selector(instrumentation_send:requestDelegate:);
         [SFSDKInstrumentationHelper swizzleMethod:originalSelector with:swizzledSelector forClass:class isInstanceMethod:YES];
     });
 }
@@ -186,7 +186,7 @@
     return [self instr_send:request delegate:delegateWrapper];
 }
 
-- (void)instr_send:(SFRestRequest *)request requestDelegate:(id<SFRestRequestDelegate>)requestDelegate {
+- (void)instrumentation_send:(SFRestRequest *)request requestDelegate:(id<SFRestRequestDelegate>)requestDelegate {
 
     // Begin an os_signpost_interval.
     os_log_t logger = self.class.oslog;
@@ -194,7 +194,7 @@
     sf_os_signpost_interval_begin(logger, sid, "Send", "Method:%ld path:%{public}@", (long)request.method, request.path);
     id<SFRestRequestDelegate> delegateWrapper = [SFRestDelegateWrapperWithInstrumentation factoryWith:requestDelegate signpost:sid logger:logger];
     request.instrumentationDelegateInternal = delegateWrapper;
-    return [self instr_send:request delegate:delegateWrapper];
+    return [self instrumentation_send:request requestDelegate:delegateWrapper];
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFRestAPI+Instrumentation.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFRestAPI+Instrumentation.m
@@ -35,13 +35,19 @@
 #import <os/signpost.h>
 #import "SFSDKCoreLogger.h"
 
-@interface SFRestDelegateWrapperWithInstrumentation<SFRestDelegate>: NSObject
-- (instancetype)initWithDelegate:(id<SFRestDelegate>) delegate signpost:(os_signpost_id_t)signpostId logger:(os_log_t) logger;
-@property (weak,nonatomic,readonly) id<SFRestDelegate> delegate;
-@property (nonatomic,readonly) os_signpost_id_t signpostId;
-@property (nonatomic,readonly) os_log_t logger;
+@interface SFRestDelegateWrapperWithInstrumentation<SFRestDelegate, SFRestRequestDelegate>: NSObject
 
-+(id<SFRestDelegate>)wrapperWith:delegate signpost:(os_signpost_id_t)signpostId logger:(os_log_t) logger;
+- (instancetype)initWithDelegate:(id<SFRestDelegate>)delegate signpost:(os_signpost_id_t)signpostId logger:(os_log_t)logger;
+- (instancetype)initWithRequestDelegate:(id<SFRestRequestDelegate>)requestDelegate signpost:(os_signpost_id_t)signpostId logger:(os_log_t)logger;
+
+@property (weak, nonatomic, readonly) id<SFRestDelegate> delegate;
+@property (weak, nonatomic, readonly) id<SFRestRequestDelegate> requestDelegate;
+@property (nonatomic, readonly) os_signpost_id_t signpostId;
+@property (nonatomic, readonly) os_log_t logger;
+
++ (id<SFRestDelegate>)wrapperWith:delegate signpost:(os_signpost_id_t)signpostId logger:(os_log_t)logger;
++ (id<SFRestRequestDelegate>)factoryWith:requestDelegate signpost:(os_signpost_id_t)signpostId logger:(os_log_t)logger;
+
 @end
 
 @implementation SFRestDelegateWrapperWithInstrumentation
@@ -49,6 +55,15 @@
 - (instancetype)initWithDelegate:(id<SFRestDelegate>)delegate signpost:(os_signpost_id_t)signpostId logger:(os_log_t)logger {
     if (self = [super init]) {
         _delegate = delegate;
+        _signpostId = signpostId;
+        _logger = logger;
+    }
+    return self;
+}
+
+- (instancetype)initWithRequestDelegate:(id<SFRestRequestDelegate>)requestDelegate signpost:(os_signpost_id_t)signpostId logger:(os_log_t)logger {
+    if (self = [super init]) {
+        _requestDelegate = requestDelegate;
         _signpostId = signpostId;
         _logger = logger;
     }
@@ -71,7 +86,6 @@
     request.instrDelegateInternal = nil;
 }
 
-
 - (void)request:(SFRestRequest *)request didFailLoadWithError:(NSError*)error rawResponse:(NSURLResponse *)rawResponse {
     sf_os_signpost_interval_end(self.logger, self.signpostId, "Send", "didFailLoadWithError:rawResponse %ld %{public}@", (long)request.method, request.path);
     if ([self.delegate respondsToSelector:@selector(request:didFailLoadWithError:rawResponse:)]) {
@@ -80,7 +94,6 @@
     request.instrDelegateInternal = nil;
 }
 
-
 - (void)request:(SFRestRequest *)request didFailLoadWithError:(NSError*)error {
     sf_os_signpost_interval_end(self.logger, self.signpostId, "Send", "didFailLoadWithError %ld %{public}@", (long)request.method, request.path);
     if ([self.delegate respondsToSelector:@selector(request:didFailLoadWithError:)]) {
@@ -88,7 +101,6 @@
     }
     request.instrDelegateInternal = nil;
 }
-
 
 - (void)requestDidCancelLoad:(SFRestRequest *)request {
     sf_os_signpost_interval_end(self.logger, self.signpostId, "Send", "requestDidCancelLoad %ld %{public}@", (long)request.method, request.path);
@@ -106,9 +118,30 @@
     request.instrDelegateInternal = nil;
 }
 
-+(id<SFRestDelegate>)wrapperWith:delegate signpost:(os_signpost_id_t)signpostId logger:(os_log_t) logger {
-    return (id<SFRestDelegate>) [[SFRestDelegateWrapperWithInstrumentation alloc] initWithDelegate:delegate  signpost:signpostId logger:logger];
+- (void)request:(SFRestRequest *)request didSucceed:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse {
+    sf_os_signpost_interval_end(self.logger, self.signpostId, "Send", "requestDidSucceed %ld %{public}@", (long)request.method, request.path);
+    if ([self.requestDelegate respondsToSelector:@selector(request:didSucceed:rawResponse:)]) {
+        [self.requestDelegate request:request didSucceed:dataResponse rawResponse:rawResponse];
+    }
+    request.instrumentationDelegateInternal = nil;
 }
+
+- (void)request:(SFRestRequest *)request didFail:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse error:(NSError *)error {
+    sf_os_signpost_interval_end(self.logger, self.signpostId, "Send", "requestDidFail %ld %{public}@", (long)request.method, request.path);
+    if ([self.requestDelegate respondsToSelector:@selector(request:didFail:rawResponse:error:)]) {
+        [self.requestDelegate request:request didFail:dataResponse rawResponse:rawResponse error:error];
+    }
+    request.instrumentationDelegateInternal = nil;
+}
+
++ (id<SFRestDelegate>)wrapperWith:delegate signpost:(os_signpost_id_t)signpostId logger:(os_log_t) logger {
+    return (id<SFRestDelegate>) [[SFRestDelegateWrapperWithInstrumentation alloc] initWithDelegate:delegate signpost:signpostId logger:logger];
+}
+
++ (id<SFRestRequestDelegate>)factoryWith:requestDelegate signpost:(os_signpost_id_t)signpostId logger:(os_log_t)logger {
+    return (id<SFRestRequestDelegate>) [[SFRestDelegateWrapperWithInstrumentation alloc] initWithRequestDelegate:requestDelegate signpost:signpostId logger:logger];
+}
+
 @end
 
 @implementation SFRestAPI(Instrumentation)
@@ -123,8 +156,7 @@
     return _logger;
 }
 
-
-+ (void)load{
++ (void)load {
     if ([SFSDKInstrumentationHelper isEnabled] && (self == SFRestAPI.self)) {
         [self enableInstrumentation];
     }
@@ -136,11 +168,15 @@
         Class class = [self class];
         SEL originalSelector = @selector(send:delegate:);
         SEL swizzledSelector = @selector(instr_send:delegate:);
-        [SFSDKInstrumentationHelper swizzleMethod:originalSelector with:swizzledSelector forClass:class  isInstanceMethod:YES];
+        [SFSDKInstrumentationHelper swizzleMethod:originalSelector with:swizzledSelector forClass:class isInstanceMethod:YES];
+        originalSelector = @selector(send:requestDelegate:);
+        swizzledSelector = @selector(instr_send:requestDelegate:);
+        [SFSDKInstrumentationHelper swizzleMethod:originalSelector with:swizzledSelector forClass:class isInstanceMethod:YES];
     });
 }
 
 - (void)instr_send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate {
+
     // Begin an os_signpost_interval.
     os_log_t logger = self.class.oslog;
     os_signpost_id_t sid = sf_os_signpost_id_generate(logger);
@@ -148,8 +184,17 @@
     id<SFRestDelegate> delegateWrapper = [SFRestDelegateWrapperWithInstrumentation wrapperWith:delegate signpost:sid logger:logger];
     request.instrDelegateInternal = delegateWrapper;
     return [self instr_send:request delegate:delegateWrapper];
- 
 }
 
+- (void)instr_send:(SFRestRequest *)request requestDelegate:(id<SFRestRequestDelegate>)requestDelegate {
+
+    // Begin an os_signpost_interval.
+    os_log_t logger = self.class.oslog;
+    os_signpost_id_t sid = sf_os_signpost_id_generate(logger);
+    sf_os_signpost_interval_begin(logger, sid, "Send", "Method:%ld path:%{public}@", (long)request.method, request.path);
+    id<SFRestRequestDelegate> delegateWrapper = [SFRestDelegateWrapperWithInstrumentation factoryWith:requestDelegate signpost:sid logger:logger];
+    request.instrumentationDelegateInternal = delegateWrapper;
+    return [self instr_send:request delegate:delegateWrapper];
+}
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -147,26 +147,23 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
     if (communityId) {
         bodyDict[@"NetworkId"] = communityId;
     }
-
     NSString *rsaPublicKey = [self getRSAPublicKey];
     if (rsaPublicKey) {
         bodyDict[@"RsaPublicKey"] = rsaPublicKey;
     }
-
     [request setCustomRequestBodyDictionary:bodyDict contentType:@"application/json"];
     __weak typeof(self) weakSelf = self;
-    [[SFRestAPI sharedInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [[SFRestAPI sharedInstance] sendRequest:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (e != nil) {
             [SFSDKCoreLogger e:[strongSelf class] format:@"Registration for notifications with Salesforce failed with error %@", e];
         }
         [strongSelf postPushNotificationRegistration:failBlock];
-    } completeBlock:^(id response, NSURLResponse *rawResponse) {
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeaturePushNotifications];
         NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*) rawResponse;
         NSInteger statusCode = httpResponse.statusCode;
-
         if (statusCode < 200 || statusCode >= 300) {
             [SFSDKCoreLogger e:[strongSelf class] format:@"Registration for notifications with Salesforce failed with status %ld", statusCode];
             [SFSDKCoreLogger e:[strongSelf class] format:@"Response:%@", response];
@@ -228,13 +225,13 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
     NSString *path = [NSString stringWithFormat:@"/%@/%@/%@", [SFRestAPI sharedInstance].apiVersion, kSFPushNotificationEndPoint, deviceSFID];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodDELETE path:path queryParams:nil];
     __weak typeof(self) weakSelf = self;
-    [[SFRestAPI sharedInstance] sendRESTRequest:request failBlock:^(NSError *e, NSURLResponse *rawResponse) {
+    [[SFRestAPI sharedInstance] sendRequest:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (e) {
             [SFSDKCoreLogger e:[strongSelf class] format:@"Push notification unregistration failed %ld %@", (long)[e code], [e localizedDescription]];
         }
         [strongSelf postPushNotificationUnregistration:completionBlock];
-    } completeBlock:^(id response, NSURLResponse *rawResponse) {
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         [strongSelf postPushNotificationUnregistration:completionBlock];
     }];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.h
@@ -33,10 +33,11 @@ NS_ASSUME_NONNULL_BEGIN
 @class SFSDKCompositeRequest;
 @class SFSDKBatchRequest;
 
-@interface SFRestAPI (Blocks) <SFRestDelegate>
+@interface SFRestAPI (Blocks) <SFRestDelegate, SFRestRequestDelegate>
 
 // Block types
-typedef void (^SFRestFailBlock) (NSError * _Nullable e, NSURLResponse * _Nullable rawResponse) NS_SWIFT_NAME(RestFailBlock);
+typedef void (^SFRestFailBlock) (NSError * _Nullable e, NSURLResponse * _Nullable rawResponse) NS_SWIFT_NAME(RestFailBlock) SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use SFRestRequestFailBlock instead.");
+typedef void (^SFRestRequestFailBlock) (id _Nullable response, NSError * _Nullable e, NSURLResponse * _Nullable rawResponse) NS_SWIFT_NAME(RestRequestFailBlock);
 typedef void (^SFRestDictionaryResponseBlock) (NSDictionary * _Nullable dict, NSURLResponse * _Nullable rawResponse)  NS_SWIFT_NAME(RestDictionaryResponseBlock);
 typedef void (^SFRestArrayResponseBlock) (NSArray * _Nullable arr, NSURLResponse * _Nullable rawResponse) NS_SWIFT_NAME(RestArrayResponseBlock);
 typedef void (^SFRestDataResponseBlock) (NSData* _Nullable data, NSURLResponse * _Nullable rawResponse) NS_SWIFT_NAME(RestDataResponseBlock);
@@ -49,14 +50,22 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
  */
 + (NSError *)errorWithDescription:(NSString *)description;
 
-
 /**
  * Send a request you've already built, using blocks to return status.
  * @param request the SFRestRequest to be sent
  * @param failBlock the block to be executed when the request fails (timeout, cancel, or error)
  * @param completeBlock the block to be executed when the request successfully completes
  */
-- (void) sendRESTRequest:(SFRestRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestResponseBlock)completeBlock NS_REFINED_FOR_SWIFT;
+- (void) sendRESTRequest:(SFRestRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestResponseBlock)completeBlock NS_REFINED_FOR_SWIFT SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use sendRequest:request:failureBlock:successBlock instead.");
+
+/**
+ * Sends a request you've already built, using blocks to return status.
+ *
+ * @param request SFRestRequest to be sent.
+ * @param failureBlock Block to be executed when the request fails (timeout, cancel, or error).
+ * @param successBlock Block to be executed when the request successfully completes.
+ */
+- (void) sendRequest:(SFRestRequest *)request failureBlock:(SFRestRequestFailBlock)failureBlock successBlock:(SFRestResponseBlock)successBlock NS_REFINED_FOR_SWIFT;
 
 /**
  * Send a request you've already built, using blocks to return status.
@@ -64,17 +73,33 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
  * @param failBlock the block to be executed when the request fails (timeout, cancel, or error)
  * @param completeBlock the block to be executed when the request successfully completes
  */
-- (void) sendCompositeRESTRequest:(SFSDKCompositeRequest *)request failBlock:(SFRestFailBlock)failBlock  completeBlock:(SFRestCompositeResponseBlock)completeBlock NS_REFINED_FOR_SWIFT;
+- (void) sendCompositeRESTRequest:(SFSDKCompositeRequest *)request failBlock:(SFRestFailBlock)failBlock  completeBlock:(SFRestCompositeResponseBlock)completeBlock NS_REFINED_FOR_SWIFT SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use sendCompositeRequest:request:failureBlock:successBlock instead.");
 
 /**
-* Send a request you've already built, using blocks to return status.
-* @param request the Batch request to be sent
-* @param failBlock the block to be executed when the request fails (timeout, cancel, or error)
-* @param completeBlock the block to be executed when the request successfully completes
-*/
-- (void) sendBatchRESTRequest:(SFSDKBatchRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestBatchResponseBlock)completeBlock NS_REFINED_FOR_SWIFT;
+ * Sends a request you've already built, using blocks to return status.
+ *
+ * @param request Composite request to be sent.
+ * @param failureBlock Block to be executed when the request fails (timeout, cancel, or error).
+ * @param successBlock Block to be executed when the request successfully completes.
+ */
+- (void) sendCompositeRequest:(SFSDKCompositeRequest *)request failureBlock:(SFRestRequestFailBlock)failureBlock successBlock:(SFRestCompositeResponseBlock)successBlock NS_REFINED_FOR_SWIFT;
 
-// Various request types.
+/**
+ * Send a request you've already built, using blocks to return status.
+ * @param request the Batch request to be sent
+ * @param failBlock the block to be executed when the request fails (timeout, cancel, or error)
+ * @param completeBlock the block to be executed when the request successfully completes
+ */
+- (void) sendBatchRESTRequest:(SFSDKBatchRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestBatchResponseBlock)completeBlock NS_REFINED_FOR_SWIFT SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use sendBatchRequest:request:failureBlock:successBlock instead.");
+
+/**
+ * Sends a request you've already built, using blocks to return status.
+ *
+ * @param request Batch request to be sent.
+ * @param failureBlock Block to be executed when the request fails (timeout, cancel, or error).
+ * @param successBlock Block to be executed when the request successfully completes.
+ */
+- (void) sendBatchRequest:(SFSDKBatchRequest *)request failureBlock:(SFRestRequestFailBlock)failureBlock successBlock:(SFRestBatchResponseBlock)successBlock NS_REFINED_FOR_SWIFT;
 
 /**
  * Executes a SOQL query.
@@ -85,7 +110,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
  */
 - (SFRestRequest *) performSOQLQuery:(NSString *)query
                            failBlock:(SFRestFailBlock)failBlock
-                       completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                       completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a SOQL query that returns the deleted objects.
@@ -97,7 +122,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
 - (SFRestRequest *) performSOQLQueryAll:(NSString *)query
                               failBlock:(SFRestFailBlock)failBlock
                           completeBlock:(SFRestDictionaryResponseBlock)completeBlock
-                          NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                          NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a SOSL search.
@@ -109,7 +134,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
 - (SFRestRequest *) performSOSLSearch:(NSString *)search
                             failBlock:(SFRestFailBlock)failBlock
                         completeBlock:(SFRestDictionaryResponseBlock)completeBlock
-                         NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                         NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a global describe.
@@ -118,7 +143,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
  * @return the newly sent SFRestRequest
  */
 - (SFRestRequest *) performDescribeGlobalWithFailBlock:(SFRestFailBlock)failBlock
-                                         completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                         completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a describe on a single sObject.
@@ -129,7 +154,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
  */
 - (SFRestRequest *) performDescribeWithObjectType:(NSString *)objectType
                                         failBlock:(SFRestFailBlock)failBlock
-                                    completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                    completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Returns an `SFRestRequest` object that provides layout data for the specified parameters.
@@ -149,7 +174,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
                                       recordTypeId:(NSString *)recordTypeId
                                          failBlock:(SFRestFailBlock)failBlock
                                      completeBlock:(SFRestDictionaryResponseBlock)completeBlock
-                                        NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");;
+                                        NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a metadata describe on a single sObject.
@@ -160,7 +185,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
  */
 - (SFRestRequest *) performMetadataWithObjectType:(NSString *)objectType
                                         failBlock:(SFRestFailBlock)failBlock
-                                    completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                    completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a retrieve for a single record.
@@ -175,7 +200,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
                                          objectId:(NSString *)objectId
                                         fieldList:(NSArray<NSString*> *)fieldList
                                         failBlock:(SFRestFailBlock)failBlock
-                                    completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                    completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a DML update for a single record.
@@ -190,7 +215,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
                                        objectId:(NSString *)objectId
                                          fields:(NSDictionary<NSString*, id> *)fields
                                       failBlock:(SFRestFailBlock)failBlock
-                                  completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                  completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a DML upsert for a single record.
@@ -207,7 +232,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
                                      externalId:(NSString *)externalId
                                          fields:(NSDictionary<NSString*, id> *)fields
                                       failBlock:(SFRestFailBlock)failBlock
-                                  completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                  completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a DML delete on a single record
@@ -220,7 +245,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
 - (SFRestRequest *) performDeleteWithObjectType:(NSString *)objectType
                                        objectId:(NSString *)objectId
                                       failBlock:(SFRestFailBlock)failBlock
-                                  completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                  completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a DML insert.
@@ -233,7 +258,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
 - (SFRestRequest *) performCreateWithObjectType:(NSString *)objectType
                                          fields:(NSDictionary<NSString*, id> *)fields
                                       failBlock:(SFRestFailBlock)failBlock
-                                  completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                  completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a request to list REST API resources
@@ -242,7 +267,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
  * @return the newly sent SFRestRequest
  */
 - (SFRestRequest *) performRequestForResourcesWithFailBlock:(SFRestFailBlock)failBlock
-                                              completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                              completeBlock:(SFRestDictionaryResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a request to list REST API versions
@@ -251,7 +276,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
  * @return the newly sent SFRestRequest
  */
 - (SFRestRequest *) performRequestForVersionsWithFailBlock:(SFRestFailBlock)failBlock
-                                             completeBlock:(SFRestArrayResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                             completeBlock:(SFRestArrayResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a request to get a file rendition
@@ -268,7 +293,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
                                      renditionType:(NSString *)renditionType
                                               page:(NSUInteger)page
                                          failBlock:(SFRestFailBlock)failBlock
-                                     completeBlock:(SFRestDataResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                     completeBlock:(SFRestDataResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a request to get search scope and order
@@ -277,7 +302,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
  * @return the newly sent SFRestRequest
  */
 - (SFRestRequest *) performRequestForSearchScopeAndOrderWithFailBlock:(SFRestFailBlock)failBlock
-                                     completeBlock:(SFRestArrayResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                     completeBlock:(SFRestArrayResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 /**
  * Executes a request to get search result layout
@@ -289,7 +314,7 @@ typedef void (^SFRestBatchResponseBlock) (SFSDKBatchResponse *response, NSURLRes
  */
 - (SFRestRequest *) performRequestForSearchResultLayout:(NSString*)objectList
                                               failBlock:(SFRestFailBlock)failBlock
-                                          completeBlock:(SFRestArrayResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.");
+                                          completeBlock:(SFRestArrayResponseBlock)completeBlock NS_SWIFT_UNAVAILABLE("Use RestRequest factory methods to construct the request and RestClient send instead.") SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use RestRequest factory methods to construct the request and RestClient send instead.");
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
@@ -23,6 +23,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
 #import "SFRestAPI+Internal.h"
 #import "SFRestAPI+Blocks.h"
 #import "SFRestAPI+Files.h"
@@ -36,7 +37,8 @@
 // whose address will be used by the objc_setAssociatedObject (no need to have a value).
 static char FailBlockKey;
 static char CompleteBlockKey;
-
+static char FailureBlockKey;
+static char SuccessBlockKey;
 
 @implementation SFRestAPI (Blocks)
 
@@ -45,24 +47,26 @@ static char CompleteBlockKey;
 + (NSError *)errorWithDescription:(NSString *)description {    
     NSArray *objArray = @[description, @""];
     NSArray *keyArray = @[NSLocalizedDescriptionKey, NSFilePathErrorKey];
-    
     NSDictionary *eDict = [NSDictionary dictionaryWithObjects:objArray
                                                       forKeys:keyArray];
-    
     NSError *err = [[NSError alloc] initWithDomain:@"API Error"
                                               code:42 // life, the universe, and everything
                                           userInfo:eDict];
-    
     return err;
 }
 
 #pragma mark - sending requests
 
-
 - (void) sendRESTRequest:(SFRestRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestResponseBlock)completeBlock {
     // Copy blocks into the request instance
     objc_setAssociatedObject(request, &FailBlockKey, failBlock, OBJC_ASSOCIATION_COPY);
     objc_setAssociatedObject(request, &CompleteBlockKey, completeBlock, OBJC_ASSOCIATION_COPY);
+    [self send:request delegate:self];
+}
+
+- (void) sendRequest:(SFRestRequest *)request failureBlock:(SFRestRequestFailBlock)failureBlock successBlock:(SFRestResponseBlock)successBlock {
+    objc_setAssociatedObject(request, &FailureBlockKey, failureBlock, OBJC_ASSOCIATION_COPY);
+    objc_setAssociatedObject(request, &SuccessBlockKey, successBlock, OBJC_ASSOCIATION_COPY);
     [self send:request delegate:self];
 }
 
@@ -74,11 +78,25 @@ static char CompleteBlockKey;
     }];
 }
 
+- (void) sendCompositeRequest:(SFSDKCompositeRequest *)request failureBlock:(SFRestRequestFailBlock)failureBlock successBlock:(SFRestCompositeResponseBlock)successBlock {
+    [self sendRequest:request failureBlock:failureBlock successBlock:^(id response, NSURLResponse * rawResponse) {
+        SFSDKCompositeResponse *compositeResponse = [[SFSDKCompositeResponse alloc] initWith:response];
+        successBlock(compositeResponse, rawResponse);
+    }];
+}
+
 - (void) sendBatchRESTRequest:(SFSDKBatchRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestBatchResponseBlock)completeBlock {
     // Copy blocks into the request instance
     [self sendRESTRequest:request failBlock:failBlock completeBlock:^(id response, NSURLResponse * rawResponse) {
         SFSDKBatchResponse *compositeResponse = [[SFSDKBatchResponse alloc]initWith:response];
         completeBlock(compositeResponse,rawResponse);
+    }];
+}
+
+- (void) sendBatchRequest:(SFSDKBatchRequest *)request failureBlock:(SFRestRequestFailBlock)failureBlock successBlock:(SFRestBatchResponseBlock)successBlock {
+    [self sendRequest:request failureBlock:failureBlock successBlock:^(id response, NSURLResponse * rawResponse) {
+        SFSDKBatchResponse *compositeResponse = [[SFSDKBatchResponse alloc] initWith:response];
+        successBlock(compositeResponse, rawResponse);
     }];
 }
 
@@ -231,12 +249,10 @@ static char CompleteBlockKey;
 
 #pragma mark - response delegate
 
-- (void) sendActionForRequest:(SFRestRequest *)request success:(BOOL)success withObject:(id)object rawResponse:(NSURLResponse* )rawResponse {
+- (void) sendActionForRequest:(SFRestRequest *)request success:(BOOL)success withObject:(id)object rawResponse:(NSURLResponse *)rawResponse {
     if (success) {
-        // This block def basically generalizes the SFRestDictionaryResponseBlock and SFRestArrayResponseBlock
-        // block typedefs, so that we can handle either.
-        void (^successBlock)(id, NSURLResponse*);
-        successBlock = (void (^) (id, NSURLResponse*))objc_getAssociatedObject(request, &CompleteBlockKey);
+        void (^successBlock)(id, NSURLResponse *);
+        successBlock = (void (^) (id, NSURLResponse *))objc_getAssociatedObject(request, &CompleteBlockKey);
         if (successBlock) {
             successBlock(object, rawResponse);    
         }
@@ -246,10 +262,29 @@ static char CompleteBlockKey;
             failBlock(object, rawResponse);
         }
     }
-    
+
     // Remove both blocks from the request
-    objc_setAssociatedObject( request, &FailBlockKey, nil, OBJC_ASSOCIATION_ASSIGN);
-    objc_setAssociatedObject( request, &CompleteBlockKey, nil, OBJC_ASSOCIATION_ASSIGN);
+    objc_setAssociatedObject(request, &FailBlockKey, nil, OBJC_ASSOCIATION_ASSIGN);
+    objc_setAssociatedObject(request, &CompleteBlockKey, nil, OBJC_ASSOCIATION_ASSIGN);
+}
+
+- (void) triggerDelegatesForRequest:(SFRestRequest *)request success:(BOOL)success withObject:(id)object rawResponse:(NSURLResponse *)rawResponse error:(NSError *)error {
+    if (success) {
+        void (^successBlock)(id, NSURLResponse *);
+        successBlock = (void (^) (id, NSURLResponse *))objc_getAssociatedObject(request, &SuccessBlockKey);
+        if (successBlock) {
+            successBlock(object, rawResponse);
+        }
+    } else {
+        SFRestRequestFailBlock failBlock = (SFRestRequestFailBlock)objc_getAssociatedObject(request, &FailureBlockKey);
+        if (failBlock) {
+            failBlock(object, rawResponse);
+        }
+    }
+
+    // Removes both blocks from the request.
+    objc_setAssociatedObject(request, &FailureBlockKey, nil, OBJC_ASSOCIATION_ASSIGN);
+    objc_setAssociatedObject(request, &SuccessBlockKey, nil, OBJC_ASSOCIATION_ASSIGN);
 }
 
 - (void)request:(SFRestRequest *)request didFailLoadWithError:(NSError *)error rawResponse:(NSURLResponse *)rawResponse {
@@ -266,6 +301,14 @@ static char CompleteBlockKey;
 
 - (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse {
     [self sendActionForRequest:request success:YES withObject:dataResponse rawResponse:rawResponse];
+}
+
+- (void)request:(SFRestRequest *)request didSucceed:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse {
+    [self triggerDelegatesForRequest:request success:YES withObject:dataResponse rawResponse:rawResponse error:nil];
+}
+
+- (void)request:(SFRestRequest *)request didFail:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse error:(NSError *)error {
+    [self triggerDelegatesForRequest:request success:NO withObject:dataResponse rawResponse:rawResponse error:error];
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
@@ -278,7 +278,7 @@ static char SuccessBlockKey;
     } else {
         SFRestRequestFailBlock failBlock = (SFRestRequestFailBlock)objc_getAssociatedObject(request, &FailureBlockKey);
         if (failBlock) {
-            failBlock(object, rawResponse);
+            failBlock(object, rawResponse, error);
         }
     }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
@@ -232,7 +232,7 @@ static char CompleteBlockKey;
 #pragma mark - response delegate
 
 - (void) sendActionForRequest:(SFRestRequest *)request success:(BOOL)success withObject:(id)object rawResponse:(NSURLResponse* )rawResponse {
-    if( success ) {
+    if (success) {
         // This block def basically generalizes the SFRestDictionaryResponseBlock and SFRestArrayResponseBlock
         // block typedefs, so that we can handle either.
         void (^successBlock)(id, NSURLResponse*);

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
@@ -67,7 +67,7 @@ static char SuccessBlockKey;
 - (void) sendRequest:(SFRestRequest *)request failureBlock:(SFRestRequestFailBlock)failureBlock successBlock:(SFRestResponseBlock)successBlock {
     objc_setAssociatedObject(request, &FailureBlockKey, failureBlock, OBJC_ASSOCIATION_COPY);
     objc_setAssociatedObject(request, &SuccessBlockKey, successBlock, OBJC_ASSOCIATION_COPY);
-    [self send:request delegate:self];
+    [self send:request requestDelegate:self];
 }
 
 - (void) sendCompositeRESTRequest:(SFSDKCompositeRequest *)request failBlock:(SFRestFailBlock)failBlock completeBlock:(SFRestCompositeResponseBlock)completeBlock {
@@ -278,7 +278,7 @@ static char SuccessBlockKey;
     } else {
         SFRestRequestFailBlock failBlock = (SFRestRequestFailBlock)objc_getAssociatedObject(request, &FailureBlockKey);
         if (failBlock) {
-            failBlock(object, rawResponse, error);
+            failBlock(object, error, rawResponse);
         }
     }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Internal.h
@@ -40,7 +40,9 @@
 
 @property (nonatomic, assign) BOOL requiresAuthentication;
 
-@property (nullable, nonatomic, strong) id<SFRestDelegate>instrDelegateInternal;
+@property (nullable, nonatomic, strong) id<SFRestDelegate> instrDelegateInternal;
+
+@property (nullable, nonatomic, strong) id<SFRestRequestDelegate> instrumentationDelegateInternal;
 
 - (void)removeActiveRequestObject:(nonnull SFRestRequest *)request;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
@@ -53,88 +53,10 @@ extern NSString* const kSFRestDefaultAPIVersion NS_SWIFT_NAME(SFRestDefaultAPIVe
 extern NSString* const kSFRestIfUnmodifiedSince NS_SWIFT_NAME(SFRestIfUnmodifiedSince);
 
 /**
- Main class used to issue REST requests to the standard Force.com REST API.
- 
- See the [Force.com REST API Developer's Guide](http://www.salesforce.com/us/developer/docs/api_rest/index.htm)
- for more information regarding the Force.com REST API.
-
- ## Initialization
- 
- This class is a singleton, and can be accessed by referencing [SFRestAPI sharedInstance].  It relies
- upon the shared credentials managed by SFAccountManager, for forming up and sending authenticated
- REST requests.
- 
- ## Sending requests
-
- Sending a request is done using `send:delegate:`.
- The class sending the request has to conform to the protocol `SFRestDelegate`.
- 
- A request can be obtained in two different ways:
-
- - by calling the appropriate `requestFor[...]` method
-
- - by building the `SFRestRequest` manually
- 
- Note: If you opt to build an SFRestRequest manually, you should be aware that
- send:delegate: expects that if the request.path does not begin with the
- request.endpoint prefix, it will add the request.endpoint prefix 
- (kSFDefaultRestEndpoint by default) to the request path.
-  
- For example, this sample code calls the `requestForDescribeWithObjectType:` method to return
- information about the Account object.
-
-    - (void)describeAccount {
-        SFRestRequest *request = [[SFRestAPI sharedInstance]
-                                  requestForDescribeWithObjectType:@"Account"];
-        [[SFRestAPI sharedInstance] send:request delegate:self];
-    }
- 
-    #pragma mark - SFRestDelegate
- 
-    - (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse {
-        NSDictionary *dict = (NSDictionary *)dataResponse;
-        NSArray *fields = (NSArray *)[dict objectForKey:@"fields"];
-        // ...
-    }
- 
-    - (void)request:(SFRestRequest*)request didFailLoadWithError:(NSError *)error rawResponse:(NSURLResponse *)rawResponse {
-        // handle error
-    }
- 
-    - (void)requestDidCancelLoad:(SFRestRequest *)request {
-        // handle error
-    }
-
-    - (void)requestDidTimeout:(SFRestRequest *)request {
-        // handle error
-    }
- 
- ## Error handling
- 
- When sending a `SFRestRequest`, you may encounter one of these errors:
-
- - The request parameters could be invalid (for instance, passing `nil` to the `requestForQuery:`,
- or trying to update a non-existent object).
- In this case, `request:didFailLoadWithError:` is called on the `SFRestDelegate`.
- The error passed will have an error domain of `kSFRestErrorDomain`
- 
- - The oauth access token (session ID) managed by SFAccountManager could have expired.
- In this case, the framework tries to acquire another access token and re-issue
- the `SFRestRequest`. This is all done transparently and the appropriate delegate method
- is called once the second `SFRestRequest` returns. 
-
- - Requesting a new access token (session ID) could fail (if the access token has expired
- and the OAuth refresh token is invalid).
- In this case, `request:didFailLoadWithError:` will be called on the `SFRestDelegate`.
- The error passed will have an error domain of `kSFOAuthErrorDomain`.
- Note that this is a very rare case.
-
- - The underlying HTTP request could fail (Salesforce server is innaccessible...)
- In this case, `request:didFailLoadWithError:` is called on the `SFRestDelegate`.
- The error passed will be a standard `RestKit` error with an error domain of `RKRestKitErrorDomain`. 
-
- */
-
+ * Main class used to issue REST requests to the standard Force.com REST API.
+ * See the [Force.com REST API Developer's Guide](http://www.salesforce.com/us/developer/docs/api_rest/index.htm)
+ * for more information regarding the Force.com REST API.
+*/
 NS_SWIFT_NAME(RestClient)
 @interface SFRestAPI : NSObject
 
@@ -192,7 +114,15 @@ NS_SWIFT_NAME(RestClient)
  * @param delegate Delegate object that handles the server response. 
  * This value overwrites the delegate property of the request.
  */
-- (void)send:(SFRestRequest *)request delegate:(nullable id<SFRestDelegate>)delegate;
+- (void)send:(SFRestRequest *)request delegate:(nullable id<SFRestDelegate>)delegate SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use send:request:requestDelegate instead.");
+
+/**
+ * Sends a REST request to the Salesforce server and invokes the appropriate delegate method.
+ *
+ * @param request `SFRestRequest` object to be sent.
+ * @param requestDelegate Delegate object that handles the server response.
+ */
+- (void)send:(SFRestRequest *)request requestDelegate:(nullable id<SFRestRequestDelegate>)requestDelegate;
 
 ///---------------------------------------------------------------------------------------
 /// @name SFRestRequest factory methods

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -230,6 +230,10 @@ static dispatch_once_t pred;
     [self send:request requestDelegate:nil delegate:delegate shouldRetry:self.requiresAuthentication && request.requiresAuthentication];
 }
 
+- (void)send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate shouldRetry:(BOOL)shouldRetry {
+    [self send:request requestDelegate:nil delegate:delegate shouldRetry:shouldRetry];
+}
+
 - (void)send:(SFRestRequest *)request requestDelegate:(id<SFRestRequestDelegate>)requestDelegate delegate:(id<SFRestDelegate>)delegate shouldRetry:(BOOL)shouldRetry {
     if (nil != delegate) {
         request.delegate = delegate;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -95,13 +95,11 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 }
 
 - (void)cancelAllRequests {
-    
     [self.activeRequests enumerateObjectsUsingBlock:^(id obj, BOOL *stop) {
         SFRestRequest *request = obj;
         [request cancel];
     }];
     [self.activeRequests removeAllObjects];
-    
 }
 
 #pragma mark - singleton
@@ -192,12 +190,13 @@ static dispatch_once_t pred;
     }
 }
 
-- (BOOL)forceTimeoutRequest:(SFRestRequest*)req {
+- (BOOL)forceTimeoutRequest:(SFRestRequest *)req {
     BOOL found = NO;
     SFRestRequest *toCancel = (nil != req ? req : [self.activeRequests anyObject]);
     if (nil != toCancel) {
         found = YES;
         [self notifyDelegateOfTimeout:toCancel.delegate request:toCancel];
+        [self notifyDelegateOfFailure:toCancel.requestDelegate request:toCancel data:nil rawResponse:nil error:nil];
     }
     return found;
 }
@@ -219,16 +218,27 @@ static dispatch_once_t pred;
 
 #pragma mark - send method
 
-- (void)send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate {
-    [self send:request delegate:delegate shouldRetry:self.requiresAuthentication && request.requiresAuthentication];
+- (void)send:(SFRestRequest *)request requestDelegate:(nullable id<SFRestRequestDelegate>)requestDelegate {
+    [self send:request requestDelegate:requestDelegate shouldRetry:self.requiresAuthentication && request.requiresAuthentication];
 }
 
-- (void)send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate shouldRetry:(BOOL)shouldRetry {
+- (void)send:(SFRestRequest *)request requestDelegate:(nullable id<SFRestRequestDelegate>)requestDelegate shouldRetry:(BOOL)shouldRetry {
+    [self send:request requestDelegate:requestDelegate delegate:nil shouldRetry:shouldRetry];
+}
+
+- (void)send:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate {
+    [self send:request requestDelegate:nil delegate:delegate shouldRetry:self.requiresAuthentication && request.requiresAuthentication];
+}
+
+- (void)send:(SFRestRequest *)request requestDelegate:(id<SFRestRequestDelegate>)requestDelegate delegate:(id<SFRestDelegate>)delegate shouldRetry:(BOOL)shouldRetry {
     if (nil != delegate) {
         request.delegate = delegate;
     }
+    if (requestDelegate != nil) {
+        request.requestDelegate = requestDelegate;
+    }
     if (!self.requiresAuthentication) {
-         NSAssert(!request.requiresAuthentication , @"Use SFRestAPI sharedInstance for authenticated requests");
+        NSAssert(!request.requiresAuthentication , @"Use SFRestAPI sharedInstance for authenticated requests");
     }
 
     // Adds this request to the list of active requests if it's not already on the list.
@@ -239,7 +249,7 @@ static dispatch_once_t pred;
         [[SFUserAccountManager sharedInstance] loginWithCompletion:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
             __strong typeof(weakSelf) strongSelf = weakSelf;
             strongSelf.user = userAccount;
-            [strongSelf enqueueRequest:request delegate:delegate shouldRetry:shouldRetry];
+            [strongSelf enqueueRequest:request requestDelegate:requestDelegate delegate:delegate shouldRetry:shouldRetry];
         } failure:^(SFOAuthInfo *authInfo, NSError *error) {
             __strong typeof(weakSelf) strongSelf = weakSelf;
             [SFSDKCoreLogger e:[strongSelf class] format:@"Authentication failed in SFRestAPI: %@. Logging out.", error];
@@ -250,7 +260,7 @@ static dispatch_once_t pred;
             [[SFUserAccountManager sharedInstance] logout];
         }];
     } else {
-        [self enqueueRequest:request delegate:delegate shouldRetry:shouldRetry];
+        [self enqueueRequest:request requestDelegate:requestDelegate delegate:delegate shouldRetry:shouldRetry];
     }
 }
 
@@ -268,7 +278,7 @@ static dispatch_once_t pred;
     return self.oauthSessionRefresher;
 }
 
-- (void)enqueueRequest:(SFRestRequest *)request delegate:(id<SFRestDelegate>)delegate shouldRetry:(BOOL)shouldRetry {
+- (void)enqueueRequest:(SFRestRequest *)request requestDelegate:(id<SFRestRequestDelegate>)requestDelegate delegate:(id<SFRestDelegate>)delegate shouldRetry:(BOOL)shouldRetry {
     __weak __typeof(self) weakSelf = self;
     NSURLRequest *finalRequest = [request prepareRequestForSend:self.user];
     if (finalRequest) {
@@ -280,7 +290,6 @@ static dispatch_once_t pred;
         } else {
             network = [self networkForRequest:request];
         }
-
         NSURLSessionDataTask *dataTask = [network sendRequest:finalRequest dataResponseBlock:^(NSData *data, NSURLResponse *response, NSError *error) {
             __strong typeof(weakSelf) strongSelf = weakSelf;
             [SFNetwork removeSharedInstanceForIdentifier:instanceIdentifier];
@@ -295,12 +304,15 @@ static dispatch_once_t pred;
                 } else {
                     [strongSelf notifyDelegateOfFailure:delegate request:request error:error rawResponse:response];
                 }
+                id dataForDelegate = [strongSelf prepareDataForDelegate:data request:request response:response];
+                [strongSelf notifyDelegateOfFailure:requestDelegate request:request data:dataForDelegate rawResponse:response error:error];
                 return;
             }
 
             // Timeout.
             if (!response) {
                 [strongSelf notifyDelegateOfTimeout:delegate request:request];
+                [strongSelf notifyDelegateOfFailure:requestDelegate request:request data:nil rawResponse:nil error:nil];
                 return;
             }
             NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
@@ -309,14 +321,19 @@ static dispatch_once_t pred;
             if ([SFRestAPI isStatusCodeSuccess:statusCode]) {
                 id dataForDelegate = [strongSelf prepareDataForDelegate:data request:request response:response];
                 [strongSelf notifyDelegateOfResponse:delegate request:request data:dataForDelegate rawResponse:response];
+                [strongSelf notifyDelegateOfSuccess:requestDelegate request:request data:dataForDelegate rawResponse:response];
             } else {
                 if (shouldRetry && (request.shouldRefreshOn403 ? (statusCode == 401 || statusCode == 403) : (statusCode == 401))) {
+
                     // 401 (and sometimes 403) indicates refresh is required.
-                    [strongSelf replayRequest:request response:response delegate:delegate];
+                    [strongSelf replayRequest:request response:response requestDelegate:requestDelegate delegate:delegate];
                 } else {
+
                     // Other status codes indicate failure.
                     NSError *errorForDelegate = [strongSelf prepareErrorForDelegate:data response:response];
                     [strongSelf notifyDelegateOfFailure:delegate request:request error:errorForDelegate rawResponse:response];
+                    id dataForDelegate = [strongSelf prepareDataForDelegate:data request:request response:response];
+                    [strongSelf notifyDelegateOfFailure:requestDelegate request:request data:dataForDelegate rawResponse:response error:errorForDelegate];
                 }
             }
         }];
@@ -388,7 +405,7 @@ static dispatch_once_t pred;
     return [[NSError alloc] initWithDomain:response.URL.absoluteString code:statusCode userInfo:errorDict];
 }
 
-- (void)replayRequest:(SFRestRequest *)request response:(NSURLResponse *)response delegate:(id<SFRestDelegate>)delegate {
+- (void)replayRequest:(SFRestRequest *)request response:(NSURLResponse *)response requestDelegate:(id<SFRestRequestDelegate>)requestDelegate delegate:(id<SFRestDelegate>)delegate {
     [SFSDKCoreLogger i:[self class] format:@"%@: REST request failed due to expired credentials. Attempting to refresh credentials.", NSStringFromSelector(_cmd)];
 
     /*
@@ -415,6 +432,7 @@ static dispatch_once_t pred;
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 [SFSDKCoreLogger e:[strongSelf class] format:@"Failed to refresh expired session. Error: %@", refreshError];
                 [strongSelf notifyDelegateOfFailure:delegate request:request error:refreshError rawResponse:response];
+                [strongSelf notifyDelegateOfFailure:requestDelegate request:request data:nil rawResponse:response error:refreshError];
                 strongSelf.pendingRequestsBeingProcessed = YES;
                 [strongSelf flushPendingRequestQueue:refreshError rawResponse:response];
                 strongSelf.sessionRefreshInProgress = NO;
@@ -438,6 +456,7 @@ static dispatch_once_t pred;
         NSSet *pendingRequests = [self.activeRequests asSet];
         for (SFRestRequest *request in pendingRequests) {
             [self notifyDelegateOfFailure:request.delegate request:request error:error rawResponse:rawResponse];
+            [self notifyDelegateOfFailure:request.requestDelegate request:request data:nil rawResponse:rawResponse error:error];
         }
         self.pendingRequestsBeingProcessed = NO;
     }
@@ -447,7 +466,7 @@ static dispatch_once_t pred;
     @synchronized (self) {
         NSSet *pendingRequests = [self.activeRequests asSet];
         for (SFRestRequest *request in pendingRequests) {
-           [self send:request delegate:request.delegate shouldRetry:NO];
+            [self send:request requestDelegate:request.requestDelegate delegate:request.delegate shouldRetry:NO];
         }
         self.pendingRequestsBeingProcessed = NO;
     }
@@ -481,6 +500,20 @@ static dispatch_once_t pred;
 - (void)notifyDelegateOfTimeout:(id<SFRestDelegate>)delegate request:(SFRestRequest *)request {
     if ([delegate respondsToSelector:@selector(requestDidTimeout:)]) {
         [delegate requestDidTimeout:request];
+    }
+    [self removeActiveRequestObject:request];
+}
+
+- (void)notifyDelegateOfSuccess:(id<SFRestRequestDelegate>)delegate request:(SFRestRequest *)request data:(id)data rawResponse:(NSURLResponse *)rawResponse {
+    if ([delegate respondsToSelector:@selector(request:didSucceed:rawResponse:)]) {
+        [delegate request:request didSucceed:data rawResponse:rawResponse];
+    }
+    [self removeActiveRequestObject:request];
+}
+
+- (void)notifyDelegateOfFailure:(id<SFRestRequestDelegate>)delegate request:(SFRestRequest *)request data:(id)data rawResponse:(NSURLResponse *)rawResponse error:(NSError *)error {
+    if ([delegate respondsToSelector:@selector(request:didFail:rawResponse:error:)]) {
+        [delegate request:request didFail:data rawResponse:rawResponse error:error];
     }
     [self removeActiveRequestObject:request];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest+Internal.h
@@ -31,7 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, nonatomic, copy) NSInputStream * _Nullable (^requestBodyStreamBlock)(void);
 @property (nullable, nonatomic, copy) NSDictionary *requestBodyAsDictionary;
 @property (nullable, nonatomic, copy) NSString *requestContentType;
-@property (nullable, nonatomic, strong) id<SFRestDelegate>instrDelegateInternal;
+@property (nullable, nonatomic, strong) id<SFRestDelegate> instrDelegateInternal;
+@property (nullable, nonatomic, strong) id<SFRestRequestDelegate> instrumentationDelegateInternal;
 
 + (nonnull NSString *)restUrlForBaseUrl:(nullable NSString *)baseUrl serviceHostType:(SFSDKRestServiceHostType)hostType credentials:(nonnull SFOAuthCredentials *)credentials;
 + (NSString *)toQueryString:(nullable NSDictionary *)components;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -48,7 +48,6 @@ typedef NS_ENUM(NSInteger, SFSDKNetworkServiceType) {
    
 } NS_SWIFT_NAME(RestRequest.NetWorkServiceType);
 
-
 /**
  * The type of service host to use for Rest requests.
  */
@@ -81,6 +80,38 @@ extern NSString * const kSFDefaultRestEndpoint;
 @class SFRestRequest;
 
 /**
+ * Lifecycle events for REST requests.
+ */
+NS_SWIFT_NAME(RestRequestDelegate)
+@protocol SFRestRequestDelegate <NSObject>
+@optional
+
+/**
+ * Called when a request was successful.
+ *
+ * @param request REST request.
+ * @param dataResponse The data from the response.  By default, this will be an object
+ * containing the parsed JSON response.  However, if the response is not JSON,
+ * the data will be contained in a binary `NSData` object.
+ * @param rawResponse Raw response returned by the server.
+ */
+- (void)request:(SFRestRequest *)request didSucceed:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse;
+
+/**
+ * Called when a request failed.
+ *
+ * @param request REST request.
+ * @param dataResponse The data from the response.  By default, this will be an object
+ * containing the parsed JSON response.  However, if the response is not JSON,
+ * the data will be contained in a binary `NSData` object.
+ * @param rawResponse Raw response returned by the server.
+ * @param error Error received.
+*/
+- (void)request:(SFRestRequest *)request didFail:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse error:(NSError *)error;
+
+@end
+
+/**
  * Lifecycle events for SFRestRequests.
  */
 NS_SWIFT_NAME(RestClientDelegate)
@@ -95,7 +126,7 @@ NS_SWIFT_NAME(RestClientDelegate)
  * the data will be contained in a binary `NSData` object.
  * @param rawResponse Raw response returned by the server.
  */
-- (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse;
+- (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use SFRestRequestDelegate methods instead.");
 
 /**
  * Sent when a request has finished loading.
@@ -107,7 +138,7 @@ NS_SWIFT_NAME(RestClientDelegate)
  * The pre SDK 6.0 signature
  * Is called only if request:didLoadResponse:rawResponse: is not provided
  */
-- (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse;
+- (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use SFRestRequestDelegate methods instead.");
 
 /**
  * Sent when a request has failed due to an error.
@@ -117,7 +148,7 @@ NS_SWIFT_NAME(RestClientDelegate)
  * @param error The error associated with the failed request.
  * @param rawResponse Raw response returned by the server.
  */
-- (void)request:(SFRestRequest *)request didFailLoadWithError:(NSError*)error rawResponse:(NSURLResponse *)rawResponse;
+- (void)request:(SFRestRequest *)request didFailLoadWithError:(NSError*)error rawResponse:(NSURLResponse *)rawResponse SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use SFRestRequestDelegate methods instead.");
 
 /**
  * Sent when a request has failed due to an error.
@@ -129,20 +160,20 @@ NS_SWIFT_NAME(RestClientDelegate)
  * The pre SDK 6.0 signature
  * Is called only if request:didFailLoadWithError:rawResponse: is not provided
  */
-- (void)request:(SFRestRequest *)request didFailLoadWithError:(NSError*)error;
+- (void)request:(SFRestRequest *)request didFailLoadWithError:(NSError*)error SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use SFRestRequestDelegate methods instead.");
 
 /**
  * Sent to the delegate when a request was cancelled.
  * @param request The canceled request.
  */
-- (void)requestDidCancelLoad:(SFRestRequest *)request;
+- (void)requestDidCancelLoad:(SFRestRequest *)request SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use SFRestRequestDelegate methods instead.");
 
 /**
  * Sent to the delegate when a request has timed out. This is sent when a
  * backgrounded request expired before completion.
  * @param request The request that timed out.
  */
-- (void)requestDidTimeout:(SFRestRequest *)request;
+- (void)requestDidTimeout:(SFRestRequest *)request SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use SFRestRequestDelegate methods instead.");
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -240,7 +240,12 @@ NS_SWIFT_NAME(RestRequest)
 /**
  * The delegate for this request. Notified of request status.
  */
-@property (nullable, nonatomic, weak) id<SFRestDelegate> delegate;
+@property (nullable, nonatomic, weak) id<SFRestDelegate> delegate SFSDK_DEPRECATED("8.2", "9.0", "Will be removed in Mobile SDK 9.0, use the 'requestDelegate' property instead.");
+
+/**
+ * The delegate for this request. Notified of request status.
+ */
+@property (nullable, nonatomic, weak) id<SFRestRequestDelegate> requestDelegate;
 
 /**
  * Typically kSFDefaultRestEndpoint but you may use eg custom Apex endpoints

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFSDKCompositeRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFSDKCompositeRequest.m
@@ -53,6 +53,7 @@ NSString* const kSFRestCompositeDefaultAPIVersion = @"v46.0";
         self.requestBodyAsDictionary = request.requestBodyAsDictionary;
         self.shouldRefreshOn403 = request.shouldRefreshOn403;
         self.delegate = request.delegate;
+        self.requestDelegate = request.requestDelegate;
     }
     return self;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.h
@@ -33,8 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString* const kTestRequestStatusWaiting;
 extern NSString* const kTestRequestStatusDidLoad;
 extern NSString* const kTestRequestStatusDidFail;
-extern NSString* const kTestRequestStatusDidCancel;
-extern NSString* const kTestRequestStatusDidTimeout;
 
 typedef NS_ENUM(NSUInteger, SFAccountManagerServiceType) {
     SFAccountManagerServiceTypeNone = 0,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
@@ -25,11 +25,10 @@
 #import "SFSDKTestRequestListener.h"
 #import "TestSetupUtils.h"
 #import "SFUserAccountManager.h"
+
 NSString* const kTestRequestStatusWaiting = @"waiting";
 NSString* const kTestRequestStatusDidLoad = @"didLoad";
 NSString* const kTestRequestStatusDidFail = @"didFail";
-NSString* const kTestRequestStatusDidCancel = @"didCancel";
-NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
 
 @interface SFSDKTestRequestListener ()
 @end
@@ -39,7 +38,6 @@ NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
 @synthesize dataResponse = _dataResponse;
 @synthesize lastError = _lastError;
 @synthesize returnStatus = _returnStatus;
-
 @synthesize maxWaitTime = _maxWaitTime;
 
 - (id)init
@@ -49,7 +47,6 @@ NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
         self.maxWaitTime = 30.0;
         self.returnStatus = kTestRequestStatusWaiting;
     }
-    
     return self;
 }
 
@@ -59,21 +56,16 @@ NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
     self.returnStatus = nil;
 }
 
-
 - (NSString *)waitForCompletion {
-    
     NSDate *startTime = [NSDate date] ;
-        
     while ([self.returnStatus isEqualToString:kTestRequestStatusWaiting]) {
         NSTimeInterval elapsed = [[NSDate date] timeIntervalSinceDate:startTime];
         if (elapsed > self.maxWaitTime) {
             [SFSDKCoreLogger d:[self class] format:@"Request took too long (> %f secs) to complete.", elapsed];
             return kTestRequestStatusDidTimeout;
         }
-        
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     }
-    
     return self.returnStatus;
 }
 
@@ -114,10 +106,12 @@ NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
     NSAssert(NO, @"User Agent flow not supported in this class.");
 }
 
-- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(ASWebAuthenticationSession *)session {
+- (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(ASWebAuthenticationSession *)session
+{
     NSAssert(NO, @"Web Server flow not supported in this class.");
 }
-- (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator {
+- (void)oauthCoordinatorDidCancelBrowserAuthentication:(SFOAuthCoordinator *)coordinator
+{
     NSAssert(NO, @"Web Server flow not supported in this class.");
 }
 
@@ -135,4 +129,3 @@ NSString* const kTestRequestStatusDidTimeout = @"didTimeout";
 }
 
 @end
-

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
@@ -62,7 +62,7 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
         NSTimeInterval elapsed = [[NSDate date] timeIntervalSinceDate:startTime];
         if (elapsed > self.maxWaitTime) {
             [SFSDKCoreLogger d:[self class] format:@"Request took too long (> %f secs) to complete.", elapsed];
-            return kTestRequestStatusDidTimeout;
+            return kTestRequestStatusDidFail;
         }
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -878,13 +878,12 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     __weak typeof (self) weakSelf = self;
     SFOAuthCredentials *spAppCredentials = [self spAppCredentials:spAppOptions];
     SFRestRequest *request = [[SFRestAPI sharedInstanceWithUser:user] requestForUserInfo];
-    [[SFRestAPI sharedInstanceWithUser:user] sendRESTRequest:request failBlock:^(NSError *error, NSURLResponse *rawResponse) {
+    [[SFRestAPI sharedInstanceWithUser:user] sendRequest:request failureBlock:^(id response, NSError *error, NSURLResponse *rawResponse) {
         [SFSDKIDPAuthHelper invokeSPAppWithError:spAppCredentials error:error reason:@"Failed refreshing credentials"];
-    } completeBlock:^(id response, NSURLResponse *rawResponse) {
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
         __strong typeof (self) strongSelf = weakSelf;
         [strongSelf authenticateOnBehalfOfSPApp:user spAppCredentials:spAppCredentials];
     }];
-
 }
 
 - (void)cancel:(NSDictionary *)spAppOptions {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
@@ -222,7 +222,7 @@ class RestClientTests: XCTestCase {
     func testBatchRequest() {
         
         let expectation = XCTestExpectation(description: "batchRequestTest")
-        let bathRequestBuilder = BatchRequestBuilder()
+
         // Create account
         let accountName = self.generateRecordName()
         let contactName = self.generateRecordName()
@@ -296,10 +296,9 @@ class RestClientTests: XCTestCase {
 
     }
     
-    func testBatchRequestStopOnFailure() {
-        
+    func testBatchRequestStopOnFailure() {        
         let expectation = XCTestExpectation(description: "batchRequestTest")
-        let bathRequestBuilder = BatchRequestBuilder()
+
         // Create account
         let accountName = self.generateRecordName()
         let contactName = self.generateRecordName()
@@ -356,7 +355,7 @@ class RestClientTests: XCTestCase {
     func testBatchRequestContinueOnFailure() {
            
        let expectation = XCTestExpectation(description: "batchRequestTest")
-       let bathRequestBuilder = BatchRequestBuilder()
+
        // Create account
        let accountName = self.generateRecordName()
        let contactName = self.generateRecordName()

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFNativeRestRequestListener.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFNativeRestRequestListener.h
@@ -26,7 +26,7 @@
 #import "SFRestRequest.h"
 #import <SalesforceSDKCore/SFSDKTestRequestListener.h>
 
-@interface SFNativeRestRequestListener : SFSDKTestRequestListener <SFRestDelegate>
+@interface SFNativeRestRequestListener : SFSDKTestRequestListener <SFRestRequestDelegate>
 
 @property (nonatomic, strong) SFRestRequest *request;
 @property (nonatomic, assign) NSTimeInterval sleepDuringLoad;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFNativeRestRequestListener.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFNativeRestRequestListener.m
@@ -42,7 +42,7 @@ int class_uid = 0;
     self = [super init];
     if (self) {
         self.request = request;
-        self.request.delegate = self;
+        self.request.requestDelegate = self;
         self->uid = class_uid++;
         [SFLogger log:[self class] level:SFLogLevelDebug format:@"## created listener %d", self->uid];
     }
@@ -51,7 +51,7 @@ int class_uid = 0;
 
 - (void)dealloc
 {
-    self.request.delegate = nil;
+    self.request.requestDelegate = nil;
     self.request = nil;
 }
 
@@ -60,31 +60,21 @@ int class_uid = 0;
     return @"SFRestRequest";
 }
 
-#pragma mark - SFRestDelegate
+#pragma mark - SFRestRequestDelegate
 
-- (void)request:(SFRestRequest *)request didLoadResponse:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse {
+- (void)request:(SFRestRequest *)request didSucceed:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse {
     if (self.sleepDuringLoad > 0) {
         [NSThread sleepForTimeInterval:self.sleepDuringLoad];
     }
-     
     self.dataResponse = dataResponse;
     self.returnStatus = kTestRequestStatusDidLoad;
 }
 
-- (void)request:(SFRestRequest*)request didFailLoadWithError:(NSError*)error rawResponse:(NSURLResponse *)rawResponse {
-    [SFLogger log:[self class] level:SFLogLevelDebug  format:@"## error for request %d", self->uid];
+- (void)request:(SFRestRequest *)request didFail:(id)dataResponse rawResponse:(NSURLResponse *)rawResponse error:(NSError *)error {
     self.lastError = error;
     self.returnStatus = kTestRequestStatusDidFail;
     self.rawResponse = rawResponse;
-}
-
-- (void)requestDidCancelLoad:(SFRestRequest *)request {
-    [SFLogger log:[self class] level:SFLogLevelDebug  format:@"## cancel for request %d", self->uid];
-    self.returnStatus = kTestRequestStatusDidCancel;
-}
-
-- (void)requestDidTimeout:(SFRestRequest *)request {
-    self.returnStatus = kTestRequestStatusDidTimeout;
+    self.dataResponse = dataResponse;
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKURLCacheTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKURLCacheTests.m
@@ -214,7 +214,7 @@
 
 - (void)sendRequest:(SFRestRequest *)request {
     SFSDKTestRequestListener *listener = [[SFSDKTestRequestListener alloc] init];
-    SFRestFailBlock failBlock = ^(NSError *error, NSURLResponse *rawResponse) {
+    SFRestRequestFailBlock failBlock = ^(id response, NSError *error, NSURLResponse *rawResponse) {
         listener.lastError = error;
         listener.returnStatus = kTestRequestStatusDidFail;
     };
@@ -222,9 +222,9 @@
         listener.dataResponse = data;
         listener.returnStatus = kTestRequestStatusDidLoad;
     };
-    [[SFRestAPI sharedGlobalInstance] sendRESTRequest:request
-                                            failBlock:failBlock
-                                        completeBlock:completeBlock];
+    [[SFRestAPI sharedGlobalInstance] sendRequest:request
+                                            failureBlock:failBlock
+                                        successBlock:completeBlock];
     [listener waitForCompletion];
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
@@ -61,7 +61,6 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     NSString * const kAccessToken   = @"howAboutaNice";
     NSString * const kRefreshToken  = @"hawaiianPunch";
     NSString * const kUserId12      = @"00530000004c";          // 12 characters   00530000004cwSi
-    NSString * const kUserId15      = @"00530000004cwSi";       // 15 characters
     NSString * const kUserId18      = @"00530000004cwSi123";    // 18 characters
 
     NSString * identifier       = kIdentifier;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -2456,7 +2456,7 @@ static NSException *authException = nil;
     [self waitForExpectations:@[getExpectation] timeout:20];
     XCTAssertTrue(error == nil,@"RestApi call to a public api should not fail");
     XCTAssertFalse(response == nil,@"RestApi call to a public api should not have a nil response");
-    XCTAssertTrue(response.count > 0 ,@"The reponse should have github/forcedotcom repos");
+    XCTAssertTrue(response.count > 0 ,@"The response should have github/forcedotcom repos");
 }
 
 - (void)testCustomSalesforceEndpoint {

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -88,7 +88,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if let _ = UserAccountManager.shared.currentUserAccount?.credentials.accessToken {
             PushNotificationManager.sharedInstance().registerForSalesforceNotifications { (result) in
                 switch (result) {
-                    case  .success(let successFlag):
+                    case .success(let successFlag):
                         SalesforceLogger.d(AppDelegate.self, message: "Registration for Salesforce notifications status:  \(successFlag)")
                     case .failure(let error):
                         SalesforceLogger.e(AppDelegate.self, message: "Registration for Salesforce notifications failed \(error)")


### PR DESCRIPTION
We have too many delegate callbacks currently in error cases that are non-standard, and complicate our code paths. They're there for legacy reasons and have been strung along as we switched network libraries for backwards compatibility. I took at stab at standardizing and simplifying the callbacks and deprecating the old ways. This allows us to clean up this area in `Mobile SDK 9.0`. In addition to this, a major drawback with the current error callbacks is that none of them return the response in the callback. I have added this in the new callbacks.

This PR:
- adds 2 simple callbacks for `onSuccess` and `onFailure`.
- adds simplified `send` methods to use the new callbacks instead of the old ones.
- deprecates the old callbacks.
- deprecates the old `send` methods.
- refactored the tests to use the new callbacks wherever possible (this will need one more round of cleanup as part of the removal effort in `Mobile SDK 9.0`).
- fixed a couple of minor issues with `RestExplorer`.
- updated all internal usage of the old APIs to use the new ones (in `Swift` extensions and `MobileSync` as well).

Testing:
- `MobileSyncExplorer` is working fine with the changes.
- All tests in `SalesforceSDKCore` are passing locally with the changes.
