### PR TITLE
Refactoring all of the NSFileManager initialization to the defaultMan…

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
@@ -157,9 +157,9 @@
 }
 
 - (void) deleteAllEvents {
-    NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:self.storeDirectory error:nil];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+    NSArray *files = [fileManager contentsOfDirectoryAtPath:self.storeDirectory error:nil];
     for (NSString *file in files) {
-        NSFileManager *fileManager = [NSFileManager defaultManager];
         NSString *filePath = [self filenameForEvent:file];
         if ([fileManager fileExistsAtPath:filePath]) {
             [fileManager removeItemAtPath:filePath error:nil];

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Util/SFPathUtil.m
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Util/SFPathUtil.m
@@ -74,7 +74,7 @@
         fileProtection = [SFFileProtectionHelper fileProtectionForPath:path];
     }
     
-    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
     
     if (![fileManager fileExistsAtPath:path]) {
         [fileManager createDirectoryAtPath:path withIntermediateDirectories:YES attributes:[NSDictionary dictionaryWithObjectsAndKeys:fileProtection, NSFileProtectionKey, nil] error:nil];
@@ -151,7 +151,7 @@
         fileProtection = [SFFileProtectionHelper fileProtectionForPath:filePath];
     }
     
-    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
     if ([fileManager fileExistsAtPath:filePath]){
         NSError *error = nil;
         NSDictionary *attrs = [fileManager attributesOfItemAtPath:filePath error:&error];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/UIDevice+SFHardware.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/UIDevice+SFHardware.m
@@ -269,14 +269,14 @@
 #pragma mark file system -- Thanks Joachim Bean!
 - (NSNumber *) totalDiskSpace
 {
-    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
     NSDictionary *fattributes = [fileManager attributesOfFileSystemForPath:NSHomeDirectory() error:nil];
     return [fattributes objectForKey:NSFileSystemSize];
 }
 
 - (NSNumber *) freeDiskSpace
 {
-    NSFileManager *fileManager = [[NSFileManager alloc] init];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
     NSDictionary *fattributes = [fileManager attributesOfFileSystemForPath:NSHomeDirectory() error:nil];
     return [fattributes objectForKey:NSFileSystemFreeSize];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/TestSetupUtils.m
@@ -40,7 +40,7 @@ static SFOAuthCredentials *credentials = nil;
 {
     NSString *tokenPath = [[NSBundle bundleForClass:testClass] pathForResource:@"ui_test_credentials" ofType:@"json"];
     NSAssert(nil != tokenPath, @"UI test config file not found!");
-    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSFileManager *fm = [NSFileManager defaultManager];
     NSData *jsonData = [fm contentsAtPath:tokenPath];
     NSArray *jsonDataArray = [[NSArray alloc] initWithArray:[SFJsonUtils objectFromJSONData:jsonData]];
     NSAssert(jsonDataArray != nil, @"Error parsing JSON from config file: %@", [SFJsonUtils lastError]);
@@ -51,7 +51,7 @@ static SFOAuthCredentials *credentials = nil;
 {
     NSString *tokenPath = [[NSBundle bundleForClass:testClass] pathForResource:@"test_credentials" ofType:@"json"];
     NSAssert(nil != tokenPath, @"Test config file not found!");
-    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSFileManager *fm = [NSFileManager defaultManager];
     NSData *tokenJson = [fm contentsAtPath:tokenPath];
     id jsonResponse = [SFJsonUtils objectFromJSONData:tokenJson];
     NSAssert(jsonResponse != nil, @"Error parsing JSON from config file: %@", [SFJsonUtils lastError]);

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFDefaultUserAccountPersister.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFDefaultUserAccountPersister.m
@@ -65,7 +65,7 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
     
     // Get the root directory, usually ~/Library/<appBundleId>/
     NSString *rootDirectory = [[SFDirectoryManager sharedManager] directoryForUser:nil type:NSLibraryDirectory components:nil];
-    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSFileManager *fm = [NSFileManager defaultManager];
     if ([fm fileExistsAtPath:rootDirectory]) {
         // Now iterate over the org and then user directories to load
         // each individual user account file.
@@ -129,7 +129,7 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
 - (BOOL)deleteAccountForUser:(SFUserAccount *)user error:(NSError **)error {
     BOOL success = NO;
     if (nil != user) {
-        NSFileManager *manager = [[NSFileManager alloc] init];
+        NSFileManager *manager = [NSFileManager defaultManager];
         NSString *userDirectory = [[SFDirectoryManager sharedManager] directoryForUser:user
                                                                                  scope:SFUserAccountScopeUser
                                                                                   type:NSLibraryDirectory
@@ -180,7 +180,7 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
     }
 
     // Remove any existing file.
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     if ([manager fileExistsAtPath:filePath]) {
         NSError *removeAccountFileError = nil;
         if (![manager removeItemAtPath:filePath error:&removeAccountFileError]) {
@@ -241,7 +241,7 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
  */
 - (BOOL)loadUserAccountFromFile:(NSString *)filePath account:(SFUserAccount**)account error:(NSError**)error {
     
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     NSString *reason = @"User account data could not be decrypted. Can't load account.";
     NSData *encryptedUserAccountData = [manager contentsAtPath:filePath];
     if (!encryptedUserAccountData) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.m
@@ -167,7 +167,7 @@ static NSString * const kUserAccountPhotoEncryptionKeyLabel = @"com.salesforce.u
             __strong typeof(weakSelf) strongSelf = weakSelf;
             [strongSelf upgradePhotoPath];
             NSString *photoPath = [strongSelf photoPathInternal:nil];
-            NSFileManager *manager = [[NSFileManager alloc] init];
+            NSFileManager *manager = [NSFileManager defaultManager];
             if ([manager fileExistsAtPath:photoPath]) {
                 UIImage *decryptedPhoto = [self decryptPhoto:photoPath];
                 if (decryptedPhoto) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
@@ -59,7 +59,7 @@ static NSString * const kDirectoryManagerErrorDomain = @"com.salesforce.mobilesd
     if (!directory) {
         return NO;
     }
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     BOOL isDirectory;
     BOOL fileExists = [manager fileExistsAtPath:directory isDirectory:&isDirectory];
     if (!fileExists) {
@@ -176,7 +176,7 @@ static NSString * const kDirectoryManagerErrorDomain = @"com.salesforce.mobilesd
 #pragma mark - File Migration Methods
 
 - (void)moveContentsOfDirectory:(NSString *)sourceDirectory toDirectory:(NSString *)destinationDirectory {
-    NSFileManager *fileManager = [[NSFileManager alloc]init];
+    NSFileManager *fileManager = [NSFileManager defaultManager];
     NSError *error = nil;
     if (sourceDirectory && [fileManager fileExistsAtPath:sourceDirectory]) {
         [SFDirectoryManager ensureDirectoryExists:destinationDirectory error:nil];
@@ -255,7 +255,7 @@ static NSString * const kDirectoryManagerErrorDomain = @"com.salesforce.mobilesd
 
 + (void)upgradeUserDirectory:(NSSearchPathDirectory)type {
     NSString *rootDirectory = [[SFDirectoryManager sharedManager] directoryForUser:nil type:type components:nil];
-    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSFileManager *fm = [NSFileManager defaultManager];
     NSError *error = nil;
 
     if ([fm fileExistsAtPath:rootDirectory]) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFPreferences.m
@@ -195,7 +195,7 @@ static NSMutableDictionary *instances = nil;
 
 - (void)removeAllObjects {
     @synchronized (self) {
-        NSFileManager *manager = [[NSFileManager alloc] init];
+        NSFileManager *manager = [NSFileManager defaultManager];
         if ([manager fileExistsAtPath:self.path]) {
             NSError *error = nil;
             BOOL success = [manager removeItemAtPath:self.path error:&error];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -110,7 +110,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     [super setUp];
     // Delete the content of the global library directory
     NSString *globalLibraryDirectory = [[SFDirectoryManager sharedManager] directoryForUser:nil type:NSLibraryDirectory components:nil];
-    [[[NSFileManager alloc] init] removeItemAtPath:globalLibraryDirectory error:nil];
+    [[NSFileManager defaultManager] removeItemAtPath:globalLibraryDirectory error:nil];
     // Set the oauth client ID after deleting the content of the global library directory
     // to ensure the SFUserAccountManager sharedInstance loads from an empty directory
     self.uam = [SFUserAccountManager sharedInstance];
@@ -218,7 +218,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     NSString *expectedLocation = [[SFDirectoryManager sharedManager] directoryForOrg:user.credentials.organizationId user:user.credentials.userId community:nil type:NSLibraryDirectory components:nil];
     expectedLocation = [expectedLocation stringByAppendingPathComponent:@"UserAccount.plist"];
     XCTAssertEqualObjects(expectedLocation, [SFDefaultUserAccountPersister userAccountPlistFileForUser:user], @"Mismatching user account paths");
-    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSFileManager *fm = [NSFileManager defaultManager];
     XCTAssertTrue([fm fileExistsAtPath:expectedLocation], @"Unable to find new UserAccount.plist");
 
     NSString *userId = [NSString stringWithFormat:kUserIdFormatString, (unsigned long)0];
@@ -232,7 +232,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 
     // Create 10 users
     [self createAndVerifyUserAccounts:10];
-    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSFileManager *fm = [NSFileManager defaultManager];
 
     // Ensure all directories have been correctly created
     {
@@ -541,7 +541,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     NSError *deleteAccountError = nil;
     [self.uam deleteAccountForUser:user error:&deleteAccountError];
     XCTAssertNil(deleteAccountError, @"Error deleting account with User ID '%@' and Org ID '%@': %@", identity.userId, identity.orgId, [deleteAccountError localizedDescription]);
-    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSFileManager *fm = [NSFileManager defaultManager];
     XCTAssertFalse([fm fileExistsAtPath:userDir], @"User directory for User ID '%@' and Org ID '%@' should be removed.", identity.userId, identity.orgId);
     SFUserAccount *inMemoryAccount = [self.uam userAccountForUserIdentity:identity];
     XCTAssertNil(inMemoryAccount, @"deleteUser should have removed user account with User ID '%@' and OrgID '%@' from the list of users.", identity.userId, identity.orgId);
@@ -619,7 +619,7 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 {
     NSString *tokenPath = [[NSBundle bundleForClass:testClass] pathForResource:@"test_credentials" ofType:@"json"];
     NSAssert(nil != tokenPath, @"Test config file not found!");
-    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSFileManager *fm = [NSFileManager defaultManager];
     NSData *tokenJson = [fm contentsAtPath:tokenPath];
     id jsonResponse = [SFJsonUtils objectFromJSONData:tokenJson];
     NSAssert(jsonResponse != nil, @"Error parsing JSON from config file: %@", [SFJsonUtils lastError]);

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserIdUpgradeTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserIdUpgradeTests.m
@@ -51,7 +51,7 @@ static NSString *communityId = @"COMMUNITYID";
 @implementation SFUserIdUpgradeTests
 
 - (void)setUp {
-    NSFileManager *fm = [[NSFileManager alloc] init];
+    NSFileManager *fm = [NSFileManager defaultManager];
     NSString *libraryDirectoryOrg = [[SFDirectoryManager sharedManager] directoryForOrg:orgId user:nil community:nil type:NSLibraryDirectory components:nil];
     [fm removeItemAtPath:libraryDirectoryOrg error:nil];
     NSString *documentDirectoryOrg = [[SFDirectoryManager sharedManager] directoryForOrg:orgId user:nil community:nil type:NSDocumentDirectory components:nil];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
@@ -136,7 +136,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
 
 - (BOOL)persistentStoreExists:(NSString*)storeName {
     NSString *fullDbFilePath = [self fullDbFilePathForStoreName:storeName];
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     return [manager fileExistsAtPath:fullDbFilePath];
 }
 
@@ -326,7 +326,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
      storeName,
      (encrypting ? @"unencrypted" : @"encrypted"),
      (encrypting ? @"Encrypting" : @"Unencrypting")];
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     
     // Use sqlcipher_export() to move the data from the input DB over to the new one.
     NSString *attachDbString = [NSString stringWithFormat:@"ATTACH DATABASE '%@' AS encrypted KEY '%@'", encDbPath, escapedKey];
@@ -459,7 +459,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
     NSError* error = nil;
     BOOL result = YES;
     NSString *storeDir = [self storeDirectoryForStoreName:storeName];
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     if (![manager fileExistsAtPath:storeDir]) {
         // This store has not yet been created; create it.
         result = [SFDirectoryManager ensureDirectoryExists:storeDir error:&error];
@@ -475,7 +475,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
 - (NSString*)getDirProtection:(NSString *)dirPath
 {
     NSError* error = nil;
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     NSDictionary *attr = [manager attributesOfItemAtPath:dirPath error:&error];
     NSString* result = attr[NSFileProtectionKey];
     if (error != nil) {
@@ -495,7 +495,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
         if (![currentProtection isEqualToString:protection]) {
             NSError* error = nil;
             NSDictionary *attr = @{NSFileProtectionKey: protection};
-            NSFileManager *manager = [[NSFileManager alloc] init];
+            NSFileManager *manager = [NSFileManager defaultManager];
             BOOL result = [manager setAttributes:attr ofItemAtPath:dirPath error:&error];
             if (error != nil || !result) {
                 [SFSDKSmartStoreLogger e:[self class] format:@"Couldn't protect dir: %@ - error:%@", dirPath, error];
@@ -520,7 +520,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
 - (void)removeStoreDir:(NSString *)storeName
 {
     NSString *storeDir = [self storeDirectoryForStoreName:storeName];
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     if ([manager fileExistsAtPath:storeDir]) {
         [manager removeItemAtPath:storeDir error:nil];
     }
@@ -551,7 +551,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
 - (NSArray *)allStoreNames {
     NSString *rootDir = [self rootStoreDirectory];
     NSError *getStoresError = nil;
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     NSArray *storesDirNames = [manager contentsOfDirectoryAtPath:rootDir error:&getStoresError];
     if (getStoresError) {
         [SFSDKSmartStoreLogger d:[self class] format:@"Warning: Problem retrieving all store names from the root stores folder: %@.", [getStoresError localizedDescription]];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.m
@@ -59,7 +59,7 @@ static NSString * const kKeyStoreHasExternalSalt = @"com.salesforce.smartstore.e
             [SFSDKSmartStoreLogger i:[SFSmartStoreUpgrade class] format:@"Successfully migrated store '%@'", storeName];
         }
     }
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     [manager removeItemAtPath:[SFSmartStoreUpgrade legacyRootStoreDirectory] error:nil];
 }
 
@@ -71,7 +71,7 @@ static NSString * const kKeyStoreHasExternalSalt = @"com.salesforce.smartstore.e
     NSString *newStoreFilePath = [[SFSmartStoreDatabaseManager sharedManager] fullDbFilePathForStoreName:storeName];
 
     // No store in the original location?  Nothing to do.
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     if (![manager fileExistsAtPath:origStoreFilePath]) {
         [SFSDKSmartStoreLogger i:[SFSmartStoreUpgrade class] format:@"File for store '%@' does not exist at legacy path.  Nothing to do.", storeName];
         [manager removeItemAtPath:origStoreDirPath error:nil];
@@ -413,7 +413,7 @@ static NSString * const kKeyStoreHasExternalSalt = @"com.salesforce.smartstore.e
 {
     NSString *rootDir = [SFSmartStoreUpgrade legacyRootStoreDirectory];
     NSError *getStoresError = nil;
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     
     // First see if the legacy root folder exists.
     BOOL rootDirIsDirectory = NO;
@@ -440,7 +440,7 @@ static NSString * const kKeyStoreHasExternalSalt = @"com.salesforce.smartstore.e
 + (BOOL)legacyPersistentStoreExists:(NSString *)storeName
 {
     NSString *fullDbFilePath = [SFSmartStoreUpgrade legacyFullDbFilePathForStoreName:storeName];
-    NSFileManager *manager = [[NSFileManager alloc] init];
+    NSFileManager *manager = [NSFileManager defaultManager];
     BOOL result = [manager fileExistsAtPath:fullDbFilePath];
     return result;
 }


### PR DESCRIPTION
We use the SalesforceMobileSDK-iOS at my company. When I was going through the source code, I found many places where [[NSFileManager alloc] init] was used to init a new FileManager instead of [NSFileManager defaultManager] singleton. We are using these changes in our code. We wanted to offer this back to the open source project. 