### PR TITLE
Deprecating 'shouldRefreshOn403' for Removal in 9.0

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -262,7 +262,7 @@ NS_SWIFT_NAME(RestRequest)
  * Used to specify if the SDK should attempt to refresh tokens on HTTP 403. If YES, the SDK will
  * attempt to refresh on HTTP 403. If NO, refresh will not be attempted.
  */
-@property (nonatomic, assign) BOOL shouldRefreshOn403;
+@property (nonatomic, assign) BOOL shouldRefreshOn403 SFSDK_DEPRECATED("8.3", "9.0", "Will be removed in Mobile SDK 9.0.");
 
 /**
  * Prepares the request before sending it out.


### PR DESCRIPTION
This parameter was added to support legacy org migration/split use cases on certain specific APIs. This doesn't apply anymore, and there are more legitimate use cases where this needs to be turned off. The SDK should only refresh on 401 going forward - that's the only legitimate refresh flow now.