### PR TITLE
SFSmartStore deprecations

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFAlterSoupLongOperation.m
+++ b/libs/SmartStore/SmartStore/Classes/SFAlterSoupLongOperation.m
@@ -208,8 +208,10 @@
         }
         
         // Removing row from soup index map table
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         NSString *sql = [NSString stringWithFormat:@"DELETE FROM %@ WHERE %@=\"%@\"",
                          SOUP_INDEX_MAP_TABLE, SOUP_NAME_COL, self.soupName];
+        SFSDK_USE_DEPRECATED_END
         [self executeUpdate:db sql:sql context:@"dropOldIndexes"];
         
         // Update row in alter status table
@@ -296,7 +298,9 @@
         // Fts
         if ([SFSoupIndex hasFts:self.indexSpecs]) {
             NSMutableArray* oldColumnsFts = [NSMutableArray arrayWithObjects:ID_COL, nil];
+            SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
             NSMutableArray* newColumnsFts = [NSMutableArray arrayWithObjects:ROWID_COL, nil];
+            SFSDK_USE_DEPRECATED_END
 
             // Adding indexed path columns that we are keeping
             for (NSString* keptPath in keptPaths) {
@@ -457,12 +461,14 @@
 {
     NSNumber* now = [self.store currentTimeInMilliseconds];
     NSMutableDictionary* values = [NSMutableDictionary dictionary];
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     values[TYPE_COL] = @"AlterSoup";
     values[DETAILS_COL] = [SFJsonUtils JSONRepresentation:[self getDetails]];
     values[STATUS_COL] = @(SFAlterSoupStepStarting);
     values[CREATED_COL] = now;
     values[LAST_MODIFIED_COL] = now;
     [self.store insertIntoTable:LONG_OPERATIONS_STATUS_TABLE values:values withDb:db];
+    SFSDK_USE_DEPRECATED_END
     return [db lastInsertRowId];
 }
 
@@ -490,6 +496,7 @@
 - (void) updateLongOperationDbRow:(SFAlterSoupStep)newStatus withDb:(FMDatabase*)db
 {
     if (newStatus == kLastStep) {
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         NSString *sql = [NSString stringWithFormat:@"DELETE FROM %@ WHERE %@ = %lld",
                                LONG_OPERATIONS_STATUS_TABLE, ID_COL, self.rowId];
         [self.store executeUpdateThrows:sql withDb:db];
@@ -500,6 +507,7 @@
         values[STATUS_COL] = [NSNumber numberWithUnsignedInteger:newStatus];
         values[LAST_MODIFIED_COL] = now;
         [self.store updateTable:LONG_OPERATIONS_STATUS_TABLE values:values entryId:@(self.rowId) idCol:ID_COL withDb:db];
+        SFSDK_USE_DEPRECATED_END
     }
 }
 

--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
@@ -320,6 +320,7 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
                 return [@[@"WHERE ", field, @" >= ? AND ", field, @" <= ? "] componentsJoinedByString:@""];
 
         case kSFSoupQueryTypeMatch:
+            SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
             return [@[@"WHERE ",
                       [self computeFieldReference:SOUP_ENTRY_ID],
                       @" IN ",
@@ -334,6 +335,7 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
                       @"') "
                       ]
                     componentsJoinedByString:@""];
+            SFSDK_USE_DEPRECATED_END
 
         default: break;
     }

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -23,6 +23,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -83,37 +84,37 @@ extern NSString *const SOUP_COL NS_SWIFT_NAME(SmartStore.soupColumn);
 /**
  The columns of a soup fts table
  */
-extern NSString *const ROWID_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
+extern NSString *const ROWID_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /**
  Soup index map table
  */
-extern NSString *const SOUP_INDEX_MAP_TABLE NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
+extern NSString *const SOUP_INDEX_MAP_TABLE NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /**
  Soup attributes table
  */
-extern NSString *const SOUP_ATTRS_TABLE NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
+extern NSString *const SOUP_ATTRS_TABLE NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /**
  Table to keep track of status of long operations in flight
 */
-extern NSString *const LONG_OPERATIONS_STATUS_TABLE NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
+extern NSString *const LONG_OPERATIONS_STATUS_TABLE NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /*
  Columns of the soup index map table
  */
-extern NSString *const SOUP_NAME_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
-extern NSString *const PATH_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
-extern NSString *const COLUMN_NAME_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
-extern NSString *const COLUMN_TYPE_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
+extern NSString *const SOUP_NAME_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
+extern NSString *const PATH_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
+extern NSString *const COLUMN_NAME_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
+extern NSString *const COLUMN_TYPE_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /*
  Columns of the long operations status table
  */
-extern NSString *const TYPE_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
-extern NSString *const DETAILS_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
-extern NSString *const STATUS_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
+extern NSString *const TYPE_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
+extern NSString *const DETAILS_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
+extern NSString *const STATUS_COL NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /*
  JSON fields added to soup element on insert/update
@@ -124,9 +125,9 @@ extern NSString *const SOUP_LAST_MODIFIED_DATE NS_SWIFT_NAME(SmartStore.lastModi
 /*
  Support for explain query plan
  */
-extern NSString *const EXPLAIN_SQL NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
-extern NSString *const EXPLAIN_ARGS NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
-extern NSString *const EXPLAIN_ROWS NS_SWIFT_UNAVAILABLE("Internal to SmartStore");
+extern NSString *const EXPLAIN_SQL NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
+extern NSString *const EXPLAIN_ARGS NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
+extern NSString *const EXPLAIN_ROWS NS_SWIFT_UNAVAILABLE("Internal to SmartStore") SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 @class FMDatabaseQueue;
 @class SFQuerySpec;

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -174,9 +174,12 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         @synchronized ([SFSmartStore class]) {
             if ([SFUserAccountManager sharedInstance].currentUser != nil && !_storeUpgradeHasRun) {
                 _storeUpgradeHasRun = YES;
+                // TODO: Remove in Mobile SDK 9.0
+                SFSDK_USE_DEPRECATED_BEGIN
                 [SFSmartStoreUpgrade updateStoreLocations];
                 [SFSmartStoreUpgrade updateEncryption];
                 [SFSmartStoreUpgrade updateEncryptionSalt];
+                SFSDK_USE_DEPRECATED_END
             }
         }
         _storeName = name;
@@ -287,7 +290,10 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         [self.dbMgr removeStoreDir:self.storeName];
     }
     if (self.user != nil) {
+        // TODO: Remove in Mobile SDK 9.0
+        SFSDK_USE_DEPRECATED_BEGIN
         [SFSmartStoreUpgrade setUsesKeyStoreEncryption:result forUser:self.user store:self.storeName];
+        SFSDK_USE_DEPRECATED_END
     }
     return result;
 }
