### PR TITLE
SmartStore encryption update

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -102,6 +102,8 @@
 		69BDD7E926F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 69BDD7E226F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.h */; };
 		69BDD7EA26F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 69BDD7E826F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.m */; };
 		69BDD82C26F86B3600C26D77 /* KeyValueFileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69BDD82626F86B3600C26D77 /* KeyValueFileStoreTests.swift */; };
+		69BDD82F26F90AA400C26D77 /* DecryptStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69BDD82D26F90AA400C26D77 /* DecryptStream.swift */; };
+		69BDD83026F90AA400C26D77 /* EncryptStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69BDD82E26F90AA400C26D77 /* EncryptStream.swift */; };
 		69CEBC7E22F368CF00F16218 /* SFNetworkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69CEBC7D22F368CF00F16218 /* SFNetworkTests.m */; };
 		69E2FD9E22FB937F008E0AF0 /* SFSDKEncryptedURLCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 69E2FD9622FB937F008E0AF0 /* SFSDKEncryptedURLCache.h */; };
 		69E2FD9F22FB937F008E0AF0 /* SFSDKEncryptedURLCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 69E2FD9D22FB937F008E0AF0 /* SFSDKEncryptedURLCache.m */; };
@@ -757,6 +759,8 @@
 		69BDD7E226F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKSalesforceSDKUpgradeManager.h; sourceTree = "<group>"; };
 		69BDD7E826F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKSalesforceSDKUpgradeManager.m; sourceTree = "<group>"; };
 		69BDD82626F86B3600C26D77 /* KeyValueFileStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = KeyValueFileStoreTests.swift; path = SalesforceSDKCoreTests/KeyValueFileStoreTests.swift; sourceTree = SOURCE_ROOT; };
+		69BDD82D26F90AA400C26D77 /* DecryptStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecryptStream.swift; sourceTree = "<group>"; };
+		69BDD82E26F90AA400C26D77 /* EncryptStream.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncryptStream.swift; sourceTree = "<group>"; };
 		69CEBC7D22F368CF00F16218 /* SFNetworkTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFNetworkTests.m; path = SalesforceSDKCoreTests/SFNetworkTests.m; sourceTree = SOURCE_ROOT; };
 		69E2FD9622FB937F008E0AF0 /* SFSDKEncryptedURLCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKEncryptedURLCache.h; sourceTree = "<group>"; };
 		69E2FD9D22FB937F008E0AF0 /* SFSDKEncryptedURLCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKEncryptedURLCache.m; sourceTree = "<group>"; };
@@ -1268,6 +1272,8 @@
 			isa = PBXGroup;
 			children = (
 				A3161CF021810D2800437BD2 /* AppLockView */,
+				69BDD82E26F90AA400C26D77 /* EncryptStream.swift */,
+				69BDD82D26F90AA400C26D77 /* DecryptStream.swift */,
 				4F96FD011BFD32130022F021 /* SFEncryptionKey.h */,
 				4F96FD021BFD32130022F021 /* SFEncryptionKey.m */,
 				4F4055C52232304D00316D91 /* SFSecureEncryptionKey.h */,
@@ -2333,6 +2339,7 @@
 				693E623124A287DB0017B222 /* KeyValueEncryptedFileStore.swift in Sources */,
 				B791409D1EC11ADE0051492F /* SFSDKWebViewStateManager.m in Sources */,
 				CE4CE3A21C0E5279009F6029 /* NSURL+SFStringUtils.m in Sources */,
+				69BDD82F26F90AA400C26D77 /* DecryptStream.swift in Sources */,
 				B7CD6D671F79CFC900F99F81 /* SFUserAccountManager+URLHandlers.m in Sources */,
 				69848CB62363FA3E00893E57 /* SFSDKPushNotificationError.m in Sources */,
 				CE4CE39A1C0E5272009F6029 /* SFSDKAsyncProcessListener.m in Sources */,
@@ -2404,6 +2411,7 @@
 				CE4CE3771C0E526A009F6029 /* SFKeyStoreManager.m in Sources */,
 				B71129111F8A780800436CFB /* SFSDKAlertMessageBuilder.m in Sources */,
 				69341D22266FF61700227CB0 /* Encryptor.swift in Sources */,
