### PR TITLE
Adding support for SOQL batch size in RestRequest and in SOQLSyncDownTarget

### DIFF
--- a/libs/MobileSync/MobileSync/Classes/Target/SFSoqlSyncDownTarget.h
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSoqlSyncDownTarget.h
@@ -31,9 +31,12 @@ NS_SWIFT_NAME(SoqlSyncDownTarget)
 
 @property (nonatomic, copy) NSString* query;
 
+@property (nonatomic, assign) NSInteger maxBatchSize;
+
 /** Factory methods
  */
 + (SFSoqlSyncDownTarget*) newSyncTarget:(NSString*)query;
++ (SFSoqlSyncDownTarget*) newSyncTarget:(NSString*)query maxBatchSize:(NSInteger) maxBatchSize;
 
 /**
  * @return query to run

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSoqlSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSoqlSyncDownTarget.m
@@ -30,6 +30,7 @@
 #import "SFSDKSoqlMutator.h"
 
 static NSString * const kSFSoqlSyncTargetQuery = @"query";
+static NSString * const kSFSoqlSyncTargetMaxBatchSize = @"maxBatchSize";
 
 @interface SFSoqlSyncDownTarget ()
 
@@ -44,6 +45,8 @@ static NSString * const kSFSoqlSyncTargetQuery = @"query";
     if (self) {
         self.queryType = SFSyncDownTargetQueryTypeSoql;
         self.query = dict[kSFSoqlSyncTargetQuery];
+        NSNumber* maxBatchSize = dict[kSFSoqlSyncTargetMaxBatchSize];
+        self.maxBatchSize = maxBatchSize != nil ? [maxBatchSize integerValue] : kSFRestSOQLDefaultBatchSize;
         [self modifyQueryIfNeeded];
     }
     return self;
@@ -88,9 +91,14 @@ static NSString * const kSFSoqlSyncTargetQuery = @"query";
 #pragma mark - Factory methods
 
 + (SFSoqlSyncDownTarget*) newSyncTarget:(NSString*)query {
+    return [SFSoqlSyncDownTarget newSyncTarget:query maxBatchSize:kSFRestSOQLDefaultBatchSize];
+}
+
++ (SFSoqlSyncDownTarget*) newSyncTarget:(NSString*)query maxBatchSize:(NSInteger)maxBatchSize {
     SFSoqlSyncDownTarget* syncTarget = [[SFSoqlSyncDownTarget alloc] init];
     syncTarget.queryType = SFSyncDownTargetQueryTypeSoql;
     syncTarget.query = query;
+    syncTarget.maxBatchSize = maxBatchSize;
     [syncTarget modifyQueryIfNeeded];
     return syncTarget;
 }
@@ -100,6 +108,7 @@ static NSString * const kSFSoqlSyncTargetQuery = @"query";
 - (NSMutableDictionary*) asDict {
     NSMutableDictionary *dict = [super asDict];
     dict[kSFSoqlSyncTargetQuery] = self.query;
+    dict[kSFSoqlSyncTargetMaxBatchSize] = [NSNumber numberWithInteger: self.maxBatchSize];
     return dict;
 }
 
@@ -122,7 +131,7 @@ static NSString * const kSFSoqlSyncTargetQuery = @"query";
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
     
-    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:queryToRun apiVersion:nil];
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:queryToRun apiVersion:nil batchSize:self.maxBatchSize];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
     } successBlock:^(NSDictionary *responseJson, NSURLResponse *rawResponse) {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSoqlSyncDownTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSoqlSyncDownTarget.m
@@ -131,7 +131,7 @@ static NSString * const kSFSoqlSyncTargetMaxBatchSize = @"maxBatchSize";
       completeBlock:(SFSyncDownTargetFetchCompleteBlock)completeBlock {
     __weak typeof(self) weakSelf = self;
     
-    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:queryToRun apiVersion:nil batchSize:self.maxBatchSize];
+    SFRestRequest* request = [self buildRequest:queryToRun];
     [SFMobileSyncNetworkUtils sendRequestWithMobileSyncUserAgent:request failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
         errorBlock(e);
     } successBlock:^(NSDictionary *responseJson, NSURLResponse *rawResponse) {
@@ -140,6 +140,10 @@ static NSString * const kSFSoqlSyncTargetMaxBatchSize = @"maxBatchSize";
         strongSelf.nextRecordsUrl = responseJson[kResponseNextRecordsUrl];
         completeBlock([strongSelf getRecordsFromResponse:responseJson]);
     }];
+}
+
+- (SFRestRequest*) buildRequest:(NSString *)queryToRun {
+    return [[SFRestAPI sharedInstance] requestForQuery:queryToRun apiVersion:nil batchSize:self.maxBatchSize];
 }
 
 - (void) continueFetch:(SFMobileSyncSyncManager *)syncManager

--- a/libs/MobileSync/MobileSyncTestApp/usersyncs.json
+++ b/libs/MobileSync/MobileSyncTestApp/usersyncs.json
@@ -1,17 +1,30 @@
 {
   "syncs": [
-    {
-      "syncName": "soqlSyncDown",
-      "syncType": "syncDown",
-      "soupName": "accounts",
-      "target": {
-        "type":"soql",
-        "query":"SELECT Id, Name, LastModifiedDate FROM Account"
+      {
+        "syncName": "soqlSyncDown",
+        "syncType": "syncDown",
+        "soupName": "accounts",
+        "target": {
+          "type":"soql",
+          "query":"SELECT Id, Name, LastModifiedDate FROM Account"
+        },
+        "options": {
+          "mergeMode":"OVERWRITE"
+        }
       },
-      "options": {
-        "mergeMode":"OVERWRITE"
-      }
-    },
+      {
+        "syncName": "soqlSyncDownWithBatchSize",
+        "syncType": "syncDown",
+        "soupName": "accounts",
+        "target": {
+          "type":"soql",
+          "query":"SELECT Id, Name, LastModifiedDate FROM Account",
+          "maxBatchSize": 200
+        },
+        "options": {
+          "mergeMode":"OVERWRITE"
+        }
+      },
     {
       "syncName": "soslSyncDown",
       "syncType": "syncDown",

--- a/libs/MobileSync/MobileSyncTests/SFSDKSyncsConfigTests.m
+++ b/libs/MobileSync/MobileSyncTests/SFSDKSyncsConfigTests.m
@@ -138,6 +138,23 @@
     expectedTotalSize:-1];
 }
 
+- (void) testSoqlSyncDownWithBatchSizeFromConfig {
+    [self.sdkManager setupUserSyncsFromDefaultConfig];
+    
+    SFSyncState* sync = [self.syncManager getSyncStatusByName:@"soqlSyncDownWithBatchSize"];
+    XCTAssertEqualObjects(sync.soupName, @"accounts");
+    [self checkStatus:sync
+         expectedType:SFSyncStateSyncTypeDown
+           expectedId:sync.syncId
+         expectedName:@"soqlSyncDown"
+       expectedTarget:[SFSoqlSyncDownTarget
+                       newSyncTarget:@"SELECT Id, Name, LastModifiedDate FROM Account" maxBatchSize:200]
+      expectedOptions:[SFSyncOptions newSyncOptionsForSyncDown:SFSyncStateMergeModeOverwrite]
+       expectedStatus:SFSyncStateStatusNew
+     expectedProgress:0
+    expectedTotalSize:-1];
+}
+
 - (void) testSoslSyncDownFromConfig {
     [self.sdkManager setupUserSyncsFromDefaultConfig];
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
@@ -53,6 +53,14 @@ extern NSString* const kSFRestDefaultAPIVersion NS_SWIFT_NAME(SFRestDefaultAPIVe
 extern NSString* const kSFRestIfUnmodifiedSince NS_SWIFT_NAME(SFRestIfUnmodifiedSince);
 
 /**
+ * SOQL batch related constants
+ */
+extern NSInteger const kSFRestSOQLMinBatchSize NS_SWIFT_NAME(SFRestSOQLMinBatchSize);
+extern NSInteger const kSFRestSOQLMaxBatchSize NS_SWIFT_NAME(SFRestSOQLMaxBatchSize);
+extern NSInteger const kSFRestSOQLDefaultBatchSize NS_SWIFT_NAME(SFRestSOQLDefaultBatchSize);
+extern NSString* const kSFRestQueryOptions NS_SWIFT_NAME(SFRestQueryOptions);
+
+/**
  * Main class used to issue REST requests to the standard Force.com REST API.
  * See the [Force.com REST API Developer's Guide](http://www.salesforce.com/us/developer/docs/api_rest/index.htm)
  * for more information regarding the Force.com REST API.
@@ -279,6 +287,16 @@ NS_SWIFT_NAME(RestClient)
  * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query.htm
  */
 - (SFRestRequest *)requestForQuery:(NSString *)soql apiVersion:(nullable NSString *)apiVersion;
