### PR TITLE
SFUserAccountManager deprecations

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFUserAccountManager+URLHandlers.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFUserAccountManager+URLHandlers.m
@@ -53,7 +53,9 @@
     }];
    
     dispatch_async(dispatch_get_main_queue(), ^{
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         self.alertDisplayBlock(messageObject,[SFSDKWindowManager sharedManager].authWindow);
+        SFSDK_USE_DEPRECATED_BEGIN
         [self stopCurrentAuthentication:nil];
     });
     return YES;
@@ -147,7 +149,9 @@
          }];
         
          dispatch_async(dispatch_get_main_queue(), ^{
+             SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
              self.alertDisplayBlock(messageObject,[SFSDKWindowManager sharedManager].authWindow);
+             SFSDK_USE_DEPRECATED_END
          });
     }
     return YES;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFDefaultUserAccountPersister.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFDefaultUserAccountPersister.h
@@ -23,12 +23,15 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "SalesforceSDKConstants.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol SFUserAccountPersister;
 
+SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
 @interface SFDefaultUserAccountPersister:NSObject<SFUserAccountPersister>
+SFSDK_USE_DEPRECATED_END
 
 /** Loads a user account from a specified file
  @param filePath The file to load the user account from

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFDefaultUserAccountPersister.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFDefaultUserAccountPersister.m
@@ -52,6 +52,9 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
 
 @implementation SFDefaultUserAccountPersister
 
+// TODO: Remove in Mobile SDK 9.0
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (BOOL)saveAccountForUser:(SFUserAccount *)userAccount error:(NSError **)error {
     BOOL success = NO;
     NSString *userAccountPlist = [SFDefaultUserAccountPersister userAccountPlistFileForUser:userAccount];
@@ -156,6 +159,7 @@ static const NSUInteger SFUserAccountManagerCannotWriteUserData = 10004;
     }
     return success;
 }
+#pragma clang diagnostic pop
 
 - (BOOL)saveUserAccount:(SFUserAccount *)userAccount toFile:(NSString *)filePath error:(NSError**)error {
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager+Internal.h
@@ -59,7 +59,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** instance of accountPersister
  *
  */
+SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
 @property (nonatomic, strong, nullable) id<SFUserAccountPersister> accountPersister;
+SFSDK_USE_DEPRECATED_END
 
 /** instance of authPreferences
  *
@@ -122,7 +124,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** Get the Account Persister being used.
  * @return SFUserAccountPersister that is used.
  */
+SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
 - (nullable id<SFUserAccountPersister>)accountPersister;
+SFSDK_USE_DEPRECATED_END
 
 /**
  * @param userIdentity to use for encoding to String

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -31,6 +31,7 @@
 #import "SFSDKLoginViewControllerConfig.h"
 #import "SFSDKAppLockViewConfig.h"
 #import "SFSecurityLockout.h"
+#import "SalesforceSDKConstants.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -215,6 +216,7 @@ NS_SWIFT_NAME(UserAccountManagerDelegate)
 @end
 
 NS_SWIFT_NAME(UserAccountPersister)
+SFSDK_DEPRECATED(8.3, 9.0, "Will be removed and managed internally.")
 @protocol SFUserAccountPersister <NSObject>
 
 /**
@@ -223,13 +225,13 @@ NS_SWIFT_NAME(UserAccountPersister)
  @param  error On output, the error if the return value is NO
  @return YES if the account was saved properly, NO in case of error
  */
-- (BOOL)saveAccountForUser:(SFUserAccount *)userAccount error:(NSError **) error NS_SWIFT_UNAVAILABLE("");
+- (BOOL)saveAccountForUser:(SFUserAccount *)userAccount error:(NSError **) error NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /** Fetches all the accounts.
   @param error On output, the error if the return value is NO
   @return NSDictionary with SFUserAccountIdentity as keys and SFUserAccount as values
   */
-- (NSDictionary<SFUserAccountIdentity *,SFUserAccount *> *)fetchAllAccounts:(NSError **)error NS_SWIFT_UNAVAILABLE("");
+- (NSDictionary<SFUserAccountIdentity *,SFUserAccount *> *)fetchAllAccounts:(NSError **)error NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Allows you to remove the given user account.
@@ -239,7 +241,7 @@ NS_SWIFT_NAME(UserAccountPersister)
  @return YES if the deletion was successful, NO otherwise.  Note: If no persisted account matching
  the user parameter is found, no action will be taken, and deletion will be reported as successful.
  */
