### PR TITLE
Added kCFURLErrorDataNotAllowed to list of "network errors".

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -313,6 +313,7 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
         case kCFURLErrorDNSLookupFailed:
         case kCFURLErrorResourceUnavailable:
         case kCFURLErrorTimedOut:
+        case kCFURLErrorDataNotAllowed:
             return YES;
             break;
         default:


### PR DESCRIPTION
This error code is returned when the device has Cellular Data disabled, and WiFi is turned off. (Reference bug W-9009187)

To test: 
1) Disable Cellular Data for the device.
2) Disable wifi connection.
3) Attempt to make a REST request.

Previously, RestRequest isNetworkError: would return NO. Now it returns YES.

@bhariharan 