### PR TITLE
fix: Makes previously added methods for retrieving and processing

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -105,7 +105,7 @@ extension RestClient {
     /// This struct requires a Model Object that conforms to Decodable
     /// This model object's properties need to match the Salesforce Schema
     ///   at least in part.
-    struct QueryResponse<Record: Decodable>: Decodable {
+    public struct QueryResponse<Record: Decodable>: Decodable {
       var totalSize: Int?
       var done: Bool?
       var records: [Record]?
@@ -176,7 +176,7 @@ extension RestClient {
     ///
     /// This method relies on the passed parameter ofModelType to infer the generic Record's
     /// concrete type.
-    func fetchRecords<Record: Decodable>(ofModelType modelType: Record.Type,
+    public func fetchRecords<Record: Decodable>(ofModelType modelType: Record.Type,
                                          forRequest request: RestRequest,
                                          withDecoder decoder: JSONDecoder = .init(),
                                        _ completionBlock: @escaping (Result<QueryResponse<Record>, RestClientError>) -> Void) {
@@ -214,7 +214,7 @@ extension RestClient {
     ///
     /// This method relies on the passed parameter ofModelType to infer the generic Record's
     /// concrete type.
-    func fetchRecords<Record: Decodable>(ofModelType modelType: Record.Type,
+    public func fetchRecords<Record: Decodable>(ofModelType modelType: Record.Type,
                                          forQuery query: String,
                                          withApiVersion version: String = SFRestDefaultAPIVersion,
                                          withDecoder decoder: JSONDecoder = .init(),
@@ -280,7 +280,7 @@ extension RestClient {
     ///   .assign(to: \.contacts, on: self)
     ///
     /// This pipeline infers it's return type from the variable in the assign subscriber.
-    func records<Record: Decodable>(forRequest request: RestRequest,
+    public func records<Record: Decodable>(forRequest request: RestRequest,
                                     withDecoder decoder: JSONDecoder = .init()) -> AnyPublisher<QueryResponse<Record>, Never> {
       guard request.isQueryRequest else {
         return Empty(completeImmediately: true).eraseToAnyPublisher()
@@ -299,7 +299,7 @@ extension RestClient {
     /// Reusable, generic Combine Pipeline returning an array of records of a local
     /// model object that conforms to Decodable. This method accepts a query string and defers
     /// to records<Record:Decodable>(forRequest request: RestRequest) -> AnyPublisher<[Record], Never>
-    func records<Record: Decodable>(forQuery query: String,
+    public func records<Record: Decodable>(forQuery query: String,
                                     withApiVersion version: String = SFRestDefaultAPIVersion,
                                     withDecoder decoder: JSONDecoder = .init()) -> AnyPublisher<QueryResponse<Record>, Never> {
         let request = RestClient.shared.request(forQuery: query, apiVersion: version)


### PR DESCRIPTION
 Salesforce data into local decodable models *public* when they were previously, wrongly defaulted to private.