### PR TITLE
Address issues with UINavigationBarAppearance scoped to certain view flows

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKViewUtils.m
@@ -28,6 +28,11 @@
 #import "SFSDKViewUtils.h"
 #import "SFSDKViewControllerConfig.h"
 
+#import "SFLoginViewController.h"
+#import "SFSDKAppLockViewController.h"
+#import "SFSDKLoginFlowSelectionViewController.h"
+#import "SFSDKLoginHostListViewController.h"
+
 @implementation SFSDKViewUtils
 
 + (void)styleNavigationBar:(UINavigationBar *)navigationBar config:(SFSDKViewControllerConfig *) config {
@@ -36,8 +41,11 @@
         return;
     }
     
+    UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
+    [appearance configureWithOpaqueBackground];
+
     if (config.navBarColor) {
-        navigationBar.standardAppearance.backgroundColor = config.navBarColor;
+        appearance.backgroundColor = config.navBarColor;
         navigationBar.backgroundColor = config.navBarColor;
     }
     
@@ -59,9 +67,18 @@
     }
     
     if ([textAttributes count] > 0) {
-        navigationBar.standardAppearance.titleTextAttributes = textAttributes;
+        appearance.titleTextAttributes = textAttributes;
         [navigationBar setTitleTextAttributes:textAttributes];
     }
+    
+    // This scopes appearance behaviors to classes "owned by" MSDK,
+    // and will prevent conflicts or changes in behavior with apps
+    // consuming this SDK.
+    NSArray *appearanceClasses = @[[SFLoginViewController class], [SFSDKAppLockViewController class], [SFSDKLoginFlowSelectionViewController class], [SFSDKLoginHostListViewController class]];
+
+    [UINavigationBar appearanceWhenContainedInInstancesOfClasses:appearanceClasses].standardAppearance = appearance;
+    [UINavigationBar appearanceWhenContainedInInstancesOfClasses:appearanceClasses].compactAppearance = appearance;
+    [UINavigationBar appearanceWhenContainedInInstancesOfClasses:appearanceClasses].scrollEdgeAppearance = appearance;
 }
 
 + ( UIImage * _Nonnull )headerBackgroundImage:(UIColor *)color {


### PR DESCRIPTION
In iOS 15 (building with Xcode 13.x), SFS has seen issues of slight navigation bar positioning which are due to the limited usage of `UINavigationBarAppearance` in MSDK. This PR expands the limited support already in place to include `configureWithOpaqueBackground` and `compactAppearance` & `scrollEdgeAppearance`.

Additionally, as the `styleNavigationBar:config:` method is only used by four VCs, appearance setting is scoped to _those_ classes only - meaning that an application which uses its own navigation bar appearance will not have its settings overridden by MSDK (depending on call lifecycle).

Screenshot shows primary issue.
![Simulator Screen Shot - iPhone 13 Pro - 2021-11-30 at 09 06 38](https://user-images.githubusercontent.com/1211078/144117880-96784868-b608-45ab-95aa-86256d3f2218.png)


