### PR TITLE
add @synchronized block for sLastErorr in SFJsonUtils

### DIFF
--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Util/SFJsonUtils.m
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Util/SFJsonUtils.m
@@ -31,7 +31,9 @@ static NSError *sLastError = nil;
 
 + (NSError *)lastError
 {
-    return sLastError;
+    @synchronized (sLastError) {
+        return sLastError;
+    }
 }
 
 + (id)objectFromJSONData:(NSData *)jsonData
@@ -46,7 +48,9 @@ static NSError *sLastError = nil;
 
         if (nil != err) {
             [SFLogger log:[self class] level:SFLogLevelDebug format:@"WARNING error parsing json: %@", err];
-            sLastError = err;
+            @synchronized(sLastError) {
+                sLastError = err;
+            }
             return nil;
         }
     }
@@ -99,7 +103,9 @@ static NSError *sLastError = nil;
          ];
         if (nil != err) {
             [SFLogger log:[self class] level:SFLogLevelDebug format:@"WARNING error writing json: %@", err];
-            sLastError = err;
+            @synchronized(sLastError) {
+                sLastError = err;
+            }
         }
         if (nil == jsonData) {
             [SFLogger log:[self class] level:SFLogLevelDebug format:@"unexpected nil json rep for: %@", obj];


### PR DESCRIPTION
@bhariharan 
we recently run into a crash in our app.
[report-2517833460030009999-60abf7df-7345-4979-9683-8a40ed77dc0d.txt](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/files/6353060/report-2517833460030009999-60abf7df-7345-4979-9683-8a40ed77dc0d.txt)
From the trace it looks like  a multi thread issue when accessing/updating sLastErorr, thus add @synchronized block for sLastErorr