### PR TITLE
Upgrading to shelljs 0.8.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run: 
           name: Install Dependencies
           command:  |
-            npm install shelljs@0.8.3
+            npm install shelljs@0.8.4
             ./install.sh
             ./build/pre-build
             chruby ${CHRUBY_VER}


### PR DESCRIPTION
To avoid circular dependencies warning with newer version of node