### PR TITLE
Add property to override user interface style on managed windows

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.h
@@ -95,6 +95,10 @@
  */
 @property (readonly,nonatomic,strong) SFSDKWindowContainer * _Nonnull mainWindow;
 
+/** Sets overrideUserInterfaceStyle on managed windows. Default is UIUserInterfaceStyleUnspecified.
+ */
+@property (nonatomic, assign) UIUserInterfaceStyle userInterfaceStyle API_AVAILABLE(ios(13));
+
 /** Returns the SFSDKWindowContainer window representing the active presented Window that has been set
  */
 - (SFSDKWindowContainer * _Nullable)activeWindow;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.h
@@ -95,6 +95,7 @@
  */
 @property (readonly,nonatomic,strong) SFSDKWindowContainer * _Nonnull mainWindow;
 
+// TODO: Remove API_AVAILABLE in Mobile SDK 9.0
 /** Sets overrideUserInterfaceStyle on managed windows. Default is UIUserInterfaceStyleUnspecified.
  */
 @property (nonatomic, assign) UIUserInterfaceStyle userInterfaceStyle API_AVAILABLE(ios(13));

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
@@ -1,3 +1,4 @@
+
 /*
  SFUIWindowManager.m
  SalesforceSDKCore
@@ -453,7 +454,7 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
     return [SFApplicationHelper sharedApplication].keyWindow;
 }
 
-// TODO remove wrapping method in Mobile SDK 9.0
+// TODO: Remove wrapping method in Mobile SDK 9.0
 - (void)overrideStyle:(SFSDKWindowContainer *)container {
     if (@available(iOS 13.0, *)) {
         container.window.overrideUserInterfaceStyle = self.userInterfaceStyle;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
@@ -143,6 +143,7 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
         _namedWindows = [NSMapTable mapTableWithKeyOptions:NSMapTableStrongMemory
                                               valueOptions:NSMapTableStrongMemory];
         _delegates = [NSHashTable weakObjectsHashTable];
+        _userInterfaceStyle = UIUserInterfaceStyleUnspecified;
     }
     return self;
 }
@@ -175,6 +176,7 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
     container.windowType = SFSDKWindowTypeMain;
     container.windowDelegate = self;
     container.window.alpha = 1.0;
+    [self overrideStyle:container];
     [self.namedWindows setObject:container forKey:kSFMainWindowKey];
 }
 
@@ -218,6 +220,7 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
         container.windowDelegate = self;
         container.windowLevel = UIWindowLevelNormal;
         container.windowType = SFSDKWindowTypeOther;
+        [self overrideStyle:container];
         [self.namedWindows setObject:container forKey:windowName];
     }
     return container;
@@ -277,6 +280,16 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
         }];
     }
 }
+
+- (void)setUserInterfaceStyle:(UIUserInterfaceStyle)userInterfaceStyle {
+    _userInterfaceStyle = userInterfaceStyle;
+    NSEnumerator *enumerator = [self.namedWindows objectEnumerator];
+    SFSDKWindowContainer *container;
+    while (container = [enumerator nextObject]) {
+        container.window.overrideUserInterfaceStyle = userInterfaceStyle;
+    }
+}
+
 #pragma mark - SFSDKWindowContainerDelegate
 - (void)presentWindow:(SFSDKWindowContainer *)window animated:(BOOL)animated withCompletion:(void (^ _Nullable)(void))completion{
     
@@ -394,6 +407,7 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
     SFSDKWindowContainer *container = [[SFSDKWindowContainer alloc] initWithName:kSFSnaphotWindowKey];
     container.windowDelegate = self;
     container.windowType = SFSDKWindowTypeSnapshot;
+    [self overrideStyle:container];
     [self.namedWindows setObject:container forKey:kSFSnaphotWindowKey];
     return container;
 }
@@ -402,6 +416,7 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
     SFSDKWindowContainer *container = [[SFSDKWindowContainer alloc] initWithName:kSFLoginWindowKey];
     container.windowDelegate = self;
     container.windowType = SFSDKWindowTypeAuth;
+    [self overrideStyle:container];
     [self.namedWindows setObject:container forKey:kSFLoginWindowKey];
     return container;
 }
@@ -410,15 +425,9 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
     SFSDKWindowContainer *container = [[SFSDKWindowContainer alloc] initWithName:kSFPasscodeWindowKey];
     container.windowDelegate = self;
     container.windowType = SFSDKWindowTypePasscode;
+    [self overrideStyle:container];
     [self.namedWindows setObject:container forKey:kSFPasscodeWindowKey];
     return container;
-}
-
--(UIWindow *)createDefaultUIWindowNamed:(NSString *)name {
-    UIWindow *window = [[SFSDKUIWindow alloc]  initWithFrame:UIScreen.mainScreen.bounds andName:name];
-    [window setAlpha:0.0];
-    window.rootViewController = [[SFSDKRootController alloc] init];
-    return  window;
 }
 
 - (BOOL)isManagedWindow:(UIWindow *) window {
@@ -442,6 +451,13 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
 
 - (UIWindow *)findActiveWindow {
     return [SFApplicationHelper sharedApplication].keyWindow;
+}
+
+// TODO remove wrapping method in Mobile SDK 9.0
+- (void)overrideStyle:(SFSDKWindowContainer *)container {
+    if (@available(iOS 13.0, *)) {
+        container.window.overrideUserInterfaceStyle = self.userInterfaceStyle;
+    }
 }
 
 + (instancetype)sharedManager {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
@@ -139,6 +139,7 @@
 }
 
 - (void)testStyleOverride {
+    // TODO: Remove this check in Mobile SDK 9.0
     if (@available(iOS 13.0, *)) {
         SFSDKWindowContainer *snapshotWindow = [SFSDKWindowManager sharedManager].snapshotWindow;
         SFSDKWindowContainer *passcodeWindow = [SFSDKWindowManager sharedManager].passcodeWindow;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
@@ -136,7 +136,22 @@
     [passcodeWindow dismissWindowAnimated:NO  withCompletion:^{
         XCTAssertFalse(passcodeWindow.window.isKeyWindow);
     }];
-    
+}
+
+- (void)testStyleOverride {
+    if (@available(iOS 13.0, *)) {
+        SFSDKWindowContainer *snapshotWindow = [SFSDKWindowManager sharedManager].snapshotWindow;
+        SFSDKWindowContainer *passcodeWindow = [SFSDKWindowManager sharedManager].passcodeWindow;
+
+        // Check default
+        XCTAssertEqual(snapshotWindow.window.overrideUserInterfaceStyle, UIUserInterfaceStyleUnspecified);
+        XCTAssertEqual(passcodeWindow.window.overrideUserInterfaceStyle, UIUserInterfaceStyleUnspecified);
+
+        // Set it directly
+        [SFSDKWindowManager sharedManager].userInterfaceStyle = UIUserInterfaceStyleDark;
+        XCTAssertEqual(snapshotWindow.window.overrideUserInterfaceStyle, UIUserInterfaceStyleDark);
+        XCTAssertEqual(passcodeWindow.window.overrideUserInterfaceStyle, UIUserInterfaceStyleDark);
+    }
 }
 
 - (void)testActive {

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Model/Actions.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Model/Actions.swift
@@ -57,6 +57,9 @@ enum ActionType {
     case logout
     case switchUser
     case exportCredentials
+    case overrideStyleLight
+    case overrideStyleDark
+    case overrideStyleUnspecified
 }
 
 struct Action {

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/ActionsTableViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/ActionsTableViewController.swift
@@ -66,8 +66,11 @@ class ActionTableViewController: UIViewController {
         let logout = Action(type: ActionType.logout, method: "logout", objectTypes: nil)
         let switchUser = Action(type: ActionType.switchUser, method: "switch user", objectTypes: nil)
         let exportCredentials = Action(type: ActionType.exportCredentials, method: "Export Credentials to pasteboard", objectTypes: nil)
+        let overrideStyleLight = Action(type: ActionType.overrideStyleLight, method: "Override user interface style: light", objectTypes: nil)
+        let overrideStyleDark = Action(type: ActionType.overrideStyleDark, method: "Override user interface style: dark", objectTypes: nil)
+        let overrideStyleUnspecified = Action(type: ActionType.overrideStyleUnspecified, method: "Override user interface style: unspecified", objectTypes: nil)
         
-        self.actions = [versions, resources, describeGlobal, metadata, describe, retrieve, create, upsert, update, delete, query, search, searchScope, searchResultLayout, ownedFiles, filesInUserGroups, filesShared, fileDetails, batchFileDetails, fileShares, addFileShare, deleteFileShare, currentUserInfo, enableBiometric, logout, switchUser, exportCredentials]
+        self.actions = [versions, resources, describeGlobal, metadata, describe, retrieve, create, upsert, update, delete, query, search, searchScope, searchResultLayout, ownedFiles, filesInUserGroups, filesShared, fileDetails, batchFileDetails, fileShares, addFileShare, deleteFileShare, currentUserInfo, enableBiometric, logout, switchUser, exportCredentials, overrideStyleLight, overrideStyleDark, overrideStyleUnspecified]
         
         super.init(nibName: nil, bundle: nil)
         

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/RootViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/RootViewController.swift
@@ -875,16 +875,19 @@ extension RootViewController: ActionTableViewDelegate {
             self.exportTestingCredentials()
             return
         case .overrideStyleLight:
+            // TODO: Remove this check in Mobile SDK 9.0
             if #available(iOS 13, *) {
                 SFSDKWindowManager.shared().userInterfaceStyle = .light
             }
             return
         case .overrideStyleDark:
+            // TODO: Remove this check in Mobile SDK 9.0
             if #available(iOS 13, *) {
                 SFSDKWindowManager.shared().userInterfaceStyle = .dark
             }
             return
         case .overrideStyleUnspecified:
+            // TODO: Remove this check in Mobile SDK 9.0
             if #available(iOS 13, *) {
                 SFSDKWindowManager.shared().userInterfaceStyle = .unspecified
             }

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/RootViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/RootViewController.swift
@@ -874,7 +874,21 @@ extension RootViewController: ActionTableViewDelegate {
         case .exportCredentials:
             self.exportTestingCredentials()
             return
-            
+        case .overrideStyleLight:
+            if #available(iOS 13, *) {
+                SFSDKWindowManager.shared().userInterfaceStyle = .light
+            }
+            return
+        case .overrideStyleDark:
+            if #available(iOS 13, *) {
+                SFSDKWindowManager.shared().userInterfaceStyle = .dark
+            }
+            return
+        case .overrideStyleUnspecified:
+            if #available(iOS 13, *) {
+                SFSDKWindowManager.shared().userInterfaceStyle = .unspecified
+            }
+            return
         }
         
         if let sendRequest = request {


### PR DESCRIPTION
This is a layer on top of Apple's "UIUserInterfaceStyle" plist setting-- if the plist entry exists and the UIWindow's override property is set to dark/light, the window property takes precedence