### PR TITLE
Add new public method allKeys()

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
@@ -277,6 +277,8 @@ public class KeyValueEncryptedFileStore: NSObject {
 
     // MARK: - Store operations
     
+    /// Store version
+    /// - Returns: version number of the store
     @objc public func storeVersion() -> Int {
         return version
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
@@ -76,6 +76,7 @@ public class KeyValueEncryptedFileStore: NSObject {
             SFSDKCoreLogger.e(KeyValueEncryptedFileStore.self, message: "\(#function): Invalid store name")
             return nil
         }
+        
         let fullPath = parentDirectory + "/\(name)"
         let isNewlyCreated = !KeyValueEncryptedFileStore.directoryExists(atPath: fullPath)
         do {
@@ -84,6 +85,7 @@ public class KeyValueEncryptedFileStore: NSObject {
             SFSDKCoreLogger.e(KeyValueEncryptedFileStore.self, message: "\(#function): Error ensuring directory exists: \(error)")
             return nil
         }
+        
         self.name = name
         self.directory = URL(fileURLWithPath: fullPath)
         self.encryptionKey = encryptionKey
@@ -259,10 +261,10 @@ public class KeyValueEncryptedFileStore: NSObject {
             SFSDKCoreLogger.e(KeyValueEncryptedFileStore.self, message: "\(#function): Global stores directory is nil")
             return
         }
+        
         let storeDirectories = contentsOfDirectory(directory)
         for store in storeDirectories {
             let storeURL = URL(fileURLWithPath: directory).appendingPathComponent(store)
-
             do {
                 try FileManager.default.removeItem(at: storeURL)
                 globalStores.removeObject(store as NSString)
@@ -359,7 +361,7 @@ public class KeyValueEncryptedFileStore: NSObject {
     @objc public func removeAll() {
         let files = KeyValueEncryptedFileStore.contentsOfDirectory(directory.path)
         for file in files {
-            if !isVersionFile(file) {
+            if !KeyValueEncryptedFileStore.isVersionFile(file) {
                 let fileURL = directory.appendingPathComponent(file)
                 KeyValueEncryptedFileStore.removeFile(fileURL)
             }
@@ -483,7 +485,7 @@ public class KeyValueEncryptedFileStore: NSObject {
         }
     }
     
-    private func isVersionFile(_ file: String) -> Bool {
+    private static func isVersionFile(_ file: String) -> Bool {
         return file == KeyValueEncryptedFileStore.storeVersionFileName
     }
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
@@ -28,6 +28,7 @@
 import Foundation
 import SalesforceSDKCommon
 
+/// File-based key-value storage
 @objc(SFSDKKeyValueEncryptedFileStore)
 public class KeyValueEncryptedFileStore: NSObject {
     @objc(storeDirectory) public let directory: URL
@@ -349,7 +350,7 @@ public class KeyValueEncryptedFileStore: NSObject {
     }
     
     /// All keys in the store
-    /// - Returns: all the keys of stored values in the store
+    /// - Returns: all keys of stored values in a v2 store, nil if it's a v2 store
     @objc public func allKeys() -> [String]? {
         guard version >= 2 else {
             SFSDKCoreLogger.e(KeyValueEncryptedFileStore.self, message: "This store does not have this capability!")

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
@@ -92,9 +92,9 @@ public class KeyValueEncryptedFileStore: NSObject {
         super.init()
         
         if isNewlyCreated {
-            _ = writeFile(key: KeyValueEncryptedFileStore.storeVersionFileName,
-                          value: KeyValueEncryptedFileStore.storeVersion,
-                          fileType: .version)
+            writeFile(key: KeyValueEncryptedFileStore.storeVersionFileName,
+                      value: KeyValueEncryptedFileStore.storeVersion,
+                      fileType: .version)
         }
     }
 
@@ -302,7 +302,7 @@ public class KeyValueEncryptedFileStore: NSObject {
         
         let valueFileWriteSuccess = writeFile(key: key, value: value, fileType: .value)
         if valueFileWriteSuccess {
-            _ = writeFile(key: key, value: key, fileType: .key)
+            writeFile(key: key, value: key, fileType: .key)
         }
         return valueFileWriteSuccess
     }
@@ -418,6 +418,7 @@ public class KeyValueEncryptedFileStore: NSObject {
         }
     }
     
+    @discardableResult
     private func writeFile(key: String, value: String, fileType: FileType, callingFunction: String = #function) -> Bool {
         guard let encryptedData = encryptionKey.encryptData(Data(value.utf8)) else {
             SFSDKCoreLogger.e(KeyValueEncryptedFileStore.self, message: "\(callingFunction): Unable to encrypt data")

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
@@ -356,7 +356,15 @@ public class KeyValueEncryptedFileStore: NSObject {
 
     /// - Returns: The number of entries in the store.
     @objc public func count() -> Int {
+        if version < 2 {
+            return KeyValueEncryptedFileStore.contentsOfDirectory(directory.path, function: #function).count
+        }
+        
         let files = KeyValueEncryptedFileStore.contentsOfDirectory(directory.path, function: #function)
+            .filter { (filePath) -> Bool in
+                let fileURL = directory.appendingPathComponent(filePath)
+                return fileURL.lastPathComponent.hasSuffix(FileType.value.nameSuffix)
+            }
         return files.count
     }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
@@ -335,7 +335,7 @@ public class KeyValueEncryptedFileStore: NSObject {
         
         let valueFileDeletionSuccess = removeFile(key: key, fileType: .value)
         if valueFileDeletionSuccess {
-            _ = removeFile(key: key, fileType: .key)
+            removeFile(key: key, fileType: .key)
         }
         return valueFileDeletionSuccess
     }
@@ -456,6 +456,7 @@ public class KeyValueEncryptedFileStore: NSObject {
         }
     }
     
+    @discardableResult
     private func removeFile(key: String, fileType: FileType, callingFunction: String = #function) -> Bool {
         guard let fileURL = encodedURL(forKey: key, fileType: fileType) else {
             SFSDKCoreLogger.e(KeyValueEncryptedFileStore.self, message: "\(callingFunction): Unable to construct file URL")

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
@@ -37,8 +37,23 @@ public class KeyValueEncryptedFileStore: NSObject {
     private let encryptionKey: SFEncryptionKey
     private static var globalStores = SafeMutableDictionary<NSString, KeyValueEncryptedFileStore>()
     private static var userStores = SafeMutableDictionary<NSString, SafeMutableDictionary<NSString, KeyValueEncryptedFileStore>>()
+    private static let storeVersion = "2"
+    private static let storeVersionFileName = "version"
     private static let keyValueStoresDirectory = "key_value_stores"
     private static let encryptionKeyLabel = "com.salesforce.keyValueStores.encryptionKey"
+    
+    private lazy var version: Int = {
+        if let version = self[Self.storeVersionFileName], let versionNumber = Int(version) {
+            return versionNumber
+        } else {
+            return 1
+        }
+    }()
+    
+    private enum KeySuffix {
+        static let key = ".key"
+        static let value = ".value"
+    }
 
     /// Creates a store.
     /// - Parameter parentDirectory: Parent directory for the store.
@@ -59,6 +74,11 @@ public class KeyValueEncryptedFileStore: NSObject {
         self.name = name
         self.directory = URL(fileURLWithPath: fullPath)
         self.encryptionKey = encryptionKey
+        super.init()
+        
+        if isEmpty() {
+            self[Self.storeVersionFileName] = Self.storeVersion
+        }
     }
 
     // MARK: - Store management

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
@@ -51,7 +51,7 @@ public class KeyValueEncryptedFileStore: NSObject {
     private static let encryptionKeyLabel = "com.salesforce.keyValueStores.encryptionKey"
     
     private enum FileType {
-        case key, value
+        case key, value, version
         
         var nameSuffix: String {
             let suffix: String
@@ -60,6 +60,8 @@ public class KeyValueEncryptedFileStore: NSObject {
                 suffix = ".key"
             case .value:
                 suffix = ".value"
+            case .version:
+                suffix = ""
             }
             return suffix
         }
@@ -346,7 +348,9 @@ public class KeyValueEncryptedFileStore: NSObject {
         let files = KeyValueEncryptedFileStore.contentsOfDirectory(directory.path, function: #function)
         for file in files {
             let fileURL = directory.appendingPathComponent(file)
-            KeyValueEncryptedFileStore.removeFile(fileURL, function: #function)
+            if !isVersionFile(fileURL) {
+                KeyValueEncryptedFileStore.removeFile(fileURL, function: #function)
+            }
         }
     }
 
@@ -431,6 +435,10 @@ public class KeyValueEncryptedFileStore: NSObject {
         } catch {
             SFSDKCoreLogger.e(KeyValueEncryptedFileStore.self, message: "\(function): Error removing file at path '\(fileURL.path)': \(error)")
         }
+    }
+    
+    private func isVersionFile(_ fileURL: URL) -> Bool {
+        return fileURL.lastPathComponent == Self.storeVersionFileName
     }
     
     private func encodedURL(forKey key: String, fileType: FileType, function: String) -> URL? {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
@@ -33,6 +33,14 @@ public class KeyValueEncryptedFileStore: NSObject {
     @objc(storeDirectory) public let directory: URL
     @objc(storeName) public let name: String
     @objc public static let maxStoreNameLength = 96
+    
+    public lazy var version: Int = {
+        if let version = self[Self.storeVersionFileName], let versionNumber = Int(version) {
+            return versionNumber
+        } else {
+            return 1
+        }
+    }()
 
     private let encryptionKey: SFEncryptionKey
     private static var globalStores = SafeMutableDictionary<NSString, KeyValueEncryptedFileStore>()
@@ -41,14 +49,6 @@ public class KeyValueEncryptedFileStore: NSObject {
     private static let storeVersionFileName = "version"
     private static let keyValueStoresDirectory = "key_value_stores"
     private static let encryptionKeyLabel = "com.salesforce.keyValueStores.encryptionKey"
-    
-    private lazy var version: Int = {
-        if let version = self[Self.storeVersionFileName], let versionNumber = Int(version) {
-            return versionNumber
-        } else {
-            return 1
-        }
-    }()
     
     private enum KeySuffix {
         static let key = ".key"

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
@@ -158,7 +158,7 @@
     XCTAssertEqual(SFSDKKeyValueEncryptedFileStore.allGlobalStoreNames.count, 0);
 }
 
-#pragma mark - Store
+#pragma mark - Store operations
 
 - (void)testIsValidName {
     XCTAssertTrue([SFSDKKeyValueEncryptedFileStore isValidStoreName:@"123456789"]);

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
@@ -53,12 +53,12 @@
 
 - (void)tearDown {
     NSError *error;
-    if ([[NSFileManager defaultManager] fileExistsAtPath:[self globalPath]]) {
-        [[NSFileManager defaultManager] removeItemAtPath:[self globalPath] error:&error];
+    if ([NSFileManager.defaultManager fileExistsAtPath:[self globalPath]]) {
+        [NSFileManager.defaultManager removeItemAtPath:[self globalPath] error:&error];
         XCTAssertNil(error, @"Error removing item at path '%@': %@", [self globalPath], error);
     }
-    if ([[NSFileManager defaultManager] fileExistsAtPath:[self userPath:self.userAccount]]) {
-        [[NSFileManager defaultManager] removeItemAtPath:[self userPath:self.userAccount] error:&error];
+    if ([NSFileManager.defaultManager fileExistsAtPath:[self userPath:self.userAccount]]) {
+        [NSFileManager.defaultManager removeItemAtPath:[self userPath:self.userAccount] error:&error];
         XCTAssertNil(error, @"Error removing item at path '%@': %@", [self userPath:self.userAccount], error);
     }
     self.userAccount = nil;
@@ -110,7 +110,7 @@
     // Verify stores exist on disk
     NSError *error;
     NSArray *storeDirectories = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[self userPath:self.userAccount] error:&error];
-    XCTAssertEqual(storeDirectories.count, 3, "Number of directories don't match number of stores created");
+    XCTAssertEqual(storeDirectories.count, 3, @"Number of directories don't match number of stores created");
 
     // Verify names
     NSArray *storeNames = [SFSDKKeyValueEncryptedFileStore allStoreNamesForUser:self.userAccount];
@@ -142,7 +142,7 @@
     // Verify stores exist on disk
     NSError *error;
     NSArray *storeDirectories = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:[self globalPath] error:&error];
-    XCTAssertEqual(storeDirectories.count, 3, "Number of directories don't match number of stores created");
+    XCTAssertEqual(storeDirectories.count, 3, @"Number of directories don't match number of stores created");
 
     // Verify names
     NSArray *storeNames = SFSDKKeyValueEncryptedFileStore.allGlobalStoreNames;
@@ -160,6 +160,16 @@
 
 #pragma mark - Store operations
 
+- (void)testStoreVersion {
+    SFSDKKeyValueEncryptedFileStore *store = [self createStoreWithName:@"new_store"];
+    XCTAssertEqual([store storeVersion], 2);
+}
+
+- (void)testV1StoreVersion {
+    SFSDKKeyValueEncryptedFileStore *store = [self createV1StoreWithName:@"legacy_store"];
+    XCTAssertEqual([store storeVersion], 1);
+}
+
 - (void)testIsValidName {
     XCTAssertTrue([SFSDKKeyValueEncryptedFileStore isValidStoreName:@"123456789"]);
     XCTAssertTrue([SFSDKKeyValueEncryptedFileStore isValidStoreName:@"test_store"]);
@@ -176,7 +186,7 @@
 - (void)testStoreName {
     NSString *storeName = @"test_store_name";
     SFSDKKeyValueEncryptedFileStore *store = [self createStoreWithName:storeName];
-    XCTAssert([store.storeName isEqualToString:storeName], "Store names don't match");
+    XCTAssert([store.storeName isEqualToString:storeName], @"Store names don't match");
 }
 
 - (void)testBadStoreName {
@@ -235,6 +245,39 @@
     XCTAssertEqual(store.count, 0);
 }
 
+- (void)testAllKeys {
+    SFSDKKeyValueEncryptedFileStore *store = [self createStoreWithName:@"test_all_keys"];
+    int entryCount = 12;
+    NSMutableArray<NSString *> *expectedKeys = [[NSMutableArray alloc] initWithCapacity:entryCount];
+    for (int i = 0; i < entryCount; i++) {
+        NSString *key = [NSString stringWithFormat:@"key%i", i];
+        NSString *value =  [NSString stringWithFormat:@"value%i", i];
+        BOOL saveSuccess = [store saveValue:value forKey:key];
+        XCTAssertTrue(saveSuccess);
+        [expectedKeys addObject:key];
+    }
+    NSArray<NSString *> *keys = [store allKeys];
+    NSArray<NSString *> *sortedKeys = [keys sortedArrayUsingComparator:^NSComparisonResult(NSString *key1, NSString *key2) {
+        return [key1 compare:key2];
+    }];
+    NSArray<NSString *> *sortedExpectedKeys = [expectedKeys sortedArrayUsingComparator:^NSComparisonResult(NSString *key1, NSString *key2) {
+        return [key1 compare:key2];
+    }];
+    XCTAssertTrue([sortedKeys isEqualToArray:sortedExpectedKeys]);
+}
+
+- (void)testV1StoreAllKeys {
+    SFSDKKeyValueEncryptedFileStore *store = [self createV1StoreWithName:@"test_all_keys_v1"];
+    int entryCount = 12;
+    for (int i = 0; i < entryCount; i++) {
+        NSString *key = [NSString stringWithFormat:@"key%i", i];
+        NSString *value =  [NSString stringWithFormat:@"value%i", i];
+        BOOL saveSuccess = [store saveValue:value forKey:key];
+        XCTAssertTrue(saveSuccess);
+    }
+    XCTAssertNil([store allKeys]);
+}
+
 - (void)testOverwriteValue {
     SFSDKKeyValueEncryptedFileStore *store = [self createStoreWithName:@"test_overwrite_value"];
     NSString *key = @"overwrite_key";
@@ -265,7 +308,7 @@
     NSError *error;
     NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:store.storeDirectory.path error:&error];
     XCTAssertNil(error, @"Error getting contents of path '%@': %@", store.storeDirectory.path, error);
-    XCTAssertEqual(files.count, 1, "Unexpected number of files in store");
+    XCTAssertEqual(files.count, 3, @"Unexpected number of files in store");
     NSString *valuePath = [store.storeDirectory.path stringByAppendingPathComponent:files[0]];
     NSData *fileData = [NSData dataWithContentsOfFile:valuePath];
     NSData *valueData = [value dataUsingEncoding:NSUTF8StringEncoding];
@@ -304,6 +347,16 @@
 - (SFSDKKeyValueEncryptedFileStore *)createStoreWithName:(NSString *)name {
     NSString *parentDirectory = [self globalPath];
     return [[SFSDKKeyValueEncryptedFileStore alloc] initWithParentDirectory:parentDirectory name:name encryptionKey:[SFEncryptionKey createKey]];
+}
+
+- (SFSDKKeyValueEncryptedFileStore *)createV1StoreWithName:(NSString *)name {
+    NSString *parentDirectory = [self globalPath];
+    SFSDKKeyValueEncryptedFileStore *store = [[SFSDKKeyValueEncryptedFileStore alloc] initWithParentDirectory:parentDirectory name:name encryptionKey:[SFEncryptionKey createKey]];
+    NSURL *versionFileURL = [store.storeDirectory URLByAppendingPathComponent:@"version"];
+    NSError *error;
+    [NSFileManager.defaultManager removeItemAtURL:versionFileURL error:&error];
+    XCTAssertNil(error, @"Error deleting '%@': %@", store.storeDirectory.path, error);
+    return store;
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
@@ -350,8 +350,7 @@
 }
 
 - (SFSDKKeyValueEncryptedFileStore *)createV1StoreWithName:(NSString *)name {
-    NSString *parentDirectory = [self globalPath];
-    SFSDKKeyValueEncryptedFileStore *store = [[SFSDKKeyValueEncryptedFileStore alloc] initWithParentDirectory:parentDirectory name:name encryptionKey:[SFEncryptionKey createKey]];
+    SFSDKKeyValueEncryptedFileStore *store = [self createStoreWithName:name];
     NSURL *versionFileURL = [store.storeDirectory URLByAppendingPathComponent:@"version"];
     NSError *error;
     [NSFileManager.defaultManager removeItemAtURL:versionFileURL error:&error];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
@@ -170,6 +170,16 @@
     XCTAssertEqual([store storeVersion], 1);
 }
 
+- (void)testStoreWithUnreadableVersion {
+    SFSDKKeyValueEncryptedFileStore *store = [self createStoreWithName:@"new_store"];
+    XCTAssertNotNil(store);
+    NSURL *versionFileURL = [store.storeDirectory URLByAppendingPathComponent:@"version"];
+    NSData *badVersionData = [@"bad_version_data" dataUsingEncoding:NSUTF8StringEncoding];
+    [badVersionData writeToFile:versionFileURL.path atomically:YES];
+    store = [self createStoreWithName:@"new_store"];
+    XCTAssertNil(store);
+}
+
 - (void)testIsValidName {
     XCTAssertTrue([SFSDKKeyValueEncryptedFileStore isValidStoreName:@"123456789"]);
     XCTAssertTrue([SFSDKKeyValueEncryptedFileStore isValidStoreName:@"test_store"]);
@@ -355,7 +365,7 @@
     NSError *error;
     [NSFileManager.defaultManager removeItemAtURL:versionFileURL error:&error];
     XCTAssertNil(error, @"Error deleting '%@': %@", store.storeDirectory.path, error);
-    return store;
+    return [self createStoreWithName:name];
 }
 
 @end


### PR DESCRIPTION
**Summary**
Add a new public method `allKeys()` to retrieve all keys in the file-based key-value storage. The design of the technical solution is identical to the one in Android (refer to [this PR](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2168)).

**Change Details**
- Creates an additional file when saving a value, which contains the key. The name of this new file is `hash(key)_key`.
- The name of the file that contains the value is changed to `hash(key)_value`.
- A v2 store contains another new file to store version number. This file is simply named `version`, name is not hashed.
- Version file is never deleted, unless the store is removed.
- When removing a value, both key and value files are deleted.
- New public `allKeys()` added.
- Updated existing tests and added tests for new methods.