### PR TITLE
ParentChildrenSyncUpTarget can now provide an external id field name

### DIFF
--- a/libs/MobileSync/MobileSync/Classes/Target/SFBatchSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFBatchSyncUpTarget.m
@@ -107,7 +107,7 @@ static NSUInteger const kSFMaxSubRequestsCompositeAPI = 25;
         NSString *refId;
         if (record[self.idFieldName] == nil || [record[self.idFieldName] isEqual:[NSNull null]]) {
             // create local id - needed for refId
-            refId = record[self.idFieldName] = [self createLocalId];
+            refId = record[self.idFieldName] = [SFSyncTarget createLocalId];
         } else {
             refId = record[self.idFieldName];
         }
@@ -201,7 +201,7 @@ static NSUInteger const kSFMaxSubRequestsCompositeAPI = 25;
                 // the following check is there for the case
                 // where the the external id field is the id field
                 // and the field is populated by a local id
-                && ![self isLocalId:externalId]) {
+                && ![SFSyncTarget isLocalId:externalId]) {
                 return [[SFRestAPI sharedInstance] requestForUpsertWithObjectType:objectType externalIdField:self.externalIdFieldName externalId:externalId fields:fields apiVersion:nil];
             } else {
                 return [[SFRestAPI sharedInstance] requestForCreateWithObjectType:objectType fields:fields apiVersion:nil];

--- a/libs/MobileSync/MobileSync/Classes/Target/SFBatchSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFBatchSyncUpTarget.m
@@ -107,7 +107,7 @@ static NSUInteger const kSFMaxSubRequestsCompositeAPI = 25;
         NSString *refId;
         if (record[self.idFieldName] == nil || [record[self.idFieldName] isEqual:[NSNull null]]) {
             // create local id - needed for refId
-            refId = record[self.idFieldName] = [self createLocalId:record];
+            refId = record[self.idFieldName] = [self createLocalId];
         } else {
             refId = record[self.idFieldName];
         }
@@ -200,8 +200,8 @@ static NSUInteger const kSFMaxSubRequestsCompositeAPI = 25;
             if (externalId
                 // the following check is there for the case
                 // where the the external id field is the id field
-                // and the empty id field was populated by BatchSyncUpTarget using createLocalId()
-                && ![externalId isEqualToString:[self createLocalId:record]]) {
+                // and the field is populated by a local id
+                && ![self isLocalId:externalId]) {
                 return [[SFRestAPI sharedInstance] requestForUpsertWithObjectType:objectType externalIdField:self.externalIdFieldName externalId:externalId fields:fields apiVersion:nil];
             } else {
                 return [[SFRestAPI sharedInstance] requestForCreateWithObjectType:objectType fields:fields apiVersion:nil];
@@ -265,10 +265,6 @@ static NSUInteger const kSFMaxSubRequestsCompositeAPI = 25;
     }
     
     return needReRun;    
-}
-
-- (NSString*) createLocalId:(NSDictionary*)record {
-    return [NSString stringWithFormat:@"local_%@", record[SOUP_ENTRY_ID]];
 }
 
 - (NSUInteger) computeMaxBatchSize:(NSNumber*)maxBatchSize {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFParentChildrenSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFParentChildrenSyncUpTarget.m
@@ -426,7 +426,7 @@ typedef void (^SFFetchLastModifiedDatesCompleteBlock)(NSDictionary<NSString *, N
                 // the following check is there for the case
                 // where the the external id field is the id field
                 // and the field is populated by a local id
-                && ![self isLocalId:externalId]) {
+                && ![SFSyncTarget isLocalId:externalId]) {
                 return [[SFRestAPI sharedInstance] requestForUpsertWithObjectType:info.sobjectType externalIdField:info.externalIdFieldName externalId:externalId fields:fields apiVersion:nil];
             } else {
                 return [[SFRestAPI sharedInstance] requestForCreateWithObjectType:info.sobjectType fields:fields apiVersion:nil];

--- a/libs/MobileSync/MobileSync/Classes/Target/SFParentChildrenSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFParentChildrenSyncUpTarget.m
@@ -405,7 +405,7 @@ typedef void (^SFFetchLastModifiedDatesCompleteBlock)(NSDictionary<NSString *, N
             return [[SFRestAPI sharedInstance] requestForDeleteWithObjectType:info.sobjectType objectId:id apiVersion:nil];
         }
     }
-        // Create/update cases
+    // Create/update cases
     else {
         fieldlist = isParent
                 ? isCreate
@@ -421,7 +421,16 @@ typedef void (^SFFetchLastModifiedDatesCompleteBlock)(NSDictionary<NSString *, N
         }
 
         if (isCreate) {
-            return [[SFRestAPI sharedInstance] requestForCreateWithObjectType:info.sobjectType fields:fields apiVersion:nil];
+            NSString *externalId = info.externalIdFieldName ? record[info.externalIdFieldName] : nil;
+            if (externalId
+                // the following check is there for the case
+                // where the the external id field is the id field
+                // and the field is populated by a local id
+                && ![self isLocalId:externalId]) {
+                return [[SFRestAPI sharedInstance] requestForUpsertWithObjectType:info.sobjectType externalIdField:info.externalIdFieldName externalId:externalId fields:fields apiVersion:nil];
+            } else {
+                return [[SFRestAPI sharedInstance] requestForCreateWithObjectType:info.sobjectType fields:fields apiVersion:nil];
+            }
         } else {
             return [[SFRestAPI sharedInstance] requestForUpdateWithObjectType:info.sobjectType objectId:id fields:fields apiVersion:nil];
         }

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.h
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.h
@@ -129,14 +129,14 @@ extern NSString * const kSyncTargetLastError;
 /**
  * Generate local id for record
  */
-- (NSString*) createLocalId;
++ (NSString*) createLocalId;
 
 /**
  * Check if record id was locally generated
  * @param recordId  The record id
  * @return YES if recordId was locally generated
  */
-- (BOOL) isLocalId:(NSString*)recordId;
++ (BOOL) isLocalId:(NSString*)recordId;
 
 @end
 

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.h
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.h
@@ -125,6 +125,19 @@ extern NSString * const kSyncTargetLastError;
  */
 - (void) deleteFromLocalStore:(SFMobileSyncSyncManager *)syncManager soupName:(NSString*)soupName record:(NSDictionary*)record NS_SWIFT_NAME(deleteFromLocalStore(syncManager:soupName:record:));
 
+
+/**
+ * Generate local id for record
+ */
+- (NSString*) createLocalId;
+
+/**
+ * Check if record id was locally generated
+ * @param recordId  The record id
+ * @return YES if recordId was locally generated
+ */
+- (BOOL) isLocalId:(NSString*)recordId;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
@@ -206,4 +206,12 @@ NSString * const kSyncTargetLastError = @"__last_error__";
     return flatArray;
 }
 
+- (NSString*) createLocalId {
+    return [NSString stringWithFormat:@"local_%@", [[NSUUID UUID] UUIDString]];
+}
+
+- (BOOL) isLocalId:(NSString*)recordId {
+    return [recordId hasPrefix:@"local_"];
+}
+
 @end

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
@@ -207,7 +207,7 @@ NSString * const kSyncTargetLastError = @"__last_error__";
 }
 
 + (NSString*) createLocalId {
-    return [NSString stringWithFormat:@"local_%@", [[NSUUID UUID] UUIDString]];
+    return [NSString stringWithFormat:@"local_%09d", arc4random_uniform(1000000000)];
 }
 
 + (BOOL) isLocalId:(NSString*)recordId {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
@@ -206,11 +206,11 @@ NSString * const kSyncTargetLastError = @"__last_error__";
     return flatArray;
 }
 