-- (BOOL)deleteAccountForUser:(SFUserAccount *)user error:(NSError **)error NS_SWIFT_UNAVAILABLE("");
+- (BOOL)deleteAccountForUser:(SFUserAccount *)user error:(NSError **)error NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 @end
 
@@ -453,7 +455,7 @@ NS_SWIFT_NAME(UserAccountManager)
  This will post user update notification.
  @param credentials The credentials to apply
  */
-- (SFUserAccount *)applyCredentials:(SFOAuthCredentials*)credentials NS_SWIFT_UNAVAILABLE("");
+- (SFUserAccount *)applyCredentials:(SFOAuthCredentials*)credentials NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /** Invoke this method to apply the specified credentials to the
  a user whose credentials match. If no user exists, a new one is created. Fire notifications.
@@ -461,7 +463,7 @@ NS_SWIFT_NAME(UserAccountManager)
  @param credentials The credentials to apply
  @param identityData The identityData to apply
  */
-- (SFUserAccount *)applyCredentials:(SFOAuthCredentials*)credentials withIdData:(nullable SFIdentityData *) identityData NS_SWIFT_UNAVAILABLE("");
+- (SFUserAccount *)applyCredentials:(SFOAuthCredentials*)credentials withIdData:(nullable SFIdentityData *) identityData NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /** Invoke this method to apply the specified credentials to the
  a user whose credentials match. If no user exists, a new one is created.
@@ -470,7 +472,7 @@ NS_SWIFT_NAME(UserAccountManager)
  @param identityData The identityData to apply
  @param shouldSendNotification whether to post notifications.
  */
-- (SFUserAccount *)applyCredentials:(SFOAuthCredentials*)credentials withIdData:(nullable SFIdentityData *) identityData andNotification:(BOOL) shouldSendNotification NS_SWIFT_UNAVAILABLE("");
+- (SFUserAccount *)applyCredentials:(SFOAuthCredentials*)credentials withIdData:(nullable SFIdentityData *) identityData andNotification:(BOOL) shouldSendNotification NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 
 /** Invoke this method to apply the specified id data to the
@@ -478,21 +480,21 @@ NS_SWIFT_NAME(UserAccountManager)
   @param idData The ID data to apply
   @param userAccount The SFUserAccount to apply this change to.
  */
-- (void)applyIdData:(SFIdentityData *)idData forUser:(SFUserAccount *)userAccount NS_SWIFT_NAME(apply(identityData:to:)) NS_SWIFT_UNAVAILABLE("");
+- (void)applyIdData:(SFIdentityData *)idData forUser:(SFUserAccount *)userAccount NS_SWIFT_NAME(apply(identityData:to:)) NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /** This method will selectively update the custom attributes identity data for the  user.
  Other identity data will not be impacted.
  @param customAttributes The new custom attributes data to update in the identity data.
  @param user The SFUserAccount to apply this change to.
  */
-- (void)applyIdDataCustomAttributes:(NSDictionary *)customAttributes forUser:(SFUserAccount *)user NS_SWIFT_UNAVAILABLE("");
+- (void)applyIdDataCustomAttributes:(NSDictionary *)customAttributes forUser:(SFUserAccount *)user NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /** This method will selectively update the custom permissions identity data for the  user.
  Other identity data will not be impacted.
  @param customPermissions The new custom permissions data to update in the identity data.
  @param user The SFUserAccount to apply this change to.
  */
-- (void)applyIdDataCustomPermissions:(NSDictionary *)customPermissions forUser:(SFUserAccount *)user NS_SWIFT_UNAVAILABLE("");
+- (void)applyIdDataCustomPermissions:(NSDictionary *)customPermissions forUser:(SFUserAccount *)user NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /** Apply custom data to the SFUserAccount that can be
  accessed outside that user's sandbox. This data will be persisted
@@ -520,7 +522,7 @@ NS_SWIFT_NAME(UserAccountManager)
  @param user  The user
  @param change The type of change (enum type). Use SFUserAccountDataChange.
  */
