### PR TITLE
Add missing include to fix compile error in consuming app

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAnalyticsPublisher.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKAnalyticsPublisher.h
@@ -28,6 +28,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 @class SFUserAccount;
 


### PR DESCRIPTION
This fixes an error with referencing the `SFSDK_DEPRECATED` macro.