+				69BDD83026F90AA400C26D77 /* EncryptStream.swift in Sources */,
 				CE88BD531D17065C00AE3BF7 /* SFSDKAILTNPublisher.m in Sources */,
 				CE4CE3AC1C0E5279009F6029 /* SFPreferences.m in Sources */,
 				CED452B81D808D0C009266EB /* SFRestAPI+Blocks.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/DecryptStream.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/DecryptStream.swift
@@ -44,7 +44,7 @@ public class DecryptStream: InputStream {
     
     override public init(data: Data) {
         stream = InputStream(data: data)
-        super.init()
+        super.init(data: data)
     }
     
     override public init?(url: URL) {
@@ -52,7 +52,7 @@ public class DecryptStream: InputStream {
             return nil
         }
         self.stream = stream
-        super.init()
+        super.init(url: url)
     }
     
     public convenience init?(fileAtPath path: String) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/DecryptStream.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/DecryptStream.swift
@@ -1,0 +1,119 @@
+//
+//  DecryptStream.swift
+//  SalesforceSDKCore
+//
+//  Created by Brianna Birman on 8/24/21.
+//  Copyright (c) 2021-present, salesforce.com, inc. All rights reserved.
+// 
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+// 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import CryptoKit
+
+
+@objc(SFSDKDecryptStream)
+public class DecryptStream: InputStream {
+    private var key: SymmetricKey?
+    private let stream: InputStream
+    
+    override public var streamStatus: Stream.Status {
+        return  stream.streamStatus
+    }
+
+    override public var hasBytesAvailable: Bool {
+        return stream.hasBytesAvailable
+    }
+    
+    override public init(data: Data) {
+        stream = InputStream(data: data)
+        super.init()
+    }
+    
+    override public init?(url: URL) {
+        guard let stream = InputStream(url: url) else {
+            return nil
+        }
+        self.stream = stream
+        super.init()
+    }
+    
+    public convenience init?(fileAtPath path: String) {
+        let url = URL(fileURLWithPath: path)
+        self.init(url: url)
+    }
+    
+    /// Setup for encryption. Always call this method before using this stream.
+    /// - Parameters:
+    ///   - key: Encryption key to use
+    @objc(setupEncryptionKey:) @available(swift, obsoleted: 1.0) // Objective-c only wrapper
+    public func setupEncryptionKey(key: Data) {
+        self.key = SymmetricKey(data: key)
+    }
+
+    /// Setup for encryption. Always call this method before using this stream.
+    /// - Parameters:
+    ///   - key: Encryption key to use
+    public func setupEncryptionKey(key: SymmetricKey) {
+        self.key = key
+    }
+   
+    override public func open() {
+        assert(key != nil, "EncryptStream - you must call setupEncryptionKey first")
+        stream.open()
+    }
+    
+    override public func read(_ buffer: UnsafeMutablePointer<UInt8>, maxLength len: Int) -> Int {
+        guard let key = key else {
+            return -1
+        }
+        
+        let numberOfBlocks = len < CryptStream.chunkSize ? 1 : len / CryptStream.chunkSize
+        let encryptedBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: CryptStream.sealedBoxSize)
+        var readCount = 0
+        for _ in 1...numberOfBlocks {
+            let bytesRead = stream.read(encryptedBuffer, maxLength: CryptStream.sealedBoxSize)
+            if bytesRead <= 0 { break } // Backing stream is empty, don't attempt decrypt
+            
+            do {
+                let data = Data(bytes: encryptedBuffer, count: bytesRead)
+                let decryptedData = try Encryptor.decrypt(data: data, using: key)
+                decryptedData.copyBytes(to: buffer.advanced(by: readCount), count: decryptedData.count)
+                readCount += decryptedData.count
+            } catch {
+                SalesforceLogger.e(DecryptStream.self, message: "Error decrypting data to stream: \(error)")
+                return readCount == 0 ? -1 : readCount
+            }
+        }
+        return readCount
+    }
+    
+    override public func property(forKey key: Stream.PropertyKey) -> Any? {
+        return self.stream.property(forKey: key)
+    }
+   
+    override public func getBuffer(_ buffer: UnsafeMutablePointer<UnsafeMutablePointer<UInt8>?>, length len: UnsafeMutablePointer<Int>) -> Bool {
+        return false
+    }
+    
+    override public func close() {
+        stream.close()
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/EncryptStream.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/EncryptStream.swift
@@ -1,0 +1,145 @@
+//
+//  EncryptStream.swift
+//  SalesforceSDKCore
+//
+//  Created by Brianna Birman on 8/31/21.
+//  Copyright (c) 2021-present, salesforce.com, inc. All rights reserved.
+// 
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+// 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import CryptoKit
+
+enum CryptStream {
+    static let chunkSize = 512
+    static let sealedBoxSize = chunkSize + 28 // Overhead for each block: 12 byte nonce + 16 byte authentication tag
+}
+
+@objc(SFSDKEncryptStream)
+public class EncryptStream: OutputStream {
+    private var key: SymmetricKey?
+    private let stream: OutputStream
+    private var remainder: Data?
+    
+    override public var streamStatus: Stream.Status {
+        return stream.streamStatus
+    }
+
+    override public var hasSpaceAvailable: Bool {
+        return stream.hasSpaceAvailable
+    }
+
+    override public init(toMemory: ()) {
+        stream = OutputStream(toMemory: toMemory)
+        super.init()
+    }
+
+    override public init(toBuffer buffer: UnsafeMutablePointer<UInt8>, capacity: Int) {
+        stream = OutputStream(toBuffer: buffer, capacity: capacity)
+        super.init()
+    }
+
+    override public init?(url: URL, append shouldAppend: Bool) {
+        guard let outputStream = OutputStream(url: url, append: shouldAppend) else {
+            return nil
+        }
+        self.stream = outputStream
+        super.init()
+    }
+
+    public convenience init?(toFileAtPath path: String, append shouldAppend: Bool) {
+        let url = URL(fileURLWithPath: path)
+        self.init(url: url, append: shouldAppend)
+    }
+
+    /// Setup for encryption. Always call this method before using this stream.
+    /// - Parameters:
+    ///   - key: Encryption key to use
+    @objc(setupEncryptionKey:) @available(swift, obsoleted: 1.0) // Objective-c only wrapper
+    public func setupEncryptionKey(key: Data) {
+        self.key = SymmetricKey(data: key)
+    }
+
+    /// Setup for encryption. Always call this method before using this stream.
+    /// - Parameters:
+    ///   - key: Encryption key to use
+    public func setupEncryptionKey(key: SymmetricKey) {
+        self.key = key
+    }
+
+    override public func property(forKey key: Stream.PropertyKey) -> Any? {
+        return self.stream.property(forKey: key)
+    }
+    
+    override public func open () {
+        assert(key != nil, "EncryptStream - you must call setupEncryptionKey first")
+        self.stream.open()
+    }
+
+    override public func write(_ buffer: UnsafePointer<UInt8>, maxLength len: Int) -> Int {
+        guard let key = key else { return -1 }
+        
+        var bufferSlice = UnsafeBufferPointer<UInt8>(start: buffer, count: len).prefix(len)
+        while (!bufferSlice.isEmpty) {
+            let dataBlock: Data
+            let sliceSize: Int
+            if let remainder = remainder {
+                let slice = bufferSlice.prefix(CryptStream.chunkSize - remainder.count)
+                sliceSize = slice.count
+                dataBlock = remainder + Data(slice)
+                self.remainder = nil
+            } else {
+                let slice = bufferSlice.prefix(CryptStream.chunkSize)
+                sliceSize = slice.count
+                dataBlock = Data(slice)
+            }
+
+            if dataBlock.count == CryptStream.chunkSize {
+                do {
+                    let encryptedData = try Encryptor.encrypt(data: dataBlock, using: key)
+                    stream.write([UInt8](encryptedData), maxLength: encryptedData.count)
+                    bufferSlice = bufferSlice.dropFirst(sliceSize)
+                } catch {
+                    SalesforceLogger.e(EncryptStream.self, message: "Error encrypting data: \(error)")
+                    return -1
+                }
+            } else {
+                remainder = dataBlock
+                break
+            }
+        }
+        return len
+    }
+
+    override public func close() {
+        defer { stream.close() }
+        guard let key = key else { return }
+
+        do {
+            if let remainder = remainder {
+                let encryptedData = try Encryptor.encrypt(data: remainder, using: key)
+                stream.write([UInt8](encryptedData), maxLength: encryptedData.count)
+            }
+        } catch {
+            SalesforceLogger.e(EncryptStream.self, message: "Error encrypting data to stream: \(error)")
+        }
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/EncryptStream.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/EncryptStream.swift
@@ -62,7 +62,7 @@ public class EncryptStream: OutputStream {
             return nil
         }
         self.stream = outputStream
-        super.init()
+        super.init(url: url, append: shouldAppend)
     }
 
     public convenience init?(toFileAtPath path: String, append shouldAppend: Bool) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/EncryptStream.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/EncryptStream.swift
@@ -49,12 +49,12 @@ public class EncryptStream: OutputStream {
 
     override public init(toMemory: ()) {
         stream = OutputStream(toMemory: toMemory)
-        super.init()
+        super.init(toMemory: toMemory)
     }
 
     override public init(toBuffer buffer: UnsafeMutablePointer<UInt8>, capacity: Int) {
         stream = OutputStream(toBuffer: buffer, capacity: capacity)
-        super.init()
+        super.init(toBuffer: buffer, capacity: capacity)
     }
 
     override public init?(url: URL, append shouldAppend: Bool) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFCryptChunks.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFCryptChunks.m
@@ -37,7 +37,10 @@ uint32_t const SFCryptChunksCipherOptions = kCCOptionPKCS7Padding;
 
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFCryptChunks
+#pragma clang diagnostic pop
 
 #pragma mark - Lifecycle
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  * `SFDecryptStream` implements an input stream that decrypts data immediately after it's read.
  * It uses `SFCryptChunks` to perform the decryption.
  */
+SFSDK_DEPRECATED(9.2, 10.0, "Will be used internally for upgrade steps only. Use SFSDKDecryptStream instead")
 @interface SFDecryptStream : NSInputStream <SFCryptChunksDelegate>
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.h
@@ -25,6 +25,7 @@
 #import <Foundation/Foundation.h>
 #import <SalesforceSDKCore/SFEncryptionKey.h>
 #import <SalesforceSDKCore/SFCryptChunks.h>
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFDecryptStream.m
@@ -39,8 +39,10 @@
 
 @end
 
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFDecryptStream
+#pragma clang diagnostic pop
 
 #pragma mark - Lifecycle
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.h
@@ -25,6 +25,7 @@
 #import <Foundation/Foundation.h>
 #import <SalesforceSDKCore/SFCryptChunks.h>
 #import <SalesforceSDKCore/SFEncryptionKey.h>
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  `SFEncryptStream` is an output stream that encrypts data before it's written out.
  *  This class uses `SFCryptChunks` to perform the encryption.
  */
+SFSDK_DEPRECATED(9.2, 10.0, "Will be removed. Use SFSDKEncryptStream instead")
 @interface SFEncryptStream : NSOutputStream <SFCryptChunksDelegate>
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFEncryptStream.m
@@ -32,8 +32,10 @@
 
 @end
 
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFEncryptStream
+#pragma clang diagnostic pop
 
 #pragma mark - Lifecycle
 