-- (void)userChanged:(SFUserAccount *)user change:(SFUserAccountDataChange)change  NS_SWIFT_UNAVAILABLE("");
+- (void)userChanged:(SFUserAccount *)user change:(SFUserAccountDataChange)change NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Kick off the login process for credentials that's previously configured.
@@ -595,7 +597,7 @@ Use this method to stop/clear any authentication which is has already been start
  @options Dictionary of name-value pairs received from open URL
  @return YES if this is a valid URL response from IDP authentication that should be handled, NO otherwise.
  */
-- (BOOL)handleIDPAuthenticationResponse:(NSURL *)url options:(nonnull NSDictionary *)options  NS_SWIFT_NAME(handleIdentityProviderResponse(from:with:));
+- (BOOL)handleIDPAuthenticationResponse:(NSURL *)url options:(nonnull NSDictionary *)options NS_SWIFT_NAME(handleIdentityProviderResponse(from:with:));
 
 /**
  Set this block to handle presentation of the Authentication View Controller.
@@ -605,19 +607,19 @@ Use this method to stop/clear any authentication which is has already been start
 /**
  Change this block to handle all alerts  required by the SFUserAccountManager.
  */
-@property (nonatomic, copy, nonnull) void (^alertDisplayBlock)(SFSDKAlertMessage *,SFSDKWindowContainer *) NS_SWIFT_UNAVAILABLE("");
+@property (nonatomic, copy, nonnull) void (^alertDisplayBlock)(SFSDKAlertMessage *,SFSDKWindowContainer *) NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Change this block to customize behavior for user initiated auth cancellation
  */
-@property (nonatomic, copy, nonnull) void (^authCancelledByUserHandlerBlock)(void) NS_SWIFT_UNAVAILABLE("");
+@property (nonatomic, copy, nonnull) void (^authCancelledByUserHandlerBlock)(void) NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Determines whether an error is due to invalid auth credentials.
  @param error The error to check against an invalid credentials error.
  @return YES if the error is due to invalid credentials, NO otherwise.
  */
-+ (BOOL)errorIsInvalidAuthCredentials:(NSError *)error NS_SWIFT_UNAVAILABLE("");
++ (BOOL)errorIsInvalidAuthCredentials:(NSError *)error NS_SWIFT_UNAVAILABLE("") SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Presents the setup screen that allows the user to opt into Touch/Face Id as a replacement for Passcode.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -167,11 +167,13 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         _authPreferences = [SFSDKAuthPreferences  new];
         _errorManager = [[SFSDKAuthErrorManager alloc] init];
         __weak typeof (self) weakSelf = self;
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         self.alertDisplayBlock = ^(SFSDKAlertMessage * message, SFSDKWindowContainer *window) {
             __strong typeof (weakSelf) strongSelf = weakSelf;
             strongSelf.alertView = [[SFSDKAlertView alloc] initWithMessage:message window:window];
             [strongSelf.alertView presentViewController:NO completion:nil];
         };
+        SFSDK_USE_DEPRECATED_END
         _authClient = ^(void){
             static  id<SFSDKOAuthProtocol> authClient = nil;
             static dispatch_once_t authClientPred;
@@ -367,7 +369,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
                 credentials.additionalOAuthFields = response.additionalOAuthFields;
             SFUserAccount *userAccount = [strongSelf accountForCredentials:credentials];
             if (!userAccount) {
-                 userAccount = [self applyCredentials:credentials];
+                SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
+                userAccount = [self applyCredentials:credentials];
+                SFSDK_USE_DEPRECATED_END
             }
             [self retrieveUserPhotoIfNeeded:userAccount];
             NSDictionary *userInfo = @{kSFNotificationUserInfoAccountKey: userAccount,
@@ -687,7 +691,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
        builder.actionOneCompletion = completion;
    }];
     dispatch_async(dispatch_get_main_queue(), ^{
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         self.alertDisplayBlock(messageObject, [SFSDKWindowManager sharedManager].authWindow);
+        SFSDK_USE_DEPRECATED_END
    });
     
 }
@@ -706,7 +712,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         };
     }];
     dispatch_async(dispatch_get_main_queue(), ^{
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         self.alertDisplayBlock(messageObject, [SFSDKWindowManager sharedManager].authWindow);
+        SFSDK_USE_DEPRECATED_END
     });
 }
 // IDP related code fetched as an identity provider app
