### PR TITLE
Fix deprecated warnings

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/UIDevice+SFHardware.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/UIDevice+SFHardware.m
@@ -608,11 +608,11 @@
 }
 
 + (BOOL)currentDeviceIsIPad {
-    return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad);
+    return ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPad);
 }
 
 + (BOOL)currentDeviceIsIPhone {
-    return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone);
+    return ([[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone);
 }
 
 - (BOOL)isSimulator {


### PR DESCRIPTION
Hi,

`UI_USER_INTERFACE_IDIOM` was deprecated in iOS 13, so this PR changes it not to use.