### PR TITLE
Adds missing Error check in refresh

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -59,7 +59,9 @@ enum {
     kSFOAuthErrorBrowserLaunchFailed,
     kSFOAuthErrorUnknownAdvancedAuthConfig,
     kSFOAuthErrorInvalidMDMConfiguration,
-    kSFOAuthErrorJWTInvalidGrant
+    kSFOAuthErrorJWTInvalidGrant,
+    kSFOAuthErrorRequestCancelled,
+    kSFOAuthErrorRefreshFailed //generic error
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -265,10 +265,14 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
         if (error) {
             NSURL *requestUrl = [request URL];
             NSString *errorUrlString = [NSString stringWithFormat:@"%@://%@%@", [requestUrl scheme], [requestUrl host], [requestUrl relativePath]];
+            
+            NSUInteger code = [SFSDKOAuth2 sfErrorCodeFromError:error.code];
+            endpointResponse = [[SFSDKOAuthTokenEndpointResponse alloc] initWithError:[NSError errorWithDomain:kSFOAuthErrorDomain code:code userInfo:nil]];
+            
             if (error.code == NSURLErrorTimedOut) {
                 [SFSDKCoreLogger d:[strongSelf class] format:@"Refresh attempt timed out after %f seconds.", endpointReq.timeout];
-                endpointResponse = [[SFSDKOAuthTokenEndpointResponse alloc] initWithError:[NSError errorWithDomain:kSFOAuthErrorDomain code:kSFOAuthErrorTimeout userInfo:nil]];
             }
+            
             [SFSDKCoreLogger d:[strongSelf class] format:@"SFOAuth2 session failed with error: error code: %ld, description: %@, URL: %@", (long)error.code, [error localizedDescription], errorUrlString];
             dispatch_async(dispatch_get_main_queue(), ^{
                 if (completionBlock) {
@@ -455,6 +459,22 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
         d = [NSDate dateWithTimeIntervalSince1970:unixTimeInSecs];
     }
     return d;
+}
+
++ (NSUInteger)sfErrorCodeFromError:(NSInteger)code {
+   
+    switch (code) {
+        case NSURLErrorTimedOut:
+            return kSFOAuthErrorTimeout;
+            break;
+            
+        case NSURLErrorCancelled:
+            return kSFOAuthErrorRequestCancelled;
+            break;
+        
+        default:
+            return kSFOAuthErrorRefreshFailed;
+    }
 }
 
 @end


### PR DESCRIPTION
During the refresh flow while using Security SDK we noticed that the refresh flow would loop indefinitely if security sdk  intercepted  and cancelled the request due to bad pins or an MITM attack. The error handling in the refresh flow was not parsing all errors. Just added a check for that situation.