### PR TITLE
More Catalyst

### DIFF
--- a/libs/MobileSync/MobileSync.xcodeproj/project.pbxproj
+++ b/libs/MobileSync/MobileSync.xcodeproj/project.pbxproj
@@ -1391,6 +1391,7 @@
 				INFOPLIST_FILE = MobileSync/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1429,6 +1430,7 @@
 				INFOPLIST_FILE = MobileSync/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/libs/SalesforceAnalytics/SalesforceAnalytics.xcodeproj/project.pbxproj
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics.xcodeproj/project.pbxproj
@@ -814,6 +814,7 @@
 				INFOPLIST_FILE = "SalesforceAnalytics/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -843,6 +844,7 @@
 				INFOPLIST_FILE = "SalesforceAnalytics/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/project.pbxproj
@@ -706,6 +706,7 @@
 				INFOPLIST_FILE = SalesforceSDKCommon/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -735,6 +736,7 @@
 				INFOPLIST_FILE = SalesforceSDKCommon/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -2765,6 +2765,7 @@
 				INFOPLIST_FILE = SalesforceSDKCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2825,6 +2826,7 @@
 				INFOPLIST_FILE = SalesforceSDKCore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFKeychainItemWrapper.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFKeychainItemWrapper.h
@@ -60,6 +60,7 @@ extern NSString * _Nullable const kSFKeychainItemExceptionErrorCodeKey SFSDK_DEP
  This class is a wrapper class used to interact with the keychain.
  */
 SFSDK_DEPRECATED("9.1", "10.0", "Will be removed in Mobile SDK 10.0, use SFSDKKeychainHelper instead.")
+API_UNAVAILABLE(macCatalyst)
 @interface SFKeychainItemWrapper : NSObject 
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -144,9 +144,9 @@ NS_SWIFT_NAME(SalesforceManager)
 
 /**
  Whether or not to use a security snapshot view when the app is backgrounded, to prevent
- sensitive data from being displayed outside of the app context.  Default is YES.
+ sensitive data from being displayed outside of the app context.  Default is YES on iOS. Disabled when running on Mac.
  */
