### PR TITLE
Fix for user identity upgrade

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -1131,6 +1131,16 @@ SFSDK_USE_DEPRECATED_END
     SFUserAccount *result = nil;
     [_accountsLock lock];
     result = (self.userAccountMap)[userIdentity];
+
+    // TODO: Remove this block in Mobile SDK 10.0, needed for upgrade step after changing from 15 character to 18 character user IDs
+    if (!result) {
+        for (SFUserAccountIdentity *key in self.userAccountMap.allKeys) {
+            if ([key isEqual:userIdentity]) {
+                result = self.userAccountMap[key];
+            }
+        }
+    }
+
     [_accountsLock unlock];
     return result;
 }


### PR DESCRIPTION
For #3274. SFUserAccountIdentity overrides isEqual and calls another method that compares 15/18 digit IDs correctly. However there seems to be an issue where this works inconsistently when accessing the dictionary by key, so this falls back to iterating through the dictionary and calling isEqual directly.