@@ -416,7 +422,10 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
             [existingStore.storeQueue close];
             [_allSharedStores[userKey] removeObjectForKey:storeName];
         }
+        // TODO: Remove in Mobile SDK 9.0
+        SFSDK_USE_DEPRECATED_BEGIN
         [SFSmartStoreUpgrade setUsesKeyStoreEncryption:NO forUser:user store:storeName];
+        SFSDK_USE_DEPRECATED_END
         [[SFSmartStoreDatabaseManager sharedManagerForUser:user] removeStoreDir:storeName];
     }
 }

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -174,8 +174,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         @synchronized ([SFSmartStore class]) {
             if ([SFUserAccountManager sharedInstance].currentUser != nil && !_storeUpgradeHasRun) {
                 _storeUpgradeHasRun = YES;
-                // TODO: Remove in Mobile SDK 9.0
-                SFSDK_USE_DEPRECATED_BEGIN
+                SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
                 [SFSmartStoreUpgrade updateStoreLocations];
                 [SFSmartStoreUpgrade updateEncryption];
                 [SFSmartStoreUpgrade updateEncryptionSalt];
@@ -290,8 +289,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         [self.dbMgr removeStoreDir:self.storeName];
     }
     if (self.user != nil) {
-        // TODO: Remove in Mobile SDK 9.0
-        SFSDK_USE_DEPRECATED_BEGIN
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         [SFSmartStoreUpgrade setUsesKeyStoreEncryption:result forUser:self.user store:self.storeName];
         SFSDK_USE_DEPRECATED_END
     }
@@ -422,8 +420,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
             [existingStore.storeQueue close];
             [_allSharedStores[userKey] removeObjectForKey:storeName];
         }
