### PR TITLE
Update analytics to send to a specific SFRestAPI instance instead of the sharedInstance.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAILTNPublisher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAILTNPublisher.m
@@ -72,12 +72,12 @@ static NSString* const kRestApiSuffix = @"connect/proxy/app-analytics-logging";
     [request setHeaderValue:@"gzip" forHeaderName:@"Content-Encoding"];
     [request setHeaderValue:[NSString stringWithFormat:@"%lu", (unsigned long)[postData length]] forHeaderName:@"Content-Length"];
 
-    [restAPI sendRequest:request failureBlock:^(id  _Nullable response, NSError * _Nullable e, NSURLResponse * _Nullable rawResponse) {
+    [restAPI sendRequest:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         if (e) {
             [SFSDKCoreLogger e:[self class] format:@"Upload failed %ld %@", (long)[e code], [e localizedDescription]];
         }
         publishCompleteBlock(NO, e);
-    } successBlock:^(id  _Nullable response, NSURLResponse * _Nullable rawResponse) {
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
         publishCompleteBlock(YES, nil);
     }];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAILTNPublisher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAILTNPublisher.m
@@ -44,6 +44,10 @@ static NSString* const kRestApiSuffix = @"connect/proxy/app-analytics-logging";
 @implementation SFSDKAILTNPublisher
 
 - (void) publish:(NSArray *) events publishCompleteBlock:(PublishCompleteBlock) publishCompleteBlock {
+    [self publish:events user:[SFUserAccountManager sharedInstance].currentUser publishCompleteBlock:publishCompleteBlock];
+}
+
+- (void) publish:(NSArray *) events user:(SFUserAccount *)user publishCompleteBlock:(PublishCompleteBlock) publishCompleteBlock {
     if (!events || [events count] == 0) {
         publishCompleteBlock(NO, nil);
         return;
@@ -51,10 +55,12 @@ static NSString* const kRestApiSuffix = @"connect/proxy/app-analytics-logging";
 
     // Builds the POST body of the request.
     NSDictionary *bodyDictionary = [[self class] buildRequestBody:events];
-    [[self class] publishLogLines:bodyDictionary publishCompleteBlock:publishCompleteBlock];
+    [[self class] publishLogLines:bodyDictionary user:user publishCompleteBlock:publishCompleteBlock];
 }
 
-+ (void) publishLogLines:(NSDictionary *) bodyDictionary publishCompleteBlock:(PublishCompleteBlock) publishCompleteBlock {
++ (void) publishLogLines:(NSDictionary *) bodyDictionary user:(SFUserAccount *)user publishCompleteBlock:(PublishCompleteBlock) publishCompleteBlock {
+    SFRestAPI *restAPI = [SFRestAPI sharedInstanceWithUser:user];
+    
     NSString *path = [NSString stringWithFormat:@"/%@/%@", kSFRestDefaultAPIVersion, kRestApiSuffix];
     SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:path queryParams:nil];
 
@@ -65,12 +71,13 @@ static NSString* const kRestApiSuffix = @"connect/proxy/app-analytics-logging";
     [request setCustomRequestBodyData:postData contentType:@"application/json"];
     [request setHeaderValue:@"gzip" forHeaderName:@"Content-Encoding"];
     [request setHeaderValue:[NSString stringWithFormat:@"%lu", (unsigned long)[postData length]] forHeaderName:@"Content-Length"];
-    [[SFRestAPI sharedInstance] sendRequest:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
+
+    [restAPI sendRequest:request failureBlock:^(id  _Nullable response, NSError * _Nullable e, NSURLResponse * _Nullable rawResponse) {
         if (e) {
             [SFSDKCoreLogger e:[self class] format:@"Upload failed %ld %@", (long)[e code], [e localizedDescription]];
         }
         publishCompleteBlock(NO, e);
-    } successBlock:^(id response, NSURLResponse *rawResponse) {
+    } successBlock:^(id  _Nullable response, NSURLResponse * _Nullable rawResponse) {
         publishCompleteBlock(YES, nil);
     }];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAnalyticsPublisher.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAnalyticsPublisher.h
@@ -29,6 +29,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class SFUserAccount;
+
 @protocol SFSDKAnalyticsPublisher <NSObject>
 
 typedef void (^ _Nonnull PublishCompleteBlock)(BOOL success, NSError * _Nullable error);
@@ -40,5 +42,14 @@ typedef void (^ _Nonnull PublishCompleteBlock)(BOOL success, NSError * _Nullable
  * @param publishCompleteBlock Completion block invoked once network publish is complete.
  */
 - (void) publish:(nonnull NSArray *) events publishCompleteBlock:(nonnull PublishCompleteBlock) publishCompleteBlock;
+
+/**
+* Publishes events to a network endpoint.
+*
+* @param events Events to be published.
+* @param user SFUserAccount to use to determine where events are to be published.
+* @param publishCompleteBlock Completion block invoked once network publish is complete.
+*/
+- (void) publish:(nonnull NSArray *) events user:(nullable SFUserAccount *)user publishCompleteBlock:(nonnull PublishCompleteBlock) publishCompleteBlock;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAnalyticsPublisher.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAnalyticsPublisher.h
@@ -41,7 +41,7 @@ typedef void (^ _Nonnull PublishCompleteBlock)(BOOL success, NSError * _Nullable
  * @param events Events to be published.
  * @param publishCompleteBlock Completion block invoked once network publish is complete.
  */
-- (void) publish:(nonnull NSArray *) events publishCompleteBlock:(nonnull PublishCompleteBlock) publishCompleteBlock;
+- (void) publish:(nonnull NSArray *) events publishCompleteBlock:(nonnull PublishCompleteBlock) publishCompleteBlock SFSDK_DEPRECATED(8.3, 9.0, "Will be removed. Use new method below the requires a user parameter.");
 
 /**
 * Publishes events to a network endpoint.
@@ -50,6 +50,6 @@ typedef void (^ _Nonnull PublishCompleteBlock)(BOOL success, NSError * _Nullable
 * @param user SFUserAccount to use to determine where events are to be published.
 * @param publishCompleteBlock Completion block invoked once network publish is complete.
 */
-- (void) publish:(nonnull NSArray *) events user:(nullable SFUserAccount *)user publishCompleteBlock:(nonnull PublishCompleteBlock) publishCompleteBlock;
+- (void) publish:(nonnull NSArray *) events user:(nonnull SFUserAccount *)user publishCompleteBlock:(nonnull PublishCompleteBlock) publishCompleteBlock;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -336,7 +336,7 @@ static NSMutableDictionary *analyticsManagerList = nil;
         }
         id<SFSDKAnalyticsPublisher> networkPublisher = tpp.publisher;
         if (networkPublisher) {
-            [networkPublisher publish:eventsArray publishCompleteBlock:publishCompleteBlock];
+            [networkPublisher publish:eventsArray user:self.userAccount publishCompleteBlock:publishCompleteBlock];
         }
     }
 }


### PR DESCRIPTION
This resolves a situation where logs can be sent to the wrong instance during a user switch.