### PR TITLE
Fixing iOS15 only styling issues

### DIFF
--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/ContactDetailViewController.m
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/ContactDetailViewController.m
@@ -69,6 +69,13 @@
     self.navigationController.navigationBar.tintColor = [UIColor whiteColor];
     [self configureInitialBarButtonItems];
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+  
+    // To address iOS 15 spacing issue
+    // See https://developer.apple.com/forums/thread/684706
+    if (@available(iOS 15.0, *)) {
+        [self.tableView setSectionHeaderTopPadding:0.0f];
+    }
+    
     if (self.isNewContact) {
         [self editContact];
     }

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/ContactListViewController.m
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/ContactListViewController.m
@@ -119,6 +119,14 @@ static NSUInteger const kColorCodesList[] = { 0x1abc9c,  0x2ecc71,  0x3498db,  0
 
     self.navigationController.navigationBar.barTintColor = [[self class] colorFromRgbHexValue:kNavBarTintColor];
 
+    // Without the following, the top bar becomes transparent on iOS 15 unless one scrolls all the way up
+    // See https://developer.apple.com/forums/thread/682420
+    UINavigationBarAppearance* appearance = [UINavigationBarAppearance new];
+    [appearance configureWithOpaqueBackground];
+    appearance.backgroundColor = [UIColor redColor];
+    self.navigationController.navigationBar.standardAppearance = appearance;
+    self.navigationController.navigationBar.scrollEdgeAppearance = appearance;
+    
     [self addTapGestureRecognizers];
 
     // Nav bar label
@@ -157,6 +165,12 @@ static NSUInteger const kColorCodesList[] = { 0x1abc9c,  0x2ecc71,  0x3498db,  0
     self.toastViewMessageLabel.textColor = [UIColor whiteColor];
     [self.toastView addSubview:self.toastViewMessageLabel];
     [self.view addSubview:self.toastView];
+    
+    // To address iOS 15 spacing issue
+    // See https://developer.apple.com/forums/thread/684706
+    if (@available(iOS 15.0, *)) {
+        [self.tableView setSectionHeaderTopPadding:0.0f];
+    }
 }
 
 - (void)viewWillLayoutSubviews {


### PR DESCRIPTION
* Nav bar appearance
* Top padding of table view
* TODO? section header styles (field labels in detail screen)

## Before (Left: 15.0, Middle 14.5, Right: 13.7)
![SearchScreenBefore](https://user-images.githubusercontent.com/1012459/131734797-e8cbf1b8-6344-4730-89b3-60991368db64.png)
![DetailScreenBefore](https://user-images.githubusercontent.com/1012459/131734792-1f190a14-e482-4241-a5df-9a593a71a1b9.png)

## After (Left: 15.0, Middle 14.5, Right: 13.7)
![SearchScreenAfter](https://user-images.githubusercontent.com/1012459/131734904-8c38386c-e634-47cf-97b6-cbe6f4258a77.png)
![DetailScreenAfter](https://user-images.githubusercontent.com/1012459/131734900-2aeb29b4-b42e-4ae4-bf2b-facb9bb23730.png)


