### PR TITLE
clean existing files before moving new files

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
@@ -268,7 +268,7 @@ static NSString * const kDirectoryManagerErrorDomain = @"com.salesforce.mobilesd
                     NSString *orgPath = [rootPath stringByAppendingPathComponent:orgContent];
                     NSString *newDirectory = [orgContent entityId18];
                     NSString *newPath = [rootPath stringByAppendingPathComponent:newDirectory];
-                    if (![fileManager fileExistsAtPath:newPath]) {
+                    if (![fm fileExistsAtPath:newPath]) {
                         // File does not exist, copy it.
                         [fm moveItemAtPath:orgPath toPath:newPath error:&error];
                         if (error) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
@@ -268,7 +268,6 @@ static NSString * const kDirectoryManagerErrorDomain = @"com.salesforce.mobilesd
                     NSString *orgPath = [rootPath stringByAppendingPathComponent:orgContent];
                     NSString *newDirectory = [orgContent entityId18];
                     NSString *newPath = [rootPath stringByAppendingPathComponent:newDirectory];
-                    [fm moveItemAtPath:orgPath toPath:newPath error:&error];
                     if (![fileManager fileExistsAtPath:newPath]) {
                         // File does not exist, copy it.
                         [fm moveItemAtPath:orgPath toPath:newPath error:&error];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFDirectoryManager.m
@@ -269,8 +269,21 @@ static NSString * const kDirectoryManagerErrorDomain = @"com.salesforce.mobilesd
                     NSString *newDirectory = [orgContent entityId18];
                     NSString *newPath = [rootPath stringByAppendingPathComponent:newDirectory];
                     [fm moveItemAtPath:orgPath toPath:newPath error:&error];
-                    if (error) {
-                        [SFSDKCoreLogger e:[self class] format:@"Error moving %@ to %@: %@", orgPath, newPath, error];
+                    if (![fileManager fileExistsAtPath:newPath]) {
+                        // File does not exist, copy it.
+                        [fm moveItemAtPath:orgPath toPath:newPath error:&error];
+                        if (error) {
+                            [SFSDKCoreLogger e:[self class] format:@"Existing Files does not exist, Error moving %@ to %@: %@", orgPath, newPath, error];
+                        }
+                    } else {
+                        [fm removeItemAtPath:newPath error:&error];
+                        if (error) {
+                            [SFSDKCoreLogger e:[self class] format:@"Existing Files exist, Error removing %@ to %@: %@", orgPath, newPath, error];
+                        }
+                        [fm moveItemAtPath:orgPath toPath:newPath error:&error];
+                        if (error) {
+                            [SFSDKCoreLogger e:[self class] format:@"Error moving %@ to %@ after removing existing files: %@", orgPath, newPath, error];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
@bhariharan 
we run into a case during file upgrade indicating a failure when there is existing files 

```
Error moving /private/var/mobile/Containers/Shared/AppGroup/D3A30C94-861F-408B-A39A-8FC786E9D84D/MASK*******/*******/[...59YEt] to /private/var/mobile/Containers/Shared/AppGroup/D3A30C94-861F-408B-A39A-8FC786E9D84D/MASK*******/*******/[...59YEt]: Error Domain=NSCocoaErrorDomain Code=516 "“[...59YEt]” couldn’t be moved to “00D****************” because an item with the same name already exists." UserInfo={NSSourceFilePathErrorKey=/private/var/mobile/Containers/Shared/AppGroup/D3A30C94-861F-408B-A39A-8FC786E9D84D/MASK*******/*******/...59YEt], NSUserStringVariant=(
    Move
), NSDestinationFilePath=/private/var/mobile/Containers/Shared/AppGroup/D3A30C94-861F-408B-A39A-8FC786E9D84D/MASK*******/*******/[...59YEt], NSFilePath=/private/var/mobile/Containers/Shared/AppGroup/D3A30C94-861F-408B-A39A-8FC786E9D84D/MASK*******/*******/[...59YEt], NSUnderlyingError=0x282a3d200 {Error Domain=NSPOSIXErrorDomain Code=17 "File exists"}}
```

Thus will removing existing files before moving new files