### PR TITLE
Fix for KV store initialization

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Storage/KeyValueEncryptedFileStore.swift
@@ -111,13 +111,17 @@ public class KeyValueEncryptedFileStore: NSObject {
         let versionFileURL = directory.appendingPathComponent(KeyValueEncryptedFileStore.storeVersionFileName)
         if isNewlyCreated {
             let versionFileCreated = writeFile(versionFileURL, content: KeyValueEncryptedFileStore.storeVersionString)
-            if !versionFileCreated {
+            let encryptionFileURL = directory.appendingPathComponent(KeyValueEncryptedFileStore.storeGCMEncryptionFileName)
+            let encryptionFileCreated = FileManager.default.createFile(atPath: encryptionFileURL.path, contents: nil, attributes: nil)
+            if !versionFileCreated || !encryptionFileCreated {
+                SFSDKCoreLogger.e(KeyValueEncryptedFileStore.self, message: "\(#function): Failed to create version file or encryption file for store")
                 return nil
             }
         } else {
             if let version = readVersion(versionFileURL) {
                 self.storeVersion = version
             } else {
+                SFSDKCoreLogger.e(KeyValueEncryptedFileStore.self, message: "\(#function): Failed to read version for store")
                 return nil
             }
         }
@@ -339,6 +343,11 @@ public class KeyValueEncryptedFileStore: NSObject {
                 SFSDKCoreLogger.e(KeyValueEncryptedFileStore.self, message: "\(#function): Error removing file at path '\(storeURL.path)': \(error)")
             }
         }
+    }
+    
+    // Internal for testing
+    static func clearGlobalCache() {
+        KeyValueEncryptedFileStore.globalStores.removeAllObjects()
     }
 
     // MARK: - Store operations

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/KeyValueFileStoreTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/KeyValueFileStoreTests.swift
@@ -80,7 +80,24 @@ class KeyValueFileStoreTests: XCTestCase {
         XCTAssertEqual(store[key], content)
         
         // Access again + verify nothing changes
+        KeyValueEncryptedFileStore.clearGlobalCache()
         let storeAgain = try XCTUnwrap(KeyValueEncryptedFileStore.sharedGlobal(withName: storeName))
         XCTAssertEqual(storeAgain[key], content)
+    }
+    
+    func testSameStoreNoCache() throws {
+        // Create legacy key to simulate scenario where app has existing stores that originally used the old key
+        // and then validate new stores can be created and reinitialized
+        let _ = try XCTUnwrap(SFKeyStoreManager.sharedInstance().retrieveKey(withLabel: "com.salesforce.keyValueStores.encryptionKey", autoCreate: true))
+        let storeName = "kv_global_shared_recreate"
+       
+        KeyValueEncryptedFileStore.clearGlobalCache()
+        var store = try XCTUnwrap(KeyValueEncryptedFileStore.sharedGlobal(withName: storeName))
+        store["key1"] = "value1"
+        
+        KeyValueEncryptedFileStore.clearGlobalCache()
+        
+        store = try XCTUnwrap(KeyValueEncryptedFileStore.sharedGlobal(withName: storeName))
+        XCTAssertEqual(store["key1"], "value1")
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKKeyValueEncryptedFileStoreTests.m
@@ -318,7 +318,7 @@
     NSError *error;
     NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:store.storeDirectory.path error:&error];
     XCTAssertNil(error, @"Error getting contents of path '%@': %@", store.storeDirectory.path, error);
-    XCTAssertEqual(files.count, 3, @"Unexpected number of files in store");
+    XCTAssertEqual(files.count, 4, @"Unexpected number of files in store");
     NSString *valuePath = [store.storeDirectory.path stringByAppendingPathComponent:files[0]];
     NSData *fileData = [NSData dataWithContentsOfFile:valuePath];
     NSData *valueData = [value dataUsingEncoding:NSUTF8StringEncoding];


### PR DESCRIPTION
If the legacy key is present new stores that didn’t use the legacy key could have an encryption update triggered when it shouldn’t