-        // TODO: Remove in Mobile SDK 9.0
-        SFSDK_USE_DEPRECATED_BEGIN
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         [SFSmartStoreUpgrade setUsesKeyStoreEncryption:NO forUser:user store:storeName];
         SFSDK_USE_DEPRECATED_END
         [[SFSmartStoreDatabaseManager sharedManagerForUser:user] removeStoreDir:storeName];
@@ -501,6 +498,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     return !error;
 }
 
+SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
 - (void)createMetaTablesWithDb:(FMDatabase*) db {
     // Create SOUP_INDEX_MAP_TABLE
     NSString *createSoupIndexTableSql = [NSString stringWithFormat:
@@ -533,6 +531,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     [self createLongOperationsStatusTableWithDb:db];
     [self executeUpdateThrows:createSoupNamesIndexSql withDb:db];
 }
+
 
 - (void)registerNewSoupAttribute:(NSString *)attrColName
 {
@@ -591,6 +590,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     [SFSDKSmartStoreLogger d:[self class] format:@"createLongOperationsStatusTableSql: %@", createLongOperationsStatusTableSql];
     [self executeUpdateThrows:createLongOperationsStatusTableSql withDb:db];
 }
+SFSDK_USE_DEPRECATED_END
 
 #pragma mark - Long operations recovery methods
 
@@ -619,12 +619,14 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     // TODO assuming all long operations are alter soup operations
     //      revisit when we introduced another type of long operation
     
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     FMResultSet* frs = [self queryTable:LONG_OPERATIONS_STATUS_TABLE forColumns:@[ID_COL, DETAILS_COL, STATUS_COL] orderBy:nil limit:nil whereClause:nil whereArgs:nil withDb:db];
     
     while([frs next]) {
         long rowId = [frs longForColumn:ID_COL];
         NSDictionary *details = [SFJsonUtils objectFromJSONString:[frs stringForColumn:DETAILS_COL]];
         SFAlterSoupStep status = (SFAlterSoupStep)[frs intForColumn:STATUS_COL];
+        SFSDK_USE_DEPRECATED_END
         SFAlterSoupLongOperation *longOperation = [[SFAlterSoupLongOperation alloc] initWithStore:self rowId:rowId details:details status:status];
         [longOperations addObject:longOperation];
     }
@@ -646,6 +648,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     if (self.captureExplainQueryPlan) {
         NSString* explainSql = [NSString stringWithFormat:@"EXPLAIN QUERY PLAN %@", sql];
         NSMutableDictionary* lastPlan = [NSMutableDictionary new];
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         lastPlan[EXPLAIN_SQL] = explainSql;
         if (arguments.count > 0) lastPlan[EXPLAIN_ARGS] = arguments;
         NSMutableArray* explainRows = [NSMutableArray new];
@@ -660,6 +663,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         }
         [frs close];
         lastPlan[EXPLAIN_ROWS] = explainRows;
+        SFSDK_USE_DEPRECATED_END
         self.lastExplainQueryPlan = lastPlan;
     }
     
