### PR TITLE
Remove ci parallelism.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
       DEVICE: << parameters.device >>
       IOS_VERSION: << parameters.ios >>
       NIGHTLY_TEST: << parameters.nightly-test >>
-    parallelism: 5
     steps:
       - checkout
       - restore_cache: 


### PR DESCRIPTION
I misunderstood what this option does and now know it is unnecessary.  