+
+/**
+ * Returns an `SFRestRequest` object that executes the specified SOQL query.
+ * @param soql String containing the query to execute. Example: "SELECT Id,
+ *             Name from Account ORDER BY Name LIMIT 20".
+ * @param apiVersion API version.
+ * @param batchSize Batch size: number between 200 and 2000 (default).
+ * @see https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_query.htm
+ */
+- (SFRestRequest *)requestForQuery:(NSString *)soql apiVersion:(nullable NSString *)apiVersion batchSize:(NSInteger)batchSize;
 
 /**
  * Returns an `SFRestRequest` object that executes the specified SOQL query.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -41,6 +41,11 @@ NSString* const kSFRestIfUnmodifiedSince = @"If-Unmodified-Since";
 NSString* const kSFRestErrorDomain = @"com.salesforce.RestAPI.ErrorDomain";
 NSString* const kSFDefaultContentType = @"application/json";
 NSInteger const kSFRestErrorCode = 999;
+NSInteger const kSFRestSOQLMinBatchSize = 200;
+NSInteger const kSFRestSOQLMaxBatchSize = 2000;
+NSInteger const kSFRestSOQLDefaultBatchSize = 2000;
+NSString* const kSFRestQueryOptions = @"Sforce-Query-Options";
+
 
 static BOOL kIsTestRun;
 static SFSDKSafeMutableDictionary *sfRestApiList = nil;
@@ -596,6 +601,15 @@ static dispatch_once_t pred;
     }
     NSString *path = [NSString stringWithFormat:@"/%@/query", [self computeAPIVersion:apiVersion]];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:queryParams];
+}
+
+- (SFRestRequest *)requestForQuery:(NSString *)soql apiVersion:(NSString *)apiVersion batchSize:(NSInteger)batchSize {
+    SFRestRequest* request = [self requestForQuery:soql apiVersion:apiVersion];
+    NSUInteger validatedBatchSize = MAX(MIN(batchSize, kSFRestSOQLMaxBatchSize), kSFRestSOQLMinBatchSize);
+    if (batchSize != kSFRestSOQLDefaultBatchSize) {
+        [request setHeaderValue:[NSString stringWithFormat:@"batchSize=%lu", validatedBatchSize] forHeaderName:kSFRestQueryOptions];
+    }
+    return request;
 }
 
 - (SFRestRequest *)requestForQueryAll:(NSString *)soql apiVersion:(NSString *)apiVersion {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientTest.swift
@@ -83,6 +83,20 @@ class RestClientTests: XCTestCase {
         XCTAssertNil(erroredResult,"Query call should not have failed")
     }
     
+    func testQueryWithDefaultBatchSize() {
+        let request = RestClient.shared.request(forQuery: "select name from CONTACT", apiVersion: nil, batchSize: 2000)
+        XCTAssertNil(request.customHeaders?["@SForce-Query-Options"]);
+    }
+    
+    func testQueryWithNonDefaultBatchSize() {
+        let request500 = RestClient.shared.request(forQuery: "select name from CONTACT", apiVersion: nil, batchSize: 500)
+        let request199 = RestClient.shared.request(forQuery: "select name from CONTACT", apiVersion: nil, batchSize: 199)
+        let request2001 = RestClient.shared.request(forQuery: "select name from CONTACT", apiVersion: nil, batchSize: 2001)
+        XCTAssertTrue("batchSize=500" == request500.customHeaders?["Sforce-Query-Options"] as! String);
+        XCTAssertTrue("batchSize=200" == request199.customHeaders?["Sforce-Query-Options"] as! String);
+        XCTAssertNil(request2001.customHeaders?["@SForce-Query-Options"]);
+    }
+    
     func testCompositeRequest() {
         let expectation = XCTestExpectation(description: "compositeTest")
         let accountName = self.generateRecordName()

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -500,6 +500,15 @@ static NSException *authException = nil;
     XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
 }
 
+// Runs a SOQL query which specifies a batch size
+// Make sure it succeeds
+-(void) testSOQLQueryWithBatchSize {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForQuery:@"Select Name from Account" apiVersion:kSFRestDefaultAPIVersion batchSize:250];
+    XCTAssertEqualObjects(@"batchSize=250", request.customHeaders[@"Sforce-Query-Options"]);
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];    listener = [self sendSyncRequest:request];
+    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+}
+
 // - create object (requestForCreateWithObjectType)
 // - query new object (requestForQuery) and make sure we just got 1 object
 // - update object


### PR DESCRIPTION
There is a way to specify a batch size when doing a SOQL query. See https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/headers_queryoptions.htm

With this PR, we are adding:

* a SFRestAPI.requestForQuery factory method that accepts a batchSize
* an option parameter for SFSOQLSyncDownTarget to use a different batch size from the default