### PR TITLE
Passcode deprecations

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -27,7 +27,7 @@
 
 @end
 
-@interface SalesforceSDKManager () <SalesforceSDKManagerFlow, SFSecurityLockoutDelegate>
+@interface SalesforceSDKManager () <SalesforceSDKManagerFlow>
 {
     BOOL _isLaunching;
     UIViewController* _snapshotViewController;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewConfig.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewConfig.h
@@ -29,6 +29,7 @@
 
 #import <Foundation/Foundation.h>
 #import "SFSDKViewControllerConfig.h"
+#import "SalesforceSDKConstants.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -46,7 +47,7 @@ NS_SWIFT_NAME(AppLockViewControllerConfig)
  *           but users will be unable to unlock the app if their pin is longer than the specified
  *           length.
  */
-@property (nonatomic) BOOL forcePasscodeLength;
+@property (nonatomic) BOOL forcePasscodeLength SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  * The number of allowed passcode entry attempts before the user is logged out.
@@ -121,7 +122,7 @@ NS_SWIFT_NAME(AppLockViewControllerConfig)
 /**
  * Length of the user's passcode.
  */
-@property (nonatomic) NSUInteger passcodeLength;
+@property (nonatomic) NSUInteger passcodeLength SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewConfig.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewConfig.m
@@ -54,7 +54,9 @@
         _buttonFont = [UIFont systemFontOfSize:14 weight:UIFontWeightBold];
         _touchIdImage = [SFSDKResourceUtils imageNamed:@"touchId"];
         _faceIdImage = [SFSDKResourceUtils imageNamed:@"faceId"];
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         _passcodeLength = [SFSecurityLockout passcodeLength];
+        SFSDK_USE_DEPRECATED_END
     }
     return self;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewController.h
@@ -32,7 +32,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_SWIFT_NAME(AppLockViewController)
+NS_SWIFT_NAME(AppLockViewController) SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.")
 @interface SFSDKAppLockViewController : SFSDKNavigationController
 
 - (instancetype)initWithMode:(SFAppLockControllerMode)mode andViewConfig:(SFSDKAppLockViewConfig *)config;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewController.m
@@ -36,6 +36,7 @@
 #import "SFSDKWindowManager.h"
 #import "SFSecurityLockout.h"
 #import "SFSDKViewUtils.h"
+#import "SFSecurityLockout+Internal.h"
 
 @interface SFSDKAppLockViewController () <SFSDKPasscodeCreateDelegate,SFSDKBiometricViewDelegate,SFSDKPasscodeVerifyDelegate>
 
@@ -46,7 +47,10 @@
 
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFSDKAppLockViewController
+#pragma clang diagnostic pop
 
 - (instancetype)initWithMode:(SFAppLockControllerMode)mode andViewConfig:(SFSDKAppLockViewConfig *)config
 {
@@ -88,6 +92,7 @@
 
 - (void)passcodeCreated:(NSString *)passcode updateMode:(BOOL)isUpdateMode
 {
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     [[SFPasscodeManager sharedManager] changePasscode:passcode];
     [SFSecurityLockout setUpgradePasscodeLength:[passcode length]];
     if ([SFSecurityLockout biometricState] == SFBiometricUnlockAvailable) {
@@ -97,6 +102,7 @@
         [self.navigationController popViewControllerAnimated:NO];
         [SFSecurityLockout unlock:action];
     }
+   SFSDK_USE_DEPRECATED_END
 }
 
 #pragma mark - SFSDKPasscodeVerifyDelegate
@@ -107,14 +113,18 @@
         [self promptBiometricEnrollment];
     } else {
         [self.navigationController popViewControllerAnimated:NO];
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         [SFSecurityLockout unlock:SFSecurityLockoutActionPasscodeVerified];
+        SFSDK_USE_DEPRECATED_END
     }
 }
 
 - (void)passcodeFailed
 {
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     [[SFPasscodeManager sharedManager] resetPasscode];
     [SFSecurityLockout wipeState];
+    SFSDK_USE_DEPRECATED_END
 }
 
 #pragma mark - SFSDKBiometricViewDelegate
