### PR TITLE
Fix for Passcode controller showing content on failure

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSecurityLockout.m
@@ -434,23 +434,24 @@ static NSString *const kSecurityLockoutSessionId = @"securityLockoutSession";
     [self sendPasscodeFlowCompletedNotification:success];
     UIViewController *passVc = [SFSecurityLockout passcodeViewController];
     if (passVc != nil) {
-        __weak typeof (self) weakSelf = self;
-        [SFSecurityLockout dismissPasscodeWithCompletion:^{
-            __strong typeof (weakSelf) strongSelf = weakSelf;
-            [SFSecurityLockout setPasscodeViewController:nil];
-            if (success) {
+        if (success) {
+            __weak typeof (self) weakSelf = self;
+            [SFSecurityLockout dismissPasscodeWithCompletion:^{
+                __strong typeof (weakSelf) strongSelf = weakSelf;
+                [SFSecurityLockout setPasscodeViewController:nil];
                 [SFSecurityLockout unlockSuccessPostProcessing:action];
-            } else {
-                // Clear the SFSecurityLockout passcode state, as it's no longer valid.
-                [SFSecurityLockout clearAllPasscodeState];
-                [[SFUserAccountManager sharedInstance] logoutAllUsers];
-                [SFSecurityLockout unlockFailurePostProcessing];
-                [SFSecurityLockout setBiometricState:SFBiometricUnlockUnavailable];
-            }
 
-            [SFSDKEventBuilderHelper createAndStoreEvent:@"passcodeUnlock" userAccount:nil className:NSStringFromClass([strongSelf class]) attributes:nil];
-            [strongSelf sendPasscodeFlowCompletedNotification:success];
-        }];
+                [SFSDKEventBuilderHelper createAndStoreEvent:@"passcodeUnlock" userAccount:nil className:NSStringFromClass([strongSelf class]) attributes:nil];
+                [strongSelf sendPasscodeFlowCompletedNotification:success];
+            }];
+        } else {
+            // Clear the SFSecurityLockout passcode state, as it's no longer valid.
+            [SFSecurityLockout clearAllPasscodeState];
+            [[SFUserAccountManager sharedInstance] logoutAllUsers];
+            [SFSecurityLockout unlockFailurePostProcessing];
+            [SFSecurityLockout setBiometricState:SFBiometricUnlockUnavailable];
+            [SFSecurityLockout setPasscodeViewController:nil];
+        }
     }
 }
 


### PR DESCRIPTION
The passcode controller dismisses before the logout process starts and shows content after max failed attempts. This fix prevents content from showing by using the logout all users path of dismissing the passcode controller.