### PR TITLE
Fixing bug when advanced auth is cancelled

### DIFF
--- a/SalesforceMobileSDK.xcworkspace/xcshareddata/xcschemes/Everything.xcscheme
+++ b/SalesforceMobileSDK.xcworkspace/xcshareddata/xcschemes/Everything.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SalesforceMobileSDK.xcworkspace/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/SalesforceMobileSDK.xcworkspace/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/libs/MobileSync/MobileSync.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
+++ b/libs/MobileSync/MobileSync.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/libs/MobileSync/MobileSync.xcodeproj/xcshareddata/xcschemes/MobileSync.xcscheme
+++ b/libs/MobileSync/MobileSync.xcodeproj/xcshareddata/xcschemes/MobileSync.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/libs/MobileSync/MobileSync.xcodeproj/xcshareddata/xcschemes/MobileSyncTestApp.xcscheme
+++ b/libs/MobileSync/MobileSync.xcodeproj/xcshareddata/xcschemes/MobileSyncTestApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/libs/SalesforceAnalytics/SalesforceAnalytics.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/libs/SalesforceAnalytics/SalesforceAnalytics.xcodeproj/xcshareddata/xcschemes/SalesforceAnalytics.xcscheme
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics.xcodeproj/xcshareddata/xcschemes/SalesforceAnalytics.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/libs/SalesforceAnalytics/SalesforceAnalytics.xcodeproj/xcshareddata/xcschemes/SalesforceAnalyticsTestApp.xcscheme
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics.xcodeproj/xcshareddata/xcschemes/SalesforceAnalyticsTestApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/project.pbxproj
@@ -383,7 +383,7 @@
 			isa = PBXProject;
 			attributes = {
 				DefaultBuildSystemTypeForWorkspace = Original;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1240;
 				ORGANIZATIONNAME = Salesforce;
 				TargetAttributes = {
 					B7136CFD216684A700F6A221 = {
@@ -684,6 +684,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/xcshareddata/xcschemes/SalesforceSDKCommon.xcscheme
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/xcshareddata/xcschemes/SalesforceSDKCommon.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/xcshareddata/xcschemes/SalesforceSDKCore.xcscheme
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/xcshareddata/xcschemes/SalesforceSDKCore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/xcshareddata/xcschemes/SalesforceSDKCoreTestApp.xcscheme
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/xcshareddata/xcschemes/SalesforceSDKCoreTestApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager+Internal.h
@@ -101,8 +101,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy, nonnull) void (^alertDisplayBlock)(SFSDKAlertMessage *, SFSDKWindowContainer *);
 
-@property (nonatomic, copy, nonnull) void (^authCancelledByUserHandlerBlock)(void);
-
 /** SFSDKAlertView used to wrap display of SFSDKMessage using an AlertController.
  *
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -177,8 +177,8 @@ FOUNDATION_EXTERN NSString * const kSFIDPSceneIdKey NS_SWIFT_NAME(UserAccountMan
 NS_SWIFT_NAME(UserAccountManagerDelegate)
 @protocol SFUserAccountManagerDelegate <NSObject>
 
-
 @optional
+
 /**
  Called when the account manager wants to determine if the network is available.
  @param userAccountManager The instance of SFUserAccountManager making the call.
@@ -232,6 +232,11 @@ NS_SWIFT_NAME(UserAccountManager.NotificationUserInfo)
  */
 NS_SWIFT_NAME(UserAccountManager)
 @interface SFUserAccountManager : NSObject
+
+/**
+ * Completion block for when auth is cancelled.
+ */
+@property (nonatomic, readwrite, copy, nonnull) void (^authCancelledByUserHandlerBlock)(void);
 
 /** The current user account.  This property may be nil if the user
  has never logged in.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -236,7 +236,7 @@ NS_SWIFT_NAME(UserAccountManager)
 /**
  * Completion block for when auth is cancelled.
  */
-@property (nonatomic, readwrite, copy, nonnull) void (^authCancelledByUserHandlerBlock)(void);
+@property (nonatomic, readwrite, copy, nullable) void (^authCancelledByUserHandlerBlock)(void);
 
 /** The current user account.  This property may be nil if the user
  has never logged in.

--- a/libs/SmartStore/SmartStore.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
+++ b/libs/SmartStore/SmartStore.xcodeproj/xcshareddata/xcschemes/Documentation.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/libs/SmartStore/SmartStore.xcodeproj/xcshareddata/xcschemes/SmartStore.xcscheme
+++ b/libs/SmartStore/SmartStore.xcodeproj/xcshareddata/xcschemes/SmartStore.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/libs/SmartStore/SmartStore.xcodeproj/xcshareddata/xcschemes/SmartStoreTestApp.xcscheme
+++ b/libs/SmartStore/SmartStore.xcodeproj/xcshareddata/xcschemes/SmartStoreTestApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/xcshareddata/xcschemes/MobileSyncExplorer.xcscheme
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/xcshareddata/xcschemes/MobileSyncExplorer.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/xcshareddata/xcschemes/MobileSyncExplorerCommon.xcscheme
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/xcshareddata/xcschemes/MobileSyncExplorerCommon.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/xcshareddata/xcschemes/RecentContactsTodayExtension.xcscheme
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/xcshareddata/xcschemes/RecentContactsTodayExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer.xcodeproj/xcshareddata/xcschemes/RestAPIExplorer.xcscheme
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer.xcodeproj/xcshareddata/xcschemes/RestAPIExplorer.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Currently, if advanced auth is cancelled, it automatically takes the user to the server picker screen. The only workaround is for the app to specify where to go instead, through a completion block. However, we accidentally make this internal. This PR makes it public again.