### PR TITLE
Update nullability indicator for attributesForSoup/specificationForSoupNamed which can return nil

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -277,7 +277,7 @@ NS_SWIFT_NAME(SmartStore)
  *  @param soupName Name of the soup.
  *  @return Specs of the soup if it exists.
  */
-- (SFSoupSpec*)attributesForSoup:(NSString*)soupName NS_SWIFT_NAME(specification(forSoupNamed:));
+- (nullable SFSoupSpec*)attributesForSoup:(NSString*)soupName NS_SWIFT_NAME(specification(forSoupNamed:));
 
 /**
  @param soupName Name of the soup.


### PR DESCRIPTION
Update nullability indicator for attributesForSoup/specificationForSoupNamed which can return nil
-  Improved swift-interoperability with this method