@@ -745,7 +749,9 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
 - (NSArray*) allSoupNamesWithDb:(FMDatabase*) db
 {
     NSMutableArray* soupNames = [NSMutableArray array];
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     FMResultSet* frs = [self executeQueryThrows:[NSString stringWithFormat:@"SELECT %@ FROM %@", SOUP_NAME_COL, SOUP_ATTRS_TABLE] withDb:db];
+    SFSDK_USE_DEPRECATED_END
     while ([frs next]) {
         [soupNames addObject:[frs stringForColumnIndex:0]];
     }
@@ -1165,11 +1171,13 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         return result;
     }
     
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     NSString *querySql = [NSString stringWithFormat:@"SELECT %@ FROM %@ WHERE %@ = ? AND %@ = ?",
                           COLUMN_NAME_COL,SOUP_INDEX_MAP_TABLE,
                           SOUP_NAME_COL,
                           PATH_COL
                           ];
+    SFSDK_USE_DEPRECATED_END
     FMResultSet *frs = [self executeQueryThrows:querySql withArgumentsInArray:@[soupName, path] withDb:db];
     if ([frs next]) {
         result = [frs stringForColumnIndex:0];
@@ -1250,7 +1258,9 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     NSString *soupTableName = [_soupNameToTableName objectForKey:soupName];
     
     if (nil == soupTableName) {
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         NSString *sql = [NSString stringWithFormat:@"SELECT %@ FROM %@ WHERE %@ = ?",ID_COL,SOUP_ATTRS_TABLE,SOUP_NAME_COL];
+        SFSDK_USE_DEPRECATED_END
         FMResultSet *frs = [self executeQueryThrows:sql withArgumentsInArray:@[soupName] withDb:db];
         if ([frs next]) {
             int colIdx = [frs columnIndexForName:ID_COL];
@@ -1278,10 +1288,12 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
 
 - (NSArray *)tableNamesForAllSoupsWithDb:(FMDatabase*) db{
     NSMutableArray* result = [NSMutableArray array]; // equivalent to: [[[NSMutableArray alloc] init] autorelease]
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     NSString* sql = [NSString stringWithFormat:@"SELECT %@ FROM %@", SOUP_NAME_COL, SOUP_ATTRS_TABLE];
     FMResultSet *frs = [self executeQueryThrows:sql withDb:db];
     while ([frs next]) {
         NSString* tableName = [frs stringForColumn:SOUP_NAME_COL];
+        SFSDK_USE_DEPRECATED_END
         [result addObject:tableName];
     }
     
@@ -1302,7 +1314,9 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     SFSoupSpec *attrs = [_attrSpecBySoup objectForKey:soupName];
     if (nil == attrs) {
         //no cached attributes ...reload from SOUP_ATTRS_TABLE
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         NSString *attrsSql = [NSString stringWithFormat:@"SELECT * FROM %@ WHERE %@ = ?", SOUP_ATTRS_TABLE, SOUP_NAME_COL];
+        SFSDK_USE_DEPRECATED_END
         [SFSDKSmartStoreLogger d:[self class] format:@"attrs sql: %@", attrsSql];
         FMResultSet *frs = [self executeQueryThrows:attrsSql withArgumentsInArray:@[soupName] withDb:db];
         if ([frs next]) {
@@ -1339,7 +1353,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     NSMutableArray *result = [_indexSpecsBySoup objectForKey:soupName];
     if (nil == result) {
         result = [NSMutableArray array];
-        
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         //no cached indices ...reload from SOUP_INDEX_MAP_TABLE
         NSString *querySql = [NSString stringWithFormat:@"SELECT %@,%@,%@ FROM %@ WHERE %@ = ?",
                               PATH_COL, COLUMN_NAME_COL, COLUMN_TYPE_COL,
@@ -1354,6 +1368,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
             SFSoupIndex *spec = [[SFSoupIndex alloc] initWithPath:path indexType:type columnName:columnName];
             [result addObject:spec];
         }
+        SFSDK_USE_DEPRECATED_END
         [frs close];
         
         // update the cache
@@ -1387,6 +1402,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
 
 
 - (void)insertIntoSoupIndexMap:(NSArray*)soupIndexMapInserts withDb:(FMDatabase*)db {
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     // update the mapping table for this soup's columns
     for (NSDictionary *map in soupIndexMapInserts) {
         [self insertIntoTable:SOUP_INDEX_MAP_TABLE values:map withDb:db];
@@ -1401,7 +1417,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         }
     }
     [self insertIntoTable:SOUP_ATTRS_TABLE values:soupMapValues withDb:db];
-
+    SFSDK_USE_DEPRECATED_END
     // Get a safe table name for the soupName
     NSString *soupTableName = [self tableNameBySoupId:[db lastInsertRowId]];
     if (nil == soupTableName) {
@@ -1423,7 +1439,9 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     }
     
     NSNumber *soupId = [self soupIdFromTableName:soupTableName];
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     [self updateTable:SOUP_ATTRS_TABLE values:featuresMapValues entryId:soupId idCol:ID_COL withDb:db];
+    SFSDK_USE_DEPRECATED_END
 }
 
 - (BOOL)registerSoup:(NSString*)soupName withIndexSpecs:(NSArray*)indexSpecs {
@@ -1528,11 +1546,13 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         }
         
         // for inserting into meta mapping table
-        NSMutableDictionary *values = [[NSMutableDictionary alloc] init ];
+        NSMutableDictionary *values = [[NSMutableDictionary alloc] init];
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         values[SOUP_NAME_COL] = soupSpec.soupName;
         values[PATH_COL] = indexSpec.path;
         values[COLUMN_NAME_COL] = columnName;
         values[COLUMN_TYPE_COL] = indexSpec.indexType;
+        SFSDK_USE_DEPRECATED_END
         [soupIndexMapInserts addObject:values];
         
         // for creating an index on the soup table
@@ -1612,11 +1632,13 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         [self executeUpdateThrows:dropFtsSql withDb:db];
     }
     
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     NSString *deleteIndexSql = [NSString stringWithFormat:@"DELETE FROM %@ WHERE %@=\"%@\"",
                                 SOUP_INDEX_MAP_TABLE, SOUP_NAME_COL, soupName];
     [self executeUpdateThrows:deleteIndexSql withDb:db];
     NSString *deleteNameSql = [NSString stringWithFormat:@"DELETE FROM %@ WHERE %@=\"%@\"",
                                SOUP_ATTRS_TABLE, SOUP_NAME_COL, soupName];
+    SFSDK_USE_DEPRECATED_END
     [self executeUpdateThrows:deleteNameSql withDb:db];
     
     // Cleanup caches
@@ -2096,9 +2118,11 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
 
     // fts
     if ([SFSoupIndex hasFts:indices]) {
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         NSMutableDictionary *ftsValues = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                           newEntryId, ROWID_COL,
                                           nil];
+        SFSDK_USE_DEPRECATED_END
         [self projectIndexedPaths:entry values:ftsValues indices:indices typeFilter:kValueExtractedToFtsColumn];
         [self insertIntoTable:[NSString stringWithFormat:@"%@_fts", soupTableName] values:ftsValues withDb:db];
     }
@@ -2155,7 +2179,9 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     if ([SFSoupIndex hasFts:indices]) {
         NSMutableDictionary *ftsValues = [NSMutableDictionary new];
         [self projectIndexedPaths:entry values:ftsValues indices:indices typeFilter:kValueExtractedToFtsColumn];
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         [self updateTable:[NSString stringWithFormat:@"%@_fts", soupTableName] values:ftsValues entryId:entryId idCol:ROWID_COL withDb:db];
+        SFSDK_USE_DEPRECATED_END
     }
     
     return mutableEntry;
@@ -2300,8 +2326,10 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
 
         // fts
         if ([self hasFts:soupName withDb:db]) {
+            SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
             NSString *deleteFtsSql = [NSString stringWithFormat:@"DELETE FROM %@_fts WHERE %@", soupTableName, [self idsInPredicate:soupEntryIds idCol:ROWID_COL]];
             [self executeUpdateThrows:deleteFtsSql withDb:db];
+            SFSDK_USE_DEPRECATED_END
         }
 
         SFSoupSpec *soupSpec = [self attributesForSoup:soupName withDb:db];
@@ -2349,7 +2377,9 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     [self executeUpdateThrows:deleteSql withArgumentsInArray:args withDb:db];
     // fts
     if ([self hasFts:soupName withDb:db]) {
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         NSString *deleteFtsSql = [NSString stringWithFormat:@"DELETE FROM %@_fts WHERE %@ in (%@)", soupTableName, ROWID_COL, querySql];
+        SFSDK_USE_DEPRECATED_END
         [self executeUpdateThrows:deleteFtsSql withDb:db];
     }
 
@@ -2531,7 +2561,9 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
                     NSMutableDictionary *ftsValues = [NSMutableDictionary dictionary];
                     [self projectIndexedPaths:entry values:ftsValues indices:indices typeFilter:kValueExtractedToFtsColumn];
                     if ([ftsValues count] > 0) {
+                        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
                         [self updateTable:[NSString stringWithFormat:@"%@_fts", soupTableName] values:ftsValues entryId:entryId idCol:ROWID_COL withDb:db];
+                        SFSDK_USE_DEPRECATED_END
                     }
                 }
             }
@@ -2588,11 +2620,13 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     [self inDatabase:^(FMDatabase *db) {
         if ([db tableExists:SOUP_NAMES_TABLE]) {
             // Renames SOUP_NAMES_TABLE to SOUP_ATTRS_TABLE
+            SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
             NSString *renameSoupNamesTableSql = [NSString stringWithFormat:
                                                  @"ALTER TABLE %@ RENAME TO %@",
                                                  SOUP_NAMES_TABLE,
                                                  SOUP_ATTRS_TABLE
                                                  ];
+            SFSDK_USE_DEPRECATED_END
             [SFSDKSmartStoreLogger d:[self class] format:@"renameSoupNamesTableSql: %@", renameSoupNamesTableSql];
             [self executeUpdateThrows:renameSoupNamesTableSql withDb:db];
         }

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreInspectorViewController.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreInspectorViewController.m
@@ -257,7 +257,9 @@ static NSString * const kInspectorPickerDefault = @"default";
         [self showAlert:[SFSDKResourceUtils localizedString:kInspectorNoSoupsFoundKey] title:errorAlertTitle];
     }
     if ([names count] > 100) {
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         self.queryField.text = [NSString stringWithFormat:@"select %@ from %@", SOUP_NAME_COL, SOUP_ATTRS_TABLE];
+        SFSDK_USE_DEPRECATED_END
     } else {
         NSMutableString* q = [NSMutableString string];
         BOOL first = YES;
@@ -274,7 +276,9 @@ static NSString * const kInspectorPickerDefault = @"default";
 
 - (void) indicesButtonClicked
 {
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     self.queryField.text = [NSString stringWithFormat:@"select %@,%@,%@ from %@", SOUP_NAME_COL, PATH_COL, COLUMN_TYPE_COL, SOUP_INDEX_MAP_TABLE];
+    SFSDK_USE_DEPRECATED_END
     [self runQuery];
 }
 

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.h
@@ -24,12 +24,14 @@
 
 #import <Foundation/Foundation.h>
 #import <SalesforceSDKCore/SFUserAccount.h>
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  Used internally for upgrading SmartStore.
  */
+SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.")
 @interface SFSmartStoreUpgrade : NSObject
 
 /**

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.m
@@ -42,7 +42,10 @@ static NSString * const kLegacyDefaultEncryptionTypeKey = @"com.salesforce.smart
 static NSString * const kKeyStoreEncryptedStoresKey = @"com.salesforce.smartstore.keyStoreEncryptedStores";
 static NSString * const kKeyStoreHasExternalSalt = @"com.salesforce.smartstore.external.hasExternalSalt";
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFSmartStoreUpgrade
+#pragma clang diagnostic pop
 
 + (void)updateStoreLocations
 {


### PR DESCRIPTION
- Deprecate old upgrade steps for removal
- Deprecate NS_SWIFT_UNAVAILABLE constants that are for internal