### PR TITLE
BootConfig/AppConfig should not be deprecated

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppConfig.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppConfig.h
@@ -38,7 +38,6 @@ extern NSString *const SFSDKDefaultNativeAppConfigFilePath NS_SWIFT_NAME(BootCon
 /** Contains this app's OAuth configuration as defined in the developer's Salesforce connected app.
  */
 NS_SWIFT_NAME(BootConfig)
-SFSDK_DEPRECATED(9.2, 11.0, "Will be removed")
 @interface SFSDKAppConfig : NSObject
 
 /**


### PR DESCRIPTION
This was probably deprecated accidentally instead of a different passcode class. Was there another reason, @brandonpage?