### PR TITLE
Better regexp for smartsql to sql conversion

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.m
@@ -176,8 +176,8 @@ static NSRegularExpression* insideQuotedStringForFTSMatchPredicateRegexp;
     // We can't have TABLE_x.json_extract(soup, ...) or table_alias.json_extract(soup, ...) in the sql query
     // Instead we should have json_extract(TABLE_x.soup, ...)
     NSError *error = nil;
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"\\s([^ ]+)\\.json_extract\\(soup" options:0 error:&error];
-    [regex replaceMatchesInString:sql options:0 range:NSMakeRange(0, [sql length]) withTemplate:@" json_extract($1.soup"];
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"([\\w]+)\\.json_extract\\(soup" options:0 error:&error];
+    [regex replaceMatchesInString:sql options:0 range:NSMakeRange(0, [sql length]) withTemplate:@"json_extract($1.soup"];
     
     return sql;
 }

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
@@ -158,6 +158,24 @@
                          @"Bad conversion");
 }
 
+- (void) testConvertSmartSqlWithSelfJoinAndJsonExtractedField {
+    XCTAssertEqualObjects(@"select json_extract(mgr.soup, '$.education'), json_extract(e.soup, '$.education') "
+                          "from TABLE_1 as mgr, TABLE_1 as e "
+                          "where json_extract(mgr.soup, '$.education') = json_extract(e.soup, '$.education')",
+                          [self.store convertSmartSql:@"select mgr.{employees:education}, e.{employees:education} "
+                           "from {employees} as mgr, {employees} as e "
+                           "where mgr.{employees:education} = e.{employees:education}"], @"Bad conversion");
+}
+
+- (void) testConvertSmartSqlWithSelfJoinAndJsonExtractedFieldNoLeadingSpaces {
+    XCTAssertEqualObjects(@"select json_extract(mgr.soup, '$.education'),json_extract(e.soup, '$.education') "
+                          "from TABLE_1 as mgr, TABLE_1 as e "
+                          "where not (json_extract(mgr.soup, '$.education')=json_extract(e.soup, '$.education'))",
+                          [self.store convertSmartSql:@"select mgr.{employees:education},e.{employees:education} "
+                           "from {employees} as mgr, {employees} as e "
+                           "where not (mgr.{employees:education}=e.{employees:education})"], @"Bad conversion");
+}
+
 - (void) testConvertSmartSqlWithSpecialColumns
 {
     XCTAssertEqualObjects(@"select TABLE_1.id, TABLE_1.created, TABLE_1.lastModified, TABLE_1.soup from TABLE_1",

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlWithExternalStorageTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlWithExternalStorageTests.m
@@ -98,6 +98,14 @@
     [super testConvertSmartSqlWithSelfJoin];
 }
 
+- (void) testConvertSmartSqlWithSelfJoinAndJsonExtractedField {
+    // Doesn't apply to external storage case
+}
+
+- (void) testConvertSmartSqlWithSelfJoinAndJsonExtractedFieldNoLeadingSpaces {
+    // Doesn't apply to external storage case
+}
+
 - (void) testConvertSmartSqlWithSpecialColumns
 {
     NSString *expected = [NSString stringWithFormat:


### PR DESCRIPTION
If the query string has a lot of stuff like <word1>.<word1'>,<word2>.<word2'> etc
So the new regexp (with has a leading \\s) will eat [<word1>.<word1'>, ... <word n>.] etc and then realize <word n'> is not json_extract.
The old regexp would try [<word1>.], [<word1>.<world1'>,<word2>.],[<word1>.<world1'>,<word2>.<word 2'>,<word3>.], [<word 2'>,<word3>.] . etc. If there are n pairs, it would be a O(n^2) if I am not mistaken.

Unfortunately it's valid to write a query without spaces, so if you do a join with table aliases without spaces, the new regexp will not do its job.

So for example
select soupL.{soup:field},soupR.{soup:field} from {soup} as soupL, {soup} as soupR
will turn into
select json_extract(soupL.json_extract(soup:field},soupR.soup, $.field), json_extract(soupR.soup, $.field) from TABLE_0 as soupL, TABLE_0 as soupR
instead of
select json_extract(soupL.soup, $.field),json_extract(soupR.soup, $.field) from TABLE_0 as soupL, TABLE_0 as soupR