-- (NSString*) createLocalId {
++ (NSString*) createLocalId {
     return [NSString stringWithFormat:@"local_%@", [[NSUUID UUID] UUIDString]];
 }
 
-- (BOOL) isLocalId:(NSString*)recordId {
++ (BOOL) isLocalId:(NSString*)recordId {
     return [recordId hasPrefix:@"local_"];
 }
 

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
@@ -156,7 +156,11 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
     NSString* objectType = [SFJsonUtils projectIntoJson:record path:kObjectTypeField];
     NSDictionary * fields = [self buildFieldsMap:record fieldlist:fieldlist];
     NSString* externalId = self.externalIdFieldName ? record[self.externalIdFieldName] : nil;
-    if (externalId) {
+    if (externalId
+        // the following check is there for the case
+        // where the the external id field is the id field
+        // and the field is populated by a local id
+        && ![self isLocalId:externalId]) {
         [self upsertOnServer:objectType fields:fields externalId:externalId completionBlock:completionBlock failBlock:failBlock];
     } else {
         [self createOnServer:objectType fields:fields completionBlock:completionBlock failBlock:failBlock];

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
@@ -160,7 +160,7 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
         // the following check is there for the case
         // where the the external id field is the id field
         // and the field is populated by a local id
-        && ![self isLocalId:externalId]) {
+        && ![SFSyncTarget isLocalId:externalId]) {
         [self upsertOnServer:objectType fields:fields externalId:externalId completionBlock:completionBlock failBlock:failBlock];
     } else {
         [self createOnServer:objectType fields:fields completionBlock:completionBlock failBlock:failBlock];

--- a/libs/MobileSync/MobileSync/Classes/Util/SFChildrenInfo.h
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFChildrenInfo.h
@@ -40,8 +40,25 @@ NS_SWIFT_NAME(ChildrenInfo)
 
 /** Factory methods
  */
-+ (SFChildrenInfo *)newWithSObjectType:(NSString *)sobjectType sobjectTypePlural:(NSString *)sobjectTypePlural soupName:(NSString *)soupName parentIdFieldName:(NSString *)parentIdFieldName;
-+ (SFChildrenInfo *)newWithSObjectType:(NSString *)sobjectType sobjectTypePlural:(NSString *)sobjectTypePlural soupName:(NSString *)soupName parentIdFieldName:(NSString *)parentIdFieldName idFieldName:(NSString *)idFieldName modificationDateFieldName:(NSString *)modificationDateFieldName;
++ (SFChildrenInfo *)newWithSObjectType:(NSString *)sobjectType
+                     sobjectTypePlural:(NSString *)sobjectTypePlural
+                              soupName:(NSString *)soupName
+                     parentIdFieldName:(NSString *)parentIdFieldName;
+
++ (SFChildrenInfo *)newWithSObjectType:(NSString *)sobjectType
+                     sobjectTypePlural:(NSString *)sobjectTypePlural
+                              soupName:(NSString *)soupName
+                     parentIdFieldName:(NSString *)parentIdFieldName
+                           idFieldName:(NSString *)idFieldName
+             modificationDateFieldName:(NSString *)modificationDateFieldName;
+
++ (SFChildrenInfo *)newWithSObjectType:(NSString *)sobjectType
+                     sobjectTypePlural:(NSString *)sobjectTypePlural
+                              soupName:(NSString *)soupName
+                     parentIdFieldName:(NSString *)parentIdFieldName
+                           idFieldName:(NSString *)idFieldName
+             modificationDateFieldName:(NSString *)modificationDateFieldName
+                   externalIdFieldName:(NSString * __nullable)externalIdFieldName;
 
 + (SFChildrenInfo*) newFromDict:(NSDictionary*)dict;
 

--- a/libs/MobileSync/MobileSync/Classes/Util/SFChildrenInfo.m
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFChildrenInfo.m
@@ -55,7 +55,7 @@ NSString * const kSFChildrenInfoParentIdFieldName = @"parentIdFieldName"; // nam
           modificationDateFieldName:(NSString *)modificationDateFieldName
                 externalIdFieldName:(NSString *)externalIdFieldName {
     
-    self = [super initWithSObjectType:sobjectType soupName:soupName idFieldName:idFieldName modificationDateFieldName:modificationDateFieldName externalIdFieldName:NULL];
+    self = [super initWithSObjectType:sobjectType soupName:soupName idFieldName:idFieldName modificationDateFieldName:modificationDateFieldName externalIdFieldName:externalIdFieldName];
 
     if (self) {
         self.sobjectTypePlural = sobjectTypePlural;

--- a/libs/MobileSync/MobileSync/Classes/Util/SFChildrenInfo.m
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFChildrenInfo.m
@@ -26,11 +26,15 @@
 #import "SFMobileSyncConstants.h"
 
 NSString * const kSFChildrenInfoSObjectTypePlural = @"sobjectTypePlural";
-NSString * const kSFChildrenInfoParentIdFieldName = @"parentIdFieldName"; // name of field on  holding parent server id
+NSString * const kSFChildrenInfoParentIdFieldName = @"parentIdFieldName"; // name of field holding parent server id
 
 @interface SFParentInfo ()
 
-- (instancetype)initWithSObjectType:(NSString *)sobjectType soupName:(NSString *)soupName idFieldName:(NSString *)idFieldName modificationDateFieldName:(NSString *)modificationDateFieldName;
+- (instancetype)initWithSObjectType:(NSString *)sobjectType
+                           soupName:(NSString *)soupName
+                        idFieldName:(NSString *)idFieldName
+          modificationDateFieldName:(NSString *)modificationDateFieldName
+                externalIdFieldName:(NSString *)externalIdFieldName;
 
 @end
 
@@ -43,8 +47,15 @@ NSString * const kSFChildrenInfoParentIdFieldName = @"parentIdFieldName"; // nam
 
 @implementation SFChildrenInfo
 
-- (instancetype)initWithSObjectType:(NSString *)sobjectType sobjectTypePlural:(NSString *)sobjectTypePlural soupName:(NSString *)soupName parentIdFieldName:(NSString *)parentIdFieldName idFieldName:(NSString *)idFieldName modificationDateFieldName:(NSString *)modificationDateFieldName {
-    self = [super initWithSObjectType:sobjectType soupName:soupName idFieldName:idFieldName modificationDateFieldName:modificationDateFieldName];
+- (instancetype)initWithSObjectType:(NSString *)sobjectType
+                  sobjectTypePlural:(NSString *)sobjectTypePlural
+                           soupName:(NSString *)soupName
+                  parentIdFieldName:(NSString *)parentIdFieldName
+                        idFieldName:(NSString *)idFieldName
+          modificationDateFieldName:(NSString *)modificationDateFieldName
+                externalIdFieldName:(NSString *)externalIdFieldName {
+    
+    self = [super initWithSObjectType:sobjectType soupName:soupName idFieldName:idFieldName modificationDateFieldName:modificationDateFieldName externalIdFieldName:NULL];
 
     if (self) {
         self.sobjectTypePlural = sobjectTypePlural;
@@ -55,17 +66,63 @@ NSString * const kSFChildrenInfoParentIdFieldName = @"parentIdFieldName"; // nam
 }
 #pragma mark Factory methods
 
-+ (SFChildrenInfo *)newWithSObjectType:(NSString *)sobjectType sobjectTypePlural:(NSString *)sobjectTypePlural soupName:(NSString *)soupName parentIdFieldName:(NSString *)parentIdFieldName {
-    return [SFChildrenInfo newWithSObjectType:sobjectType sobjectTypePlural:sobjectTypePlural soupName:soupName parentIdFieldName:parentIdFieldName idFieldName:kId modificationDateFieldName:kLastModifiedDate];
++ (SFChildrenInfo *)newWithSObjectType:(NSString *)sobjectType
+                     sobjectTypePlural:(NSString *)sobjectTypePlural
+                              soupName:(NSString *)soupName
+                     parentIdFieldName:(NSString *)parentIdFieldName {
+    
+    return [SFChildrenInfo newWithSObjectType:sobjectType
+                            sobjectTypePlural:sobjectTypePlural
+                                     soupName:soupName
+                            parentIdFieldName:parentIdFieldName
+                                  idFieldName:kId
+                    modificationDateFieldName:kLastModifiedDate
+                          externalIdFieldName:NULL
+            ];
 }
 
 
-+ (SFChildrenInfo *)newWithSObjectType:(NSString *)sobjectType sobjectTypePlural:(NSString *)sobjectTypePlural soupName:(NSString *)soupName parentIdFieldName:(NSString *)parentIdFieldName idFieldName:(NSString *)idFieldName modificationDateFieldName:(NSString *)modificationDateFieldName {
-    return [[SFChildrenInfo alloc] initWithSObjectType:sobjectType sobjectTypePlural:sobjectTypePlural soupName:soupName parentIdFieldName:parentIdFieldName idFieldName:idFieldName modificationDateFieldName:modificationDateFieldName];
++ (SFChildrenInfo *)newWithSObjectType:(NSString *)sobjectType
+                     sobjectTypePlural:(NSString *)sobjectTypePlural
+                              soupName:(NSString *)soupName
+                     parentIdFieldName:(NSString *)parentIdFieldName
+                           idFieldName:(NSString *)idFieldName
+             modificationDateFieldName:(NSString *)modificationDateFieldName {
+    
+    return [SFChildrenInfo newWithSObjectType:sobjectType
+                            sobjectTypePlural:sobjectTypePlural
+                                     soupName:soupName
+                            parentIdFieldName:parentIdFieldName
+                                  idFieldName:idFieldName
+                    modificationDateFieldName:modificationDateFieldName
+                          externalIdFieldName:NULL];
+}
+
++ (SFChildrenInfo *)newWithSObjectType:(NSString *)sobjectType
+                     sobjectTypePlural:(NSString *)sobjectTypePlural
+                              soupName:(NSString *)soupName
+                     parentIdFieldName:(NSString *)parentIdFieldName
+                           idFieldName:(NSString *)idFieldName
+             modificationDateFieldName:(NSString *)modificationDateFieldName
+                   externalIdFieldName:(NSString *)externalIdFieldName {
+    
+    return [[SFChildrenInfo alloc] initWithSObjectType:sobjectType
+                                     sobjectTypePlural:sobjectTypePlural
+                                              soupName:soupName parentIdFieldName:parentIdFieldName
+                                           idFieldName:idFieldName
+                             modificationDateFieldName:modificationDateFieldName
+                                   externalIdFieldName:externalIdFieldName];
 }
 
 + (SFChildrenInfo*) newFromDict:(NSDictionary*)dict {
-    return [SFChildrenInfo newWithSObjectType:dict[kSFParentInfoSObjectType] sobjectTypePlural:dict[kSFChildrenInfoSObjectTypePlural] soupName:dict[kSFParentInfoSoupName] parentIdFieldName:dict[kSFChildrenInfoParentIdFieldName] idFieldName:dict[kSFParentInfoIdFieldName] modificationDateFieldName:dict[kSFParentInfoModifificationDateFieldName]];
+    return [SFChildrenInfo newWithSObjectType:dict[kSFParentInfoSObjectType]
+                            sobjectTypePlural:dict[kSFChildrenInfoSObjectTypePlural]
+                                     soupName:dict[kSFParentInfoSoupName]
+                            parentIdFieldName:dict[kSFChildrenInfoParentIdFieldName]
+                                  idFieldName:dict[kSFParentInfoIdFieldName]
+                    modificationDateFieldName:dict[kSFParentInfoModifificationDateFieldName]
+                          externalIdFieldName:dict[kSFParentInfoExternalIdFieldName]
+            ];
 }
 
 #pragma mark - To dictionary

--- a/libs/MobileSync/MobileSync/Classes/Util/SFParentInfo.h
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFParentInfo.h
@@ -30,6 +30,7 @@ extern NSString * const kSFParentInfoSObjectType;
 extern NSString * const kSFParentInfoSoupName;
 extern NSString * const kSFParentInfoIdFieldName;
 extern NSString * const kSFParentInfoModifificationDateFieldName;
+extern NSString * const kSFParentInfoExternalIdFieldName;
 
 /**
  * Simple object to capture details of parent in parent-child relationship
@@ -41,14 +42,23 @@ NS_SWIFT_NAME(ParentInfo)
 @property (nonatomic, readonly) NSString* idFieldName;
 @property (nonatomic, readonly) NSString* modificationDateFieldName;
 @property (nonatomic, readonly) NSString* soupName;
-
+@property (nonatomic, readonly) NSString* externalIdFieldName;
 
 /** Factory methods
  */
 + (SFParentInfo *)newWithSObjectType:(NSString *)sobjectType
                             soupName:(NSString *)soupName;
 
-+ (SFParentInfo *)newWithSObjectType:(NSString *)sobjectType soupName:(NSString *)soupName idFieldName:(NSString *)idFieldName modificationDateFieldName:(NSString *)modificationDateFieldName;
++ (SFParentInfo *)newWithSObjectType:(NSString *)sobjectType
+                            soupName:(NSString *)soupName
+                         idFieldName:(NSString *)idFieldName
+           modificationDateFieldName:(NSString *)modificationDateFieldName;
+
++ (SFParentInfo *)newWithSObjectType:(NSString *)sobjectType
+                            soupName:(NSString *)soupName
+                         idFieldName:(NSString *)idFieldName
+           modificationDateFieldName:(NSString *)modificationDateFieldName
+                 externalIdFieldName:(NSString * __nullable) externalIdFieldName;
 
 + (SFParentInfo*) newFromDict:(NSDictionary*)dict;
 

--- a/libs/MobileSync/MobileSync/Classes/Util/SFParentInfo.m
+++ b/libs/MobileSync/MobileSync/Classes/Util/SFParentInfo.m
@@ -29,6 +29,8 @@ NSString * const kSFParentInfoSObjectType = @"sobjectType";
 NSString * const kSFParentInfoSoupName = @"soupName";
 NSString * const kSFParentInfoIdFieldName = @"idFieldName";
 NSString * const kSFParentInfoModifificationDateFieldName = @"modificationDateFieldName";
+NSString * const kSFParentInfoExternalIdFieldName = @"externalIdFieldName";
+
 
 @interface SFParentInfo ()
 
@@ -36,18 +38,25 @@ NSString * const kSFParentInfoModifificationDateFieldName = @"modificationDateFi
 @property (nonatomic, readwrite) NSString* idFieldName;
 @property (nonatomic, readwrite) NSString* modificationDateFieldName;
 @property (nonatomic, readwrite) NSString* soupName;
+@property (nonatomic, readwrite) NSString* externalIdFieldName;
 
 @end
 
 @implementation SFParentInfo
 
-- (instancetype)initWithSObjectType:(NSString *)sobjectType soupName:(NSString *)soupName idFieldName:(NSString *)idFieldName modificationDateFieldName:(NSString *)modificationDateFieldName {
+- (instancetype)initWithSObjectType:(NSString *)sobjectType
+                           soupName:(NSString *)soupName
+                        idFieldName:(NSString *)idFieldName
+          modificationDateFieldName:(NSString *)modificationDateFieldName
+                externalIdFieldName:(NSString *)externalIdFieldName {
+    
     self = [self init];
     if (self) {
         self.sobjectType = sobjectType;
         self.idFieldName = idFieldName;
         self.modificationDateFieldName = modificationDateFieldName;
         self.soupName = soupName;
+        self.externalIdFieldName = externalIdFieldName;
     }
     return self;
 }
@@ -57,19 +66,47 @@ NSString * const kSFParentInfoModifificationDateFieldName = @"modificationDateFi
 + (SFParentInfo *)newWithSObjectType:(NSString *)sobjectType
                             soupName:(NSString *)soupName
 {
-    return [SFParentInfo newWithSObjectType:sobjectType soupName:soupName idFieldName:kId modificationDateFieldName:kLastModifiedDate];
+    return [SFParentInfo newWithSObjectType:sobjectType
+                                   soupName:soupName
+                                idFieldName:kId
+                  modificationDateFieldName:kLastModifiedDate
+                        externalIdFieldName:NULL];
 }
 
 
-+ (SFParentInfo *)newWithSObjectType:(NSString *)sobjectType soupName:(NSString *)soupName idFieldName:(NSString *)idFieldName modificationDateFieldName:(NSString *)modificationDateFieldName {
-    return [[SFParentInfo alloc] initWithSObjectType:sobjectType soupName:soupName idFieldName:idFieldName modificationDateFieldName:modificationDateFieldName];
++ (SFParentInfo *)newWithSObjectType:(NSString *)sobjectType
+                            soupName:(NSString *)soupName
+                         idFieldName:(NSString *)idFieldName
+           modificationDateFieldName:(NSString *)modificationDateFieldName {
+    
+    return [SFParentInfo newWithSObjectType:sobjectType
+                                   soupName:soupName
+                                idFieldName:idFieldName
+                  modificationDateFieldName:modificationDateFieldName
+                        externalIdFieldName:NULL];
 }
+
++ (SFParentInfo *)newWithSObjectType:(NSString *)sobjectType
+                            soupName:(NSString *)soupName
+                         idFieldName:(NSString *)idFieldName
+           modificationDateFieldName:(NSString *)modificationDateFieldName
+                 externalIdFieldName:(NSString *)externalIdFieldName {
+    
+    return [[SFParentInfo alloc] initWithSObjectType:sobjectType
+                                            soupName:soupName
+                                         idFieldName:idFieldName
+                           modificationDateFieldName:modificationDateFieldName
+                                 externalIdFieldName:externalIdFieldName];
+}
+
 
 + (SFParentInfo*) newFromDict:(NSDictionary*)dict {
     return [SFParentInfo newWithSObjectType:dict[kSFParentInfoSObjectType]
                                    soupName:dict[kSFParentInfoSoupName]
                                 idFieldName:dict[kSFParentInfoIdFieldName]
-                  modificationDateFieldName:dict[kSFParentInfoModifificationDateFieldName]];
+                  modificationDateFieldName:dict[kSFParentInfoModifificationDateFieldName]
+                        externalIdFieldName:dict[kSFParentInfoExternalIdFieldName]
+            ];
 }
 
 #pragma mark - To dictionary
@@ -81,6 +118,7 @@ NSString * const kSFParentInfoModifificationDateFieldName = @"modificationDateFi
     dict[kSFParentInfoIdFieldName] = self.idFieldName;
     dict[kSFParentInfoModifificationDateFieldName] = self.modificationDateFieldName;
     dict[kSFParentInfoSoupName] = self.soupName;
+    dict[kSFParentInfoExternalIdFieldName] = self.externalIdFieldName;
     return dict;
 }
 

--- a/libs/MobileSync/MobileSyncTestApp/usersyncs.json
+++ b/libs/MobileSync/MobileSyncTestApp/usersyncs.json
@@ -148,6 +148,7 @@
         "androidImpl": "com.salesforce.androidsdk.mobilesync.target.ParentChildrenSyncUpTarget",
         "parent" : {
           "idFieldName" : "IdX",
+          "externalIdFieldName": "ExternalIdX",
           "sobjectType" : "Account",
           "modificationDateFieldName" : "LastModifiedDateX",
           "soupName" : "accounts"
@@ -157,6 +158,7 @@
         "children" : {
           "parentIdFieldName" : "AccountId",
           "idFieldName" : "IdY",
+          "externalIdFieldName": "ExternalIdY",
           "sobjectType" : "Contact",
           "modificationDateFieldName" : "LastModifiedDateY",
           "soupName" : "contacts",

--- a/libs/MobileSync/MobileSyncTests/ParentChildrenSyncTests.m
+++ b/libs/MobileSync/MobileSyncTests/ParentChildrenSyncTests.m
@@ -261,10 +261,10 @@ typedef NS_ENUM(NSInteger, SFSyncUpChange) {
     NSMutableDictionary * mapAccountContacts = [NSMutableDictionary new];
 
     for (NSUInteger i = 0; i<numberAccounts; i++) {
-        NSDictionary * account = @{ID: [self createLocalId], ATTRIBUTES: accountAttributes};
+        NSDictionary * account = @{ID: [SFSyncTarget createLocalId], ATTRIBUTES: accountAttributes};
         NSMutableArray * contacts = [NSMutableArray new];
         for (NSUInteger j = 0; j < numberContactsPerAccount; j++) {
-            [contacts addObject:@{ID: [self createLocalId], ATTRIBUTES: contactAttributes, ACCOUNT_ID: account[ID]}];
+            [contacts addObject:@{ID: [SFSyncTarget createLocalId], ATTRIBUTES: contactAttributes, ACCOUNT_ID: account[ID]}];
         }
         mapAccountContacts[account] = contacts;
         [accounts addObject:account];
@@ -355,14 +355,14 @@ typedef NS_ENUM(NSInteger, SFSyncUpChange) {
     NSMutableDictionary * mapAccountContacts = [NSMutableDictionary new];
 
     for (NSUInteger i = 0; i<numberAccounts; i++) {
-        NSDictionary * account = @{ID: [self createLocalId],
+        NSDictionary * account = @{ID: [SFSyncTarget createLocalId],
                 ATTRIBUTES: accountAttributes,
                 @"AccountTimeStamp1": timeStampStrs[i % timeStampStrs.count],
                 @"AccountTimeStamp2": timeStampStrs[0]
         };
         NSMutableArray * contacts = [NSMutableArray new];
         for (NSUInteger j = 0; j < numberContactsPerAccount; j++) {
-            [contacts addObject:@{ID: [self createLocalId],
+            [contacts addObject:@{ID: [SFSyncTarget createLocalId],
                     ATTRIBUTES: contactAttributes,
                     ACCOUNT_ID: account[ID],
                     @"ContactTimeStamp1": timeStampStrs[1],
@@ -1435,7 +1435,7 @@ typedef NS_ENUM(NSInteger, SFSyncUpChange) {
     NSDictionary *attributes = @{TYPE: ACCOUNT_TYPE};
     for (NSString* name in names) {
         NSDictionary *account = @{
-                                  ID: [self createLocalId],
+                                  ID: [SFSyncTarget createLocalId],
                                   NAME: name,
                                   DESCRIPTION: [@[DESCRIPTION, name] componentsJoinedByString:@"_"],
                                   ATTRIBUTES: attributes,
@@ -1469,7 +1469,7 @@ typedef NS_ENUM(NSInteger, SFSyncUpChange) {
         NSMutableArray* contacts = [NSMutableArray new];
         for (NSUInteger i=0; i<numberOfContactsPerAccount; i++) {
             NSDictionary *contact = @{
-                    ID: [self createLocalId],
+                    ID: [SFSyncTarget createLocalId],
                     LAST_NAME: [self createRecordName:CONTACT_TYPE],
                     ATTRIBUTES: attributes,
                     ACCOUNT_ID: accountId,

--- a/libs/MobileSync/MobileSyncTests/ParentChildrenSyncTests.m
+++ b/libs/MobileSync/MobileSyncTests/ParentChildrenSyncTests.m
@@ -1277,6 +1277,129 @@ typedef NS_ENUM(NSInteger, SFSyncUpChange) {
     [self checkServer:contactIdToFieldsExpectedOnServer objectType:CONTACT_TYPE];
 }
 
+/**
+ * Create accounts and contacts on server.
+ * Create accounts and contacts locally - some with external id matching server record:
+ * - account with external id populated with contact with no external id
+ * - account with external id populated with contact with external id
+ * - account with no external id with contact with external id
+ *
+ * Sync up with external id field name provided, check smartstore and server afterwards.
+ */
+- (void) testParentChildrenSyncUpWithExternalId
+{
+    NSString* externalIdFieldName = @"Id";
+
+    // Creating test accounts and contacts on server
+    [self createAccountsAndContactsOnServer:3 numberContactsPerAccount:1];
+
+    // Get id of accounts on the server
+    NSArray<NSString*>* accountIds = [accountIdToFields allKeys];
+    NSString* accountId0 = accountIds[0];
+    NSString* accountId1 = accountIds[1];
+    NSString* accountId2 = accountIds[2];
+    
+    // Get name of third account on server
+    NSString* originalAccountName2 = accountIdToFields[accountId2][NAME];
+
+    // Get id of contacts on the server
+    NSString* contactId0 = [accountIdContactIdToFields[accountId0] allKeys][0];
+    NSString* contactId1 = [accountIdContactIdToFields[accountId1] allKeys][0];
+    NSString* contactId2 = [accountIdContactIdToFields[accountId2] allKeys][0];
+
+    // Get name of first contact on server
+    NSString* originalContactName0 = accountIdContactIdToFields[accountId0][contactId0][LAST_NAME];
+
+    // Creating 3 new account names
+    NSString* accountName0 = [self createAccountName];
+    NSString* accountName1 = [self createAccountName];
+    NSString* accountName2 = [self createAccountName];
+
+    // Create accounts and contacts locally
+    NSDictionary* accountToContactMap = [self createAccountsAndContactsLocally:@[accountName0, accountName1, accountName2] numberOfContactsPerAccount:1];
+    NSArray<NSMutableDictionary*>* localAccounts = [self arrayOfMutableDicts:[accountToContactMap allKeys]];
+    NSArray<NSMutableDictionary*>* localContacts = [self arrayOfMutableDicts:@[accountToContactMap[localAccounts[0]][0],
+                                                                               accountToContactMap[localAccounts[1]][0],
+                                                                               accountToContactMap[localAccounts[2]][0]
+                                                    ]];
+
+    // Local contact names
+    NSString* contactName0 = localContacts[0][LAST_NAME];
+    NSString* contactName1 = localContacts[1][LAST_NAME];
+    NSString* contactName2 = localContacts[2][LAST_NAME];
+
+    // Update Id field to match existing id for account 0 and 1
+    localAccounts[0][externalIdFieldName] = accountId0;
+    localAccounts[1][externalIdFieldName] = accountId1;
+    [self.store upsertEntries:localAccounts toSoup:ACCOUNTS_SOUP];
+    
+    // Update Id field to match existing id for contact 1 and 2
+    // Update accountId field also for contact 0 and 1
+    localContacts[0][ACCOUNT_ID] = accountId0;
+    localContacts[1][externalIdFieldName] = contactId1;
+    localContacts[1][ACCOUNT_ID] = accountId1;
+    localContacts[2][externalIdFieldName] = contactId2;
+    [self.store upsertEntries:localContacts toSoup:CONTACTS_SOUP];
+
+    // Sync up
+    [self trySyncUp:3
+             target:[self getAccountContactsSyncUpTargetWithAccountModificationDateFieldName:LAST_MODIFIED_DATE
+                                                                     contactModificationDateFieldName:LAST_MODIFIED_DATE
+                                                                           accountExternalIdFieldName:externalIdFieldName
+                                                                           contactExternalIdFieldName:externalIdFieldName]
+          mergeMode:SFSyncStateMergeModeOverwrite];
+    
+    // Getting id for third account upserted - the one without an valid external id
+    NSString* newAccountId = [[self getIdToFieldsByName:ACCOUNTS_SOUP fieldNames:@[] nameField:NAME names:@[accountName2]] allKeys][0];
+
+    // Getting id for first contact upserted - the one without an valid external id
+    NSString* newContactId = [[self getIdToFieldsByName:CONTACTS_SOUP fieldNames:@[] nameField:LAST_NAME names:@[contactName0]] allKeys][0];
+
+    // Expected accounts records locally
+    NSMutableDictionary* expectedAccountsDbIdToFields = [NSMutableDictionary new];
+    expectedAccountsDbIdToFields[accountId0] = @{NAME: accountName0};
+    expectedAccountsDbIdToFields[accountId1] = @{NAME: accountName1};
+    expectedAccountsDbIdToFields[newAccountId] = @{NAME: accountName2};
+
+    // Check db
+    [self checkDbStateFlags:[expectedAccountsDbIdToFields allKeys] soupName:ACCOUNTS_SOUP expectedLocallyCreated:NO expectedLocallyUpdated:NO expectedLocallyDeleted:NO];
+    [self checkDb:expectedAccountsDbIdToFields soupName:ACCOUNTS_SOUP];
+    
+    // Expected contacts records locally
+    NSMutableDictionary* expectedContactsDbIdToFields = [NSMutableDictionary new];
+    expectedContactsDbIdToFields[newContactId] = @{LAST_NAME: contactName0};
+    expectedContactsDbIdToFields[newContactId] = @{LAST_NAME: contactName1};
+    expectedContactsDbIdToFields[contactId2] = @{LAST_NAME: contactName2};
+
+    // Check db
+    [self checkDbStateFlags:[expectedContactsDbIdToFields allKeys] soupName:CONTACTS_SOUP expectedLocallyCreated:NO expectedLocallyUpdated:NO expectedLocallyDeleted:NO];
+    [self checkDb:expectedContactsDbIdToFields soupName:CONTACTS_SOUP];
+
+    // Expected accounts on server
+    NSMutableDictionary* expectedAccountsServerIdToFields = [NSMutableDictionary new];
+    expectedAccountsServerIdToFields[accountId0] = @{NAME: accountName0};
+    expectedAccountsServerIdToFields[accountId1] = @{NAME: accountName1};
+    expectedAccountsServerIdToFields[accountId2] = @{NAME: originalAccountName2};
+    expectedAccountsServerIdToFields[newAccountId] = @{NAME: accountName2};
+
+    // Check server
+    [self checkServer:expectedAccountsServerIdToFields objectType:ACCOUNT_TYPE];
+
+    // Expected contacts on server
+    NSMutableDictionary* expectedContactsServerIdToFields = [NSMutableDictionary new];
+    expectedContactsServerIdToFields[newContactId] = @{LAST_NAME: contactName0};
+    expectedContactsServerIdToFields[contactId0] = @{LAST_NAME: originalContactName0};
+    expectedContactsServerIdToFields[contactId1] = @{LAST_NAME: contactName1};
+    expectedContactsServerIdToFields[contactId2] = @{LAST_NAME: contactName2};
+   
+    // Check server
+    [self checkServer:expectedContactsServerIdToFields objectType:CONTACT_TYPE];
+
+    // Cleanup
+    [self deleteRecordsOnServer:@[newAccountId] objectType:ACCOUNT_TYPE];
+    [self deleteRecordsOnServer:@[newContactId] objectType:CONTACT_TYPE];
+}
+
 #pragma mark - Helper methods
 
 - (void)createTestData {
@@ -1888,27 +2011,47 @@ typedef NS_ENUM(NSInteger, SFSyncUpChange) {
 }
 
 - (SFParentChildrenSyncUpTarget *)getAccountContactsSyncUpTarget {
-    return [self getAccountContactsSyncUpTargetWithParentSoqlFilter:@""];
+    return [self getAccountContactsSyncUpTargetWithAccountModificationDateFieldName:LAST_MODIFIED_DATE
+                                                   contactModificationDateFieldName:LAST_MODIFIED_DATE
+                                                         accountExternalIdFieldName:NULL
+                                                         contactExternalIdFieldName:NULL
+            ];
 }
 
-- (SFParentChildrenSyncUpTarget *)getAccountContactsSyncUpTargetWithParentSoqlFilter:(NSString*)parentSoqlFilter {
-    return [self getAccountContactsSyncUpTargetWithParentSoqlFilter:parentSoqlFilter accountModificationDateFieldName:LAST_MODIFIED_DATE contactModificationDateFieldName:LAST_MODIFIED_DATE];
-}
-
-- (SFParentChildrenSyncUpTarget *)getAccountContactsSyncUpTargetWithParentSoqlFilter:(NSString*)parentSoqlFilter
-                                                    accountModificationDateFieldName:(NSString*)accountModificationDateFieldName
-                                                    contactModificationDateFieldName:(NSString*)contactModificationDateFieldName {
+- (SFParentChildrenSyncUpTarget *)getAccountContactsSyncUpTargetWithAccountModificationDateFieldName:(NSString*)accountModificationDateFieldName
+                                                                    contactModificationDateFieldName:(NSString*)contactModificationDateFieldName
+                                                                          accountExternalIdFieldName:(NSString*)accountExternalIdFieldName
+                                                                          contactExternalIdFieldName:(NSString*)contactExternalIdFieldName
+{
 
 
     SFParentChildrenSyncUpTarget *target = [SFParentChildrenSyncUpTarget
-            newSyncTargetWithParentInfo:[SFParentInfo newWithSObjectType:ACCOUNT_TYPE soupName:ACCOUNTS_SOUP idFieldName:ID modificationDateFieldName:accountModificationDateFieldName]
+            newSyncTargetWithParentInfo:[SFParentInfo newWithSObjectType:ACCOUNT_TYPE
+                                                                soupName:ACCOUNTS_SOUP
+                                                             idFieldName:ID
+                                               modificationDateFieldName:accountModificationDateFieldName
+                                                     externalIdFieldName:accountExternalIdFieldName]
                         parentCreateFieldlist:@[ID, NAME, DESCRIPTION]
                   parentUpdateFieldlist:@[NAME, DESCRIPTION]
-                           childrenInfo:[SFChildrenInfo newWithSObjectType:CONTACT_TYPE sobjectTypePlural:CONTACT_TYPE_PLURAL soupName:CONTACTS_SOUP parentIdFieldName:ACCOUNT_ID idFieldName:ID modificationDateFieldName:contactModificationDateFieldName]
+                           childrenInfo:[SFChildrenInfo newWithSObjectType:CONTACT_TYPE
+                                                         sobjectTypePlural:CONTACT_TYPE_PLURAL
+                                                                  soupName:CONTACTS_SOUP
+                                                         parentIdFieldName:ACCOUNT_ID
+                                                               idFieldName:ID
+                                                 modificationDateFieldName:contactModificationDateFieldName
+                                                       externalIdFieldName:contactExternalIdFieldName]
                       childrenCreateFieldlist:@[LAST_NAME, ACCOUNT_ID]
             childrenUpdateFieldlist:@[LAST_NAME, ACCOUNT_ID]
                        relationshipType:SFParentChildrenRelationpshipMasterDetail]; // account-contacts are master-detail
     return target;
+}
+
+- (NSArray<NSMutableDictionary*>*) arrayOfMutableDicts:(NSArray<NSDictionary*>*)arrayDicts {
+    NSMutableArray* result = [NSMutableArray new];
+    for (NSDictionary* dict in arrayDicts) {
+        [result addObject:[dict mutableCopy]];
+    }
+    return result;
 }
 
 @end

--- a/libs/MobileSync/MobileSyncTests/ParentChildrenSyncTests.m
+++ b/libs/MobileSync/MobileSyncTests/ParentChildrenSyncTests.m
@@ -1310,18 +1310,18 @@ typedef NS_ENUM(NSInteger, SFSyncUpChange) {
     // Get name of first contact on server
     NSString* originalContactName0 = accountIdContactIdToFields[accountId0][contactId0][LAST_NAME];
 
-    // Creating 3 new account names
-    NSString* accountName0 = [self createAccountName];
-    NSString* accountName1 = [self createAccountName];
-    NSString* accountName2 = [self createAccountName];
-
     // Create accounts and contacts locally
-    NSDictionary* accountToContactMap = [self createAccountsAndContactsLocally:@[accountName0, accountName1, accountName2] numberOfContactsPerAccount:1];
+    NSDictionary* accountToContactMap = [self createAccountsAndContactsLocally:@[[self createAccountName], [self createAccountName], [self createAccountName]] numberOfContactsPerAccount:1];
     NSArray<NSMutableDictionary*>* localAccounts = [self arrayOfMutableDicts:[accountToContactMap allKeys]];
     NSArray<NSMutableDictionary*>* localContacts = [self arrayOfMutableDicts:@[accountToContactMap[localAccounts[0]][0],
                                                                                accountToContactMap[localAccounts[1]][0],
                                                                                accountToContactMap[localAccounts[2]][0]
                                                     ]];
+
+    // Local account names
+    NSString* accountName0 = localAccounts[0][NAME];
+    NSString* accountName1 = localAccounts[1][NAME];
+    NSString* accountName2 = localAccounts[2][NAME];
 
     // Local contact names
     NSString* contactName0 = localContacts[0][LAST_NAME];
@@ -1368,7 +1368,7 @@ typedef NS_ENUM(NSInteger, SFSyncUpChange) {
     // Expected contacts records locally
     NSMutableDictionary* expectedContactsDbIdToFields = [NSMutableDictionary new];
     expectedContactsDbIdToFields[newContactId] = @{LAST_NAME: contactName0};
-    expectedContactsDbIdToFields[newContactId] = @{LAST_NAME: contactName1};
+    expectedContactsDbIdToFields[contactId1] = @{LAST_NAME: contactName1};
     expectedContactsDbIdToFields[contactId2] = @{LAST_NAME: contactName2};
 
     // Check db

--- a/libs/MobileSync/MobileSyncTests/SFSDKSyncsConfigTests.m
+++ b/libs/MobileSync/MobileSyncTests/SFSDKSyncsConfigTests.m
@@ -308,7 +308,8 @@
                                                     newWithSObjectType:@"Account"
                                                     soupName:@"accounts"
                                                     idFieldName:@"IdX"
-                                                    modificationDateFieldName:@"LastModifiedDateX"]
+                                                    modificationDateFieldName:@"LastModifiedDateX"
+                                                    externalIdFieldName:@"ExternalIdX"]
                        parentCreateFieldlist:@[@"IdX",@"Name", @"Description"]
                        parentUpdateFieldlist:@[@"Name", @"Description"]
                        childrenInfo:[SFChildrenInfo
@@ -317,7 +318,8 @@
                                      soupName:@"contacts"
                                      parentIdFieldName:@"AccountId"
                                      idFieldName:@"IdY"
-                                     modificationDateFieldName:@"LastModifiedDateY"]
+                                     modificationDateFieldName:@"LastModifiedDateY"
+                                     externalIdFieldName:@"ExternalIdY"]
                        childrenCreateFieldlist:@[@"LastName", @"AccountId"]
                        childrenUpdateFieldlist:@[@"FirstName", @"AccountId"]
                        relationshipType:SFParentChildrenRelationpshipMasterDetail]

--- a/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.h
+++ b/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.h
@@ -42,7 +42,6 @@
 #define ACCOUNT_ID          @"AccountId"
 #define CONTACT_TYPE_PLURAL @"Contacts"
 #define TOTAL_SIZE_UNKNOWN  -2
-#define LOCAL_ID_PREFIX     @"local_"
 #define REMOTELY_UPDATED    @"_r_upd"
 #define LOCALLY_UPDATED     @"_l_upd"
 
@@ -61,7 +60,6 @@ typedef NSMutableDictionary* (^SFRecordMutatorBlock) (NSMutableDictionary* recor
 - (NSString *)createRecordName:(NSString *)objectType;
 - (NSString *)createAccountName;
 - (NSString *)createDescription:(NSString *)name;
-- (NSString *) createLocalId;
 - (NSString *)buildInClause:(NSArray *)values;
 
 - (NSArray *) createAccountsLocally:(NSArray*)names;

--- a/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.m
+++ b/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.m
@@ -136,7 +136,7 @@ static NSException *authException = nil;
     attributes[TYPE] = ACCOUNT_TYPE;
     for (NSString* name in names) {
         NSMutableDictionary* account = [NSMutableDictionary new];
-        NSString* accountId = [self createLocalId];
+        NSString* accountId = [SFSyncTarget createLocalId];
         account[ID] = accountId;
         account[NAME] = name;
         account[DESCRIPTION] = [self createDescription:name];
@@ -149,10 +149,6 @@ static NSException *authException = nil;
         [createdAccounts addObject:account];
     }
     return [self.store upsertEntries:createdAccounts toSoup:ACCOUNTS_SOUP];
-}
-
-- (NSString*) createLocalId {
-    return [NSString stringWithFormat:@"local_%08d", arc4random_uniform(100000000)];
 }
 
 - (void)createAccountsSoup {
@@ -502,8 +498,8 @@ static NSException *authException = nil;
         XCTAssertEqualObjects(@(expectedLocallyUpdated), recordFromDb[kSyncTargetLocallyUpdated]);
         XCTAssertEqualObjects(@(expectedLocallyDeleted), recordFromDb[kSyncTargetLocallyDeleted]);
         NSString* id = recordFromDb[ID];
-        bool hasLocalIdPrefix = [id hasPrefix:LOCAL_ID_PREFIX];
-        XCTAssertEqual(expectedLocallyCreated, hasLocalIdPrefix);
+        bool isLocalId = [SFSyncTarget isLocalId:id];
+        XCTAssertEqual(expectedLocallyCreated, isLocalId);
 
         // Last error field should be empty for a clean record
         if (!expectedDirty) {

--- a/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.m
+++ b/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.m
@@ -710,7 +710,7 @@ static NSException *authException = nil;
     for (NSDictionary* record in records) {
         NSString* recordId = record[ID];
         for (NSString* fieldName in [idToFields[recordId] allKeys]) {
-            XCTAssertEqualObjects(idToFields[recordId][fieldName], record[fieldName]);
+            XCTAssertEqualObjects(idToFields[recordId][fieldName], record[fieldName], "Wrong value for field %@ on record %@", fieldName, recordId);
         }
     }
 }

--- a/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.m
+++ b/libs/MobileSync/MobileSyncTests/SyncManagerTestCase.m
@@ -498,7 +498,7 @@ static NSException *authException = nil;
         XCTAssertEqualObjects(@(expectedLocallyUpdated), recordFromDb[kSyncTargetLocallyUpdated]);
         XCTAssertEqualObjects(@(expectedLocallyDeleted), recordFromDb[kSyncTargetLocallyDeleted]);
         NSString* id = recordFromDb[ID];
-        bool isLocalId = [SFSyncTarget isLocalId:id];
+        BOOL isLocalId = [SFSyncTarget isLocalId:id];
         XCTAssertEqual(expectedLocallyCreated, isLocalId);
 
         // Last error field should be empty for a clean record


### PR DESCRIPTION
Locally created parents and/or children providing an external id are upserted during sync up.

* ParentInfo and ChildrenInfo both have the new field,
* Added test for ParentChildrenSyncUpTarget,
* Using the new field in one of the example config and modified config test accordingly,
* Added new methods in SFSyncTarget: createLocalId and isLocalId - they should be used to get the correct behavior if using id field as the external id field.

The work for andrdoi is in https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2142
The work for other sync up target was done in https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2010.