### PR TITLE
Adding auth providers in addition to SAML providers to list of SSO domains

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.m
@@ -27,6 +27,7 @@
 static NSString * const kAuthConfigMobileSDKKey        = @"MobileSDK";
 static NSString * const kAuthConfigUseNativeBrowserKey = @"UseiOSNativeBrowserForAuthentication";
 static NSString * const kAuthConfigSamlProvidersKey    = @"SamlProviders";
+static NSString * const kAuthConfigAuthProvidersKey    = @"AuthProviders";
 static NSString * const kAuthConfigSSOUrlKey           = @"SsoUrl";
 static NSString * const kAuthConfigLoginPageKey        = @"LoginPage";
 static NSString * const kAuthConfigLoginPageUrlKey     = @"LoginPageUrl";
@@ -55,12 +56,26 @@ static NSString * const kAuthConfigLoginPageUrlKey     = @"LoginPageUrl";
 
 - (NSArray<NSString *> *)ssoUrls {
     NSMutableArray<NSString *> *ssoUrls = [[NSMutableArray alloc] init];
+
+    // Parses SAML provider list and adds it to the list of SSO URLs.
     NSArray *samlProviders = self.authConfigDict[kAuthConfigSamlProvidersKey];
     if (samlProviders && samlProviders.count > 0) {
         for (int i = 0; i < samlProviders.count; i++) {
             NSDictionary *provider = samlProviders[i];
             if (provider) {
                 ssoUrls[i] = provider[kAuthConfigSSOUrlKey];
+            }
+        }
+    }
+    int curPos = samlProviders.count;
+
+    // Parses auth provider list and adds it to the list of SSO URLs.
+    NSArray *authProviders = self.authConfigDict[kAuthConfigAuthProvidersKey];
+    if (authProviders && authProviders.count > 0) {
+        for (int i = 0; i < authProviders.count; i++) {
+            NSDictionary *provider = authProviders[i];
+            if (provider) {
+                ssoUrls[curPos + i] = provider[kAuthConfigSSOUrlKey];
             }
         }
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthConfigUtilTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthConfigUtilTests.m
@@ -81,21 +81,7 @@ static NSString * const kSFSandboxEndpoint = @"test.salesforce.com";
         XCTAssertNotNil(authConfig, @"Auth config should not be nil");
         XCTAssertNotNil(authConfig.authConfigDict, @"Auth config dictionary should not be nil");
         XCTAssertNotNil(authConfig.ssoUrls, @"SSO URLs should not be nil");
-        XCTAssertTrue(authConfig.ssoUrls.count >= 1, @"SSO URLs should have at least 1 valid entry");
-        [expect fulfill];
-    } loginDomain:credentials.domain];
-    [self waitForExpectationsWithTimeout:20 handler:nil];
-}
-
-- (void)testGetNoSSOUrls {
-    SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:kSFTestId clientId:kSFTestClientId encrypted:YES];
-    [credentials setDomain:kSFMyDomainEndpoint];
-    XCTestExpectation *expect = [self expectationWithDescription:@"testGetNoSSOUrls"];
-    [SFSDKAuthConfigUtil getMyDomainAuthConfig:^(SFOAuthOrgAuthConfiguration *authConfig, NSError *error) {
-        XCTAssertNil(error, @"Error should be nil");
-        XCTAssertNotNil(authConfig, @"Auth config should not be nil");
-        XCTAssertNotNil(authConfig.authConfigDict, @"Auth config dictionary should not be nil");
-        XCTAssertTrue(authConfig.ssoUrls.count == 0, @"SSO URLs should be empty");
+        XCTAssertEqual(authConfig.ssoUrls.count, 3, @"SSO URLs should have 3 valid entries");
         [expect fulfill];
     } loginDomain:credentials.domain];
     [self waitForExpectationsWithTimeout:20 handler:nil];


### PR DESCRIPTION
SSO URLs can be configured as SAML providers or auth providers on the Salesforce backend. Currently, we're only fetching the list of SAML providers, but social login is configured through auth providers, such as Facebook, Google, Apple, etc. These should be a part of the SSO URLs list as well to handle all cases.