-@property (nonatomic, assign) BOOL useSnapshotView NS_SWIFT_NAME(usesSnapshotView);
+@property (nonatomic, assign) BOOL useSnapshotView NS_SWIFT_NAME(usesSnapshotView) API_UNAVAILABLE(macCatalyst);
 
 /**
  The block to provide custom view to use for IDP selection flow.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -40,6 +40,7 @@
 #import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 #import "SFSDKResourceUtils.h"
 #import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
+#import "UIDevice+SFHardware.h"
 
 static NSString * const kSFAppFeatureSwiftApp   = @"SW";
 static NSString * const kSFAppFeatureMultiUser   = @"MU";
@@ -284,7 +285,8 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserDidSwitch:) name:kSFNotificationUserDidSwitch object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(passcodeFlowWillBegin:) name:kSFPasscodeFlowWillBegin object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(passcodeFlowDidComplete:) name:kSFPasscodeFlowCompleted object:nil];
-        self.useSnapshotView = YES;
+
+        _useSnapshotView = ![self isOnMac];
         [self computeWebViewUserAgent]; // web view user agent is computed asynchronously so very first call to self.userAgentString(...) will be missing it
         self.userAgentString = [self defaultUserAgentString];
         self.URLCacheType = kSFURLCacheTypeEncrypted;
@@ -531,6 +533,15 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
     }
 }
 
+- (BOOL)isOnMac {
+    NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+    BOOL isOnMac = processInfo.macCatalystApp;
+    if (@available(iOS 14.0, *)) {
+        isOnMac |= [NSProcessInfo processInfo].isiOSAppOnMac;
+    }
+    return isOnMac;
+}
+
 - (void)setupServiceConfiguration
 {
     [SFUserAccountManager sharedInstance].oauthClientId = self.appConfig.remoteAccessConsumerKey;
@@ -620,7 +631,6 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
 
     // Set up snapshot security view, if it's configured.
     @try {
-        [SFSDKCoreLogger d:[self class] format:@"Scene %@ is trying to present snapshot.", sceneId];
         [self presentSnapshot:scene];
     }
     @catch (NSException *exception) {
@@ -700,10 +710,11 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
 }
 
 - (void)presentSnapshot:(UIScene *)scene {
-    if (!self.useSnapshotView) {
+    if (!_useSnapshotView) {
         return;
     }
     NSString *sceneId = scene.session.persistentIdentifier;
+    [SFSDKCoreLogger d:[self class] format:@"Scene %@ is trying to present snapshot.", sceneId];
     // Try to retrieve a custom snapshot view controller
     UIViewController* customSnapshotViewController = nil;
     if (self.snapshotViewControllerCreationAction) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -539,8 +539,8 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
 + (BOOL)isOnMac {
     NSProcessInfo *processInfo = [NSProcessInfo processInfo];
     BOOL isOnMac = processInfo.macCatalystApp;
-    if (@available(iOS 14.0, *)) {
-        isOnMac |= [NSProcessInfo processInfo].isiOSAppOnMac;
+    if (@available(iOS 14.0, *)) { // TODO: Remove in Mobile SDK 10.0
+        isOnMac = isOnMac || [NSProcessInfo processInfo].isiOSAppOnMac;
     }
     return isOnMac;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -40,7 +40,6 @@
 #import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 #import "SFSDKResourceUtils.h"
 #import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
-#import "UIDevice+SFHardware.h"
 
 static NSString * const kSFAppFeatureSwiftApp   = @"SW";
 static NSString * const kSFAppFeatureMultiUser   = @"MU";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -41,8 +41,9 @@
 #import "SFSDKResourceUtils.h"
 #import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
 
-static NSString * const kSFAppFeatureSwiftApp   = @"SW";
+static NSString * const kSFAppFeatureSwiftApp    = @"SW";
 static NSString * const kSFAppFeatureMultiUser   = @"MU";
+static NSString * const kSFAppFeatureMacApp      = @"MC";
 
 // Error constants
 NSString * const kSalesforceSDKManagerErrorDomain     = @"com.salesforce.sdkmanager.error";
@@ -208,6 +209,9 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
         if([SFSwiftDetectUtil isSwiftApp]) {
             [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureSwiftApp];
         }
+        if ([SalesforceSDKManager isOnMac]) {
+            [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureMacApp];
+        }
         if([[[SFUserAccountManager sharedInstance] allUserIdentities] count]>1){
             [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureMultiUser];
         }
@@ -285,7 +289,7 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(passcodeFlowWillBegin:) name:kSFPasscodeFlowWillBegin object:nil];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(passcodeFlowDidComplete:) name:kSFPasscodeFlowCompleted object:nil];
 
-        _useSnapshotView = ![self isOnMac];
+        _useSnapshotView = ![SalesforceSDKManager isOnMac];
         [self computeWebViewUserAgent]; // web view user agent is computed asynchronously so very first call to self.userAgentString(...) will be missing it
         self.userAgentString = [self defaultUserAgentString];
         self.URLCacheType = kSFURLCacheTypeEncrypted;
@@ -532,7 +536,7 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
     }
 }
 
-- (BOOL)isOnMac {
++ (BOOL)isOnMac {
     NSProcessInfo *processInfo = [NSProcessInfo processInfo];
     BOOL isOnMac = processInfo.macCatalystApp;
     if (@available(iOS 14.0, *)) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
@@ -473,7 +473,7 @@ static NSString *const kSFPasscodeWindowKey = @"passcode";
     
     if (!mainWindow && [scene.delegate respondsToSelector:@selector(window)]) {
         mainWindow = [scene.delegate performSelector:@selector(window)];
-    } else if (!mainWindow) {
+    } else if (!mainWindow && [[SFApplicationHelper sharedApplication].delegate respondsToSelector:@selector(window)]) {
         mainWindow = [SFApplicationHelper sharedApplication].delegate.window;
     }
     

--- a/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
+++ b/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
@@ -1133,6 +1133,7 @@
 				INFOPLIST_FILE = SmartStore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1143,6 +1144,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1169,6 +1171,7 @@
 				INFOPLIST_FILE = SmartStore/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1179,6 +1182,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
@@ -32,6 +32,7 @@
 #import <SalesforceSDKCore/SFUserAccount.h>
 #import <SalesforceSDKCore/SFDirectoryManager.h>
 #import <SalesforceSDKCore/SFKeychainItemWrapper.h>
+#import <SalesforceSDKCommon/SFPathUtil.h>
 #import <sqlite3.h>
 #import "SFSmartStoreUtils.h"
 #import "FMDatabase.h"
@@ -486,7 +487,7 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
 
 - (BOOL) protectDir:(NSString*)dirPath protection:(NSString*)protection {
     NSString* currentProtection = [self getDirProtection:dirPath];
-    if (currentProtection == nil) {
+    if (currentProtection == nil || [dirPath isEqualToString: [SFPathUtil applicationDocumentDirectory]]) {
         // We don't own the dir, we are done
         return YES;
     }

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
@@ -1126,7 +1126,6 @@
 				GCC_PREFIX_HEADER = "MobileSyncExplorer/MobileSyncExplorer-Prefix.pch";
 				INFOPLIST_FILE = "MobileSyncExplorer/MobileSyncExplorer-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1134,8 +1133,9 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.salesforce.mobilesdk.MobileSyncExplorer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -1151,7 +1151,6 @@
 				GCC_PREFIX_HEADER = "MobileSyncExplorer/MobileSyncExplorer-Prefix.pch";
 				INFOPLIST_FILE = "MobileSyncExplorer/MobileSyncExplorer-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1159,8 +1158,9 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.salesforce.mobilesdk.MobileSyncExplorer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
@@ -1126,6 +1126,7 @@
 				GCC_PREFIX_HEADER = "MobileSyncExplorer/MobileSyncExplorer-Prefix.pch";
 				INFOPLIST_FILE = "MobileSyncExplorer/MobileSyncExplorer-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1150,6 +1151,7 @@
 				GCC_PREFIX_HEADER = "MobileSyncExplorer/MobileSyncExplorer-Prefix.pch";
 				INFOPLIST_FILE = "MobileSyncExplorer/MobileSyncExplorer-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer.xcodeproj/project.pbxproj
@@ -775,6 +775,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RestAPIExplorer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -797,6 +798,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = RestAPIExplorer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]" = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
- Bug fixes
- Bumped the mac minimum to the latest
- Disable snapshot when running on mac and made deprecated keychain class unavailable 
- I enabled Catalyst on Mobile Sync Explorer sample in my last PR but I didn't get a chance to update the UI, so I turned it off again. It'll still be enabled in RestAPIExplorer and MobileSyncExplorerSwift template