### PR TITLE
Allowing dev support menu title to be overridable at the app layer

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -53,7 +53,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSString *SFAppTypeGetDescription(SFAppType appType) NS_SWIFT_NAME(getter:SFAppType.description(self:));
 
-
 /**
  Block typedef for presenting the snapshot view controller.
  */
@@ -244,6 +243,13 @@ NS_SWIFT_NAME(SalesforceManager)
  * @return Dev info (list of name1, value1, name2, value2 etc) to show in SFSDKDevInfoController
  */
 - (NSArray<NSString *>*)getDevSupportInfos NS_SWIFT_NAME(devSupportInfoList());
+
+/**
+ * Returns the title string of the dev support menu.
+ *
+ * @return Title string of the dev support menu.
+ */
+- (nonnull NSString *)devInfoTitleString;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -411,6 +411,7 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
 
 - (void) showDevSupportDialog:(UIViewController *)presentedViewController
 {
+
     // Do nothing if dev support is not enabled or dialog is already being shown
     if (!self.isDevSupportEnabled || self.actionSheet) {
         return;
@@ -418,14 +419,9 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
 
     // On larger devices we don't have an anchor point for the action sheet
     UIAlertControllerStyle style = [[UIDevice currentDevice] userInterfaceIdiom] == UIUserInterfaceIdiomPhone ? UIAlertControllerStyleActionSheet : UIAlertControllerStyleAlert;
-    self.actionSheet = [UIAlertController alertControllerWithTitle:[SFSDKResourceUtils localizedString:@"devInfoTitle"]
-                                                       message:@""
-                                                preferredStyle:style];
-
+    self.actionSheet = [UIAlertController alertControllerWithTitle:[self devInfoTitleString] message:@"" preferredStyle:style];
     NSArray<SFSDKDevAction *>* devActions = [self getDevActions:presentedViewController];
-    
-    
-    for (int i=0; i<devActions.count; i++) {
+    for (int i = 0; i < devActions.count; i++) {
         [self.actionSheet addAction:[UIAlertAction actionWithTitle:devActions[i].name
                                                              style:UIAlertActionStyleDefault
                                                            handler:^(__unused UIAlertAction *action) {
@@ -433,18 +429,19 @@ static NSInteger const kDefaultCacheDiskCapacity = 1024 * 1024 * 20;  // 20MB
                                                                self.actionSheet = nil;
                                                            }]];
     }
-    
-    [self.actionSheet addAction:[UIAlertAction actionWithTitle:[SFSDKResourceUtils localizedString:@"devInfoCancelKey"]
-                                                         style:UIAlertActionStyleCancel
+    [self.actionSheet addAction:[UIAlertAction actionWithTitle:[SFSDKResourceUtils localizedString:@"devInfoCancelKey"] style:UIAlertActionStyleCancel
                                                        handler:^(__unused UIAlertAction *action) {
                                                            self.actionSheet = nil;
                                                        }]];
-
-    
     [presentedViewController presentViewController:self.actionSheet animated:YES completion:nil];
 }
 
--(NSArray<SFSDKDevAction *>*) getDevActions:(UIViewController *)presentedViewController
+- (NSString *)devInfoTitleString
+{
+    return [SFSDKResourceUtils localizedString:@"devInfoTitle"];
+}
+
+- (NSArray<SFSDKDevAction *>*) getDevActions:(UIViewController *)presentedViewController
 {
     return @[
              [[SFSDKDevAction alloc]initWith:@"Show dev info" handler:^{

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKDevInfoViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKDevInfoViewController.m
@@ -31,8 +31,8 @@
 // Nav bar
 static CGFloat      const kNavBarHeight          = 44.0;
 static CGFloat      const kNavBarTitleFontSize   = 18.0;
+
 // Resource keys
-static NSString * const kDevInfoTitleKey = @"devInfoTitle";
 static NSString * const kDevInfoBackButtonTitleKey = @"devInfoBackButtonTitle";
 static NSString * const kDevInfoOKKey = @"devInfoOKKey";
 
@@ -41,7 +41,6 @@ static NSString * const kDevInfoOKKey = @"devInfoOKKey";
 @property (nonatomic, strong) UINavigationBar *navBar;
 @property (nonatomic, strong) UITableView *infoTable;
 @property (nonatomic, strong) NSArray *infoData;
-
 
 @end
 
@@ -57,8 +56,6 @@ static NSString * const kDevInfoOKKey = @"devInfoOKKey";
     }
     return self;
 }
-
-#pragma mark - View lifecycle
 
 #pragma mark - Actions handlers
 
@@ -97,14 +94,13 @@ static NSString * const kDevInfoOKKey = @"devInfoOKKey";
 
     // Table view
     self.infoTable = [self createTableView];
-
 }
 
 - (UINavigationBar*) createNavBar
 {
     UINavigationBar* navBar = [[UINavigationBar alloc] initWithFrame:CGRectMake(0, 0, self.view.bounds.size.width, kNavBarHeight)];
     navBar.delegate = self;
-    UINavigationItem *navItem = [[UINavigationItem alloc] initWithTitle:[SFSDKResourceUtils localizedString:kDevInfoTitleKey]];
+    UINavigationItem *navItem = [[UINavigationItem alloc] initWithTitle:[[SalesforceSDKManager sharedManager] devInfoTitleString]];
     UIBarButtonItem *backItem = [[UIBarButtonItem alloc] initWithTitle:[SFSDKResourceUtils localizedString:kDevInfoBackButtonTitleKey] style:UIBarButtonItemStylePlain target:self action:@selector(backButtonClicked)];
     [navItem setLeftBarButtonItem:backItem];
     [navBar setItems:@[navItem] animated:YES];

--- a/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
+++ b/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
@@ -55,7 +55,6 @@
 "accessibilityUnlockAnnouncement" = "Passcode confirmed.";
 "accessibilityLoggedOutAnnouncement" = "You are logged out.";
 
-
 // OAuth flow
 "authAlertContinueButton"="Continue";
 "authAlertErrorTitle" = "Server Error";
@@ -115,7 +114,6 @@
 "devInfoBackButtonTitle" = "Back";
 "devInfoOKKey" = "OK";
 "devInfoCancelKey" = "Cancel";
-
 
 //IDP User Selection Screen
 "idpSelectUserLabel" = "Select your account to log into";


### PR DESCRIPTION
Currently it says `"Mobile SDK Dev Support"`, and the only way is to override it in the resource bundle. However, not all apps use the main bundle. Our code doesn't allow for those use cases. This makes it simpler to override and doesn't impose additional constraints on the app.