### PR TITLE
Key value stores not always cleared on logout

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.m
+++ b/libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.m
@@ -37,7 +37,7 @@
 
 -(instancetype)init {
     if (self = [super init]) {
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogout:)  name:kSFNotificationUserWillLogout object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserWillLogoutForSmartStoreManager:)  name:kSFNotificationUserWillLogout object:nil];
     }
     return self;
 }
@@ -46,7 +46,7 @@
     [super initializeSDKWithClass:self.class];
 }
 
-- (void)handleUserWillLogout:(NSNotification *)notification {
+- (void)handleUserWillLogoutForSmartStoreManager:(NSNotification *)notification {
     SFUserAccount *user = notification.userInfo[kSFNotificationUserInfoAccountKey];
     [SFSmartStore removeAllStoresForUser:user];
 }


### PR DESCRIPTION
SalesforceSDKManager deletes the key value stores by listening for the logout notification and using handleUserWillLogout, this works when an app just uses SalesforceSDKManager. If an app uses SmartStoreSDKManager which is a subclass of SalesforceSDKManager instead, there's an issue because SmartStoreSDKManager uses the same handleUserWillLogout selector and only the one on SmartStoreSDKManager is triggered.

==> Solution using a different selector in SmartStoreSDKManager