@@ -754,6 +762,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
                                kSFNotificationUserInfoAuthTypeKey: authInfo };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserCancelledAuth
                                                        object:self userInfo:userInfo];
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     if (!self.authCancelledByUserHandlerBlock) {
            SFSDKLoginHostListViewController *hostListViewController = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
            hostListViewController.delegate = self;
@@ -766,6 +775,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     } else {
         self.authCancelledByUserHandlerBlock();
     }
+    SFSDK_USE_DEPRECATED_END
 }
 
 #pragma mark - SFIdentityCoordinatorDelegate
@@ -793,7 +803,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             };
         }];
         dispatch_async(dispatch_get_main_queue(), ^{
-           self.alertDisplayBlock(message, [SFSDKWindowManager sharedManager].authWindow);
+            SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
+            self.alertDisplayBlock(message, [SFSDKWindowManager sharedManager].authWindow);
+            SFSDK_USE_DEPRECATED_END
         });
     }
 }
@@ -947,7 +959,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     return _userAccountMap;
 }
 
+SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
 - (void)setAccountPersister:(id<SFUserAccountPersister>) persister {
+SFSDK_USE_DEPRECATED_END
     if(persister != _accountPersister) {
         [_accountsLock lock];
         _accountPersister = persister;
@@ -1091,7 +1105,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     [_accountsLock lock];
 
     NSError *internalError = nil;
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     NSDictionary<SFUserAccountIdentity *,SFUserAccount *> *accounts = [self.accountPersister fetchAllAccounts:&internalError];
+    SFSDK_USE_DEPRECATED_END
     
     if (_userAccountMap)
         [_userAccountMap removeAllObjects];
@@ -1191,7 +1207,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     if ([self.userAccountMap objectForKey:userAccount.accountIdentity]!=nil)
         [self.userAccountMap removeObjectForKey:userAccount.accountIdentity];
 
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     success = [self.accountPersister saveAccountForUser:userAccount error:error];
+    SFSDK_USE_DEPRECATED_END
     if (success) {
         [self.userAccountMap setObject:userAccount forKey:userAccount.accountIdentity];
         if (self.userAccountMap.count>1 && oldCount<self.userAccountMap.count ) {
@@ -1206,7 +1224,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 - (BOOL)deleteAccountForUser:(SFUserAccount *)user error:(NSError **)error {
     BOOL success = NO;
     [_accountsLock lock];
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     success = [self.accountPersister deleteAccountForUser:user error:error];
+    SFSDK_USE_DEPRECATED_END
 
     if (success) {
         user.userDeleted = YES;
@@ -1539,7 +1559,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         };
     }];
     dispatch_async(dispatch_get_main_queue(), ^{
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         weakSelf.alertDisplayBlock(message, SFSDKWindowManager.sharedManager.authWindow);
+        SFSDK_USE_DEPRECATED_END
     });
 }
 
@@ -1557,7 +1579,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         };
     }];
     dispatch_async(dispatch_get_main_queue(), ^{
-         weakSelf.alertDisplayBlock(message, SFSDKWindowManager.sharedManager.authWindow);
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
+        weakSelf.alertDisplayBlock(message, SFSDKWindowManager.sharedManager.authWindow);
+        SFSDK_USE_DEPRECATED_END
     });
 }
 
@@ -1636,10 +1660,11 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 }
 
 - (void)finalizeAuthCompletion:(SFSDKAuthSession *)authSession {
-
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     // Apply the credentials that will ensure there is a user and that this
     // current user as the proper credentials.
     SFUserAccount *userAccount = [self applyCredentials:authSession.oauthCoordinator.credentials withIdData:authSession.identityCoordinator.idData];
+    SFSDK_USE_DEPRECATED_END
     BOOL loginStateTransitionSucceeded = [userAccount transitionToLoginState:SFUserAccountLoginStateLoggedIn];
     if (!loginStateTransitionSucceeded) {
 


### PR DESCRIPTION
Deprecating anything on SFUserAccountManager that's already NS_SWIFT_UNAVAILABLE to be internal and hiding warnings from internal usage