--- a/libs/SmartStore/SmartStore/Classes/NSData+SFAdditions.m
+++ b/libs/SmartStore/SmartStore/Classes/NSData+SFAdditions.m
@@ -31,11 +31,14 @@
 @implementation NSData (SFSHA)
 
 - (NSString *)digest {
-    // TODO: Remove in Mobile SDK 9.1
-    //NOTE:  Will be removed and replaced by a random byte string. Requires migration of database from previous salt to a new salt. Is only used when SFSmartStore is used with app groups that are enabled.
+    // NOTE: This is no longer used, it's only here to be able to migrate from the old digest to the new salt
+    // (only applicable to SFSmartStore with app groups enabled)
     unsigned char digest[CC_MD5_DIGEST_LENGTH];
     digest[0] = 0;
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CC_MD5([self bytes], (CC_LONG)[self length], digest);
+    #pragma clang diagnostic pop
     NSMutableString *ms = [NSMutableString string];
     for(int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
         [ms appendFormat:@"%02x", digest[i]];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore+Internal.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore+Internal.h
@@ -244,9 +244,19 @@ static NSString *const EXPLAIN_ROWS = @"rows";
 - (NSNumber*)currentTimeInMilliseconds;
 
 /**
+ @return The legacy key used to encrypt the store.
+ */
++ (NSString *)legacyEncKey;
+
+/**
  @return The key used to encrypt the store.
  */
 + (NSString *)encKey;
+
+/**
+ @return The legacy salt used to encrypt the store for shared mode. Sqlite headers are maintained in plain text for database.
+ */
++ (NSString *)legacySalt;
 
 /**
  @return The key used to encrypt the store for shared mode. Sqlite headers are maintained in plain text for database.

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -64,9 +64,14 @@ extern NSString * const kSFSmartStoreEncryptionKeyLabel NS_SWIFT_NAME(SmartStore
 extern NSString * const kSFSmartStoreEncryptionSaltLabel NS_SWIFT_NAME(SmartStore.encryptionSaltLabel);
 
 /**
+ Block typedef for generating legacy encryption key.
+ */
+typedef SFEncryptionKey* _Nullable (^SFSmartStoreEncryptionKeyBlock)(void) NS_SWIFT_NAME(EncryptionKeyBlock) __attribute__ ((deprecated("Deprecated in Salesforce Mobile SDK 9.2 and only used for upgrade")));
+
+/**
  Block typedef for generating an encryption key.
  */
-typedef SFEncryptionKey*  _Nullable (^SFSmartStoreEncryptionKeyBlock)(void) NS_SWIFT_NAME(EncryptionKeyBlock);
+typedef NSData* _Nullable (^SFSmartStoreEncryptionKeyGenerator)(void) NS_SWIFT_NAME(EncryptionKeyGenerator);
 
 /**
  Block typedef for generating a 16 byte hash for sharing data betwween multiple apps.
@@ -145,10 +150,16 @@ NS_SWIFT_NAME(SmartStore)
 @property (nonatomic, class, readonly) NSArray<NSString*> *allGlobalStoreNames;
 
 /**
+ Block used to generate the legacy encryption key.
+ */
+@property (nonatomic, class, readonly) SFSmartStoreEncryptionKeyBlock encryptionKeyBlock __attribute__ ((deprecated("Deprecated in Salesforce Mobile SDK 9.2 and only used for upgrade")));
+
+/**
  Block used to generate the encryption key.
  Salesforce recommends using the default encryption key derivation.
  */
-@property (nonatomic, class, readonly)  SFSmartStoreEncryptionKeyBlock encryptionKeyBlock;
+@property (nonatomic, class, readonly) SFSmartStoreEncryptionKeyGenerator encryptionKeyGenerator;
+
 
 /**
  Block used to generate the salt. The salt is maintained in the keychain. Used only when database needs to be shared between apps.
@@ -216,7 +227,9 @@ NS_SWIFT_NAME(SmartStore)
 + (void)removeAllGlobalStores NS_SWIFT_NAME(removeAllGlobal());
 
 /**
- Sets a custom block for deriving the encryption key used to encrypt stores.
+ Sets a custom block for deriving the encryption key used to encrypt stores. This uses a legacy encryption key
+ and is only used for upgrade scenarios. This should only be set if an app was already using it
+ before Mobile SDK 9.2.
  
  ** WARNING: **
  If you choose to override the encryption key derivation, you must set
@@ -227,7 +240,21 @@ NS_SWIFT_NAME(SmartStore)
  
  @param newEncryptionKeyBlock The new encryption key derivation block to use with SmartStore.
  */
-+ (void)setEncryptionKeyBlock:(SFSmartStoreEncryptionKeyBlock)newEncryptionKeyBlock;
++ (void)setEncryptionKeyBlock:(SFSmartStoreEncryptionKeyBlock)newEncryptionKeyBlock __attribute__ ((deprecated("Deprecated in Salesforce Mobile SDK 9.2 and should only be used for upgrade")));
+
+/**
+ Sets a custom block for deriving the encryption key used to encrypt stores.
+ 
+ ** WARNING: **
+ If you choose to override the encryption key derivation, you must set
+ this value before opening any stores.  Setting the value after stores have been opened
+ will result in the corruption and loss of existing data.
+ Also, SmartStore does not use initialization vectors.
+ ** WARNING **
+ 
+ @param newEncryptionKeyGenerator The new encryption key derivation block to use with SmartStore.
+ */
++ (void)setEncryptionKeyGenerator:(SFSmartStoreEncryptionKeyGenerator)newEncryptionKeyGenerator;
 
 #pragma mark - Soup manipulation methods
 

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -176,10 +176,9 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         }
         [SFSDKSmartStoreLogger d:[self class] format:@"%@ %@, user: %@, isGlobal: %d", NSStringFromSelector(_cmd), name, [SFSmartStoreUtils userKeyForUser:user], isGlobal];
         @synchronized ([SFSmartStore class]) {
-            SFUserAccount *currentUser = [SFUserAccountManager sharedInstance].currentUser;
-            if (currentUser != nil && !_storeUpgradeHasRun) {
+            if (!_storeUpgradeHasRun) {
+                [SFSmartStoreUpgrade upgrade];
                 _storeUpgradeHasRun = YES;
-                [SFSmartStoreUpgrade updateEncryptionForUser:currentUser];
             }
         }
         _storeName = name;

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -28,7 +28,6 @@
 #import "FMDatabase.h"
 #import "FMDatabaseAdditions.h"
 #import "FMDatabaseQueue.h"
-#import <SalesforceSDKCommon/SFJsonUtils.h>
 #import "SFSmartStore+Internal.h"
 #import "SFSmartStoreUpgrade.h"
 #import "SFSmartStoreUtils.h"
@@ -39,12 +38,12 @@
 #import "SFSoupSpec.h"
 #import "SFSoupSpec+Internal.h"
 #import "NSData+SFAdditions.h"
+#import "SFAlterSoupLongOperation.h"
+#import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 #import <SalesforceSDKCore/SFKeyStoreManager.h>
 #import <SalesforceSDKCore/SFEncryptionKey.h>
 #import <SalesforceSDKCore/SFSDKCryptoUtils.h>
-#import <SalesforceSDKCore/SFEncryptStream.h>
 #import <SalesforceSDKCore/SFDecryptStream.h>
-#import "SFAlterSoupLongOperation.h"
 #import <SalesforceSDKCore/SFUserAccountManager.h>
 #import <SalesforceSDKCore/SFDirectoryManager.h>
 #import <SalesforceSDKCore/SalesforceSDKManager.h>
@@ -52,11 +51,17 @@
 #import <SalesforceSDKCore/SFSDKAppFeatureMarkers.h>
 #import <SalesforceSDKCore/SFSDKCryptoUtils.h>
 #import <SalesforceSDKCore/SFKeychainItemWrapper.h>
+#import <SalesforceSDKCore/NSData+SFAdditions.h>
 #import <SalesforceSDKCommon/SFSDKDataSharingHelper.h>
+#import <SalesforceSDKCommon/SFJsonUtils.h>
 
 static NSMutableDictionary *_allSharedStores;
 static NSMutableDictionary *_allGlobalSharedStores;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 static SFSmartStoreEncryptionKeyBlock _encryptionKeyBlock = NULL;
+#pragma clang diagnostic pop
+static SFSmartStoreEncryptionKeyGenerator _encryptionKeyGenerator = NULL;
 static SFSmartStoreEncryptionSaltBlock _encryptionSaltBlock = NULL;
 static BOOL _storeUpgradeHasRun = NO;
 static BOOL _jsonSerializationCheckEnabled = NO;
@@ -117,23 +122,42 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
 
 + (void)initialize
 {
-    if (!_encryptionKeyBlock) {
-        _encryptionKeyBlock = ^SFEncryptionKey *{
-            SFEncryptionKey *key = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:kSFSmartStoreEncryptionKeyLabel autoCreate:YES];
+    if (!_encryptionKeyGenerator) {
+        _encryptionKeyGenerator = ^NSData *{
+            NSError *error = nil;
+            NSData *key = [SFSDKKeyGenerator encryptionKeyFor:kSFSmartStoreEncryptionKeyLabel error:&error];
+            if (error) {
+                [SFSDKSmartStoreLogger e:[self class] format:@"Error getting encryption key: %@", error.localizedDescription];
+            }
             return key;
         };
     }
     
     if (!_encryptionSaltBlock) {
         _encryptionSaltBlock = ^ {
-            NSString* salt = nil;
-            if ([[SFKeyStoreManager sharedInstance] keyWithLabelExists:kSFSmartStoreEncryptionSaltLabel] || [[SFSDKDatasharingHelper sharedInstance] appGroupEnabled]) {
-                SFEncryptionKey *saltKey = [[SFKeyStoreManager sharedInstance]   retrieveKeyWithLabel:kSFSmartStoreEncryptionSaltLabel autoCreate:YES];
-                salt = [[saltKey key] digest];
+            NSString *salt = nil;
+            if ([SFSDKKeyGenerator encryptionKeyExistsFor:kSFSmartStoreEncryptionSaltLabel] || [[SFSDKDatasharingHelper sharedInstance] appGroupEnabled]) {
+                NSError *error = nil;
+                NSData *saltKey = [SFSDKKeyGenerator encryptionKeyFor:kSFSmartStoreEncryptionSaltLabel keySize:128 error:&error];
+                if (error) {
+                    [SFSDKSmartStoreLogger e:[self class] format:@"Error getting key for salt: %@", error.localizedDescription];
+                }
+                salt = [saltKey newHexStringFromBytes];
             }
             return salt;
         };
     }
+
+    // Used for upgrade steps
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if (!_encryptionKeyBlock) {
+        _encryptionKeyBlock = ^SFEncryptionKey *{
+            SFEncryptionKey *key = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:kSFSmartStoreEncryptionKeyLabel autoCreate:YES];
+            return key;
+        };
+    }
+    #pragma clang diagnostic pop
 }
 
 - (id)initWithName:(NSString *)name user:(SFUserAccount *)user {
@@ -152,9 +176,10 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         }
         [SFSDKSmartStoreLogger d:[self class] format:@"%@ %@, user: %@, isGlobal: %d", NSStringFromSelector(_cmd), name, [SFSmartStoreUtils userKeyForUser:user], isGlobal];
         @synchronized ([SFSmartStore class]) {
-            if ([SFUserAccountManager sharedInstance].currentUser != nil && !_storeUpgradeHasRun) {
+            SFUserAccount *currentUser = [SFUserAccountManager sharedInstance].currentUser;
+            if (currentUser != nil && !_storeUpgradeHasRun) {
                 _storeUpgradeHasRun = YES;
-                [SFSmartStoreUpgrade updateEncryptionSalt];
+                [SFSmartStoreUpgrade updateEncryptionForUser:currentUser];
             }
         }
         _storeName = name;
@@ -298,7 +323,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
 
 - (BOOL) openStoreDatabase {
     NSError *openDbError = nil;
-    NSString *salt =  [[self class]encryptionSaltBlock] ? [[self class] encryptionSaltBlock]() :nil;
+    NSString *salt = [[self class]encryptionSaltBlock] ? [[self class] encryptionSaltBlock]() : nil;
     self.storeQueue = [self.dbMgr openStoreQueueWithName:self.storeName key:[[self class] encKey] salt:salt error:&openDbError];
     if (self.storeQueue == nil) {
         [SFSDKSmartStoreLogger e:[self class] format:@"Error opening store '%@': %@", self.storeName, [openDbError localizedDescription]];
@@ -720,17 +745,15 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     return soupNames;
 }
 
-+ (NSString *)encKey
-{
-    if (_encryptionKeyBlock) {
-        SFEncryptionKey *key = _encryptionKeyBlock();
-        return key.keyAsString;
++ (NSString *)encKey {
+    if (_encryptionKeyGenerator) {
+        NSData *key = _encryptionKeyGenerator();
+        return [key base64EncodedStringWithOptions:0];
     }
     return nil;
 }
 
-+ (NSString *)salt
-{
++ (NSString *)salt {
     if (_encryptionSaltBlock) {
         return  _encryptionSaltBlock();
     }
@@ -747,13 +770,13 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     }
 }
 
-+ (SFSmartStoreEncryptionKeyBlock)encryptionKeyBlock {
-    return _encryptionKeyBlock;
++ (SFSmartStoreEncryptionKeyGenerator)encryptionKeyGenerator {
+    return _encryptionKeyGenerator;
 }
 
-+ (void)setEncryptionKeyBlock:(SFSmartStoreEncryptionKeyBlock)newEncryptionKeyBlock {
-    if (newEncryptionKeyBlock != _encryptionKeyBlock) {
-        _encryptionKeyBlock = newEncryptionKeyBlock;
++ (void)setEncryptionKeyGenerator:(SFSmartStoreEncryptionKeyGenerator)newEncryptionKeyGenerator {
+    if (newEncryptionKeyGenerator != _encryptionKeyGenerator) {
+        _encryptionKeyGenerator = newEncryptionKeyGenerator;
     }
 }
 
@@ -828,11 +851,11 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     
     // Setting up output stream
     NSOutputStream *outputStream = nil;
-    SFSmartStoreEncryptionKeyBlock keyBlock = [SFSmartStore encryptionKeyBlock];
+    SFSmartStoreEncryptionKeyGenerator keyBlock = [SFSmartStore encryptionKeyGenerator];
     if (keyBlock) {
-        SFEncryptStream *encryptStream = [[SFEncryptStream alloc] initToFileAtPath:tmpFilePath append:NO];
-        SFEncryptionKey *encKey = keyBlock();
-        [encryptStream setupWithEncryptionKey:encKey];
+        SFSDKEncryptStream *encryptStream = [[SFSDKEncryptStream alloc] initToFileAtPath:tmpFilePath append:NO];
+        NSData *encKey = keyBlock();
+        [encryptStream setupEncryptionKey:encKey];
         outputStream = encryptStream;
     } else {
         outputStream = [[NSOutputStream alloc] initToFileAtPath:tmpFilePath append:NO];
@@ -930,50 +953,43 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
 }
 
 - (NSString*)loadExternalSoupEntryAsString:(NSNumber *)soupEntryId
-                             soupTableName:(NSString *)soupTableName
-{
+                             soupTableName:(NSString *)soupTableName {
     NSString *filePath = [self externalStorageSoupFilePath:soupEntryId
                                              soupTableName:soupTableName];
     
-    SFSmartStoreEncryptionKeyBlock keyBlock = [SFSmartStore encryptionKeyBlock];
-    SFEncryptionKey* encKey;
-    if (keyBlock) {
-        encKey = keyBlock();
+    SFSmartStoreEncryptionKeyGenerator keyGenerator = [SFSmartStore encryptionKeyGenerator];
+    NSData *encKey;
+    if (keyGenerator) {
+        encKey = keyGenerator();
     }
     
-    NSString* entryAsString = [self readFromEncryptedFile:filePath
-                                                   encKey:encKey];
+    NSString *entryAsString = [self readFromEncryptedFile:filePath
+                                            encryptionKey:encKey];
     
-    // Before 6.2, we were using nill IV when encrypting.
-    // Starting in 6.2, we are using a non-nil IV when encrypting.
-    // If it doesn't look like proper json, it means the entry was encrypted with pre 6.2 SDK.
-    // It needs to be stored back with a non-nil IV encryption.
-    if (![entryAsString hasPrefix:@"{"]) {
-        NSDictionary* entry = [SFJsonUtils objectFromJSONString:entryAsString];
+    // If it doesn't look like proper json, it means the entry was encrypted with an older key/IV.
+    // It needs to be stored back with the current encryption.
+    if (![entryAsString hasPrefix:@"{"] && ![SFJsonUtils objectFromJSONString:entryAsString]) {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        SFSmartStoreEncryptionKeyBlock keyBlock = [SFSmartStore encryptionKeyBlock];
+        SFEncryptionKey *legacyEncKey = keyBlock();
+        #pragma clang diagnostic pop
         
-        if(!entry) {
-            if (encKey.initializationVector) {
-                entryAsString = [self readFromEncryptedFile:filePath encKey:encKey useNilIV:YES];
-                if ([entryAsString length] > 0) {
-                    [self writeToEncryptedFile:filePath
-                                       content:entryAsString
-                                        encKey:encKey];
-                } else {
-                    [SFSDKSmartStoreLogger e:[self class] format:@"Attempt to migrate an encrypted externally saved soup '%@' with a null IV  failed.", soupTableName];
-                }
+        // Try for 9.2 upgrade case -- pre 9.2/post 6.2 used SFEncryptionKey with a non-nil IV
+        entryAsString = [self readFromEncryptedFile:filePath encKey:legacyEncKey useNilIV:NO];
+        if ([entryAsString hasPrefix:@"{"] && [SFJsonUtils objectFromJSONString:entryAsString]) {
+            [self writeToEncryptedFile:filePath
+                               content:entryAsString
+                         encryptionKey:encKey];
+        } else {
+            // Try 6.2 upgrade case -- pre 6.2 used SFEncryptionKey with a nil IV
+            entryAsString = [self readFromEncryptedFile:filePath encKey:legacyEncKey useNilIV:YES];
+            if ([entryAsString hasPrefix:@"{"] && [SFJsonUtils objectFromJSONString:entryAsString]) {
+                [self writeToEncryptedFile:filePath
+                                   content:entryAsString
+                             encryptionKey:encKey];
             } else {
-                NSError* error = [SFJsonUtils lastError];
-                NSString *errorMessage = [NSString stringWithFormat:@"Loading external soup from file failed! encrypted: %@, soupEntryId: %@, soupTableName: %@, filePath: '%@', error: %@.",
-                                          encKey ? @"YES" : @"NO",
-                                          soupEntryId,
-                                          soupTableName,
-                                          filePath,
-                                          error];
-                [SFSDKSmartStoreLogger e:[self class] format:errorMessage];
-                @throw [NSException exceptionWithName:kSFSmartStoreErrorLoadExternalSoup
-                                               reason:errorMessage
-                                             userInfo:nil];
-                
+                [SFSDKSmartStoreLogger e:[self class] format:@"Attempt to migrate an encrypted externally saved soup '%@' with failed.", soupTableName];
             }
         }
     }
@@ -986,23 +1002,12 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     }
 }
 
-- (NSString*) readFromEncryptedFile:(NSString*)filePath
-                             encKey:(SFEncryptionKey*)encKey
-{
-    return [self readFromEncryptedFile:filePath encKey:encKey useNilIV:NO];
-}
-
-- (NSString*) readFromEncryptedFile:(NSString*)filePath
-                             encKey:(SFEncryptionKey*)encKey
-                           useNilIV:(BOOL)useNilIV
-{
+- (NSString *)readFromEncryptedFile:(NSString *)filePath
+                      encryptionKey:(NSData *)encKey {
     NSInputStream *inputStream = nil;
     if (encKey) {
-        SFDecryptStream *decryptStream = [[SFDecryptStream alloc] initWithFileAtPath:filePath];
-        if (useNilIV) {
-            encKey = [[SFEncryptionKey alloc] initWithData:encKey.key initializationVector:nil];
-        }
-        [decryptStream setupWithDecryptionKey:encKey];
+        SFSDKDecryptStream *decryptStream = [[SFSDKDecryptStream alloc] initWithFileAtPath:filePath];
+        [decryptStream setupEncryptionKey:encKey];
         inputStream = decryptStream;
     } else {
         inputStream = [[NSInputStream alloc] initWithFileAtPath:filePath];
@@ -1028,14 +1033,14 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     return [[NSString alloc] initWithData:content encoding:NSUTF8StringEncoding];
 }
 
-- (void) writeToEncryptedFile:(NSString*)filePath
+- (void)writeToEncryptedFile:(NSString *)filePath
                        content:(NSString *)content
-                       encKey:(SFEncryptionKey*)encKey
+                       encryptionKey:(NSData *)encKey
 {
     NSOutputStream *outputStream = nil;
     if (encKey) {
-        SFEncryptStream *encryptStream = [[SFEncryptStream alloc] initToFileAtPath:filePath append:NO];
-        [encryptStream setupWithEncryptionKey:encKey];
+        SFSDKEncryptStream *encryptStream = [[SFSDKEncryptStream alloc] initToFileAtPath:filePath append:NO];
+        [encryptStream setupEncryptionKey:encKey];
         outputStream = encryptStream;
     } else {
         outputStream = [[NSOutputStream alloc] initToFileAtPath:filePath append:NO];
@@ -2593,5 +2598,55 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
 
     return result;
 }
+
+#pragma mark - Legacy used for upgrade steps
+
++ (SFSmartStoreEncryptionKeyBlock)encryptionKeyBlock {
+    return _encryptionKeyBlock;
+}
+
++ (void)setEncryptionKeyBlock:(SFSmartStoreEncryptionKeyBlock)newEncryptionKeyBlock {
+    if (newEncryptionKeyBlock != _encryptionKeyBlock) {
+        _encryptionKeyBlock = newEncryptionKeyBlock;
+    }
+}
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
++ (NSString *)legacyEncKey {
+    if (_encryptionKeyBlock) {
+        SFEncryptionKey *key = _encryptionKeyBlock();
+        return key.keyAsString;
+    }
+    return nil;
+}
+
++ (NSString *)legacySalt {
+    NSString *salt = nil;
+    if ([[SFKeyStoreManager sharedInstance] keyWithLabelExists:kSFSmartStoreEncryptionSaltLabel] || [[SFSDKDatasharingHelper sharedInstance] appGroupEnabled]) {
+        SFEncryptionKey *saltKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:kSFSmartStoreEncryptionSaltLabel autoCreate:YES];
+        salt = [[saltKey key] digest];
+    }
+    return salt;
+}
+
+- (NSString *)readFromEncryptedFile:(NSString *)filePath
+                             encKey:(SFEncryptionKey *)encKey
+                           useNilIV:(BOOL)useNilIV {
+    NSInputStream *inputStream = nil;
+    if (encKey) {
+        SFDecryptStream *decryptStream = [[SFDecryptStream alloc] initWithFileAtPath:filePath];
+        if (useNilIV) {
+            encKey = [[SFEncryptionKey alloc] initWithData:encKey.key initializationVector:nil];
+        }
+        [decryptStream setupWithDecryptionKey:encKey];
+        inputStream = decryptStream;
+    } else {
+        inputStream = [[NSInputStream alloc] initWithFileAtPath:filePath];
+    }
+    
+    return [SFSmartStore stringFromInputStream:inputStream];
+}
+#pragma clang diagnostic pop
 
 @end

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.h
@@ -29,17 +29,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 extern NSString * _Nonnull const kKeyStoreHasExternalSalt;
-extern NSString * _Nonnull const kStoreEncryptionUpgrade;
+extern NSString * _Nonnull const kSmartStoreVersionKey;
 
 /**
  Used internally for upgrading SmartStore.
  */
 @interface SFSmartStoreUpgrade : NSObject
 
-/**
- Updates any existing stores from their legacy SFEncryptionKey and potential MD5 salt to new key and new salt
- */
-+ (void)updateEncryptionForUser:(SFUserAccount *)user;
++ (void)upgrade;
 
 @end
 

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreUpgrade.h
@@ -28,17 +28,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString * _Nonnull const kKeyStoreHasExternalSalt;
+extern NSString * _Nonnull const kStoreEncryptionUpgrade;
+
 /**
  Used internally for upgrading SmartStore.
  */
 @interface SFSmartStoreUpgrade : NSObject
 
 /**
- Updates any existing stores from their legacy location to their new user-specific location.
+ Updates any existing stores from their legacy SFEncryptionKey and potential MD5 salt to new key and new salt
  */
-+ (void)updateStoreLocations;
-
-+ (void)updateEncryptionSalt;
++ (void)updateEncryptionForUser:(SFUserAccount *)user;
 
 @end
 

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreSharingUpgradeTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreSharingUpgradeTests.m
@@ -24,7 +24,9 @@
 
 #import <XCTest/XCTest.h>
 #import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
+#import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 #import <SalesforceSDKCore/SFKeyStoreManager.h>
+#import <SalesforceSDKCore/NSData+SFAdditions.h>
 #import "NSData+SFAdditions.h"
 #import "SFSmartStoreTestCase.h"
 #import "SFSmartStoreUpgrade.h"
@@ -46,6 +48,7 @@
 
 @interface SFSmartStoreUpgrade (Private)
 + (BOOL)updateSaltForStore:(NSString *)storeName user:(SFUserAccount *)user;
++ (BOOL)updateEncryptionForStore:(NSString *)storeName user:(SFUserAccount *)user;
 @end
 
 @interface SFSmartStoreSharingUpgradeTests : SFSmartStoreTestCase
@@ -79,66 +82,132 @@
 
 - (void) setUp {
     [super setUp];
-    if ([[SFKeyStoreManager sharedInstance] keyWithLabelExists:kSFSmartStoreEncryptionSaltLabel]) {
-        [[SFKeyStoreManager sharedInstance] removeKeyWithLabel:kSFSmartStoreEncryptionSaltLabel];
-    }
-    [[NSUserDefaults msdkUserDefaults] setBool:NO forKey:@"com.salesforce.smartstore.external.hasExternalSalt"];
-    
     [SFSDKSmartStoreLogger setLogLevel:SFLogLevelDebug];
     self.smartStoreUser = [self setUpSmartStoreUser];
     [SFSmartStore removeSharedStoreWithName:kTestUpgradeSmartStoreName];
-    self.store = [SFSmartStore sharedStoreWithName:kTestUpgradeSmartStoreName];
     self.store.captureExplainQueryPlan = YES;
+    [self resetKeys];
 }
 
-- (void) tearDown
-{
+- (void) tearDown {
+    [self resetKeys];
     [SFSmartStore removeSharedStoreWithName:kTestUpgradeSmartStoreName];
     [self tearDownSmartStoreUser:self.smartStoreUser];
     self.smartStoreUser = nil;
     self.store = nil;
-    
-    if ([[SFKeyStoreManager sharedInstance] keyWithLabelExists:kSFSmartStoreEncryptionSaltLabel]) {
-        [[SFKeyStoreManager sharedInstance] removeKeyWithLabel:kSFSmartStoreEncryptionSaltLabel];
-    }
-    [[NSUserDefaults msdkUserDefaults] setBool:NO forKey:@"com.salesforce.smartstore.external.hasExternalSalt"];
     [super tearDown];
 }
 
-- (void)testUpgrade {
-    //test existence of a datastore with inlined salt
-    SFEncryptionKey *origKey = [SFSmartStore encryptionKeyBlock]();
+- (void)resetKeys {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    if ([[SFKeyStoreManager sharedInstance] keyWithLabelExists:kSFSmartStoreEncryptionSaltLabel]) {
+        [[SFKeyStoreManager sharedInstance] removeKeyWithLabel:kSFSmartStoreEncryptionSaltLabel];
+    }
+    #pragma clang diagnostic pop
+    if ([SFSDKKeyGenerator encryptionKeyExistsFor:kSFSmartStoreEncryptionSaltLabel]) {
+        [SFSDKKeyGenerator removeEncryptionKeyFor:kSFSmartStoreEncryptionSaltLabel];
+    }
+    NSString *userUpgradeKey = [NSString stringWithFormat:@"%@-%@", kStoreEncryptionUpgrade, self.smartStoreUser.credentials.userId];
+    [[NSUserDefaults msdkUserDefaults] removeObjectForKey:userUpgradeKey];
+    [[NSUserDefaults msdkUserDefaults] removeObjectForKey:kKeyStoreHasExternalSalt];
+}
+
+// No salt and legacy encryption key -> salt and new encryption key
+- (void)testUpgradeNoSaltLegacyKey {
+    // Simulate store being created with legacy key
+    [SFSmartStore setEncryptionKeyGenerator:^NSData * _Nullable {
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        return [SFSmartStore encryptionKeyBlock]().key;
+        #pragma clang diagnostic pop
+    }];
+    NSData *origKey = [SFSmartStore encryptionKeyGenerator]();
     SFSmartStore *store = [SFSmartStore sharedStoreWithName:kTestUpgradeSmartStoreName];
-    XCTAssertNotNil(origKey,@"Database must be setup to have an encKey");
-    XCTAssertNotNil(store,@"Store should not be nil");
-    XCTAssertFalse([SFSmartStore hasPlainTextHeader:store.storeName user:store.user],@"Database must not have plain text header");
-    [self setupSaltBlock];
+    XCTAssertNotNil(origKey, @"Database must be setup to have an encKey");
+    XCTAssertNotNil(store, @"Store should not be nil");
+    XCTAssertFalse([SFSmartStore hasPlainTextHeader:store.storeName user:store.user], @"Database must not have plain text header");
+    
+    // Set salt for upgrade
+    [SFSmartStore setEncryptionSaltBlock:^NSString * _Nullable {
+        NSError *error = nil;
+        NSData *saltKey = [SFSDKKeyGenerator encryptionKeyFor:kSFSmartStoreEncryptionSaltLabel keySize:128 error:&error];
+        if (error) {
+            [SFSDKSmartStoreLogger e:[self class] format:@"Error getting key for salt: %@", error.localizedDescription];
+            return nil;
+        }
+        return [saltKey newHexStringFromBytes];
+    }];
+    
+    // Set encryption key to back to default
+    [SFSmartStore setEncryptionKeyGenerator:^NSData * _Nullable{
+        return [SFSDKKeyGenerator encryptionKeyFor:kSFSmartStoreEncryptionKeyLabel error:nil];
+    }];
     NSString *salt = [SFSmartStore encryptionSaltBlock]();
-    SFEncryptionKey *key = [SFSmartStore encryptionKeyBlock]();
+
+    NSData *key = [SFSmartStore encryptionKeyGenerator]();
     XCTAssertNotNil(salt,@"Database must be setup to have a salt");
-    XCTAssertEqualObjects(origKey,key,@"Database must  be setup to have the same encKey");
-    BOOL result = [SFSmartStoreUpgrade updateSaltForStore:store.storeName user:store.user];
-    XCTAssertTrue(result,"Upgrade to using external salt should have worked");
-    XCTAssertTrue([SFSmartStore hasPlainTextHeader:store.storeName user:store.user],@"Database now must  have plain text header");
+    XCTAssertNotEqualObjects(origKey, key, @"Database should have different encryption key after upgrade");
+    XCTAssertNotEqualObjects(origKey, key, @"Database should have different encryption key after upgrade");
+    BOOL result = [SFSmartStoreUpgrade updateEncryptionForStore:store.storeName user:store.user];
+    XCTAssertTrue(result,"Upgrade should have worked");
+    XCTAssertTrue([SFSmartStore hasPlainTextHeader:store.storeName user:store.user],@"Database now must have plain text header");
+    store = [SFSmartStore sharedStoreWithName:kTestUpgradeSmartStoreName];
+    XCTAssertNotNil(store, @"Store should not be nil after upgrade");
+    [self clearSaltBlock];
+}
+
+// Legacy salt and legacy encryption key -> new salt and new encryption key
+- (void)testUpgradeLegacySaltLegacyKey {
+    // Simulate store being created with legacy key and legacy salt
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [SFSmartStore setEncryptionKeyGenerator:^NSData * _Nullable{
+        return [SFSmartStore encryptionKeyBlock]().key;
+    }];
+    [SFSmartStore setEncryptionSaltBlock:^NSString * _Nullable {
+        SFEncryptionKey *saltKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:kSFSmartStoreEncryptionSaltLabel autoCreate:YES];
+        return [[saltKey key] digest];
+    }];
+    #pragma clang diagnostic pop
+    [[NSUserDefaults msdkUserDefaults] setBool:YES forKey:kKeyStoreHasExternalSalt];
+    
+    NSData *origKey = [SFSmartStore encryptionKeyGenerator]();
+    SFSmartStore *store = [SFSmartStore sharedStoreWithName:kTestUpgradeSmartStoreName];
+    XCTAssertNotNil(origKey, @"Database must be setup to have an encKey");
+    XCTAssertNotNil(store, @"Store should not be nil");
+    XCTAssertTrue([SFSmartStore hasPlainTextHeader:store.storeName user:store.user], @"Database should have plain text header");
+    
+    // Set encryption key and salt back to default for upgrade
+    [SFSmartStore setEncryptionSaltBlock:^NSString * _Nullable {
+        NSError *error = nil;
+        NSData *saltKey = [SFSDKKeyGenerator encryptionKeyFor:kSFSmartStoreEncryptionSaltLabel keySize:128 error:&error];
+        if (error) {
+            [SFSDKSmartStoreLogger e:[self class] format:@"Error getting key for salt: %@", error.localizedDescription];
+            return nil;
+        }
+        return [saltKey newHexStringFromBytes];
+    }];
+    
+    // Set encryption key to back to default
+    [SFSmartStore setEncryptionKeyGenerator:^NSData * _Nullable{
+        return [SFSDKKeyGenerator encryptionKeyFor:kSFSmartStoreEncryptionKeyLabel error:nil];
+    }];
+    NSString *salt = [SFSmartStore encryptionSaltBlock]();
+
+    NSData *key = [SFSmartStore encryptionKeyGenerator]();
+    XCTAssertNotNil(salt ,@"Database must be setup to have a salt");
+    XCTAssertNotEqualObjects(origKey, key, @"Database should have different encryption key after upgrade");
+    BOOL result = [SFSmartStoreUpgrade updateEncryptionForStore:store.storeName user:store.user];
+    XCTAssertTrue(result, "Upgrade should have worked");
+    XCTAssertTrue([SFSmartStore hasPlainTextHeader:store.storeName user:store.user], @"Database now must have plain text header");
     store = [SFSmartStore sharedStoreWithName:kTestUpgradeSmartStoreName];
     XCTAssertNotNil(store,@"Store should not be nil after upgrade");
     [self clearSaltBlock];
 }
 
-- (void)setupSaltBlock {
-    [SFSmartStore setEncryptionSaltBlock:^NSString * _Nullable{
-            SFEncryptionKey *saltKey = [[SFKeyStoreManager sharedInstance]   retrieveKeyWithLabel:kSFSmartStoreEncryptionSaltLabel autoCreate:YES];
-            NSString *salt = [[saltKey key] digest];
-            return salt;
-    }];
-}
-
 - (void)clearSaltBlock {
     [SFSmartStore setEncryptionSaltBlock:nil];
-    if ([[SFKeyStoreManager sharedInstance] keyWithLabelExists:kSFSmartStoreEncryptionSaltLabel]) {
-        [[SFKeyStoreManager sharedInstance] removeKeyWithLabel:kSFSmartStoreEncryptionSaltLabel];
-    }
 }
-
 
 @end

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -23,6 +23,7 @@
  */
 
 #import "SFSmartStoreTests.h"
+#import <SalesforceSDKCommon/SalesforceSDKCommon-Swift.h>
 #import <SalesforceSDKCommon/SFJsonUtils.h>
 #import "FMDatabase.h"
 #import "FMDatabaseAdditions.h"
@@ -33,6 +34,7 @@
 #import "SFSmartStore+Internal.h"
 #import "SFSoupIndex.h"
 #import "SFSmartStoreUpgrade.h"
+#import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 #import <SalesforceSDKCore/SFKeyStoreManager.h>
 #import <SalesforceSDKCore/SFEncryptionKey.h>
 #import <SalesforceSDKCore/NSString+SFAdditions.h>
@@ -951,8 +953,9 @@
 }
 
 - (void)testSmartStoreIsRecreatedWhenKeyIsLost {
-    NSString* storeName = @"testSmartStoreIsRecreatedWhenKeyIsLost";
-    SFEncryptionKey *originalKey = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:kSFSmartStoreEncryptionKeyLabel autoCreate:YES];
+    NSString *storeName = @"testSmartStoreIsRecreatedWhenKeyIsLost";
+    NSString *keyLabel = [NSString stringWithFormat:@"com.salesforce.keystore.%@", kSFSmartStoreEncryptionKeyLabel];
+    NSData *originalKey = [SFSDKKeychainHelper readWithService:keyLabel account:nil].data;
 
     @try {
         // Create store
@@ -980,7 +983,7 @@
         [SFSmartStore clearSharedStoreMemoryState];
         
         // Drop key
-        [[SFKeyStoreManager sharedInstance] removeKeyWithLabel:kSFSmartStoreEncryptionKeyLabel];
+        [SFSDKKeyGenerator removeEncryptionKeyFor:kSFSmartStoreEncryptionKeyLabel];
         
         // Re-open store -- but expect new empty store since key has changed
         store = [SFSmartStore sharedStoreWithName:storeName];
@@ -992,7 +995,7 @@
         // Drop store
         [SFSmartStore removeSharedStoreWithName:storeName];
         // Restore key
-        [[SFKeyStoreManager sharedInstance] storeKey:originalKey withLabel:kSFSmartStoreEncryptionKeyLabel];
+        XCTAssertTrue([SFSDKKeychainHelper writeWithService:keyLabel data:originalKey account:nil].success);
     }
 }
 

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreWithExternalStorageTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreWithExternalStorageTests.m
@@ -151,94 +151,6 @@ static NSInteger const kSSMegaBytePayloadSize = 1024 * 1024;
     }
 }
 
-- (void)testMigrateNullIVtoIVWithExternalStorage {
-    
-    SFSmartStoreEncryptionKeyBlock originalEncryptionBlock = [SFSmartStore encryptionKeyBlock];
-    
-    @try {
-        
-        NSUInteger const iterations = 10;
-        SFSoupSpec *soupSpec = [SFSoupSpec newSoupSpec:kSSExternalStorage_TestSoupName withFeatures:@[kSoupFeatureExternalStorage]];
-        NSDictionary* soupIndex = @{@"path": @"name", @"type": @"string"};
-        
-        SFEncryptionKey *key = [[SFKeyStoreManager sharedInstance] retrieveKeyWithLabel:kSFSmartStoreEncryptionKeyLabel autoCreate:YES];
-        
-        // create a nill IV based store
-        __block NSData *origIV = key.initializationVector;
-        origIV = key.initializationVector;
-        
-        
-        NSMutableArray *entries = [[NSMutableArray alloc] initWithCapacity:iterations];
-        
-        for (SFSmartStore *store in @[ self.store, self.globalStore ]) {
-            
-            SFSmartStore.encryptionKeyBlock = ^SFEncryptionKey *{
-                key.initializationVector= nil;
-                return key;
-            };
-            
-            [store registerSoupWithSpec:soupSpec withIndexSpecs:[SFSoupIndex asArraySoupIndexes:@[soupIndex]] error:nil];
-            __block NSString *soupTableName;
-            [store.storeQueue inDatabase:^(FMDatabase *db) {
-                soupTableName = [store tableNameForSoup:kSSExternalStorage_TestSoupName withDb:db];
-            }];
-            
-            // Insert entries
-            for (NSUInteger i = 0; i < iterations; i++) {
-                NSDictionary *entry = @{@"name": [NSString stringWithFormat:@"somebody_%lu", (unsigned long) i]};
-                [store upsertEntries:@[entry] toSoup:kSSExternalStorage_TestSoupName];
-                [entries addObject:entry];
-            }
-            
-            // Check if entries are in DB
-            SFQuerySpec *query = [SFQuerySpec newAllQuerySpec:kSSExternalStorage_TestSoupName
-                                                withOrderPath:nil
-                                                    withOrder:kSFSoupQuerySortOrderAscending
-                                                 withPageSize:iterations];
-            NSArray *entriesInserted = [store queryWithQuerySpec:query
-                                                       pageIndex:0
-                                                           error:nil];
-            XCTAssertEqual(entriesInserted.count, iterations, @"Did not insert all entries.");
-            // Check if external files exist
-            for (NSDictionary *savedEntry in entriesInserted) {
-                NSString *externalEntryFilePath = [store externalStorageSoupFilePath:savedEntry[SOUP_ENTRY_ID]
-                                                                       soupTableName:soupTableName];
-                BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:externalEntryFilePath];
-                
-                XCTAssertTrue(fileExists, @"External file of a saved entry does not exists.");
-            }
-            // now lets change to IV and read files
-            SFSmartStore.encryptionKeyBlock = ^SFEncryptionKey *{
-                key.initializationVector= origIV;
-                return key;
-            };
-            
-            // Check if external files exist
-            NSArray *retrievedEntries = [store retrieveEntries:[self entriesIdFromEntries:entriesInserted]
-                                                      fromSoup:kSSExternalStorage_TestSoupName];
-            XCTAssertEqualObjects(retrievedEntries, entriesInserted, @"Retrieve entries failed.");
-            
-            // now lets change back to nil IV and try to read files
-            SFSmartStore.encryptionKeyBlock = ^SFEncryptionKey *{
-                key.initializationVector= nil;
-                return key;
-            };
-            
-            // The retrievedEntries now must be nill.
-            retrievedEntries = [store retrieveEntries:[self entriesIdFromEntries:entriesInserted]
-                                             fromSoup:kSSExternalStorage_TestSoupName];
-            XCTAssertNil(retrievedEntries,@"Migration of External soup storage failed.");
-            
-        }
-        
-    }
-    
-    @finally {
-        // Restore encryption block
-        [SFSmartStore setEncryptionKeyBlock:originalEncryptionBlock];
-    }
-}
-
 - (void)testUpdateEntryWithExternalStorage {
     NSUInteger const iterations = 10;
     SFSoupSpec *soupSpec = [SFSoupSpec newSoupSpec:kSSExternalStorage_TestSoupName withFeatures:@[kSoupFeatureExternalStorage]];
@@ -444,15 +356,12 @@ static NSInteger const kSSMegaBytePayloadSize = 1024 * 1024;
 }
 
 - (void)testExternalStorageIsEncryptedWhenDbIsEncrypted {
-    SFSmartStoreEncryptionKeyBlock originalEncryptionBlock = [SFSmartStore encryptionKeyBlock];
+    SFSmartStoreEncryptionKeyGenerator originalEncryptionBlock = [SFSmartStore encryptionKeyGenerator];
     
     @try {
         // Define a key
-        NSString *secretKey = @"secretKey";
-        SFEncryptionKey *key = [[SFEncryptionKey alloc] initWithData:[secretKey dataUsingEncoding:NSUTF8StringEncoding]
-                                                initializationVector:nil];
-        [SFSmartStore setEncryptionKeyBlock:^SFEncryptionKey *{
-            return key;
+        [SFSmartStore setEncryptionKeyGenerator:^NSData *{
+            return [SFSDKKeyGenerator encryptionKeyFor:@"testExternalStorageIsEncryptedWhenDbIsEncrypted" error:nil];
         }];
         NSString * const superSecret = @"super secret";
         NSData * const superSecretAsData = [superSecret dataUsingEncoding:NSUTF8StringEncoding];
@@ -487,16 +396,17 @@ static NSInteger const kSSMegaBytePayloadSize = 1024 * 1024;
     
     @finally {
         // Restore encryption block
-        [SFSmartStore setEncryptionKeyBlock:originalEncryptionBlock];
+        [SFSmartStore setEncryptionKeyGenerator:originalEncryptionBlock];
+        [SFSDKKeyGenerator removeEncryptionKeyFor:@"testExternalStorageIsEncryptedWhenDbIsEncrypted"];
     }
 }
 
 - (void)testExternalStorageIsNotEncryptedWhenDbIsNotEncrypted {
-    SFSmartStoreEncryptionKeyBlock originalEncryptionBlock = [SFSmartStore encryptionKeyBlock];
+    SFSmartStoreEncryptionKeyGenerator originalEncryptionBlock = [SFSmartStore encryptionKeyGenerator];
     
     @try {
-        // Unset encrytpion
-        [SFSmartStore setEncryptionKeyBlock:nil];
+        // Unset encryption
+        [SFSmartStore setEncryptionKeyGenerator:nil];
         NSString * const notReallyASecret = @"there are no secrets";
         NSData * const notReallyASecretAsData = [notReallyASecret dataUsingEncoding:NSUTF8StringEncoding];
         
@@ -531,7 +441,7 @@ static NSInteger const kSSMegaBytePayloadSize = 1024 * 1024;
     
     @finally {
         // Restore encryption block
-        [SFSmartStore setEncryptionKeyBlock:originalEncryptionBlock];
+        [SFSmartStore setEncryptionKeyGenerator:originalEncryptionBlock];
     }
 }
 


### PR DESCRIPTION
- Create new encrypt/decrypt stream classes
- SmartStore to use new encryption key and new salt to get off MD5 + migration steps
- Remove old upgrade steps for going from single user -> multiuser