@@ -123,9 +133,11 @@
 {
     [SFSecurityLockout userAllowedBiometricUnlock:YES];
     
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     if ([SFSecurityLockout locked]) {
         [self.navigationController popViewControllerAnimated:NO];
         [SFSecurityLockout unlock:SFSecurityLockoutActionBiometricVerified];
+        SFSDK_USE_DEPRECATED_END
     } else {
         [self dismissStandaloneBiometricSetup];
     }
@@ -141,9 +153,11 @@
     } else {
         [SFSecurityLockout userAllowedBiometricUnlock:NO];
        
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         if ([SFSecurityLockout locked]) {
             [self.navigationController popViewControllerAnimated:NO];
             [SFSecurityLockout unlock:SFSecurityLockoutActionPasscodeCreated];
+            SFSDK_USE_DEPRECATED_END
         } else {
             [self dismissStandaloneBiometricSetup];
         }
@@ -152,7 +166,9 @@
 
 - (void)dismissStandaloneBiometricSetup
 {
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     [SFSecurityLockout setupTimer];
+    SFSDK_USE_DEPRECATED_END
     [[[SFSDKWindowManager sharedManager] passcodeWindow].viewController dismissViewControllerAnimated:NO completion:^{
         [[SFSDKWindowManager sharedManager].passcodeWindow dismissWindowAnimated:NO withCompletion:^{}];
     }];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeCreateController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeCreateController.m
@@ -100,7 +100,9 @@ static CGFloat      const kSFViewBorderWidth                   = 0.5f;
     self.passcodeTextView.layer.borderWidth = kSFViewBorderWidth;
     self.passcodeTextView.accessibilityIdentifier = @"passcodeTextField";
     self.passcodeTextView.accessibilityLabel = [SFSDKResourceUtils localizedString:@"accessibilityPasscodeFieldLabel"];
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     self.passcodeTextView.accessibilityHint = [[NSString alloc] initWithFormat:[SFSDKResourceUtils localizedString:@"accessibilityPasscodeLengthHint"], self.viewConfig.passcodeLength];
+    SFSDK_USE_DEPRECATED_END
     self.passcodeTextView.secureTextEntry = YES;
     self.passcodeTextView.isAccessibilityElement = YES;
     [self.passcodeTextView clearPasscode];
@@ -200,11 +202,13 @@ static CGFloat      const kSFViewBorderWidth                   = 0.5f;
         return NO;
     }
     
-   if (self.passcodeTextView.passcodeInput.length < self.viewConfig.passcodeLength) {
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
+    if (self.passcodeTextView.passcodeInput.length < self.viewConfig.passcodeLength) {
         [self.passcodeTextView.passcodeInput appendString:rString];
     }
     
     if ([self.passcodeTextView.passcodeInput length] == self.viewConfig.passcodeLength) {
+    SFSDK_USE_DEPRECATED_END
         if (self.firstPasscodeValidated) {
             if ([self.passcodeTextView.passcodeInput isEqualToString:self.initialPasscode] ) {
                 if ([self.passcodeTextView isFirstResponder]) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeTextField.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeTextField.m
@@ -58,8 +58,10 @@ static CGFloat      const kPasscodeCircleDiameter            = 22.f;
 {
     if (self = [super initWithFrame:frame]) {
         _subLayerRefs = [[NSMutableArray alloc] init];
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         _passcodeLength = config.passcodeLength;
         _passcodeLengthKnown = (config.passcodeLength != 0);
+        SFSDK_USE_DEPRECATED_END
         _viewConfig = config;
         self.keyboardType = UIKeyboardTypeNumberPad;
         self.backgroundColor = config.secondaryBackgroundColor;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeVerifyController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKPasscodeVerifyController.m
@@ -98,7 +98,9 @@ NSUInteger const kSFMaxNumberofAttempts = 10;
         if (self.remainingAttempts == 0) {
             [self resetReaminingAttemps];
         }
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         self.passcodeLengthKnown = (self.viewConfig.passcodeLength != 0);
+        SFSDK_USE_DEPRECATED_END
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(layoutVerifyButton:) name:UIKeyboardDidShowNotification object:nil];
     }
     return self;
@@ -122,7 +124,9 @@ NSUInteger const kSFMaxNumberofAttempts = 10;
     self.passcodeTextView.secureTextEntry = YES;
     self.passcodeTextView.isAccessibilityElement = YES;
     if (self.passcodeLengthKnown) {
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         self.passcodeTextView.accessibilityHint = [NSString stringWithFormat:[SFSDKResourceUtils localizedString:@"accessibilityPasscodeLengthHint"], self.viewConfig.passcodeLength];
+        SFSDK_USE_DEPRECATED_END
     }
     [self.passcodeTextView clearPasscode];
     [self.view addSubview:self.passcodeTextView];
@@ -228,7 +232,9 @@ NSUInteger const kSFMaxNumberofAttempts = 10;
 #pragma mark - UITextFieldDelegate
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)rString
 {
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     NSUInteger length = (self.passcodeLengthKnown) ? self.viewConfig.passcodeLength : kSFMaxPasscodeLength;
+    SFSDK_USE_DEPRECATED_END
     
     // This fixes deleting if VoiceOver is on.
     if (UIAccessibilityIsVoiceOverRunning() && [rString isEqualToString:@""]) {
@@ -283,6 +289,7 @@ NSUInteger const kSFMaxNumberofAttempts = 10;
 
 - (void)verifyPasscode
 {
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     if ([[SFPasscodeManager sharedManager] verifyPasscode:self.passcodeTextView.passcodeInput]) {
         if ([self.passcodeTextView isFirstResponder]) {
             [self.passcodeTextView resignFirstResponder];
@@ -292,6 +299,7 @@ NSUInteger const kSFMaxNumberofAttempts = 10;
         // This can happen when upgrading to new UX that requires actual length.
         if ([SFSecurityLockout passcodeLength] == 0) {
             [SFSecurityLockout setUpgradePasscodeLength:[self.passcodeTextView.passcodeInput length]];
+            SFSDK_USE_DEPRECATED_END
         }
         [self validatePasscodeConfirmed:self.passcodeTextView.passcodeInput];
     } else {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager+Internal.h
@@ -27,7 +27,7 @@
 #import "SFGeneratedKeyStore.h"
 #import "SFPasscodeKeyStore.h"
 
-@interface SFKeyStoreManager () <SFPasscodeManagerDelegate>
+@interface SFKeyStoreManager ()
 
 @property (nonatomic, strong) SFGeneratedKeyStore *generatedKeyStore;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFKeyStoreManager.m
@@ -55,7 +55,9 @@ static NSString * const kKeyStoreDecryptionFailedMessage = @"Could not decrypt k
     self = [super init];
     if (self) {
         [self initializeKeyStores];
+        SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
         [[SFPasscodeManager sharedManager] addObserver:self forKeyPath:@"encryptionKey" options:(NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew) context:NULL];
+        SFSDK_USE_DEPRECATED_END
     }
     return self;
 }
@@ -214,7 +216,7 @@ SFSDK_USE_DEPRECATED_END
     // Starting in SDK 6.0, we no longer use SFPasscodeKeyStore.
     // The only reason we are still watching the encryption key of the passcode manager is to handle upgrade from pre-6.0 SDK to 6+.
     // As soon as we get the passcode, we migrate all the keys from the passcode key store to the generated key store.
-    
+    SFSDK_USE_DEPRECATED_BEGIN
     if (!(object == [SFPasscodeManager sharedManager] && [keyPath isEqualToString:@"encryptionKey"])) {
         return;
     }
@@ -227,7 +229,6 @@ SFSDK_USE_DEPRECATED_END
 
         if ([oldKey length] == 0 && [newKey length] > 0) {
             // We just got the passcode, migrate keys (if any)
-            SFSDK_USE_DEPRECATED_BEGIN
             SFPasscodeKeyStore *passcodeKeyStore = [[SFPasscodeKeyStore alloc] init];
             passcodeKeyStore.keyStoreKey.encryptionKey.key = [[self class] keyStringToData:newKey];
             if (passcodeKeyStore.keyStoreKey != nil && passcodeKeyStore.keyStoreDictionary.count > 0) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPBKDF2PasscodeProvider.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPBKDF2PasscodeProvider.h
@@ -24,13 +24,14 @@
 
 #import <Foundation/Foundation.h>
 #import "SFPasscodeProviderManager.h"
+#import "SalesforceSDKConstants.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Contains configuration values for generating an encryption key.
  */
-
+SFSDK_DEPRECATED(8.3, 9.0, "Will be removed and passcode will be managed internally.")
 @interface SFPBKDF2PasscodeProvider : NSObject <SFPasscodeProvider>
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPBKDF2PasscodeProvider.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPBKDF2PasscodeProvider.m
@@ -40,7 +40,11 @@ static NSString * const kPBKDFArchiveDataKey = @"pbkdfDataArchive";
 
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFPBKDF2PasscodeProvider
+#pragma clang diagnostic pop
+
 @synthesize passcodeLength;
 @synthesize saltLengthInBytes = _saltLengthInBytes;
 @synthesize numDerivationRounds = _numDerivationRounds;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeKeyStore.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeKeyStore.m
@@ -27,6 +27,7 @@
 #import "SFPasscodeManager.h"
 #import "SFKeyStoreManager+Internal.h"
 #import "SFKeychainItemWrapper.h"
+#import "SFSecurityLockout.h"
 
 // Keychain and NSCoding constants
 static NSString * const kPasscodeKeyStoreKeychainIdentifier = @"com.salesforce.keystore.passcodeKeystoreKeychainId";
@@ -74,7 +75,7 @@ NSString * const kPasscodeKeyLabelSuffix = @"Passcode";
 
 - (BOOL)keyStoreEnabled
 {
-    return [[SFPasscodeManager sharedManager] passcodeIsSet];
+    return [SFSecurityLockout isPasscodeSet];
 }
 
 - (SFKeyStoreKey *)keyStoreKey

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeManager+Internal.h
@@ -24,6 +24,7 @@
 
 #import "SFPasscodeManager.h"
 
+SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.")
 @interface SFPasscodeManager ()
 
 @property (nonatomic, strong, nonnull) NSHashTable<id<SFPasscodeManagerDelegate>> *delegates;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeManager.h
@@ -23,6 +23,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "SalesforceSDKConstants.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,26 +32,27 @@ NS_ASSUME_NONNULL_BEGIN
  populated with old passcode stored with `SFPasscodeResetOldPasscodeKey` key and new passcode
  stored with `SFPasscodeResetNewPasscodeKey` key.
  */
-extern NSString *const SFPasscodeResetNotification;
+extern NSString *const SFPasscodeResetNotification SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /** Key in userInfo published by `SFPasscodeResetNotification`.
  
  The value of this key is the old hashed passcode before the passcode reset
  */
-extern NSString *const SFPasscodeResetOldPasscodeKey;
+extern NSString *const SFPasscodeResetOldPasscodeKey SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 
 /** Key in userInfo published by `SFPasscodeResetNotification`.
  
  The value of this key is the new hashed passcode that triggers the new passcode reset
  */
-extern NSString *const SFPasscodeResetNewPasscodeKey;
+extern NSString *const SFPasscodeResetNewPasscodeKey SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 @class SFPasscodeManager;
 
 /**
  Delegate protocol for SFPasscodeManager callbacks
  */
+SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.")
 @protocol SFPasscodeManagerDelegate <NSObject>
 
 @optional
@@ -68,63 +70,64 @@ extern NSString *const SFPasscodeResetNewPasscodeKey;
 /**
  Class for managing storage, retrieval, and verification of passcodes.
  */
+SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.")
 @interface SFPasscodeManager : NSObject
 
 /**
  @return The shared instance of the passcode manager.
  */
-+ (SFPasscodeManager *)sharedManager;
++ (SFPasscodeManager *)sharedManager SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  The encryption key associated with the app.
  */
-@property (nonatomic, readonly, nullable) NSString *encryptionKey;
+@property (nonatomic, readonly, nullable) NSString *encryptionKey SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  The preferred passcode provider for the app.  If another provider was previously configured,
  the passcode manager will automatically update to the preferred provider at the next passcode
  update or verification.
  */
-@property (nonatomic, copy) NSString *preferredPasscodeProvider;
+@property (nonatomic, copy) NSString *preferredPasscodeProvider SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  The lenght of the user's passcode.
  */
-@property (nonatomic) NSUInteger passcodeLength;
+@property (nonatomic) NSUInteger passcodeLength SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Whether the device has the capability to use biometric unlock.
  */
-@property (nonatomic) BOOL deviceHasBiometric;
+@property (nonatomic) BOOL deviceHasBiometric SFSDK_DEPRECATED(8.3, 9.0, "Use deviceHasBiometric on SFSecurityLockout instead");
 
 /**
  Adds a delegate to the list of passcode manager delegates.
  @param delegate Delegate to add to the list.
  */
-- (void)addDelegate:(id<SFPasscodeManagerDelegate>)delegate;
+- (void)addDelegate:(id<SFPasscodeManagerDelegate>)delegate SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Removes a delegate from the delegate list.  No action is taken if the delegate does not exist.
  @param delegate Delegate to be removed.
  */
-- (void)removeDelegate:(id<SFPasscodeManagerDelegate>)delegate;
+- (void)removeDelegate:(id<SFPasscodeManagerDelegate>)delegate SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  @return Whether or not a passcode has been set.
  */
-- (BOOL)passcodeIsSet;
+- (BOOL)passcodeIsSet SFSDK_DEPRECATED(8.3, 9.0, "Use isPasscodeSet on SFSecurityLockout instead.");
 
 /**
  Reset the passcode in the keychain.
  */
-- (void)resetPasscode;
+- (void)resetPasscode SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /**
  Verify the passcode.
  @param passcode The passcode to verify.
  @return YES if the passcode verifies, NO otherwise.
  */
-- (BOOL)verifyPasscode:(NSString *)passcode;
+- (BOOL)verifyPasscode:(NSString *)passcode SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /**
  Change the current passcode.  This method serves as an entry point for managing the change
@@ -133,13 +136,13 @@ extern NSString *const SFPasscodeResetNewPasscodeKey;
  @param newPasscode The new passcode to change to.  If nil or empty, this method will unset the
  existing passcode.
  */
-- (void)changePasscode:(nullable NSString *)newPasscode;
+- (void)changePasscode:(nullable NSString *)newPasscode SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /**
  Set the passcode.
  @param newPasscode The passcode to set.
  */
-- (void)setPasscode:(NSString *)newPasscode;
+- (void)setPasscode:(NSString *)newPasscode SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeManager.m
@@ -24,10 +24,13 @@
 
 #import "SFPasscodeManager+Internal.h"
 #import "SFPasscodeProviderManager.h"
-#import <LocalAuthentication/LocalAuthentication.h>
 #import "SFKeychainItemWrapper.h"
+#import "SFSecurityLockout+Internal.h"
+#import "SFSecurityLockout.h"
 
+SFSDK_USE_DEPRECATED_BEGIN
 static SFPasscodeManager *sharedInstance = nil;
+SFSDK_USE_DEPRECATED_END
 
 //
 // Public constants
@@ -43,7 +46,10 @@ NSString *const SFPasscodeResetOldPasscodeKey = @"SFPasscodeResetOldPasswordKey"
 // Key in userInfo published by `SFPasscodeResetNotification` to store the new hashed passcode that triggers the new passcode reset
 NSString *const SFPasscodeResetNewPasscodeKey = @"SFPasscodeResetNewPasswordKey";
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFPasscodeManager
+#pragma clang diagnostic pop
 
 @synthesize encryptionKey = _encryptionKey;
 @synthesize preferredPasscodeProvider = _preferredPasscodeProvider;
@@ -111,7 +117,7 @@ NSString *const SFPasscodeResetNewPasscodeKey = @"SFPasscodeResetNewPasswordKey"
 }
 
 #pragma mark - Passcode management
-
+SFSDK_USE_DEPRECATED_BEGIN
 - (void)setEncryptionKeyForPasscode:(NSString *)passcode
 {
     id<SFPasscodeProvider> currentProvider = [SFPasscodeProviderManager currentPasscodeProvider];
@@ -167,6 +173,7 @@ NSString *const SFPasscodeResetNewPasscodeKey = @"SFPasscodeResetNewPasswordKey"
         return [currentProvider verifyPasscode:passcode];
     }
 }
+SFSDK_USE_DEPRECATED_END
 
 - (void)changePasscode:(NSString *)newPasscode
 {
@@ -220,7 +227,6 @@ NSString *const SFPasscodeResetNewPasscodeKey = @"SFPasscodeResetNewPasswordKey"
         [SFPasscodeProviderManager setCurrentPasscodeProviderByName:preferredProvider.providerName];
         currentProvider = [SFPasscodeProviderManager currentPasscodeProvider];
     }
-    
     [currentProvider setVerificationPasscode:newPasscode];
     NSString *encryptionKey = [currentProvider generateEncryptionKey:newPasscode];
     [self setEncryptionKey:encryptionKey];
@@ -232,15 +238,8 @@ NSString *const SFPasscodeResetNewPasscodeKey = @"SFPasscodeResetNewPasswordKey"
     return self.passcodeLength;
 }
 
-- (BOOL)deviceHasBiometric
-{
-    LAContext *context = [[LAContext alloc] init];
-    NSError *biometricError;
-    BOOL deviceHasBiometric = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&biometricError];
-    if (!deviceHasBiometric) {
-        [SFSDKCoreLogger d:[self class] format:@"Device cannot use Touch Id or Face Id.  Error: %@", biometricError];
-    }
-    return deviceHasBiometric;
+- (BOOL)deviceHasBiometric {
+    return [SFSecurityLockout deviceHasBiometric];
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeProviderManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeProviderManager.h
@@ -23,6 +23,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "SalesforceSDKConstants.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -35,16 +36,17 @@ typedef NSString * SFPasscodeProviderId NS_EXTENSIBLE_STRING_ENUM;
 /**
  * String representing the provider name for the SHA-256 passcode provider.
  */
-FOUNDATION_EXTERN SFPasscodeProviderId const kSFPasscodeProviderSHA256;
+FOUNDATION_EXTERN SFPasscodeProviderId const kSFPasscodeProviderSHA256 SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  * String representing the provider name for the PBKDF2 passcode provider.
  */
-FOUNDATION_EXTERN SFPasscodeProviderId const kSFPasscodeProviderPBKDF2;
+FOUNDATION_EXTERN SFPasscodeProviderId const kSFPasscodeProviderPBKDF2 SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  * Protocol that a passcode provider class must implement.
  */
+SFSDK_DEPRECATED(8.3, 9.0, "Will be removed and passcode will be managed internally.")
 @protocol SFPasscodeProvider <NSObject>
 
 /**
@@ -103,6 +105,7 @@ FOUNDATION_EXTERN SFPasscodeProviderId const kSFPasscodeProviderPBKDF2;
 /**
  * Class for managing passcode providers.
  */
+SFSDK_DEPRECATED(8.3, 9.0, "Will be removed and passcode will be managed internally.")
 @interface SFPasscodeProviderManager : NSObject
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeProviderManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFPasscodeProviderManager.m
@@ -37,7 +37,10 @@ static NSString * const kSFCurrentPasscodeProviderUserDefaultsKey = @"com.salesf
 
 static NSMutableDictionary *PasscodeProviderMap;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFPasscodeProviderManager
+#pragma clang diagnostic pop
 
 + (void)initialize
 {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
@@ -23,6 +23,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "SalesforceSDKConstants.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -63,7 +64,16 @@ extern NSUInteger const kSFPBKDFDefaultSaltByteLength;
  * @param stringToHash Plain-text string used to generate the key.
  * @return `SFPBKDFData` object representing the derived key.
  */
-+ (SFPBKDFData *)createPBKDF2DerivedKey:(NSString *)stringToHash;
++ (SFPBKDFData *)createPBKDF2DerivedKey:(NSString *)stringToHash SFSDK_DEPRECATED(8.3, 9.0, "Use pbkdf2DerivedKey: instead.");
+
+/**
+ * Creates a PBKDF2 derived key from an input key string. Uses default values for the
+ * random-generated salt data and its length, the number of derivation rounds, and the
+ * derived key length.
+ * @param stringToHash Plain-text string used to generate the key.
+ * @return The derived key.
+ */
++ (nullable NSData *)pbkdf2DerivedKey:(NSString *)stringToHash;
 
 /**
  * Creates a PBKDF2-derived key from an input key string, a salt, number of derivation
@@ -77,7 +87,21 @@ extern NSUInteger const kSFPBKDFDefaultSaltByteLength;
 + (nullable SFPBKDFData *)createPBKDF2DerivedKey:(NSString *)stringToHash
                                    salt:(NSData *)salt
                        derivationRounds:(NSUInteger)numDerivationRounds
-                              keyLength:(NSUInteger)derivedKeyLength;
+                              keyLength:(NSUInteger)derivedKeyLength SFSDK_DEPRECATED(8.3, 9.0, "Use pbkdf2DerivedKey:salt:derivationRounds:keyLength: instead.");
+
+/**
+ * Creates a PBKDF2-derived key from an input key string, a salt, number of derivation
+ * rounds, and the given derived key length.
+ * @param stringToHash Base string to use for the derived key.
+ * @param salt Salt to append to the string.
+ * @param numDerivationRounds Number of derivation rounds used to generate the key.
+ * @param derivedKeyLength Requested derived key length.
+ * @return The derived key.
+ */
++ (nullable NSData *)pbkdf2DerivedKey:(NSString *)stringToHash
+                                 salt:(NSData *)salt
+                     derivationRounds:(NSUInteger)numDerivationRounds
+                            keyLength:(NSUInteger)derivedKeyLength;
 
 /**
  * Encrypt the given data using the AES-128 algorithm.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
@@ -124,11 +124,31 @@ static NSString * const kSFECPrivateKeyTagPrefix = @"com.salesforce.eckey.privat
                                           keyLength:kSFPBKDFDefaultDerivedKeyByteLength];
 }
 
++ (nullable NSData *)pbkdf2DerivedKey:(NSString *)stringToHash {
+    NSData *salt = [SFSDKCryptoUtils randomByteDataWithLength:kSFPBKDFDefaultSaltByteLength];
+    return [SFSDKCryptoUtils pbkdf2DerivedKey:stringToHash
+                                         salt:salt
+                             derivationRounds:kSFPBKDFDefaultNumberOfDerivationRounds
+                                    keyLength:kSFPBKDFDefaultDerivedKeyByteLength];
+}
+
 + (SFPBKDFData *)createPBKDF2DerivedKey:(NSString *)stringToHash
                                    salt:(NSData *)salt
                        derivationRounds:(NSUInteger)numDerivationRounds
                               keyLength:(NSUInteger)derivedKeyLength
 {
+    NSData *keyData = [SFSDKCryptoUtils pbkdf2DerivedKey:stringToHash salt:salt derivationRounds:numDerivationRounds keyLength:derivedKeyLength];
+    if (keyData) {
+        return [[SFPBKDFData alloc] initWithKey:keyData salt:salt derivationRounds:numDerivationRounds derivedKeyLength:derivedKeyLength];
+    } else {
+        return nil;
+    }
+}
+
++ (nullable NSData *)pbkdf2DerivedKey:(NSString *)stringToHash
+                                 salt:(NSData *)salt
+                     derivationRounds:(NSUInteger)numDerivationRounds
+                            keyLength:(NSUInteger)derivedKeyLength {
     NSData *stringToHashAsData = [stringToHash dataUsingEncoding:NSUTF8StringEncoding];
     unsigned char key[derivedKeyLength];
     int result = CCKeyDerivationPBKDF(kCCPBKDF2, [stringToHashAsData bytes], [stringToHashAsData length], [salt bytes], [salt length], kCCPRFHmacAlgSHA256, (uint)numDerivationRounds, key, derivedKeyLength);
@@ -137,9 +157,7 @@ static NSString * const kSFECPrivateKeyTagPrefix = @"com.salesforce.eckey.privat
         // Error
         return nil;
     } else {
-        NSData *keyData = [NSData dataWithBytes:key length:derivedKeyLength];
-        SFPBKDFData *returnPBKDFData = [[SFPBKDFData alloc] initWithKey:keyData salt:salt derivationRounds:numDerivationRounds derivedKeyLength:derivedKeyLength];
-        return returnPBKDFData;
+        return [NSData dataWithBytes:key length:derivedKeyLength];
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSHA256PasscodeProvider.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSHA256PasscodeProvider.h
@@ -24,12 +24,14 @@
 
 #import <Foundation/Foundation.h>
 #import "SFPasscodeProviderManager.h"
+#import "SalesforceSDKConstants.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Passcode provider for passcodes hashed with the SHA-256 algorithm.
  */
+SFSDK_DEPRECATED(8.3, 9.0, "Will be removed and passcode will be managed internally.")
 @interface SFSHA256PasscodeProvider : NSObject <SFPasscodeProvider>
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSHA256PasscodeProvider.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSHA256PasscodeProvider.m
@@ -31,7 +31,11 @@
 static NSString * const kKeychainIdentifierPasscode = @"com.salesforce.security.passcode";
 static NSString * const kKeychainIdentifierPasscodeLength = @"com.salesforce.security.passcodeLength";
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFSHA256PasscodeProvider
+#pragma clang diagnostic pop
+
 @synthesize passcodeLength;
 @synthesize providerName = _providerName;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout+Internal.h
@@ -9,6 +9,7 @@ static NSString * _Nullable const kSecurityIsLockedLegacyKey = @"security.islock
 static NSString * const kBiometricUnlockAllowedKey           = @"security.biometric.allowed"; // Enabled in the Org
 static NSString * const kBiometricStateKey                   = @"secuirty.biometric.state";
 
+SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.")
 @interface SFSecurityLockout ()
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.h
@@ -26,6 +26,7 @@
 #import <UIKit/UIKit.h>
 
 #import "SFAppLockViewControllerTypes.h"
+#import "SalesforceSDKConstants.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -94,7 +95,7 @@ typedef NS_ENUM(NSUInteger, SFBiometricUnlockState) {
      Biometric unlock is not available.
      */
     SFBiometricUnlockUnavailable
-}NS_SWIFT_NAME(BiometricUnlockState);
+} NS_SWIFT_NAME(BiometricUnlockState);
 
 @class SFSDKAppLockViewConfig;
 
@@ -119,21 +120,22 @@ typedef void (^SFLockScreenFailureCallbackBlock)(void);
 /**
  Block typedef for creating the passcode view controller.
  */
-typedef UIViewController* _Nullable  (^SFPasscodeViewControllerCreationBlock)(SFAppLockControllerMode mode,SFSDKAppLockViewConfig *viewConfig);
+typedef UIViewController* _Nullable  (^SFPasscodeViewControllerCreationBlock)(SFAppLockControllerMode mode,SFSDKAppLockViewConfig *viewConfig) SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Block typedef for displaying and dismissing the passcode view controller.
  */
-typedef void (^SFPasscodeViewControllerPresentationBlock)(UIViewController*);
+typedef void (^SFPasscodeViewControllerPresentationBlock)(UIViewController*) SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Block typedef for displaying and dismissing the passcode view controller.
  */
-typedef void (^SFPasscodeViewControllerDismissBlock)(UIViewController*,void(^_Nullable)(void));
+typedef void (^SFPasscodeViewControllerDismissBlock)(UIViewController*,void(^_Nullable)(void)) SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Delegate protocol for SFSecurityLockout events and callbacks.
  */
+SFSDK_DEPRECATED(8.3, 9.0, "Use notifications or SFLockScreenSuccessCallbackBlock and SFLockScreenFailureCallbackBlock instead")
 @protocol SFSecurityLockoutDelegate <NSObject>
 
 @optional
@@ -170,25 +172,25 @@ typedef void (^SFPasscodeViewControllerDismissBlock)(UIViewController*,void(^_Nu
  Adds a delegate to the list of SFSecurityLockout delegates.
  @param delegate The delegate to add to the list.
  */
-+ (void)addDelegate:(id<SFSecurityLockoutDelegate>)delegate;
++ (void)addDelegate:(id<SFSecurityLockoutDelegate>)delegate SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Removes a delegate from the list of SFSecurityLockout delegates.
  @param delegate The delegate to remove from the list.
  */
-+ (void)removeDelegate:(id<SFSecurityLockoutDelegate>)delegate;
++ (void)removeDelegate:(id<SFSecurityLockoutDelegate>)delegate SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Get the current lockout time, in seconds
  @return The lockout time limit.
  */
-+ (NSUInteger)lockoutTime;
++ (NSUInteger)lockoutTime SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /**
  Gets the configured passcode length.
  @return The passcode length.
  */
-+ (NSUInteger)passcodeLength;
++ (NSUInteger)passcodeLength SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /**
  The current state of biometric unlock.
@@ -212,26 +214,26 @@ typedef void (^SFPasscodeViewControllerDismissBlock)(UIViewController*,void(^_Nu
  policy.  I.e. passcode state can only be cleared if the current user is the only user who would
  be subject to that policy.
  */
-+ (void)clearPasscodeState;
++ (void)clearPasscodeState SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Resets the passcode state of the app, *if* there aren't other users with an overriding passcode
  policy.  I.e. passcode state can only be cleared if the  user is the only user who would
  be subject to that policy.
  */
-+ (void)clearPasscodeState:(SFUserAccount *)userLoggingOut;
++ (void)clearPasscodeState:(SFUserAccount *)userLoggingOut SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /** Initialize the timer
  */
-+ (void)setupTimer;
++ (void)setupTimer SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /** Unregister and invalidate the timer
  */
-+ (void)removeTimer;
++ (void)removeTimer SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /** Validate the timer upon app entering the foreground
  */
-+ (void)validateTimer;
++ (void)validateTimer SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /** Check if passcode is enabled.
  @return `YES` if passcode is enabled and required.
@@ -260,33 +262,45 @@ typedef void (^SFPasscodeViewControllerDismissBlock)(UIViewController*,void(^_Nu
 /** Unlock the device (e.g a result of a successful passcode/biometric challenge)
  @param action Action that was taken during lockout.
  */
-+ (void)unlock:(SFSecurityLockoutAction)action;
++ (void)unlock:(SFSecurityLockoutAction)action SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /** Wipe the device (e.g. because passcode/biometric challenge failed)
 */
-+ (void)wipeState;
++ (void)wipeState SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /** Toggle the locked state
  @param locked Locks the device if `YES`, otherwise unlocks the device.
  */
-+ (void)setIsLocked:(BOOL)locked;
++ (void)setIsLocked:(BOOL)locked SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /** Check if device is locked
  */
-+ (BOOL)locked;
++ (BOOL)locked SFSDK_DEPRECATED(8.3, 9.0, "Will be internal");
 
 /** Check if the passcode is valid
  */
-+ (BOOL)isPasscodeValid;
++ (BOOL)isPasscodeValid SFSDK_DEPRECATED(8.3, 9.0, "Will be internal.");
 
 /** Check to see if the passcode screen is needed.
  */
-+ (BOOL)isPasscodeNeeded;
++ (BOOL)isPasscodeNeeded SFSDK_DEPRECATED(8.3, 9.0, "Use shouldLock instead.");
+
+ /** Whether or not a passcode has been set.
+ */
++ (BOOL)isPasscodeSet;
+
+/** Whether screen should be locked or not.
+ */
++ (BOOL)shouldLock;
+
+/** Whether the device has the capability to use biometric unlock.
+ */
++ (BOOL)deviceHasBiometric;
 
 /** Show the passcode view. Used by unit tests.
  @param showPasscode If YES, passcode view can be displayed.
  */
-+ (void)setCanShowPasscode:(BOOL)showPasscode;
++ (void)setCanShowPasscode:(BOOL)showPasscode SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Sets the callback block to be called on any action that triggers screen lock, and unlocks
@@ -315,49 +329,49 @@ typedef void (^SFPasscodeViewControllerDismissBlock)(UIViewController*,void(^_Nu
 /**
  @return The block used to create the passcode view controller
  */
-+ (SFPasscodeViewControllerCreationBlock)passcodeViewControllerCreationBlock;
++ (SFPasscodeViewControllerCreationBlock)passcodeViewControllerCreationBlock SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Sets the block that will create the passcode view controller.
  @param vcBlock The passcode view controller creation block to use.
  */
-+ (void)setPasscodeViewControllerCreationBlock:(SFPasscodeViewControllerCreationBlock)vcBlock;
++ (void)setPasscodeViewControllerCreationBlock:(SFPasscodeViewControllerCreationBlock)vcBlock SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  @return The block used to present the passcode view controller.
  */
-+ (SFPasscodeViewControllerPresentationBlock)presentPasscodeViewControllerBlock;
++ (SFPasscodeViewControllerPresentationBlock)presentPasscodeViewControllerBlock SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Sets the block that will present the passcode view controller.
  @param vcBlock The block to use to present the passcode view controller.
  */
-+ (void)setPresentPasscodeViewControllerBlock:(SFPasscodeViewControllerPresentationBlock)vcBlock;
++ (void)setPresentPasscodeViewControllerBlock:(SFPasscodeViewControllerPresentationBlock)vcBlock SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Set the block that will dismiss the passcode view controller.
  @param vcBlock The block defined to dismiss the passcode view controller.
  */
-+ (void)setDismissPasscodeViewControllerBlock:(SFPasscodeViewControllerDismissBlock)vcBlock;
++ (void)setDismissPasscodeViewControllerBlock:(SFPasscodeViewControllerDismissBlock)vcBlock SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Sets a retained instance of the current passcode view controller that's displayed.
  @param vc The passcode view controller.
  */
-+ (void)setPasscodeViewController:(nullable UIViewController *)vc;
++ (void)setPasscodeViewController:(nullable UIViewController *)vc SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  Presents the biometric enrollment view controller block.
  This can be used to prompt the user to enable biometric unlock if it was denied upon inital login or upgrade.
  @param viewConfig SFSDKPasscodeViewConfig used to create the view controller.  Supply nil to use the current SFSDKPasscodeViewConfig.
  */
-+ (void)presentBiometricEnrollment:(nullable SFSDKAppLockViewConfig*)viewConfig;
++ (void)presentBiometricEnrollment:(nullable SFSDKAppLockViewConfig *)viewConfig;
 
 /**
  * Returns the currently displayed passcode view controller, or nil if the passcode view controller
  * is not currently displayed.
  */
-+ (UIViewController *)passcodeViewController;
++ (UIViewController *)passcodeViewController SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  * Whether to force the passcode screen to be displayed, despite sanity conditions for whether passcodes
@@ -365,21 +379,21 @@ typedef void (^SFPasscodeViewControllerDismissBlock)(UIViewController*,void(^_Nu
  * to its default value of NO.
  * @param forceDisplay Whether to force the passcode screen to be displayed.  Default value is NO.
  */
-+ (void)setForcePasscodeDisplay:(BOOL)forceDisplay;
++ (void)setForcePasscodeDisplay:(BOOL)forceDisplay SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  * @return Whether or not the app is configured to force the display of the passcode screen.
  */
-+ (BOOL)forcePasscodeDisplay;
++ (BOOL)forcePasscodeDisplay SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  * @return Whether or not to validate the passcode at app startup.
  */
-+ (BOOL)validatePasscodeAtStartup;
++ (BOOL)validatePasscodeAtStartup SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 /**
  * Set the response of the user being prompted to use biometric unlock.
- * @param userAllowedBiometric YES if the user accpeted, NO otherwise.
+ * @param userAllowedBiometric YES if the user accepted, NO otherwise.
  */
 + (void)userAllowedBiometricUnlock:(BOOL)userAllowedBiometric;
 
@@ -387,7 +401,7 @@ typedef void (^SFPasscodeViewControllerDismissBlock)(UIViewController*,void(^_Nu
  * Set the passcode length upon upgrade if it was not previously set.
  * @param length Length of the user's passcode.
  */
-+ (void)setUpgradePasscodeLength:(NSUInteger)length;
++ (void)setUpgradePasscodeLength:(NSUInteger)length SFSDK_DEPRECATED(8.3, 9.0, "Will be removed.");
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -539,7 +539,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     [self deleteAccountForUser:user error:nil];
     id<SFSDKOAuthProtocol> authClient = self.authClient();
     [authClient revokeRefreshToken:user.credentials];
+    SFSDK_USE_DEPRECATED_BEGIN // TODO: Remove in Mobile SDK 9.0
     [SFSecurityLockout clearPasscodeState:user];
+    SFSDK_USE_DEPRECATED_END
     BOOL isCurrentUser = [user isEqual:self.currentUser];
     if (isCurrentUser) {
         [self setCurrentUserInternal:nil];
@@ -1437,7 +1439,7 @@ SFSDK_USE_DEPRECATED_END
 }
 
 - (BOOL)deviceHasBiometric {
-    return [[SFPasscodeManager sharedManager] deviceHasBiometric];
+    return [SFSecurityLockout deviceHasBiometric];
 }
 
 - (SFBiometricUnlockState)biometricUnlockState {

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -175,7 +175,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         passcodeViewConfig.instructionTextColor = UIColor.white
         passcodeViewConfig.borderColor = UIColor.yellow
         passcodeViewConfig.maxNumberOfAttempts = 3
-        passcodeViewConfig.forcePasscodeLength = true
         UserAccountManager.shared.appLockViewControllerConfig = passcodeViewConfig
     }
 


### PR DESCRIPTION
The goals for 9.0:
- Remove old passcode based encryption key code and passcode providers and just use PBKDF2 (keeping anything we need for upgrade internal)
- Remove the ability to set custom passcode creation / presentation / dismiss blocks and then making all the methods that those would have potentially used internal
- Merge SFPasscodeManager and SFSecurityLockout because they'll be smaller and have more overlap