### PR TITLE
Fix creation of request with full https url

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.m
@@ -187,17 +187,18 @@ NSString * const kSFDefaultRestEndpoint = @"/services/data";
             [fullUrl appendString:[SFRestRequest toQueryString:self.queryParams]];
         }
         self.request = [[NSMutableURLRequest alloc] initWithURL:[[NSURL alloc] initWithString:fullUrl]];
-
-        // Sets the timeout interval.
-        self.request.timeoutInterval = self.timeoutInterval;
-
-        // Sets the service host type.
-        NSURLRequestNetworkServiceType serviceType = [self urlRequestServiceType:self.networkServiceType];
-        [self.request setNetworkServiceType:serviceType];
-        
-        // Sets HTTP method on the request.
-        [self.request setHTTPMethod:[SFRestRequest httpMethodFromSFRestMethod:self.method]];
     }
+
+    // Sets the timeout interval.
+    self.request.timeoutInterval = self.timeoutInterval;
+
+    // Sets the service host type.
+    NSURLRequestNetworkServiceType serviceType = [self urlRequestServiceType:self.networkServiceType];
+    [self.request setNetworkServiceType:serviceType];
+
+    // Sets HTTP method on the request.
+    [self.request setHTTPMethod:[SFRestRequest httpMethodFromSFRestMethod:self.method]];
+
 
     // Sets OAuth Bearer token header on the request (if not already present).
     // Allows Authenticated clients to make api calls that dont require access token.

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -2353,6 +2353,17 @@ static NSException *authException = nil;
     XCTAssertEqualObjects(finalRequest.URL.absoluteString, expectedURL, @"Final URL should utilize base URL that was passed in");
 }
 
+- (void)testCustomBaseURLRequestPOST {
+    SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST path:@"https://www.apple.com/test/testing" queryParams:nil];
+    [request setCustomRequestBodyData:[@"hello" dataUsingEncoding:NSUTF8StringEncoding] contentType:@"application/octet-stream"];
+    NSURLRequest *finalRequest = [request prepareRequestForSend:_currentUser];
+    XCTAssertEqualObjects(finalRequest.URL.absoluteString, @"https://www.apple.com/test/testing", @"Final URL should utilize base URL that was passed in");
+    XCTAssertEqualObjects([finalRequest valueForHTTPHeaderField:@"Content-Type"], @"application/octet-stream");
+    XCTAssertEqualObjects([finalRequest valueForHTTPHeaderField:@"Content-Length"], @"5");
+    XCTAssertEqualObjects(finalRequest.HTTPMethod, @"POST");
+    XCTAssertNotNil(finalRequest.HTTPBodyStream);
+}
+
 #pragma mark - miscellaneous tests
 
 - (void)testRestUrlForBaseUrl {


### PR DESCRIPTION
This ensures that the method, timeout, and service type are set
correctly when processing a `RestRequest` that includes a full url in
the path.

Previously too much code was within the conditional block and was only
getting set when hitting the path that prepends the instance url.