### PR TITLE
Minor improvements to KeyValueEncryptedFileStore

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
@@ -45,6 +45,7 @@
 @implementation SFSDKKeyValueEncryptedFileStoreTests
 
 - (void)setUp {
+    [super setUp];
     SFOAuthCredentials *credentials = [[SFOAuthCredentials alloc] initWithIdentifier:[NSString stringWithFormat:@"keyvalue-test"] clientId:@"fakeClientIdForTesting" encrypted:YES];
     self.userAccount = [[SFUserAccount alloc] initWithCredentials:credentials];
     self.userAccount.credentials.identityUrl = [NSURL URLWithString:@"https://login.salesforce.com/id/00D000000000062EA0/005R0000000Dsl0IAC"];
@@ -61,6 +62,7 @@
         XCTAssertNil(error, @"Error removing item at path '%@': %@", [self userPath:self.userAccount], error);
     }
     self.userAccount = nil;
+    [super tearDown];
 }
 
 #pragma mark - Store management


### PR DESCRIPTION
**Changes**
- Use `isEmpty` instead of `count`
- Use `Data` initializer to convert `String` to `Data` to avoid dealing with optional
- Call super `setUp` and `tearDown` in test