### PR TITLE
Multiple window support

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		6938392723C82F38008E8E9A /* SFSDKNullURLCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 6938392523C82F38008E8E9A /* SFSDKNullURLCache.m */; };
 		693E623124A287DB0017B222 /* KeyValueEncryptedFileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693E623024A287DB0017B222 /* KeyValueEncryptedFileStore.swift */; };
 		693E623B24A29B6B0017B222 /* SFSDKKeyValueEncryptedFileStoreTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 693E623A24A29B6B0017B222 /* SFSDKKeyValueEncryptedFileStoreTests.m */; };
+		694490D025B8F4C4007747CD /* SFSDKWindowManager+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 694490C725B8E567007747CD /* SFSDKWindowManager+Internal.h */; };
 		6975869F23296D7500574148 /* SFSDKURLCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 691D129F23296A93000D6D41 /* SFSDKURLCacheTests.m */; };
 		697A91A02363C3D800D2836F /* SFSDKPushNotificationDecryption.h in Headers */ = {isa = PBXBuildFile; fileRef = 697A919E2363C3D800D2836F /* SFSDKPushNotificationDecryption.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		697A91A12363C3D800D2836F /* SFSDKPushNotificationDecryption.m in Sources */ = {isa = PBXBuildFile; fileRef = 697A919F2363C3D800D2836F /* SFSDKPushNotificationDecryption.m */; };
@@ -731,6 +732,7 @@
 		6938392523C82F38008E8E9A /* SFSDKNullURLCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKNullURLCache.m; sourceTree = "<group>"; };
 		693E623024A287DB0017B222 /* KeyValueEncryptedFileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueEncryptedFileStore.swift; sourceTree = "<group>"; };
 		693E623A24A29B6B0017B222 /* SFSDKKeyValueEncryptedFileStoreTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKKeyValueEncryptedFileStoreTests.m; path = SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m; sourceTree = SOURCE_ROOT; };
+		694490C725B8E567007747CD /* SFSDKWindowManager+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SFSDKWindowManager+Internal.h"; sourceTree = "<group>"; };
 		697A919E2363C3D800D2836F /* SFSDKPushNotificationDecryption.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKPushNotificationDecryption.h; sourceTree = "<group>"; };
 		697A919F2363C3D800D2836F /* SFSDKPushNotificationDecryption.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKPushNotificationDecryption.m; sourceTree = "<group>"; };
 		69848CA42363F8AF00893E57 /* SFSDKPushNotificationFieldsConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKPushNotificationFieldsConstants.h; sourceTree = "<group>"; };
@@ -1576,6 +1578,7 @@
 				B7A20F7F1F25850E00D1E4B0 /* SFSDKWindowContainer.h */,
 				B7A20F801F25850E00D1E4B0 /* SFSDKWindowContainer.m */,
 				B7A20F811F25850E00D1E4B0 /* SFSDKWindowManager.h */,
+				694490C725B8E567007747CD /* SFSDKWindowManager+Internal.h */,
 				B7A20F821F25850E00D1E4B0 /* SFSDKWindowManager.m */,
 				B7A20FAB1F26C39700D1E4B0 /* SFSDKRootController.h */,
 				B7A20FAC1F26C39700D1E4B0 /* SFSDKRootController.m */,
@@ -1883,6 +1886,7 @@
 				CE4CE3A91C0E5279009F6029 /* SFManagedPreferences.h in Headers */,
 				CE4CE31C1C0E523B009F6029 /* SFKeychainItemWrapper.h in Headers */,
 				CE4CE3291C0E523B009F6029 /* NSData+SFSDKUtils_Internal.h in Headers */,
+				694490D025B8F4C4007747CD /* SFSDKWindowManager+Internal.h in Headers */,
 				B7D7A5322360D9CC00363A9B /* SFSDKViewControllerConfig.h in Headers */,
 				82A195A51E73247F008F5AA8 /* SFSDKAppFeatureMarkers.h in Headers */,
 				CE4CE3A51C0E5279009F6029 /* SFDirectoryManager.h in Headers */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -1,3 +1,4 @@
+#import <SalesforceSDKCommon/SFSDKSafeMutableDictionary.h>
 #import "SalesforceSDKManager.h"
 #import "SFSecurityLockout+Internal.h"
 #import "SFUserAccountManager.h"
@@ -9,8 +10,6 @@
 - (void)handleAppForeground:(nonnull NSNotification *)notification;
 - (void)handleAppBackground:(nonnull NSNotification *)notification;
 - (void)handleAppTerminate:(nonnull NSNotification *)notification;
-- (void)handleAppDidBecomeActive:(nonnull NSNotification *)notification;
-- (void)handleAppWillResignActive:(nonnull NSNotification *)notification;
 - (void)handlePostLogout;
 - (void)handleAuthCompleted:(nonnull NSNotification *)notification;
 - (void)handleIDPInitiatedAuthCompleted:(nonnull NSNotification *)notification;
@@ -25,17 +24,14 @@
 @end
 
 @interface SalesforceSDKManager () <SalesforceSDKManagerFlow>
-{
-    BOOL _isLaunching;
-    UIViewController* _snapshotViewController;
-}
 
 @property (nonatomic, assign) SFAppType appType;
 @property (nonatomic, weak, nullable) id<SalesforceSDKManagerFlow> sdkManagerFlow;
+@property (nonatomic, strong, nonnull) SFSDKSafeMutableDictionary<NSString *, UIViewController *> *snapshotViewControllers;
 @property (nonatomic, assign, getter=isPasscodeDisplayed) BOOL passcodeDisplayed;
 
-- (void)presentSnapshot;
-- (BOOL)isSnapshotPresented;
-- (void)dismissSnapshot;
+- (void)presentSnapshot:(nullable UIScene *)scene;
+- (BOOL)isSnapshotPresented:(nullable UIScene *)scene;
+- (void)dismissSnapshot:(nullable UIScene *)scene;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -30,8 +30,8 @@
 @property (nonatomic, strong, nonnull) SFSDKSafeMutableDictionary<NSString *, UIViewController *> *snapshotViewControllers;
 @property (nonatomic, assign, getter=isPasscodeDisplayed) BOOL passcodeDisplayed;
 
-- (void)presentSnapshot:(nullable UIScene *)scene;
-- (BOOL)isSnapshotPresented:(nullable UIScene *)scene;
-- (void)dismissSnapshot:(nullable UIScene *)scene;
+- (void)presentSnapshot:(nonnull UIScene *)scene;
+- (BOOL)isSnapshotPresented:(nonnull UIScene *)scene;
+- (void)dismissSnapshot:(nonnull UIScene *)scene completion:(void (^ __nullable)(void))completion;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthHelper.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthHelper.m
@@ -100,10 +100,10 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
     NSURL *url = [responseCommand requestURL];
    
     dispatch_async(dispatch_get_main_queue(), ^{
-        SFSDKWindowContainer *authWindow = [SFSDKWindowManager sharedManager].authWindow;
+        SFSDKWindowContainer *authWindow = [[SFSDKWindowManager sharedManager] authWindow:nil];
         [authWindow.viewController.presentedViewController dismissViewControllerAnimated:YES  completion:^{
-           [authWindow dismissWindow];
-           [[SFSDKWindowManager sharedManager].mainWindow presentWindow];
+            [authWindow dismissWindow];
+            [[[SFSDKWindowManager sharedManager] mainWindow:nil] presentWindow];
         }];
         BOOL launched  = [SFApplicationHelper openURL:url];
         completionBlock(launched);
@@ -117,10 +117,10 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
     NSURL *spAppUrl = [NSURL URLWithString:spAppUrlStr];
     NSURL *url = [self appURLWithError:error reason:reason app:spAppUrl.scheme];
     dispatch_async(dispatch_get_main_queue(), ^{
-        SFSDKWindowContainer *authWindow = [SFSDKWindowManager sharedManager].authWindow;
+        SFSDKWindowContainer *authWindow = [[SFSDKWindowManager sharedManager] authWindow:nil];
         [authWindow.viewController.presentedViewController dismissViewControllerAnimated:YES  completion:^{
             [authWindow dismissWindow];
-            [[SFSDKWindowManager sharedManager].mainWindow presentWindow];
+            [[[SFSDKWindowManager sharedManager] mainWindow:nil] presentWindow];
         }];
         BOOL launched  = [SFApplicationHelper openURL:url];
         if (!launched) {
@@ -131,7 +131,6 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
         }];
     });
 }
-
 
 + (NSURL *)appURLWithError:(NSError *)error reason:(NSString *)reason app:(NSString *)appScheme {
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFUserAccountManager+URLHandlers.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFUserAccountManager+URLHandlers.h
@@ -59,8 +59,9 @@
 
 /**
  Handle an IDP response received from an IDP APP.
- @param  response The URL response from the IDP APP.
+ @param response The URL response from the IDP APP.
+ @param sceneId The identifier for the scene that's handling the response.
  @return YES if this is request is handled, NO otherwise.
  */
-- (BOOL)handleIdpResponse:(SFSDKAuthResponseCommand *_Nonnull)response;
+- (BOOL)handleIdpResponse:(SFSDKAuthResponseCommand *_Nonnull)response sceneId:(nullable NSString *)sceneId;
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -272,13 +272,14 @@
 }
 
 - (void)handleBackButtonAction {
+    UIScene *scene = self.view.window.windowScene;
     [[SFUserAccountManager sharedInstance] stopCurrentAuthentication:nil];
     if (![SFUserAccountManager sharedInstance].idpEnabled) {
-        [[SFSDKWindowManager sharedManager].authWindow.viewController.presentedViewController dismissViewControllerAnimated:NO completion:^{
-            [[SFSDKWindowManager sharedManager].authWindow dismissWindow];
+        [[[SFSDKWindowManager sharedManager] authWindow:scene].viewController.presentedViewController dismissViewControllerAnimated:NO completion:^{
+            [[[SFSDKWindowManager sharedManager] authWindow:scene] dismissWindow];
         }];
     } else {
-        [[SFSDKWindowManager sharedManager].authWindow.viewController dismissViewControllerAnimated:NO completion:nil];
+        [[[SFSDKWindowManager sharedManager] authWindow:scene].viewController dismissViewControllerAnimated:NO completion:nil];
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -48,6 +48,7 @@
 #import "SFSDKOAuth2+Internal.h"
 #import "SFSDKOAuthConstants.h"
 #import "SFSDKAuthSession.h"
+#import "SFSDKAuthRequest.h"
 @interface SFOAuthCoordinator()
 
 @property (nonatomic) NSString *networkIdentifier;
@@ -271,11 +272,13 @@
     if (_view == nil) {
         WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
         config.processPool = SFSDKWebViewStateManager.sharedProcessPool;
-        _view = [[WKWebView alloc] initWithFrame:[[UIScreen mainScreen] bounds] configuration:config];
+        UIWindowScene *scene = (UIWindowScene *)self.authSession.oauthRequest.scene;
+        CGRect viewBounds = scene? scene.coordinateSpace.bounds : [UIScreen mainScreen].bounds;
+        _view = [[WKWebView alloc] initWithFrame:viewBounds configuration:config];
         _view.navigationDelegate = self;
         _view.autoresizesSubviews = YES;
         _view.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
-         _view.clipsToBounds = YES;
+        _view.clipsToBounds = YES;
         _view.translatesAutoresizingMaskIntoConstraints = NO;
         _view.customUserAgent = [SalesforceSDKManager sharedManager].userAgentString(@"");
         _view.UIDelegate = self;
@@ -375,11 +378,11 @@
     _asWebAuthenticationSession = [[ASWebAuthenticationSession alloc] initWithURL:nativeBrowserUrl callbackURLScheme:self.credentials.redirectUri   completionHandler:^(NSURL *callbackURL, NSError *error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!error && [[SFSDKURLHandlerManager sharedInstance] canHandleRequest:callbackURL options:nil]) {
-            [[SFSDKURLHandlerManager sharedInstance] processRequest:callbackURL options:nil];
+            NSDictionary *options = @{kSFIDPSceneIdKey : self.authSession.sceneId};
+            [[SFSDKURLHandlerManager sharedInstance] processRequest:callbackURL options:options];
         } else {
             [strongSelf.delegate oauthCoordinatorDidCancelBrowserAuthentication:strongSelf];
         }
-
     }];
  
     _asWebAuthenticationSession.prefersEphemeralWebBrowserSession = [SalesforceSDKManager sharedManager].useEphemeralSessionForAdvancedAuth;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRequest.h
@@ -43,6 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSSet<NSString*> *scopes;
 @property (nonatomic,strong) SFSDKLoginViewControllerConfig *loginViewControllerConfig;
 @property (nonatomic,strong) SFSDKAppLockViewConfig *appLockViewControllerConfig;
+@property (nullable, nonatomic, strong) UIScene *scene;
 @property (nonatomic, copy) NSString *jwtToken;
 @property (nonatomic, copy, nullable) NSString *userAgentForAuth;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRequest.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSString *userAgentForAuth;
 
 //IDP flow related properties (SPApp related properties)
-@property (nonatomic, readonly, assign) BOOL ipdEnabled;
+@property (nonatomic, readonly, assign) BOOL idpEnabled;
 @property (nonatomic, copy) NSString *idpAppURIScheme;
 @property (nonatomic, copy, nullable) NSString *userHint;
 @property (nonatomic, copy, nullable) UIViewController<SFSDKLoginFlowSelectionView> * (^spAppLoginFlowSelectionAction)(void);

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRequest.m
@@ -29,7 +29,7 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
 
 @implementation SFSDKAuthRequest
 
-- (BOOL)ipdEnabled {
+- (BOOL)idpEnabled {
      return self.idpAppURIScheme && self.idpAppURIScheme.length > 0;
 }
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) SFOAuthCredentials *credentials;
 @property (nonatomic, strong) SFOAuthCoordinator *oauthCoordinator;
 @property (nonatomic, strong) SFSDKAuthRequest *oauthRequest;
+@property (nonatomic, strong, readonly) NSString *sceneId;
 @property (nonatomic, copy, nullable) void (^authSuccessCallback)(SFOAuthInfo *, SFUserAccount *);
 @property (nonatomic, copy, nullable) void (^authFailureCallback)(SFOAuthInfo *, NSError *);
 @property (nonatomic, strong) SFIdentityCoordinator *identityCoordinator;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.m
@@ -47,6 +47,7 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
         _credentials = (creds == nil) ? [self newClientCredentials] : creds;
         _credentials.jwt = request.jwtToken;
         _spAppCredentials = spAppCredentials;
+        _sceneId = request.scene.session.persistentIdentifier; // Pass through for convenience
         [self initCoordinator];
     }
     return self;
@@ -74,11 +75,6 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
     creds.domain = self.oauthRequest.loginHost;
     creds.accessToken = nil;
     return creds;
-}
-
-// Pass through for convenience
-- (NSString *)sceneId {
-    return self.oauthRequest.scene.session.persistentIdentifier;
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.m
@@ -76,4 +76,9 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
     return creds;
 }
 
+// Pass through for convenience
+- (NSString *)sceneId {
+    return self.oauthRequest.scene.session.persistentIdentifier;
+}
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthViewHandler.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthViewHandler.h
@@ -47,11 +47,13 @@ NS_SWIFT_NAME(AuthViewHolder)
 
 @property (nonatomic,weak,nullable) WKWebView *wkWebView;
 
-@property (nonatomic,weak) SFLoginViewController *loginController;
+@property (nonatomic, strong) SFLoginViewController *loginController;
 
 @property (nonatomic,weak,nullable) ASWebAuthenticationSession *session;
 
 @property (nonatomic,assign) BOOL isAdvancedAuthFlow;
+
+@property (nonatomic, strong) UIScene *scene;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -485,7 +485,7 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
         return;
     }
     
-    if ([SFApplicationHelper sharedApplication].applicationState == UIApplicationStateActive || ![SFSDKWindowManager sharedManager].snapshotWindow.isEnabled) {
+    if ([SFApplicationHelper sharedApplication].applicationState == UIApplicationStateActive || ![[SFSDKWindowManager sharedManager] snapshotWindow:nil].isEnabled) {
         if (![SFSecurityLockout deviceHasBiometric]) {
             [self setBiometricState:SFBiometricUnlockUnavailable];
         }
@@ -505,8 +505,8 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
         return;
     }
     
-    if ([[SFSDKWindowManager sharedManager].snapshotWindow isEnabled]) {
-        [[SFSDKWindowManager sharedManager].snapshotWindow dismissWindow];
+    if ([[[SFSDKWindowManager sharedManager] snapshotWindow:nil] isEnabled]) {
+        [[[SFSDKWindowManager sharedManager] snapshotWindow:nil] dismissWindow];
     }
     // Don't present the passcode screen if it's already present.
     if ([SFSecurityLockout passcodeScreenIsPresent]) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKAdvancedAuthURLHandler.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKAdvancedAuthURLHandler.m
@@ -45,7 +45,7 @@
 }
 
 - (BOOL)processRequest:(NSURL *)url options:(NSDictionary *)options {
-    return [[SFUserAccountManager sharedInstance] handleAdvancedAuthURL:url];
+    return [[SFUserAccountManager sharedInstance] handleAdvancedAuthURL:url options:options];
 }
 
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKIDPResponseHandler.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKIDPResponseHandler.m
@@ -47,7 +47,7 @@
     SFSDKAuthResponseCommand *command = [[SFSDKAuthResponseCommand alloc] init];
     [command fromRequestURL:url];
 
-    [[SFUserAccountManager sharedInstance] handleIdpResponse:command];
+    [[SFUserAccountManager sharedInstance] handleIdpResponse:command sceneId:options[kSFIDPSceneIdKey]];
     return NO;
 
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager+Internal.h
@@ -108,15 +108,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong, nullable) SFSDKAuthErrorManager *errorManager;
 
-/** SFSDKAlertView used to wrap display of SFSDKMessage using an AlertController.
- *
- */
-@property (nonatomic, strong, nullable) SFSDKAuthSession *authSession;
+@property (nonatomic, strong, nonnull) SFSDKSafeMutableDictionary<NSString *, SFSDKAuthSession *> *authSessions;
 
 /**
  Indicates if the app is configured to require browser based authentication.
  */
 @property (nonatomic, assign) BOOL useBrowserAuth;
+
+/**
+Set this block to handle presentation of the Authentication View Controller.
+*/
+@property (nonatomic, strong) SFSDKAuthViewHandler *authViewHandler;
 
 - (void)setCurrentUserInternal:(SFUserAccount* _Nullable)user;
 
@@ -183,15 +185,17 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (SFUserAccountIdentity *_Nullable)decodeUserIdentity:(NSString *_Nullable)userIdentityEncoded;
 
-- (BOOL)handleAdvancedAuthURL:(NSURL *)advancedAuthURL;
-
-- (void)restartAuthentication;
+- (BOOL)handleAdvancedAuthURL:(NSURL *)advancedAuthURL options:(nullable NSDictionary *)options;
 
 - (BOOL)authenticateUsingIDP:(SFSDKAuthRequest *)request completion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock;
 
 - (BOOL)authenticateWithRequest:(SFSDKAuthRequest *)request completion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock;
 
 - (SFSDKAuthRequest *)defaultAuthRequest;
+
+- (BOOL)loginWithCompletion:(nullable SFUserAccountManagerSuccessCallbackBlock)completionBlock
+                    failure:(nullable SFUserAccountManagerFailureCallbackBlock)failureBlock
+                      scene:(nullable UIScene *)scene;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -162,6 +162,10 @@ FOUNDATION_EXTERN NSString * const kSFNotificationFromUserKey NS_SWIFT_NAME(User
  */
 FOUNDATION_EXTERN NSString * const kSFNotificationToUserKey NS_SWIFT_NAME(UserAccountManager.userInfoToUserKey);
 
+/**  Key used to provide triggering scene info for IDP flow from a scene delegate.
+ */
+FOUNDATION_EXTERN NSString * const kSFIDPSceneIdKey NS_SWIFT_NAME(UserAccountManager.IDPSceneKey);
+
 @class SFUserAccountManager;
 @class SFSDKAlertMessage;
 @class SFSDKWindowContainer;
@@ -504,23 +508,12 @@ Use this method to stop/clear any authentication which is has already been start
 - (void)logoutAllUsers;
 
 /**
- Dismisses the auth view controller, resetting the UI state back to its original
- presentation.
- */
-- (void)dismissAuthViewControllerIfPresent NS_SWIFT_UNAVAILABLE("");
-
-/**
  Handle an authentication response from the IDP application
  @param url The URL response returned to the app from the IDP application.
  @options Dictionary of name-value pairs received from open URL
  @return YES if this is a valid URL response from IDP authentication that should be handled, NO otherwise.
  */
 - (BOOL)handleIDPAuthenticationResponse:(NSURL *)url options:(nonnull NSDictionary *)options NS_SWIFT_NAME(handleIdentityProviderResponse(from:with:));
-
-/**
- Set this block to handle presentation of the Authentication View Controller.
- */
-@property (nonatomic, strong) SFSDKAuthViewHandler *authViewHandler NS_SWIFT_UNAVAILABLE("");
 
 /**
  Presents the setup screen that allows the user to opt into Touch/Face Id as a replacement for Passcode.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -21,7 +21,9 @@
  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#import "SalesforceSDKManager+Internal.h"
 #import "SFUserAccountManager+Internal.h"
+#import "SFSDKWindowManager+Internal.h"
 #import "SFUserAccount+Internal.h"
 #import "SFIdentityData+Internal.h"
 #import "SFDefaultUserAccountPersister.h"
@@ -57,6 +59,7 @@
 #import "SFNetwork.h"
 #import "SFSDKSalesforceAnalyticsManager.h"
 #import "SFSecurityLockout+Internal.h"
+#import "SFApplicationHelper.h"
 
 // Notifications
 NSNotificationName SFUserAccountManagerDidChangeUserNotification       = @"SFUserAccountManagerDidChangeUserNotification";
@@ -108,12 +111,13 @@ static NSString * const kAlertRetryButtonKey = @"authAlertRetryButton";
 static NSString * const kAlertDismissButtonKey = @"authAlertDismissButton";
 static NSString * const kAlertConnectionErrorFormatStringKey = @"authAlertConnectionErrorFormatString";
 static NSString * const kAlertVersionMismatchErrorKey = @"authAlertVersionMismatchError";
-static NSString *const kErroredClientKey = @"SFErroredOAuthClientKey";
+static NSString * const kErroredClientKey = @"SFErroredOAuthClientKey";
 static NSString * const kSFSPAppFeatureIDPLogin   = @"SP";
 static NSString * const kSFIDPAppFeatureIDPLogin   = @"IP";
-static NSString *const  kOptionsClientKey          = @"clientIdentifier";
+static NSString * const kOptionsClientKey          = @"clientIdentifier";
 
 NSString * const kSFSDKUserAccountManagerErrorDomain = @"com.salesforce.mobilesdk.SFUserAccountManager";
+NSString * const kSFIDPSceneIdKey = @"sceneIdentifier";
 
 static NSString * const kSFInvalidCredentialsAuthErrorHandler = @"InvalidCredentialsErrorHandler";
 static NSString * const kSFConnectedAppVersionAuthErrorHandler = @"ConnectedAppVersionErrorHandler";
@@ -202,6 +206,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             __strong typeof(weakSelf) strongSelf = weakSelf;
             [strongSelf dismissAuthViewControllerIfPresent];
         }];
+        
+        _authSessions = [SFSDKSafeMutableDictionary new];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(sceneDidDisconnect:) name:UISceneDidDisconnectNotification object:nil];
         
         [self populateErrorHandlers];
      }
@@ -338,7 +345,15 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 }
 
 - (BOOL)loginWithCompletion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
-    return [self authenticateWithCompletion:completionBlock failure:failureBlock];
+    BOOL result = NO;
+    for (UIScene *scene in [SFApplicationHelper sharedApplication].connectedScenes) {
+        result |= [self loginWithCompletion:completionBlock failure:failureBlock scene:scene];
+    }
+    return result;
+}
+
+- (BOOL)loginWithCompletion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock scene:(UIScene *)scene {
+    return [self authenticateWithCompletion:completionBlock failure:failureBlock scene:scene];
 }
 
 - (BOOL)refreshCredentials:(SFOAuthCredentials *)credentials completion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
@@ -391,28 +406,38 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         return;
     }
     BOOL result = NO;
-    if (self.authSession && self.authSession.isAuthenticating) {
-        [self resetAuthentication];
-        result = YES;
-    } else {
-        [SFSDKCoreLogger e:[self class] format:@"Authentication has already been stopped."];
+    for (NSString *sceneId in self.authSessions.allKeys) {
+        SFSDKAuthSession *authSession = self.authSessions[sceneId];
+        if (authSession.isAuthenticating) {
+            result = YES;
+            [self dismissAuthViewControllerIfPresentForScene:authSession.oauthRequest.scene completion:nil];
+        }
     }
     
-    if (completionBlock) {
-        [self dismissAuthViewControllerIfPresent:^{
-            completionBlock(result);
-        }];
+    [self resetAuthentication];
+    
+    if (!result) {
+        [SFSDKCoreLogger e:[self class] format:@"Authentication has already been stopped."];
     }
-  
+
+    if (completionBlock) {
+        completionBlock(result);
+    }
 }
 
-- (BOOL)authenticateWithCompletion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
-    if (_authSession && _authSession.isAuthenticating) {
-        [SFSDKCoreLogger e:[self class] format:@"Login has already been called. Stop current authentication using SFUserAccountmanger::stopAuthentication and then retry."];
+- (BOOL)authenticateWithCompletion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock scene:(UIScene *)scene {
+    SFSDKAuthSession *authSession = self.authSessions[scene.session.persistentIdentifier];
+    if (authSession && authSession.isAuthenticating) {
+        [SFSDKCoreLogger e:[self class] format:@"Login has already been called. Stop current authentication using SFUserAccountManager::stopCurrentAuthentication and then retry."];
         return NO;
     }
+    
     SFSDKAuthRequest *request = [self defaultAuthRequest];
-    if (request.ipdEnabled) {
+    if (scene) {
+        request.scene = scene;
+    }
+
+    if (request.idpEnabled) {
        return [self authenticateUsingIDP:request completion:completionBlock failure:failureBlock];
     }
     return [self authenticateWithRequest:request completion:completionBlock failure:failureBlock];
@@ -432,6 +457,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     request.useBrowserAuth = self.useBrowserAuth;
     request.spAppLoginFlowSelectionAction = self.idpLoginFlowSelectionAction;
     request.idpAppURIScheme = self.idpAppURIScheme;
+    request.scene = [[SFSDKWindowManager sharedManager] defaultScene];
     return request;
 }
 
@@ -441,26 +467,27 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     authSession.authFailureCallback = failureBlock;
     authSession.authSuccessCallback = completionBlock;
     authSession.oauthCoordinator.delegate = self;
-    self.authSession = authSession;
+    NSString *sceneId = authSession.sceneId;
+    self.authSessions[sceneId] = authSession;
     dispatch_async(dispatch_get_main_queue(), ^{
         [SFSDKWebViewStateManager removeSession];
         [authSession.oauthCoordinator authenticate];
     });
-    return self.authSession.isAuthenticating;
+    return self.authSessions[sceneId].isAuthenticating;
 }
 
 - (BOOL)authenticateWithRequestOnBehalfOfSpApp:(SFSDKAuthRequest *)request spAppCredentials:(SFOAuthCredentials *)spAppCrendetials completion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
-    SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] initWith:request credentials:nil  spAppCredentials:spAppCrendetials];
+    SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] initWith:request credentials:nil spAppCredentials:spAppCrendetials];
     authSession.isAuthenticating = YES;
     authSession.authFailureCallback = failureBlock;
     authSession.authSuccessCallback = completionBlock;
     authSession.oauthCoordinator.delegate = self;
-    self.authSession = authSession;
+    self.authSessions[authSession.sceneId] = authSession;
     dispatch_async(dispatch_get_main_queue(), ^{
         [SFSDKWebViewStateManager removeSession];
         [authSession.oauthCoordinator authenticate];
     });
-    return self.authSession.isAuthenticating;
+    return self.authSessions[authSession.sceneId].isAuthenticating;
 }
 
 - (BOOL)loginWithJwtToken:(NSString *)jwtToken completion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
@@ -496,19 +523,15 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     }];
 }
 
-- (void)restartAuthentication {
-    [self restartAuthentication:self.authSession];
-}
-
 - (void)restartAuthentication:(SFSDKAuthSession *)session {
     [session.oauthCoordinator stopAuthentication];
     __weak typeof(self) weakSelf = self;
-    [self dismissAuthViewControllerIfPresent:^{
+    UIScene *scene = session.oauthRequest.scene;
+    [self dismissAuthViewControllerIfPresentForScene:scene completion:^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        strongSelf.authSession.isAuthenticating = NO;
+        strongSelf.authSessions[scene.session.persistentIdentifier].isAuthenticating = NO;
         [strongSelf authenticateWithRequest:session.oauthRequest completion:session.authSuccessCallback failure:session.authFailureCallback];
     }];
-    
 }
 
 - (void)postPushUnregistration:(SFUserAccount *)user {
@@ -580,36 +603,38 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     [self logoutUser:[SFUserAccountManager sharedInstance].currentUser];
 }
 
-- (void)dismissAuthViewControllerIfPresent
-{
-    [self dismissAuthViewControllerIfPresent:nil];
+- (void)dismissAuthViewControllerIfPresent {
+    NSArray *scenes = [SFApplicationHelper sharedApplication].connectedScenes.allObjects;
+    for (UIScene *scene in scenes) {
+        [self dismissAuthViewControllerIfPresentForScene:scene completion:nil];
+    }
 }
 
-- (void)dismissAuthViewControllerIfPresent:(void (^)(void))completionBlock {
+- (void)dismissAuthViewControllerIfPresentForScene:(UIScene *)scene completion:(void (^)(void))completionBlock {
     if (![NSThread isMainThread]) {
         dispatch_sync(dispatch_get_main_queue(), ^{
-            [self dismissAuthViewControllerIfPresent:completionBlock];
+            [self dismissAuthViewControllerIfPresentForScene:scene completion:completionBlock];
         });
         return;
     }
-    
-    if (![SFSDKWindowManager sharedManager].authWindow.isEnabled) {
+
+    SFSDKWindowContainer *authWindow = [[SFSDKWindowManager sharedManager] authWindow:scene];
+    if (![[SFSDKWindowManager sharedManager] authWindow:scene].isEnabled) {
         if (completionBlock) completionBlock();
         return;
     }
-    
-    UIViewController *presentedViewController = [SFSDKWindowManager sharedManager].authWindow.viewController.presentedViewController;
-    
+
+    UIViewController *presentedViewController = authWindow.viewController.presentedViewController;
     if (presentedViewController && presentedViewController.isBeingPresented) {
         [presentedViewController dismissViewControllerAnimated:NO completion:^{
-            [[SFSDKWindowManager sharedManager].authWindow dismissWindowAnimated:NO withCompletion:^{
+            [[[SFSDKWindowManager sharedManager] authWindow:scene] dismissWindowAnimated:NO withCompletion:^{
                 if (completionBlock) {
                     completionBlock();
                 }
             }];
         }];
     } else {
-        [[SFSDKWindowManager sharedManager].authWindow dismissWindowAnimated:NO withCompletion:^{
+        [[[SFSDKWindowManager sharedManager] authWindow:scene] dismissWindowAnimated:NO withCompletion:^{
             if (completionBlock) {
                 completionBlock();
             }
@@ -656,7 +681,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             [SFSDKCoreLogger e:[self class] format:@"Unhandled Error during authentication. Handle the error using   [SFUserAccountManagerDelegate userAccountManager:error:info:] and return true. %@", error.localizedDescription];
         }
     }
-    self.authSession.notifiesDelegatesOfFailure = YES;
+    coordinator.authSession.notifiesDelegatesOfFailure = YES;
     [self handleFailure:error session:coordinator.authSession];
 }
 
@@ -683,7 +708,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
        builder.actionOneCompletion = completion;
    }];
     dispatch_async(dispatch_get_main_queue(), ^{
-        self.alertDisplayBlock(messageObject, [SFSDKWindowManager sharedManager].authWindow);
+        self.alertDisplayBlock(messageObject, [[SFSDKWindowManager sharedManager] authWindow:coordinator.authSession.oauthRequest.scene]);
    });
     
 }
@@ -702,7 +727,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         };
     }];
     dispatch_async(dispatch_get_main_queue(), ^{
-        self.alertDisplayBlock(messageObject, [SFSDKWindowManager sharedManager].authWindow);
+        self.alertDisplayBlock(messageObject, [[SFSDKWindowManager sharedManager] authWindow:coordinator.authSession.oauthRequest.scene]);
     });
 }
 // IDP related code fetched as an identity provider app
@@ -710,10 +735,10 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     coordinator.authSession.authInfo = authInfo;
     
     // Fetched auth code as an idp app
-    [SFSDKIDPAuthHelper invokeSPApp:self.authSession completion:^(BOOL result) {
+    [SFSDKIDPAuthHelper invokeSPApp:coordinator.authSession completion:^(BOOL result) {
         [self dismissAuthViewControllerIfPresent];
     }];
-    
+
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(WKWebView *)view {
@@ -722,6 +747,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     loginViewController.oauthView = view;
     SFSDKAuthViewHolder *viewHolder = [SFSDKAuthViewHolder new];
     viewHolder.loginController = loginViewController;
+    viewHolder.scene = coordinator.authSession.oauthRequest.scene;
     // Ensure this runs on the main thread.  Has to be sync, because the coordinator expects the auth view
     // to be added to a superview by the end of this method.
     if (![NSThread isMainThread]) {
@@ -737,6 +763,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     SFSDKAuthViewHolder *viewHolder = [SFSDKAuthViewHolder new];
     viewHolder.isAdvancedAuthFlow = YES;
     viewHolder.session = session;
+    viewHolder.scene = coordinator.authSession.oauthRequest.scene;
     NSDictionary *userInfo = @{ kSFNotificationUserInfoCredentialsKey: coordinator.credentials,
                                 kSFNotificationUserInfoAuthTypeKey: coordinator.authInfo };
     [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserWillShowAuthView object:self  userInfo:userInfo];
@@ -756,8 +783,8 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
            SFSDKNavigationController *controller = [[SFSDKNavigationController alloc] initWithRootViewController:hostListViewController];
            hostListViewController.hidesCancelButton = YES;
            controller.modalPresentationStyle = UIModalPresentationFullScreen;
-           [[SFSDKWindowManager sharedManager].authWindow presentWindowAnimated:NO withCompletion:^{
-               [[SFSDKWindowManager sharedManager].authWindow.viewController presentViewController:controller animated:NO completion:nil];
+        [[[SFSDKWindowManager sharedManager] authWindow:coordinator.authSession.oauthRequest.scene] presentWindowAnimated:NO withCompletion:^{
+            [[[SFSDKWindowManager sharedManager] authWindow:coordinator.authSession.oauthRequest.scene].viewController presentViewController:controller animated:NO completion:nil];
            }];
     } else {
         self.authCancelledByUserHandlerBlock();
@@ -776,7 +803,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         [SFSDKCoreLogger e:[self class] format:@"Missing parameters attempting to retrieve identity data.  Error domain: %@, code: %ld, description: %@", [error domain], [error code], [error localizedDescription]];
         id<SFSDKOAuthProtocol> authClient = self.authClient();
         [authClient revokeRefreshToken:coordinator.credentials];
-       [self handleFailure:error session:self.authSession];
+       [self handleFailure:error session:coordinator.authSession];
     } else {
         [SFSDKCoreLogger e:[self class] format:@"Error retrieving idData:%@", error];
         SFSDKAlertMessage *message = [SFSDKAlertMessage messageWithBlock:^(SFSDKAlertMessageBuilder *builder) {
@@ -789,7 +816,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             };
         }];
         dispatch_async(dispatch_get_main_queue(), ^{
-            self.alertDisplayBlock(message, [SFSDKWindowManager sharedManager].authWindow);
+            self.alertDisplayBlock(message, [[SFSDKWindowManager sharedManager] authWindow:coordinator.authSession.oauthRequest.scene]);
         });
     }
 }
@@ -800,8 +827,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     self.loginHost = newLoginHost.host;
     NSNotification *loginHostChangedNotification = [NSNotification notificationWithName:kSFNotificationDidChangeLoginHost object:self userInfo:userInfo];
     [[NSNotificationCenter defaultCenter] postNotification:loginHostChangedNotification];
-    self.authSession.oauthRequest.loginHost = newLoginHost.host;
-    [self restartAuthentication];
+    NSString *sceneId = loginViewController.view.window.windowScene.session.persistentIdentifier;
+    self.authSessions[sceneId].oauthRequest.loginHost = newLoginHost.host;
+    [self restartAuthentication:self.authSessions[sceneId]];
 }
 
 #pragma mark - SFSDKLoginHostDelegate
@@ -815,7 +843,8 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     self.loginHost = newLoginHost.host;
     NSNotification *loginHostChangedNotification = [NSNotification notificationWithName:kSFNotificationDidChangeLoginHost object:self userInfo:userInfo];
     [[NSNotificationCenter defaultCenter] postNotification:loginHostChangedNotification];
-    self.authSession.oauthRequest.loginHost = newLoginHost.host;
+    NSString *sceneId = hostListViewController.view.window.windowScene.session.persistentIdentifier;
+    [self.authSessions objectForKey:sceneId].oauthRequest.loginHost = newLoginHost.host;
     [_accountsLock unlock];
 }
 
@@ -824,29 +853,34 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 }
 
 - (void)loginHostSelected:(SFSDKLoginHostListViewController *)hostListViewController {
+    NSString *sceneId = hostListViewController.view.window.windowScene.session.persistentIdentifier;
     [hostListViewController dismissViewControllerAnimated:YES completion:nil];
-    [self restartAuthentication];
+    [self restartAuthentication: [self.authSessions objectForKey:sceneId]];
 }
 
 #pragma mark - SFSDKLoginFlowSelectionViewDelegate (SP App flow Related Actions)
 
 -(void)loginFlowSelectionIDPSelected:(UIViewController *)controller options:(NSDictionary *)appOptions {
     //User picked IDP flow from login Selection screen. start the idp flow.
+    UIScene *scene = controller.view.window.windowScene;
+    NSString *sceneId = scene.session.persistentIdentifier;
     NSString *loginHost = appOptions[kSFLoginHostParam];
     if (loginHost) {
-        self.authSession.oauthCoordinator.credentials.domain = loginHost;
+        self.authSessions[sceneId].oauthCoordinator.credentials.domain = loginHost;
     }
-    self.authSession.oauthRequest.appDisplayName = self.appDisplayName;
-    [SFSDKIDPAuthHelper invokeIDPApp:self.authSession completion:^(BOOL result) {
-       [SFSDKCoreLogger d:[self class] format:@"Launced IDP App"];
+    self.authSessions[sceneId].oauthRequest.appDisplayName = self.appDisplayName;
+    [SFSDKIDPAuthHelper invokeIDPApp:self.authSessions[sceneId] completion:^(BOOL result) {
+       [SFSDKCoreLogger d:[self class] format:@"Launched IDP App"];
     }];
 }
 
 -(void)loginFlowSelectionLocalLoginSelected:(UIViewController *)controller options:(NSDictionary *)appOptions  {
     __weak typeof (self) weakSelf = self;
-    [self dismissAuthViewControllerIfPresent:^{
+    UIScene *scene = controller.view.window.windowScene;
+    NSString *sceneId = scene.session.persistentIdentifier;
+    [self dismissAuthViewControllerIfPresentForScene:scene completion:^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        [strongSelf authenticateWithRequest:strongSelf.authSession.oauthRequest completion:strongSelf.authSession.authSuccessCallback  failure:strongSelf.authSession.authFailureCallback];
+        [strongSelf authenticateWithRequest:strongSelf.authSessions[sceneId].oauthRequest completion:strongSelf.authSessions[sceneId].authSuccessCallback failure:strongSelf.authSessions[sceneId].authFailureCallback];
     }];
 }
 
@@ -883,7 +917,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 }
 
 - (void)cancel:(NSDictionary *)spAppOptions {
-   // Uset Cancelled auth in the idp app mode
+   // User Cancelled auth in the idp app mode
     SFOAuthCredentials *spAppCredentials = [self spAppCredentials:spAppOptions];
     [SFSDKIDPAuthHelper invokeSPAppWithError:spAppCredentials error:nil reason:@"User cancelled Authentication"];
 }
@@ -952,10 +986,11 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     }
 }
 
-- (BOOL)handleAdvancedAuthURL:(NSURL *)advancedAuthURL {
+- (BOOL)handleAdvancedAuthURL:(NSURL *)advancedAuthURL options:(NSDictionary *)options {
     BOOL result = NO;
-    if (self.authSession) {
-        result = [self.authSession.oauthCoordinator handleAdvancedAuthenticationResponse:advancedAuthURL];
+    NSString *sceneId = options[kSFIDPSceneIdKey];
+    if (self.authSessions[sceneId]) {
+        result = [self.authSessions[sceneId].oauthCoordinator handleAdvancedAuthenticationResponse:advancedAuthURL];
     }
     return result;
 }
@@ -1402,12 +1437,13 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     authSession.authFailureCallback = failureBlock;
     authSession.authSuccessCallback = completionBlock;
     authSession.oauthCoordinator.delegate = self;
-    self.authSession = authSession;
+    NSString *sceneId = request.scene.session.persistentIdentifier;
+    self.authSessions[sceneId] = authSession;
     if (request.idpInitiatedAuth && request.userHint) {
         //no need to show login selection view
-        self.authSession.oauthRequest.appDisplayName = self.appDisplayName;
-        [SFSDKIDPAuthHelper invokeIDPApp:self.authSession completion:^(BOOL result) {
-           [SFSDKCoreLogger d:[self class] format:@"Launced IDP App"];
+        self.authSessions[sceneId].oauthRequest.appDisplayName = self.appDisplayName;
+        [SFSDKIDPAuthHelper invokeIDPApp:self.authSessions[sceneId] completion:^(BOOL result) {
+           [SFSDKCoreLogger d:[self class] format:@"Launched IDP App"];
         }];
     } else {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -1420,31 +1456,30 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             }
             controller.appOptions = options;
             controller.selectionFlowDelegate = [SFUserAccountManager sharedInstance];
-            SFSDKWindowContainer *authWindow = [SFSDKWindowManager sharedManager].authWindow;
+            SFSDKWindowContainer *authWindow = [[SFSDKWindowManager sharedManager] authWindow:request.scene];
            
             SFSDKNavigationController *navcontroller = [[SFSDKNavigationController alloc] initWithRootViewController:controller];
             navcontroller.modalPresentationStyle = UIModalPresentationFullScreen;
             [authWindow presentWindowAnimated:NO withCompletion:^{
-               authWindow.viewController.modalPresentationStyle = UIModalPresentationFullScreen;
-               [authWindow.viewController presentViewController:navcontroller animated:YES completion:^{
-               }];
+                authWindow.viewController.modalPresentationStyle = UIModalPresentationFullScreen;
+                [authWindow.viewController presentViewController:navcontroller animated:YES completion:nil];
             }];
         });
     }
-    return self.authSession.isAuthenticating;
+    return self.authSessions[sceneId].isAuthenticating;
 }
 
 - (void)authenticateOnBehalfOfSPApp:(SFUserAccount *)user spAppCredentials:(SFOAuthCredentials *)spAppCredentials {
-    
     SFSDKAuthRequest *request = [self defaultAuthRequest];
-    self.authSession = [[SFSDKAuthSession alloc] initWith:request credentials:user.credentials spAppCredentials:spAppCredentials];
-    self.authSession.oauthCoordinator.delegate = self;
-    self.authSession.identityCoordinator.delegate = self;
+    SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] initWith:request credentials:user.credentials spAppCredentials:spAppCredentials];
+    authSession.oauthCoordinator.delegate = self;
+    authSession.identityCoordinator.delegate = self;
+    self.authSessions[authSession.sceneId] = authSession;
     __weak typeof(self) weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        [strongSelf dismissAuthViewControllerIfPresent:^{
-             [strongSelf.authSession.oauthCoordinator beginIDPFlow];
+        [strongSelf dismissAuthViewControllerIfPresentForScene:authSession.oauthRequest.scene completion:^{
+             [strongSelf.authSessions[authSession.sceneId].oauthCoordinator beginIDPFlow];
         }];
     });
 }
@@ -1469,7 +1504,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         __strong typeof (weakSelf) strongSelf = weakSelf;
         NSString *alertMessage = [NSString stringWithFormat:[SFSDKResourceUtils localizedString:kAlertConnectionErrorFormatStringKey], [error localizedDescription]];
         NSString *okButton = [SFSDKResourceUtils localizedString:kAlertOkButtonKey];
-        [strongSelf showErrorAlertWithMessage:alertMessage buttonTitle:okButton andCompletion:^() {
+        [strongSelf showErrorAlertWithMessage:alertMessage buttonTitle:okButton scene:session.oauthRequest.scene andCompletion:^() {
             [session.oauthCoordinator stopAuthentication];
             [strongSelf notifyUserCancelledOrDismissedAuth:session.oauthCoordinator.credentials andAuthInfo:session.authInfo];
             NSString *host = [[SFSDKLoginHostStorage sharedInstance] loginHostAtIndex:0].host;
@@ -1484,8 +1519,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 
         NSString *message =[NSString stringWithFormat:[SFSDKResourceUtils localizedString:kAlertConnectionErrorFormatStringKey], [error localizedDescription]];
         NSString *retryButton = [SFSDKResourceUtils localizedString:kAlertOkButtonKey];
-        [strongSelf showErrorAlertWithMessage:message buttonTitle:retryButton   andCompletion:^() {
-            //TODO: RestartAuth
+        [strongSelf showErrorAlertWithMessage:message buttonTitle:retryButton scene:session.oauthRequest.scene andCompletion:^() {
             [strongSelf restartAuthentication:session];
         }];
     };
@@ -1497,7 +1531,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     };
 }
 
-- (void)showErrorAlertWithMessage:(NSString *)alertMessage buttonTitle:(NSString *)buttonTitle andCompletion:(void(^)(void))completionBlock {
+- (void)showErrorAlertWithMessage:(NSString *)alertMessage buttonTitle:(NSString *)buttonTitle scene:(UIScene *)scene andCompletion:(void(^)(void))completionBlock {
     __weak typeof (self) weakSelf = self;
     SFSDKAlertMessage *message = [SFSDKAlertMessage messageWithBlock:^(SFSDKAlertMessageBuilder *builder) {
         builder.alertTitle = [SFSDKResourceUtils localizedString:kAlertErrorTitleKey];
@@ -1508,7 +1542,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         };
     }];
     dispatch_async(dispatch_get_main_queue(), ^{
-        weakSelf.alertDisplayBlock(message, SFSDKWindowManager.sharedManager.authWindow);
+        weakSelf.alertDisplayBlock(message, [SFSDKWindowManager.sharedManager authWindow:scene]);
     });
 }
 
@@ -1526,15 +1560,15 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         };
     }];
     dispatch_async(dispatch_get_main_queue(), ^{
-        weakSelf.alertDisplayBlock(message, SFSDKWindowManager.sharedManager.authWindow);
+        weakSelf.alertDisplayBlock(message, [SFSDKWindowManager.sharedManager authWindow:session.oauthRequest.scene]);
     });
 }
 
 - (void)loggedIn:(BOOL)fromOffline coordinator:(SFOAuthCoordinator *)coordinator notifyDelegatesOfFailure:(BOOL)shouldNotify {
     if (!fromOffline) {
         SFIdentityCoordinator *identityCoordinator = [[SFIdentityCoordinator alloc] initWithAuthSession:coordinator.authSession];
-        self.authSession.identityCoordinator = identityCoordinator;
-        self.authSession.notifiesDelegatesOfFailure = shouldNotify;
+        self.authSessions[coordinator.authSession.sceneId].identityCoordinator = identityCoordinator;
+        self.authSessions[coordinator.authSession.sceneId].notifiesDelegatesOfFailure = shouldNotify;
         identityCoordinator.delegate = self;
         [identityCoordinator initiateIdentityDataRetrieval];
     } else {
@@ -1550,17 +1584,18 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     NSNumber *biometricUnlockKey = [identityCoordinator.idData.customAttributes objectForKey:@"BIOMETRIC_UNLOCK"];
     BOOL biometricUnlockAvailable = (biometricUnlockKey == nil) ? YES : [biometricUnlockKey boolValue];
     __weak typeof(self) weakSelf = self;
-    [self dismissAuthViewControllerIfPresent:^{
+    [self dismissAuthViewControllerIfPresentForScene:authSession.oauthRequest.scene completion:^{
           __strong typeof(weakSelf) strongSelf = weakSelf;
         if (authSession.authInfo.authType != SFOAuthTypeRefresh) {
            [SFSecurityLockout setPasscodeViewConfig:authSession.oauthRequest.appLockViewControllerConfig];
-           [SFSecurityLockout setLockScreenSuccessCallbackBlock:^(SFSecurityLockoutAction action) {
-               [strongSelf finalizeAuthCompletion:authSession];
-           }];
-           [SFSecurityLockout setLockScreenFailureCallbackBlock:^{
-               strongSelf.authSession.notifiesDelegatesOfFailure = YES;
-               [strongSelf handleFailure:authSession.authError session:strongSelf.authSession];
-           }];
+            [SFSecurityLockout setLockScreenSuccessCallbackBlock:^(SFSecurityLockoutAction action) {
+                [strongSelf finalizeAuthCompletion:authSession];
+            }];
+            NSString *sceneId = authSession.sceneId;
+            [SFSecurityLockout setLockScreenFailureCallbackBlock:^{
+                strongSelf.authSessions[sceneId].notifiesDelegatesOfFailure = YES;
+                [strongSelf handleFailure:authSession.authError session:strongSelf.authSessions[sceneId]];
+            }];
            // Check to see if a passcode needs to be created or updated, based on passcode policy data from the
            // identity service.
            [SFSecurityLockout setInactivityConfiguration:identityCoordinator.idData.mobileAppPinLength
@@ -1570,8 +1605,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
            [strongSelf finalizeAuthCompletion:authSession];
        }
     }];
-    
-   
+    [self dismissAuthViewControllerIfPresent];
 }
 
 - (void)handleFailure:(NSError *)error session:(SFSDKAuthSession *)authSession {
@@ -1588,19 +1622,35 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             }
         }];
     }
-    [self resetAuthentication];
+    // [self resetAuthentication:authSession];
 }
 
 - (void)resetAuthentication {
-    
     [_accountsLock lock];
-    if (self.authSession.authInfo.authType == SFOAuthTypeUserAgent) {
-        [self.authSession.oauthCoordinator.view removeFromSuperview];
+    for (NSString *key in self.authSessions.allKeys) {
+        SFSDKAuthSession *authSession = self.authSessions[key];
+        if (authSession.authInfo.authType == SFOAuthTypeUserAgent) {
+            [authSession.oauthCoordinator.view removeFromSuperview];
+        }
+        NSString *sceneId = authSession.sceneId;
+        [self.authSessions[sceneId].oauthCoordinator stopAuthentication];
+        self.authSessions[sceneId].identityCoordinator.idData = nil;
+        self.authSessions[sceneId].isAuthenticating = NO;
+        [self.authSessions removeObject:sceneId];
     }
-    [self.authSession.oauthCoordinator stopAuthentication];
-    self.authSession.identityCoordinator.idData = nil;
-    self.authSession.isAuthenticating = NO;
-    self.authSession = nil;
+    [_accountsLock unlock];
+}
+
+- (void)resetAuthentication:(SFSDKAuthSession *)authSession {
+    [_accountsLock lock];
+    if (authSession.authInfo.authType == SFOAuthTypeUserAgent) {
+        [authSession.oauthCoordinator.view removeFromSuperview];
+    }
+    NSString *sceneId = authSession.sceneId;
+    [self.authSessions[sceneId].oauthCoordinator stopAuthentication];
+    self.authSessions[sceneId].identityCoordinator.idData = nil;
+    self.authSessions[sceneId].isAuthenticating = NO;
+    [self.authSessions removeObject:sceneId];
     [_accountsLock unlock];
 }
 
@@ -1618,7 +1668,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         NSError *error = [NSError errorWithDomain:@"SFUserAccountManager"
                                              code:1005
                                          userInfo:@{ NSLocalizedDescriptionKey : reason } ];
-        self.authSession.notifiesDelegatesOfFailure = YES;
+        authSession.notifiesDelegatesOfFailure = YES;
         [self handleFailure:error session:authSession];
         return;
     }
@@ -1639,7 +1689,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     SFOAuthInfo *authInfo = authSession.authInfo;
     
     if (authSession.authSuccessCallback) {
-        authSession.authSuccessCallback(authSession.authInfo,userAccount);
+        authSession.authSuccessCallback(authSession.authInfo, userAccount);
     }
     //notify for all login flows except during an SP apps login request.
     if (shouldNotify) {
@@ -1656,11 +1706,11 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
      
      NSDictionary *userInfo = @{kSFNotificationUserInfoAccountKey: userAccount,
                                 kSFNotificationUserInfoAuthTypeKey: authInfo};
-     if (self.authSession.authInfo.authType != SFOAuthTypeRefresh) {
+     if (authInfo.authType != SFOAuthTypeRefresh) {
          [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidLogIn
                                                              object:self
-                                                           userInfo:userInfo];
-     }  else if (self.authSession.authInfo.authType == SFOAuthTypeRefresh) {
+                                                           userInfo:userInfo]; 
+     }  else if (authInfo.authType == SFOAuthTypeRefresh) {
          [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidRefreshToken
                                                              object:self
                                                            userInfo:userInfo];
@@ -1714,6 +1764,11 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 - (void)initAnalyticsManager {
     SFSDKSalesforceAnalyticsManager *analyticsManager = [SFSDKSalesforceAnalyticsManager sharedInstanceWithUser:self.currentUser];
     [analyticsManager updateLoggingPrefs];
+}
+
+- (void)sceneDidDisconnect:(NSNotification *)notification {
+    UIScene *scene = (UIScene *)notification.object;
+    [self.authSessions removeObject:scene.session.persistentIdentifier];
 }
 
 #pragma mark Switching Users
@@ -1829,33 +1884,42 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 }
 
 - (void)presentLoginView:(SFSDKAuthViewHolder *)viewHandler {
-   
-    [[SFSDKWindowManager sharedManager].authWindow presentWindow];
     void (^presentViewBlock)(void) = ^void() {
         if (!viewHandler.isAdvancedAuthFlow) {
-            UIViewController *controllerToPresent = [[SFSDKNavigationController  alloc]  initWithRootViewController:viewHandler.loginController];
+            UIViewController *controllerToPresent = [[SFSDKNavigationController alloc] initWithRootViewController:viewHandler.loginController];
             controllerToPresent.modalPresentationStyle = UIModalPresentationFullScreen;
-            [[SFSDKWindowManager sharedManager].authWindow.viewController presentViewController:controllerToPresent animated:NO completion:^{
+            [[[SFSDKWindowManager sharedManager] authWindow:viewHandler.scene].viewController presentViewController:controllerToPresent animated:NO completion:^{
                 NSAssert((nil != [viewHandler.loginController.oauthView superview]), @"No superview for oauth web view invoke [super viewDidLayoutSubviews] in the SFLoginViewController subclass");
             }];
         }
         else {
             SFSDKAuthRootController* authRootController = [[SFSDKAuthRootController alloc] init];
-            [SFSDKWindowManager sharedManager].authWindow.viewController = authRootController;
+            [[SFSDKWindowManager sharedManager] authWindow:viewHandler.scene].viewController = authRootController;
             authRootController.modalPresentationStyle = UIModalPresentationFullScreen;
-            viewHandler.session.presentationContextProvider = (id<ASWebAuthenticationPresentationContextProviding>) [SFSDKWindowManager sharedManager].authWindow.viewController;
+            viewHandler.session.presentationContextProvider = (id<ASWebAuthenticationPresentationContextProviding>) [[SFSDKWindowManager sharedManager] authWindow:viewHandler.scene].viewController;
             [viewHandler.session start];
         }
     };
   
-    //dismiss if already presented and then present
-    UIViewController* presentedViewController = [SFSDKWindowManager sharedManager].authWindow.viewController.presentedViewController;
-    if ([self isAlreadyPresentingLoginController:presentedViewController]) {
-        [presentedViewController dismissViewControllerAnimated:NO completion:^{
+    void (^presentWindowBlock)(void) = ^void() {
+        [[[SFSDKWindowManager sharedManager] authWindow:viewHandler.scene] presentWindow];
+        //dismiss if already presented and then present
+        UIViewController* presentedViewController = [[SFSDKWindowManager sharedManager] authWindow:viewHandler.scene].viewController.presentedViewController;
+        if ([self isAlreadyPresentingLoginController:presentedViewController]) {
+            [presentedViewController dismissViewControllerAnimated:NO completion:^{
+                presentViewBlock();
+            }];
+        } else {
             presentViewBlock();
+        }
+    };
+    
+    if ([[SalesforceSDKManager sharedManager] isSnapshotPresented:viewHandler.scene]) {
+        [[SalesforceSDKManager sharedManager] dismissSnapshot:viewHandler.scene completion:^{
+            presentWindowBlock();
         }];
     } else {
-        presentViewBlock();
+        presentWindowBlock();
     }
  }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/ViewControllers/SFDefaultUserManagementViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/ViewControllers/SFDefaultUserManagementViewController.m
@@ -84,7 +84,7 @@
 
 - (void)actionCreateNewUser
 {
-    [[SFUserAccountManager sharedInstance] switchToNewUser:self.scene completion:^(NSError * error, SFUserAccount * newUser) {
+    [[SFUserAccountManager sharedInstance] switchToNewUserWithCompletion:^(NSError * error, SFUserAccount * newUser) {
         if (error) {
             [SFSDKCoreLogger e:[self class] format:@"Attempt to add new user failed %@",[error localizedDescription]];
         } else {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/ViewControllers/SFDefaultUserManagementViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/ViewControllers/SFDefaultUserManagementViewController.m
@@ -25,6 +25,13 @@
 #import "SFDefaultUserManagementViewController+Internal.h"
 #import "SFDefaultUserManagementListViewController.h"
 #import "SFUserAccountManager.h"
+
+@interface SFDefaultUserManagementViewController ()
+
+@property (nonatomic, strong) UIScene *scene;
+
+@end
+
 @implementation SFDefaultUserManagementViewController
 
 - (id)initWithCompletionBlock:(SFUserManagementCompletionBlock)completionBlock
@@ -77,7 +84,7 @@
 
 - (void)actionCreateNewUser
 {
-    [[SFUserAccountManager sharedInstance] switchToNewUserWithCompletion:^(NSError * error, SFUserAccount * newUser) {
+    [[SFUserAccountManager sharedInstance] switchToNewUser:self.scene completion:^(NSError * error, SFUserAccount * newUser) {
         if (error) {
             [SFSDKCoreLogger e:[self class] format:@"Attempt to add new user failed %@",[error localizedDescription]];
         } else {
@@ -90,6 +97,7 @@
 {
     self.action = action;
     self.actionAccount = actionAccount;
+    self.scene = self.view.window.windowScene;
     if (self.completionBlock) {
         self.completionBlock(action);
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthHelper.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthHelper.h
@@ -27,6 +27,8 @@
  */
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 NS_SWIFT_NAME(AuthHelper)
 @interface SFSDKAuthHelper : NSObject
 
@@ -36,14 +38,31 @@ NS_SWIFT_NAME(AuthHelper)
  @param completionBlock Block that executes immediately if the user is already logged in, or if the app config's `shouldAuthenticate` is set to false.
                         Otherwise, this block executes after the user logs in successfully, if login is required.
  */
-+ (void)loginIfRequired:(void (^)(void))completionBlock;
++ (void)loginIfRequired:(nullable void (^)(void))completionBlock;
 
-+ (void)handleLogout:(void (^)(void))completionBlock;
+/**
+ Initiate a login flow if the user is not already logged in to Salesforce and if the app config's `shouldAuthenticate` flag is set to false.
+ 
+ @param scene Scene that login is initiated for.
+ @param completionBlock Block that executes immediately if the user is already logged in, or if the app config's `shouldAuthenticate` is set to false.
+                        Otherwise, this block executes after the user logs in successfully, if login is required.
+ */
++ (void)loginIfRequired:(UIScene *)scene completion:(nullable void (^)(void))completionBlock;
+
++ (void)handleLogout:(nullable void (^)(void))completionBlock;
+
++ (void)handleLogout:(UIScene *)scene completion:(nullable void (^)(void))completionBlock;
 
 + (void)registerBlockForCurrentUserChangeNotifications:(void (^)(void))completionBlock;
 
++ (void)registerBlockForCurrentUserChangeNotifications:(UIScene *)scene completion:(void (^)(void))completionBlock;
+
 + (void)registerBlockForLogoutNotifications:(void (^)(void))completionBlock;
+
++ (void)registerBlockForLogoutNotifications:(UIScene *)scene completion:(void (^)(void))completionBlock;
 
 + (void)registerBlockForSwitchUserNotifications:(void (^)(void))completionBlock;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthHelper.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthHelper.m
@@ -26,29 +26,39 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #import "SalesforceSDKManager.h"
+#import "SalesforceSDKManager+Internal.h"
 #import "SFSDKAppConfig.h"
 #import "SFSDKAuthHelper.h"
 #import "SFUserAccountManager.h"
+#import "SFUserAccountManager+Internal.h"
 #import "SFSDKWindowManager.h"
+#import "SFSDKWindowManager+Internal.h"
 #import "SFDefaultUserManagementViewController.h"
 #import "SFSecurityLockout.h"
+#import "SFApplicationHelper.h"
 
 @implementation SFSDKAuthHelper
 
 + (void)loginIfRequired:(void (^)(void))completionBlock {
+    UIScene *scene = [[SFSDKWindowManager sharedManager] defaultScene];
+    [SFSDKAuthHelper loginIfRequired:scene completion:completionBlock];
+}
+
++ (void)loginIfRequired:(UIScene *)scene completion:(void (^)(void))completionBlock {
+    [SFSDKAuthHelper registerBlockForLoginNotification:^{
+        if (completionBlock) {
+            completionBlock();
+        }
+    }];
+
     if (![SFUserAccountManager sharedInstance].currentUser && [SalesforceSDKManager sharedManager].appConfig.shouldAuthenticate) {
-        SFUserAccountManagerSuccessCallbackBlock successBlock = ^(SFOAuthInfo *authInfo,SFUserAccount *userAccount) {
-            if (completionBlock) {
-                completionBlock();
-            }
-        };
         SFUserAccountManagerFailureCallbackBlock failureBlock = ^(SFOAuthInfo *authInfo, NSError *authError) {
-            [SFSDKCoreLogger e:[self class] format:@"Authentication failed: %@.",[authError localizedDescription]];
+            [SFSDKCoreLogger e:[self class] format:@"Authentication failed: %@.", [authError localizedDescription]];
         };
-        BOOL result = [[SFUserAccountManager sharedInstance] loginWithCompletion:successBlock failure:failureBlock];
+        BOOL result = [[SFUserAccountManager sharedInstance] loginWithCompletion:nil failure:failureBlock scene:scene];
         if (!result) {
             [[SFUserAccountManager sharedInstance] stopCurrentAuthentication:^(BOOL result) {
-                [[SFUserAccountManager sharedInstance] loginWithCompletion:successBlock failure:failureBlock];
+                [[SFUserAccountManager sharedInstance] loginWithCompletion:nil failure:failureBlock scene:scene];
             }];
         }
     } else {
@@ -56,7 +66,7 @@
     }
 }
 
-+ (void) passcodeValidation:(void (^)(void))completionBlock  {
++ (void)passcodeValidation:(void (^)(void))completionBlock  {
     [SFSecurityLockout setLockScreenSuccessCallbackBlock:^(SFSecurityLockoutAction action) {
         [SFSDKCoreLogger i:[self class] format:@"Passcode verified, or not configured.  Proceeding with authentication validation."];
         if (completionBlock) {
@@ -73,6 +83,11 @@
 }
 
 + (void)handleLogout:(void (^)(void))completionBlock {
+    UIScene *scene = [[SFSDKWindowManager sharedManager] defaultScene];
+    [SFSDKAuthHelper handleLogout:scene completion:completionBlock];
+}
+
++ (void)handleLogout:(UIScene *)scene completion:(void (^)(void))completionBlock {
     // Multi-user pattern:
     // - If there are two or more existing accounts after logout, let the user choose the account
     //   to switch to.
@@ -84,9 +99,9 @@
     NSArray *allAccounts = [SFUserAccountManager sharedInstance].allUserAccounts;
     if ([allAccounts count] > 1) {
         SFDefaultUserManagementViewController *userSwitchVc = [[SFDefaultUserManagementViewController alloc] initWithCompletionBlock:^(SFUserManagementAction action) {
-            [[SFSDKWindowManager sharedManager].mainWindow.window.rootViewController dismissViewControllerAnimated:YES completion:NULL];
+            [[[SFSDKWindowManager sharedManager] mainWindow:scene].window.rootViewController dismissViewControllerAnimated:YES completion:NULL];
         }];
-        [[SFSDKWindowManager sharedManager].mainWindow.window.rootViewController presentViewController:userSwitchVc animated:YES completion:NULL];
+        [[[SFSDKWindowManager sharedManager] mainWindow:scene].window.rootViewController presentViewController:userSwitchVc animated:YES completion:NULL];
     } else {
         if ([allAccounts count] == 1) {
             [[SFUserAccountManager sharedInstance] switchToUser:([SFUserAccountManager sharedInstance].allUserAccounts)[0]];
@@ -94,25 +109,43 @@
                 completionBlock();
             }
         } else {
-            [self loginIfRequired:completionBlock];
+            [self loginIfRequired:scene completion:completionBlock];
         }
     }
 }
 
++ (void)registerBlockForLoginNotification:(void (^)(void))completionBlock {
+    [[NSNotificationCenter defaultCenter] addObserverForName:kSFNotificationUserDidLogIn object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * note) {
+           if (completionBlock) {
+               completionBlock();
+           }
+       }];
+}
+
 + (void)registerBlockForCurrentUserChangeNotifications:(void (^)(void))completionBlock {
-    [self registerBlockForLogoutNotifications:completionBlock];
+    UIScene *scene = [[SFSDKWindowManager sharedManager] defaultScene];
+    [SFSDKAuthHelper registerBlockForCurrentUserChangeNotifications:scene completion:completionBlock];
+}
+
++ (void)registerBlockForCurrentUserChangeNotifications:(UIScene *)scene completion:(void (^)(void))completionBlock {
+    [self registerBlockForLogoutNotifications:scene completion:completionBlock];
     [self registerBlockForSwitchUserNotifications:completionBlock];
 }
 
 + (void)registerBlockForLogoutNotifications:(void (^)(void))completionBlock {
+    UIScene *scene = [[SFSDKWindowManager sharedManager] defaultScene];
+    [SFSDKAuthHelper registerBlockForLogoutNotifications:scene completion:completionBlock];
+}
+
++ (void)registerBlockForLogoutNotifications:(UIScene *)scene completion:(void (^)(void))completionBlock {
     __weak typeof (self) weakSelf = self;
-    [[NSNotificationCenter defaultCenter] addObserverForName:kSFNotificationUserDidLogout  object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
-        [weakSelf handleLogout:completionBlock];
+    [[NSNotificationCenter defaultCenter] addObserverForName:kSFNotificationUserDidLogout object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *note) {
+        [weakSelf handleLogout:scene completion:completionBlock];
     }];
 }
 
 + (void)registerBlockForSwitchUserNotifications:(void (^)(void))completionBlock {
-    [[NSNotificationCenter defaultCenter] addObserverForName:kSFNotificationUserDidSwitch   object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * note) {
+    [[NSNotificationCenter defaultCenter] addObserverForName:kSFNotificationUserDidSwitch object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification * note) {
         if (completionBlock) {
             completionBlock();
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager+Internal.h
@@ -1,0 +1,34 @@
+//
+//  SFSDKWindowManager+Internal.h
+//  SalesforceSDKCore
+//
+//  Created by Brianna Birman on 1/20/21.
+//  Copyright (c) 2021-present, salesforce.com, inc. All rights reserved.
+// 
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+// 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#import "SFSDKWindowManager.h"
+
+@interface SFSDKWindowManager ()
+
+- (UIScene *)defaultScene;
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.h
@@ -87,19 +87,19 @@
  */
 - (nonnull SFSDKWindowContainer *)passcodeWindow;
 
-/** SDK uses this window to present the login flow for the given scene. Defaults to the first connected scene if one isn't provided.
+/** SDK uses this window to present the login flow for the given scene. Defaults a connected scene if one isn't provided.
  */
 - (nonnull SFSDKWindowContainer *)authWindow:(nullable UIScene *)scene;
 
-/** SDK uses this window to present the snapshot view for a given scene. Defaults to the first connected scene if one isn't provided.
+/** SDK uses this window to present the snapshot view for a given scene. Defaults to a connected scene if one isn't provided.
  */
 - (nonnull SFSDKWindowContainer *)snapshotWindow:(nullable UIScene *)scene;
 
-/** Returns the SFSDKWindowContainer window representing the mainWindow that has been set for a given scene. Defaults to the first connected scene if one isn't provided.
+/** Returns the SFSDKWindowContainer window representing the mainWindow that has been set for a given scene. Defaults to a connected scene if one isn't provided.
  */
 - (nonnull SFSDKWindowContainer *)mainWindow:(nullable UIScene *)scene;
 
-/** Returns the SFSDKWindowContainer window representing the active presented window that has been set for a given scene. Defaults to the first connected scene if one isn't provided.
+/** Returns the SFSDKWindowContainer window representing the active presented window that has been set for a given scene. Defaults to a connected scene if one isn't provided.
  */
 - (nullable SFSDKWindowContainer *)activeWindow:(nullable UIScene *)scene;
 
@@ -107,7 +107,7 @@
  */
 - (void)setMainUIWindow:(UIWindow *_Nonnull)window;
 
-/** Used to setup the main window for a given scene. Defaults to the first connected scene if one isn't provided.
+/** Used to setup the main window for a given scene. Defaults to a connected scene if one isn't provided.
  */
 - (void)setMainUIWindow:(nonnull UIWindow *)window scene:(nullable UIScene *)scene;
 
@@ -115,7 +115,7 @@
  */
 - (SFSDKWindowContainer *_Nullable)createNewNamedWindow:(NSString *_Nonnull)windowName;
 
-/** Used to create a new window keyed by a specified name for a given scene. Defaults to the first connected scene if one isn't provided.
+/** Used to create a new window keyed by a specified name for a given scene. Defaults to a  connected scene if one isn't provided.
  */
 - (nullable SFSDKWindowContainer *)createNewNamedWindow:(nonnull NSString *)windowName scene:(nullable UIScene *)scene;
 
@@ -123,7 +123,7 @@
  */
 - (BOOL)removeNamedWindow:(NSString *_Nonnull)windowName;
 
-/** Used to remove a window by a specified name for a given scene. Defaults to the first connected scene if one isn't provided.
+/** Used to remove a window by a specified name for a given scene. Defaults to a connected scene if one isn't provided.
  */
 - (BOOL)removeNamedWindow:(nonnull NSString *)windowName scene:(nullable UIScene *)scene;
 
@@ -131,7 +131,7 @@
  */
 - (SFSDKWindowContainer *_Nullable)windowWithName:(NSString *_Nonnull)name;
 
-/** Used to retrieve a window by a specified name for a given scene. Defaults to the first connected scene if one isn't provided.
+/** Used to retrieve a window by a specified name for a given scene. Defaults to a connected scene if one isn't provided.
  */
 - (nullable SFSDKWindowContainer *)windowWithName:(nonnull NSString *)name scene:(nullable UIScene *)scene;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.h
@@ -79,29 +79,13 @@
 
 @interface SFSDKWindowManager : NSObject
 
-/** SDK uses this window to present the login flow.
- */
-@property (readonly,nonatomic,strong) SFSDKWindowContainer * _Nonnull authWindow;
-
-/** SDK uses this window to present the snapshot View.
- */
-@property (readonly,nonatomic,strong) SFSDKWindowContainer * _Nonnull snapshotWindow;
-
-/** SDK uses this window to present the passcode View.
- */
-@property (readonly,nonatomic,strong) SFSDKWindowContainer * _Nonnull passcodeWindow;
-
-/** Returns the SFSDKWindowContainer window representing the mainWindow that has been set
- */
-@property (readonly,nonatomic,strong) SFSDKWindowContainer * _Nonnull mainWindow;
-
 /** Sets overrideUserInterfaceStyle on managed windows. Default is UIUserInterfaceStyleUnspecified.
  */
 @property (nonatomic, assign) UIUserInterfaceStyle userInterfaceStyle;
 
-/** Returns the SFSDKWindowContainer window representing the active presented Window that has been set
+/** SDK uses this window to present the passcode view.
  */
-- (SFSDKWindowContainer * _Nullable)activeWindow;
+- (nonnull SFSDKWindowContainer *)passcodeWindow;
 
 /** SDK uses this window to present the login flow for the given scene. Defaults to the first connected scene if one isn't provided.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
@@ -489,9 +489,21 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
 
 - (UIScene *)nonnullScene:(UIScene *)scene {
     if (!scene) {
-        return [SFApplicationHelper sharedApplication].connectedScenes.allObjects.firstObject;
+        return [self defaultScene];
     }
     return scene;
+}
+
+- (UIScene *)defaultScene {
+    NSArray *connectedScenes = [SFApplicationHelper sharedApplication].connectedScenes.allObjects;
+    for (UIScene *connectedScene in connectedScenes) {
+        if (connectedScene.activationState == UISceneActivationStateForegroundActive) {
+            return connectedScene;
+        } else if (connectedScene.activationState == UISceneActivationStateForegroundInactive) {
+            return connectedScene;
+        }
+    }
+    return connectedScenes.firstObject;
 }
 
 - (void)sceneDidDisconnect:(NSNotification *)notification {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SDSDKAlertMessageTest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SDSDKAlertMessageTest.m
@@ -107,7 +107,7 @@
         };
     }];
     
-    SFSDKAlertView *view = [[SFSDKAlertView alloc] initWithMessage:message window:[[SFSDKWindowManager sharedManager] authWindow:nil] ];
+    SFSDKAlertView *view = [[SFSDKAlertView alloc] initWithMessage:message window:[[SFSDKWindowManager sharedManager] authWindow:nil]];
     XCTAssertNotNil(view);
     XCTAssertNotNil(view.controller);
     XCTAssertNotNil(view.window);

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SDSDKAlertMessageTest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SDSDKAlertMessageTest.m
@@ -107,13 +107,11 @@
         };
     }];
     
-    SFSDKAlertView *view = [[SFSDKAlertView alloc] initWithMessage:message window:[SFSDKWindowManager sharedManager].authWindow];
+    SFSDKAlertView *view = [[SFSDKAlertView alloc] initWithMessage:message window:[[SFSDKWindowManager sharedManager] authWindow:nil] ];
     XCTAssertNotNil(view);
     XCTAssertNotNil(view.controller);
     XCTAssertNotNil(view.window);
-    XCTAssertTrue(view.window == [SFSDKWindowManager sharedManager].authWindow);
+    XCTAssertTrue(view.window == [[SFSDKWindowManager sharedManager] authWindow:nil]);
 }
-
-
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
@@ -100,27 +100,22 @@
 - (void)testSetMainWindow {
     XCTAssert(_origApplicationWindow!=nil);
     [[SFSDKWindowManager sharedManager] setMainUIWindow:_origApplicationWindow];
-    XCTAssert([SFSDKWindowManager sharedManager].mainWindow.window == _origApplicationWindow);
+    XCTAssert([[SFSDKWindowManager sharedManager] mainWindow: nil].window == _origApplicationWindow);
     XCTAssert([[SFSDKWindowManager sharedManager] mainWindow:nil].window == _origApplicationWindow);
     UIScene *scene = [SFApplicationHelper sharedApplication].connectedScenes.allObjects.firstObject;
     XCTAssert([[SFSDKWindowManager sharedManager] mainWindow:scene].window == _origApplicationWindow);
 }
 
 - (void)testLoginWindow {
-    SFSDKWindowContainer *authWindow = [SFSDKWindowManager sharedManager].authWindow;
-    XCTAssert(authWindow.window!=nil);
-    XCTAssert(authWindow.windowType == SFSDKWindowTypeAuth);
-    
     SFSDKWindowContainer *authWindowNilScene = [[SFSDKWindowManager sharedManager] authWindow:nil];
     XCTAssert(authWindowNilScene.window != nil);
     XCTAssert(authWindowNilScene.windowType == SFSDKWindowTypeAuth);
-    XCTAssertEqualObjects(authWindow, authWindowNilScene);
     
     UIScene *scene = [SFApplicationHelper sharedApplication].connectedScenes.allObjects.firstObject;
     SFSDKWindowContainer *authWindowScene = [[SFSDKWindowManager sharedManager] authWindow:scene];
     XCTAssert(authWindowScene.window != nil);
     XCTAssert(authWindowScene.windowType == SFSDKWindowTypeAuth);
-    XCTAssertEqualObjects(authWindow, authWindowScene);
+    XCTAssertEqualObjects(authWindowNilScene, authWindowScene);
 }
 
 - (void)testPasscodeWindow {
@@ -130,20 +125,15 @@
 }
 
 - (void)testSnapshotWindow {
-    SFSDKWindowContainer *snapshotWindow = [SFSDKWindowManager sharedManager].snapshotWindow;
-    XCTAssert(snapshotWindow.window!=nil);
-    XCTAssert(snapshotWindow.windowType == SFSDKWindowTypeSnapshot);
-    
     SFSDKWindowContainer *snapshotWindowNilScene = [[SFSDKWindowManager sharedManager] snapshotWindow:nil];
     XCTAssert(snapshotWindowNilScene.window != nil);
     XCTAssert(snapshotWindowNilScene.windowType == SFSDKWindowTypeSnapshot);
-    XCTAssertEqualObjects(snapshotWindow, snapshotWindowNilScene);
     
     UIScene *scene = [SFApplicationHelper sharedApplication].connectedScenes.allObjects.firstObject;
     SFSDKWindowContainer *snapshowWindowScene = [[SFSDKWindowManager sharedManager] snapshotWindow:scene];
     XCTAssert(snapshowWindowScene.window != nil);
     XCTAssert(snapshowWindowScene.windowType == SFSDKWindowTypeSnapshot);
-    XCTAssertEqualObjects(snapshotWindow, snapshowWindowScene);
+    XCTAssertEqualObjects(snapshotWindowNilScene, snapshowWindowScene);
 }
 
 - (void)testEnable {
@@ -166,8 +156,8 @@
 }
 
 - (void)testStyleOverride {
-    SFSDKWindowContainer *snapshotWindow = [SFSDKWindowManager sharedManager].snapshotWindow;
-    SFSDKWindowContainer *passcodeWindow = [SFSDKWindowManager sharedManager].passcodeWindow;
+    SFSDKWindowContainer *snapshotWindow = [[SFSDKWindowManager sharedManager] snapshotWindow:nil];
+    SFSDKWindowContainer *passcodeWindow = [[SFSDKWindowManager sharedManager] passcodeWindow];
 
     // Check default
     XCTAssertEqual(snapshotWindow.window.overrideUserInterfaceStyle, UIUserInterfaceStyleUnspecified);
@@ -184,33 +174,32 @@
     
     SFSDKWindowContainer *passcodeWindow = [SFSDKWindowManager sharedManager].passcodeWindow;
     [passcodeWindow presentWindow];
-    SFSDKWindowContainer *activeWindow = [SFSDKWindowManager sharedManager].activeWindow;
+    SFSDKWindowContainer *activeWindow = [[SFSDKWindowManager sharedManager] activeWindow:nil];
     XCTAssert(passcodeWindow==activeWindow);
     [passcodeWindow dismissWindowAnimated:NO withCompletion:^{
         XCTAssertFalse(passcodeWindow.window.isKeyWindow);
         [expectation fulfill];
     }];
     [self waitForExpectations:@[expectation] timeout:10];
-    activeWindow = [SFSDKWindowManager sharedManager].activeWindow;
+    activeWindow = [[SFSDKWindowManager sharedManager] activeWindow:nil];
     XCTAssert(passcodeWindow!=activeWindow);
 
 }
 
 - (void)testLevels {
     // these 3 statements should not make any difference
-    [SFSDKWindowManager sharedManager].snapshotWindow.window.windowLevel = 1;
-    [SFSDKWindowManager sharedManager].passcodeWindow.window.windowLevel = 4;
-    [SFSDKWindowManager sharedManager].authWindow.window.windowLevel = 3;
-    XCTAssertTrue([SFSDKWindowManager sharedManager].snapshotWindow.windowLevel !=1  );
-    XCTAssertTrue([SFSDKWindowManager sharedManager].passcodeWindow.windowLevel != 4);
-    XCTAssertTrue([SFSDKWindowManager sharedManager].authWindow.windowLevel != 3);
+    [[SFSDKWindowManager sharedManager] snapshotWindow:nil].window.windowLevel = 1;
+    [[SFSDKWindowManager sharedManager] passcodeWindow].window.windowLevel = 4;
+    [[SFSDKWindowManager sharedManager] authWindow:nil].window.windowLevel = 3;
+    XCTAssertTrue([[SFSDKWindowManager sharedManager] snapshotWindow:nil].windowLevel != 1);
+    XCTAssertTrue([[SFSDKWindowManager sharedManager] passcodeWindow].windowLevel != 4);
+    XCTAssertTrue([[SFSDKWindowManager sharedManager] authWindow:nil].windowLevel != 3);
    
 }
 
 - (void)testCompletionBlockForEnable {
-    
     XCTestExpectation *completionBlock  = [[XCTestExpectation alloc] initWithDescription:@"CompletionBlockCalled"];
-    [[SFSDKWindowManager sharedManager].authWindow presentWindowAnimated:NO withCompletion:^{
+    [[[SFSDKWindowManager sharedManager] authWindow:nil] presentWindowAnimated:NO withCompletion:^{
         [completionBlock fulfill];
     }];
     [self waitForExpectations:@[completionBlock] timeout:2];
@@ -219,9 +208,9 @@
 
 - (void)testCompletionBlockForDisable {
     
-    XCTestExpectation *completionBlock  = [[XCTestExpectation alloc] initWithDescription:@"CompletionBlockCalled"];
-    [[SFSDKWindowManager sharedManager].authWindow presentWindow];
-    [[SFSDKWindowManager sharedManager].authWindow dismissWindowAnimated:NO withCompletion:^{
+    XCTestExpectation *completionBlock = [[XCTestExpectation alloc] initWithDescription:@"CompletionBlockCalled"];
+    [[[SFSDKWindowManager sharedManager] authWindow:nil] presentWindow];
+    [[[SFSDKWindowManager sharedManager] authWindow:nil] dismissWindowAnimated:NO withCompletion:^{
         [completionBlock fulfill];
     }];
     [self waitForExpectations:@[completionBlock] timeout:2];
@@ -235,14 +224,14 @@
     delegate.after = [[XCTestExpectation alloc] initWithDescription:@"AfterEnablement"];
     
     [[SFSDKWindowManager sharedManager] addDelegate:delegate];
-    [[SFSDKWindowManager sharedManager].authWindow presentWindow];
+    [[[SFSDKWindowManager sharedManager] authWindow:nil] presentWindow];
     
     [self waitForExpectations:@[delegate.before,delegate.after] timeout:2];
     
     delegate.before = [[XCTestExpectation alloc] initWithDescription:@"BeforeDisablement"];
     delegate.after = [[XCTestExpectation alloc] initWithDescription:@"AfterDisablement"];
     
-    [[SFSDKWindowManager sharedManager].authWindow dismissWindow];
+    [[[SFSDKWindowManager sharedManager] authWindow:nil] dismissWindow];
     [self waitForExpectations:@[delegate.before,delegate.after] timeout:2];
     
     XCTAssertTrue(delegate.notificationWindow.isAuthWindow);

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFTestSDKManagerFlow.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFTestSDKManagerFlow.m
@@ -63,16 +63,6 @@
     
 }
 
-- (void)handleAppDidBecomeActive:(NSNotification *)notification
-{
-    
-}
-
-- (void)handleAppWillResignActive:(NSNotification *)notification
-{
-    
-}
-
 - (void)handleAuthCompleted:(NSNotification *)notification
 {
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
@@ -165,7 +165,8 @@ static NSString* const kTestAppName = @"OverridenAppName";
         creationViewControllerCalled = YES;
         return nil;
     };
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillResignActiveNotification object:nil];
+    UIScene *scene = UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillDeactivateNotification object:scene];
     XCTAssertTrue(creationViewControllerCalled, @"Did not call the snapshot view controller creation block upon application resigning active, when use snapshot is set to YES.");
 }
 
@@ -196,9 +197,10 @@ static NSString* const kTestAppName = @"OverridenAppName";
     [SalesforceSDKManager sharedManager].snapshotDismissalAction = ^(UIViewController* snapshotViewController) {
         dismissOnDidBecomeActive = YES;
     };
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillResignActiveNotification object:nil];
+    UIScene *scene = UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillDeactivateNotification object:scene];
     XCTAssertTrue(presentOnResignActive, @"Did not respond to app resign active.");
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneDidActivateNotification object:scene];
     XCTAssertTrue(dismissOnDidBecomeActive, @"Did not respond to app did become active.");
 }
 
@@ -236,13 +238,14 @@ static NSString* const kTestAppName = @"OverridenAppName";
     [SalesforceSDKManager sharedManager].snapshotDismissalAction = ^(UIViewController* snapshotViewController) {
         defaultViewControllerOnDismissal = snapshotViewController;
     };
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillResignActiveNotification object:nil];
+    UIScene *scene = UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillDeactivateNotification object:scene];
     XCTAssertTrue([defaultViewControllerOnPresentation isKindOfClass:UIViewController.class], @"Did not provide a valid default snapshot view controller.");
 
     // This will simulate that the snapshot view is being presented
     UIView* fakeView = [UIView new];
     [fakeView addSubview:defaultViewControllerOnPresentation.view];
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneDidActivateNotification object:scene];
     XCTAssertEqual(defaultViewControllerOnPresentation, defaultViewControllerOnDismissal, @"Default snapshot view controller on dismissal is different than the one provided on presentation!");
 }
 
@@ -260,7 +263,8 @@ static NSString* const kTestAppName = @"OverridenAppName";
 
         // Need to set the dismissal block in order to get the presentation block called.
     };
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillResignActiveNotification object:nil];
+    UIScene *scene = UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillDeactivateNotification object:scene];
     XCTAssertTrue([defaultViewController isKindOfClass:UIViewController.class], @"Did not provide a valid default snapshot view controller.");
 }
 
@@ -280,13 +284,14 @@ static NSString* const kTestAppName = @"OverridenAppName";
         snapshotOnDismissal = snapshotViewController;
     };
     
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillResignActiveNotification object:nil];
+    UIScene *scene = UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
+    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillDeactivateNotification object:scene];
     XCTAssertEqual(customSnapshot, snapshotOnPresentation, @"Custom snapshot view controller was not used on presentation!");
 
     // This will simulate that the snapshot view is being presented
     UIView* fakeView = [UIView new];
     [fakeView addSubview:customSnapshot.view];
-    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidBecomeActiveNotification object:nil];
+    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneDidActivateNotification object:scene];
     XCTAssertEqual(customSnapshot, snapshotOnDismissal, @"Custom snapshot view controller was not used on dismissal!");
 }
 

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6965555E2589961000A1AB82 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6965555D2589961000A1AB82 /* SceneDelegate.swift */; };
 		A34601F72176B16700DC6900 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C0B9082175444F0037A7CB /* main.swift */; };
 		A3D23079219749C3009F433D /* SalesforceSDKCommon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7D641C8218F429D006DF5F0 /* SalesforceSDKCommon.framework */; };
 		A3D2307A219749C3009F433D /* SalesforceSDKCommon.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B7D641C8218F429D006DF5F0 /* SalesforceSDKCommon.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -202,6 +203,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		6965555D2589961000A1AB82 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		A3C0B9082175444F0037A7CB /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		B79F06DC20EA931200BC7D6F /* MobileSync.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = MobileSync.xcodeproj; path = ../../../libs/MobileSync/MobileSync.xcodeproj; sourceTree = "<group>"; };
 		B79F06EC20EA931900BC7D6F /* SalesforceSDKCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SalesforceSDKCore.xcodeproj; path = ../../../libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj; sourceTree = "<group>"; };
@@ -310,6 +312,7 @@
 				B7CEA6FE20B71060007D0564 /* Info.plist */,
 				B7C5120920C084B100B39DAA /* bootconfig.plist */,
 				A3C0B9082175444F0037A7CB /* main.swift */,
+				6965555D2589961000A1AB82 /* SceneDelegate.swift */,
 			);
 			path = RestAPIExplorer;
 			sourceTree = "<group>";
@@ -602,6 +605,7 @@
 				B7CEA71C20B71202007D0564 /* UIFont+helper.swift in Sources */,
 				B7CEA71D20B71202007D0564 /* UIColors+helper.swift in Sources */,
 				B7CEA71520B71202007D0564 /* ActionTableViewCell.swift in Sources */,
+				6965555E2589961000A1AB82 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -41,6 +41,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       
         SalesforceManager.initializeSDK()
         SalesforceManager.shared.appDisplayName = "Rest API Explorer"
+        
+        //Uncomment following block to enable IDP Login flow.
+        //SalesforceManager.shared.identityProviderURLScheme = "sampleidpapp"
     }
     
     // MARK: - App delegate lifecycle
@@ -85,13 +88,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error ) {
         // Respond to any push notification registration errors here.
-    }
-    
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        
-        // Uncomment following block to enable IDP Login flow
-        // return  UserAccountManager.shared.handleIdentityProviderResponse(from: url, with: options)
-        return false;
     }
     
     // MARK: - Private methods

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -41,22 +41,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       
         SalesforceManager.initializeSDK()
         SalesforceManager.shared.appDisplayName = "Rest API Explorer"
-        
-        //Uncomment following block to enable IDP Login flow.
-        //SalesforceManager.shared.identityProviderURLScheme = "sampleidpapp"
-        AuthHelper.registerBlock(forCurrentUserChangeNotifications: {
-            self.resetViewState {
-                self.initializeAppViewState()
-                self.setupRootViewController()
-            }
-        })
     }
     
     // MARK: - App delegate lifecycle
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         self.window = UIWindow(frame: UIScreen.main.bounds)
-        self.initializeAppViewState()
         
         // If you wish to register for push notifications, uncomment the line below.  Note that,
         // if you want to receive push notifications from Salesforce, you will also need to
@@ -71,10 +61,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Touch Id and Face Id lock screens.  To use this feature please enable inactivity timeout
         // in your connected app.
         // self.customizePasscodeView()
-
-        AuthHelper.loginIfRequired {
-            self.setupRootViewController()
-        }
         return true
     }
 
@@ -109,34 +95,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     // MARK: - Private methods
-    func initializeAppViewState() {
-        if !Thread.isMainThread {
-            DispatchQueue.main.async {
-                self.initializeAppViewState()
-            }
-            return
-        }
-        
-        self.window!.rootViewController = InitialViewController(nibName: nil, bundle: nil)
-        self.window!.makeKeyAndVisible()
-    }
-    
-    func setupRootViewController() {
-        let rootVC = RootViewController(nibName: nil, bundle: nil)
-        let navVC = UINavigationController(rootViewController: rootVC)
-        self.window!.rootViewController = navVC
-    }
-    
-    func resetViewState(_ postResetBlock: @escaping () -> Void ) {
-        if let rootViewController = self.window!.rootViewController {
-            if let _ = rootViewController.presentedViewController {
-                rootViewController.dismiss(animated: false, completion: postResetBlock)
-                return
-            }
-        }
-        postResetBlock()
-    }
-
     func registerForRemotePushNotifications() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { (granted, error) in
             if granted {

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Info.plist
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Info.plist
@@ -35,6 +35,8 @@
 	<true/>
 	<key>NSFaceIDUsageDescription</key>
 	<string>"Use FaceID"</string>
+	<key>SFDCOAuthLoginHost</key>
+	<string>mobilesdk.my.salesforce.com</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Info.plist
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/Info.plist
@@ -34,9 +34,24 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSFaceIDUsageDescription</key>
-	<string>&quot;Use FaceID&quot;</string>
-	<key>SFDCOAuthLoginHost</key>
-	<string>mobilesdk.my.salesforce.com</string>
+	<string>"Use FaceID"</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/SceneDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/SceneDelegate.swift
@@ -1,0 +1,108 @@
+//
+//  SceneDelegate.swift
+//  RestAPIExplorer
+//
+//  Created by Brianna Birman on 12/15/20.
+//  Copyright (c) 2020-present, salesforce.com, inc. All rights reserved.
+// 
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+// 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import UIKit
+import SalesforceSDKCore
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    public var window: UIWindow?
+    
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        self.window = UIWindow(frame: windowScene.coordinateSpace.bounds)
+        self.window?.windowScene = windowScene
+
+        AuthHelper.registerBlock(forCurrentUserChangeNotifications: scene) {
+            self.resetViewState {
+                self.setupRootViewController()
+            }
+        }
+        self.initializeAppViewState()
+        AuthHelper.loginIfRequired(scene) {
+            self.setupRootViewController()
+        }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+    
+    // MARK: - Private methods
+   func initializeAppViewState() {
+       if (!Thread.isMainThread) {
+           DispatchQueue.main.async {
+               self.initializeAppViewState()
+           }
+           return
+       }
+       
+       self.window?.rootViewController = InitialViewController(nibName: nil, bundle: nil)
+       self.window?.makeKeyAndVisible()
+   }
+   
+   func setupRootViewController() {
+        let rootVC = RootViewController(nibName: nil, bundle: nil)
+        let navVC = UINavigationController(rootViewController: rootVC)
+        self.window!.rootViewController = navVC
+    }
+   
+   func resetViewState(_ postResetBlock: @escaping () -> ()) {
+       if let rootViewController = self.window?.rootViewController {
+           if let _ = rootViewController.presentedViewController {
+               rootViewController.dismiss(animated: false, completion: postResetBlock)
+               return
+           }
+       }
+       postResetBlock()
+   }
+}

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/SceneDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/SceneDelegate.swift
@@ -77,6 +77,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
     
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        // Uncomment following block to enable IDP Login flow
+//        if let urlContext = URLContexts.first {
+//            UserAccountManager.shared.handleIdentityProviderResponse(from: urlContext.url, with: [UserAccountManager.IDPSceneKey: scene.session.persistentIdentifier])
+//        }
+    }
+    
     // MARK: - Private methods
    func initializeAppViewState() {
        if (!Thread.isMainThread) {


### PR DESCRIPTION
- The SDK can now display snapshot and login (including IDP and advanced auth) on multiple scenes. Passcode won't be supported for multiple windows in 9.0
- Updated RestAPIExplorer to use a scene delegate and enabled multiple windows on it