### PR TITLE
Trust work on SalesforceSDKCommon tests

### DIFF
--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/project.pbxproj
@@ -191,12 +191,12 @@
 		B7136D0B216684A700F6A221 /* SalesforceSDKCommonTests */ = {
 			isa = PBXGroup;
 			children = (
+				B7136D0E216684A700F6A221 /* Info.plist */,
 				B7182B002614346B00867BFE /* KeychainItemManagerTests.swift */,
+				B7D3CAB9218BA32B00780B72 /* SFLoggerTests.m */,
 				B7D3CABB218BC80600780B72 /* SFSDKSafeMutableArrayTests.m */,
 				B7D3CABC218BC80600780B72 /* SFSDKSafeMutableDictionaryTests.m */,
 				B7D3CABD218BC80600780B72 /* SFSDKSafeMutableSetTests.m */,
-				B7136D0E216684A700F6A221 /* Info.plist */,
-				B7D3CAB9218BA32B00780B72 /* SFLoggerTests.m */,
 			);
 			path = SalesforceSDKCommonTests;
 			sourceTree = "<group>";

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommonTests/KeychainItemManagerTests.swift
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommonTests/KeychainItemManagerTests.swift
@@ -26,29 +26,17 @@
 //  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import XCTest
-import SalesforceSDKCommon
-enum KeychainTestError: Error {
-    case failed(osStatus: OSStatus)
-    case failedToRead
-}
+@testable import SalesforceSDKCommon
 
-class KeychainItemManagerTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testCreateIfNotPresent()  throws {
+final class KeychainItemManagerTests: XCTestCase {
+    
+    func testCreateIfNotPresent() {
         let accountName = "account.two"
         let serviceName = "test.two"
         _  = KeychainHelper.remove(service: serviceName, account: accountName)
         let keychainResult = KeychainHelper.createIfNotPresent(service: serviceName, account: accountName)
         XCTAssertTrue(keychainResult.success)
-
+        
         let keychainReadResult = KeychainHelper.read(service: serviceName, account: accountName)
         XCTAssertTrue(keychainReadResult.success)
         XCTAssertNil(keychainReadResult.data)
@@ -71,7 +59,7 @@ class KeychainItemManagerTests: XCTestCase {
         XCTAssertNil(readAgainRTesult.data)
     }
     
-    func testConcurrentCreateIfNotPresent() throws {
+    func testConcurrentCreateIfNotPresent() {
         let serviceName = "test"
         addTeardownBlock {
             _ = KeychainHelper.remove(service: serviceName, account: "0")
@@ -84,11 +72,11 @@ class KeychainItemManagerTests: XCTestCase {
         }
     }
     
-    func testCreateIfNotPresentNilAccount()  throws {
+    func testCreateIfNotPresentNilAccount() {
         let serviceName = "test.two"
         let check = KeychainHelper.read(service: serviceName, account: nil)
         XCTAssertFalse(check.success)
-    
+        
         let keychainResult = KeychainHelper.createIfNotPresent(service: serviceName, account: nil)
         XCTAssertTrue(keychainResult.success)
         let keychainReadResult = KeychainHelper.read(service: serviceName, account: nil)
@@ -108,98 +96,96 @@ class KeychainItemManagerTests: XCTestCase {
         let removeResult = KeychainHelper.remove(service: serviceName, account: nil)
         XCTAssertTrue(removeResult.success)
         XCTAssertNil(removeResult.data)
-    
+        
         let readAgainResult = KeychainHelper.read(service: serviceName, account: nil)
         XCTAssertFalse(readAgainResult.success)
         XCTAssertNil(readAgainResult.data)
+    }
+    
+    func testWriteAndReadItem() {
+        let serviceName = "test.two"
+        let check = KeychainHelper.read(service: serviceName, account: nil)
+        XCTAssertFalse(check.success)
         
-   }
-    
-    func testWriteAndReadItem()  throws {
-          let serviceName = "test.two"
-          let check = KeychainHelper.read(service: serviceName, account: nil)
-          XCTAssertFalse(check.success)
-      
-          let data = "ATESTSTRING2".data(using: .utf8)  ?? Data()
-          let writeResult = KeychainHelper.write(service: serviceName, data: data, account: nil)
-          XCTAssertTrue(writeResult.success)
-          XCTAssertNotNil(writeResult.data)
-          
-          let readResult = KeychainHelper.read(service: serviceName, account: nil)
-          XCTAssertTrue(readResult.success)
-          XCTAssertNotNil(readResult.data)
-          
-          let removeResult = KeychainHelper.remove(service: serviceName, account: nil)
-          XCTAssertTrue(removeResult.success)
-          XCTAssertNil(removeResult.data)
-      
-          let readAgainRTesult = KeychainHelper.read(service: serviceName, account: nil)
-          XCTAssertFalse(readAgainRTesult.success)
-          XCTAssertNil(readAgainRTesult.data)
+        let data = "ATESTSTRING2".data(using: .utf8)  ?? Data()
+        let writeResult = KeychainHelper.write(service: serviceName, data: data, account: nil)
+        XCTAssertTrue(writeResult.success)
+        XCTAssertNotNil(writeResult.data)
+        
+        let readResult = KeychainHelper.read(service: serviceName, account: nil)
+        XCTAssertTrue(readResult.success)
+        XCTAssertNotNil(readResult.data)
+        
+        let removeResult = KeychainHelper.remove(service: serviceName, account: nil)
+        XCTAssertTrue(removeResult.success)
+        XCTAssertNil(removeResult.data)
+        
+        let readAgainRTesult = KeychainHelper.read(service: serviceName, account: nil)
+        XCTAssertFalse(readAgainRTesult.success)
+        XCTAssertNil(readAgainRTesult.data)
     }
     
-    func testWriteAndReadItemWithAccount()  throws {
-          let serviceName = "test.two"
-          let accountName = "account.two"
-          let check = KeychainHelper.read(service: serviceName, account: accountName)
-          XCTAssertFalse(check.success)
-      
-          let data = "ATESTSTRING2".data(using: .utf8)  ?? Data()
-          let writeResult = KeychainHelper.write(service: serviceName, data: data, account: accountName)
-          XCTAssertTrue(writeResult.success)
-          XCTAssertNotNil(writeResult.data)
-          XCTAssertTrue(writeResult.status == errSecSuccess)
-          
-          let readResult = KeychainHelper.read(service: serviceName, account: accountName)
-          XCTAssertTrue(readResult.success)
-          XCTAssertNotNil(readResult.data)
-          XCTAssertTrue(readResult.status == errSecSuccess)
-          
-          
-          let removeResult = KeychainHelper.remove(service: serviceName, account: accountName)
-          XCTAssertTrue(removeResult.success)
-          XCTAssertNil(removeResult.data)
-          XCTAssertTrue(readResult.status == errSecSuccess)
-      
-          let readAgainRTesult = KeychainHelper.read(service: serviceName, account: accountName)
-          XCTAssertFalse(readAgainRTesult.success)
-          XCTAssertNil(readAgainRTesult.data)
-          XCTAssertTrue(readResult.status == errSecSuccess)
+    func testWriteAndReadItemWithAccount() {
+        let serviceName = "test.two"
+        let accountName = "account.two"
+        let check = KeychainHelper.read(service: serviceName, account: accountName)
+        XCTAssertFalse(check.success)
+        
+        let data = "ATESTSTRING2".data(using: .utf8)  ?? Data()
+        let writeResult = KeychainHelper.write(service: serviceName, data: data, account: accountName)
+        XCTAssertTrue(writeResult.success)
+        XCTAssertNotNil(writeResult.data)
+        XCTAssertTrue(writeResult.status == errSecSuccess)
+        
+        let readResult = KeychainHelper.read(service: serviceName, account: accountName)
+        XCTAssertTrue(readResult.success)
+        XCTAssertNotNil(readResult.data)
+        XCTAssertTrue(readResult.status == errSecSuccess)
+        
+        let removeResult = KeychainHelper.remove(service: serviceName, account: accountName)
+        XCTAssertTrue(removeResult.success)
+        XCTAssertNil(removeResult.data)
+        XCTAssertTrue(readResult.status == errSecSuccess)
+        
+        let readAgainRTesult = KeychainHelper.read(service: serviceName, account: accountName)
+        XCTAssertFalse(readAgainRTesult.success)
+        XCTAssertNil(readAgainRTesult.data)
+        XCTAssertTrue(readResult.status == errSecSuccess)
     }
     
-    func testDeleteItemIfNotPresent()  throws {
-          let serviceName = "test.two"
-          let removeResult = KeychainHelper.remove(service: serviceName, account: nil)
-          XCTAssertFalse(removeResult.success)
-          XCTAssertNil(removeResult.data)
-          XCTAssertNotNil(removeResult.error)
-          XCTAssertTrue(removeResult.status == errSecItemNotFound)
+    func testDeleteItemIfNotPresent() {
+        let serviceName = "test.two"
+        let removeResult = KeychainHelper.remove(service: serviceName, account: nil)
+        XCTAssertFalse(removeResult.success)
+        XCTAssertNil(removeResult.data)
+        XCTAssertNotNil(removeResult.error)
+        XCTAssertTrue(removeResult.status == errSecItemNotFound)
     }
     
-    func testDeleteItemIfNotPresentWithAccount()  throws {
-          let serviceName = "test.two"
-          let accountName = "account.two"
-          let removeResult = KeychainHelper.remove(service: serviceName, account: accountName)
-          XCTAssertFalse(removeResult.success)
-          XCTAssertNil(removeResult.data)
-          XCTAssertNotNil(removeResult.error)
-          XCTAssertTrue(removeResult.status == errSecItemNotFound)
+    func testDeleteItemIfNotPresentWithAccount() {
+        let serviceName = "test.two"
+        let accountName = "account.two"
+        let removeResult = KeychainHelper.remove(service: serviceName, account: accountName)
+        XCTAssertFalse(removeResult.success)
+        XCTAssertNil(removeResult.data)
+        XCTAssertNotNil(removeResult.error)
+        XCTAssertTrue(removeResult.status == errSecItemNotFound)
     }
     
-    func testCreateMultipleTimes()  throws {
+    func testCreateMultipleTimes() {
         let accountName = "account.two"
         let serviceName = "test.two"
         _  = KeychainHelper.remove(service: serviceName, account: accountName)
         var keychainResult = KeychainHelper.createIfNotPresent(service: serviceName, account: accountName)
         XCTAssertTrue(keychainResult.success)
-
+        
         var keychainReadResult = KeychainHelper.read(service: serviceName, account: accountName)
         XCTAssertTrue(keychainReadResult.success)
         XCTAssertNil(keychainReadResult.data)
         
         keychainResult = KeychainHelper.createIfNotPresent(service: serviceName, account: accountName)
         XCTAssertTrue(keychainResult.success)
-
+        
         keychainReadResult = KeychainHelper.read(service: serviceName, account: accountName)
         XCTAssertTrue(keychainReadResult.success)
         XCTAssertNil(keychainReadResult.data)
@@ -213,8 +199,7 @@ class KeychainItemManagerTests: XCTestCase {
         XCTAssertNil(readAgainRTesult.data)
     }
     
-    func testCreateAndRemoveAll()  throws {
-       
+    func testCreateAndRemoveAll() {
         let accounts = [( "test.one", "account.one"),
                         ( "test.two", "account.two"),
                         ( "test.three", "account.three"),
@@ -235,7 +220,6 @@ class KeychainItemManagerTests: XCTestCase {
     }
     
     func testChangeAccesibilityAttribute() throws {
-       
         let accounts = [( "test.one", "account.one"),
                         ( "test.two", "account.two"),
                         ( "test.three", "account.three"),
@@ -275,15 +259,12 @@ class KeychainItemManagerTests: XCTestCase {
         }
     }
     
-    
     private func readKeychainItem(service: String, account: String) throws -> [String : Any] {
         let query: [String: Any] = [String(kSecClass): String(kSecClassGenericPassword),
                                     String(kSecAttrService): service,
                                     String(kSecMatchLimit): kSecMatchLimitOne,
                                     String(kSecReturnAttributes): kCFBooleanTrue as Any,
                                     String(kSecReturnData): kCFBooleanTrue as Any]
-        
-        
         
         var queryResult: CFTypeRef?
         let status = SecItemCopyMatching(query as CFDictionary, &queryResult)
@@ -299,5 +280,9 @@ class KeychainItemManagerTests: XCTestCase {
         return item
     }
     
-   
+    private enum KeychainTestError: Error {
+        case failed(osStatus: OSStatus)
+        case failedToRead
+    }
+
 }

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommonTests/SFSDKSafeMutableArrayTests.m
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommonTests/SFSDKSafeMutableArrayTests.m
@@ -21,31 +21,24 @@
  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 #import <XCTest/XCTest.h>
 #import "SFSDKSafeMutableArray.h"
+
 @interface SFSDKSafeMutableArrayTests : XCTestCase
 @end
 
 @implementation SFSDKSafeMutableArrayTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testReadWrites {
-    
     SFSDKSafeMutableArray *array = [SFSDKSafeMutableArray array];
     NSString *obj1 = @"Test1";
     NSString *obj2 = @"Test2";
-
+    
     [array addObject:obj1];
     [array addObject:obj2];
     [array addObject:[NSNumber numberWithInt:10]];
-
+    
     XCTAssertTrue([array containsObject:obj1]);
     XCTAssertTrue([array containsObject:obj2]);
     XCTAssertTrue([[array[0] description] isEqualToString:obj1]);
@@ -53,9 +46,7 @@
     XCTAssertEqual([array[2] integerValue], 10);
 }
 
-
 - (void)testReadWriteDelete {
-    
     SFSDKSafeMutableArray *array = [SFSDKSafeMutableArray arrayWithCapacity:3];
     [array insertObject:@"Test2" atIndex:0];
     [array insertObject:@"Test1" atIndex:1];
@@ -135,7 +126,6 @@
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
     //Have all items been removed
     XCTAssertTrue(array.count == 0);
-    
 }
 
 - (void)testConcurrentReadsAndRemoveAll {
@@ -163,7 +153,6 @@
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
     //Have all items been removed
     XCTAssertTrue(array.count == 0);
-    
 }
 
 - (void)testConcurrentReadsAndRemoveWithIndexes {
@@ -175,7 +164,7 @@
     
     NSIndexSet* indexSet = [[NSIndexSet alloc] initWithIndexesInRange:NSMakeRange(1, 5)];
     [array insertObjects:inputs atIndexes:indexSet];
-
+    
     
     XCTAssertEqual(array.count,inputs.count + 1);
     [array enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
@@ -196,4 +185,5 @@
     //Have all items been removed
     XCTAssertTrue(array.count == 1);
 }
+
 @end

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommonTests/SFSDKSafeMutableDictionaryTests.m
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommonTests/SFSDKSafeMutableDictionaryTests.m
@@ -29,6 +29,7 @@
 
 @property (strong, nonatomic) SFSDKSafeMutableDictionary *testDictionary;
 @property (strong, nonatomic) NSArray *testKeys;
+
 @end
 
 @implementation SFSDKSafeMutableDictionaryTests
@@ -41,10 +42,6 @@
     [self.testKeys enumerateObjectsUsingBlock:^(NSString * _Nonnull key, NSUInteger idx, BOOL * _Nonnull stop) {
         [self.testDictionary setObject:objects[idx] forKey:key];
     }];
-}
-
-- (void)tearDown {
-    [super tearDown];
 }
 
 - (void)testConcurrentReadWrites {

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommonTests/SFSDKSafeMutableSetTests.m
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommonTests/SFSDKSafeMutableSetTests.m
@@ -23,21 +23,13 @@
  */
 #import <XCTest/XCTest.h>
 #import "SFSDKSafeMutableSet.h"
+
 @interface SFSDKSafeMutableSetTests : XCTestCase
 @end
 
 @implementation SFSDKSafeMutableSetTests
 
-- (void)setUp {
-    [super setUp];
-}
-
-- (void)tearDown {
-    [super tearDown];
-}
-
 - (void)testReadWrites {
-    
     SFSDKSafeMutableSet *set = [SFSDKSafeMutableSet set];
     [set addObject:@"Test1"];
     [set addObject:@"Test2"];
@@ -49,9 +41,7 @@
     XCTAssertTrue([set containsObject:[NSNumber numberWithInt:10]]);
 }
 
-
 - (void)testReadWriteDelete {
-    
     SFSDKSafeMutableSet *set = [SFSDKSafeMutableSet set];
     [set addObject:@"Test1"];
     [set addObject:@"Test2"];
@@ -68,7 +58,7 @@
     
     SFSDKSafeMutableSet *set = [SFSDKSafeMutableSet set];
     dispatch_group_t group = dispatch_group_create();
-   
+    
     [inputs enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             [set addObject:inputs[idx]];
@@ -76,12 +66,12 @@
     }];
     
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
-        
+    
     //Does the set have the right number of items?
     XCTAssertTrue(set.count == inputs.count);
     //Does the set have each of our items?
     [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-       XCTAssertTrue([set containsObject:inputs[idx]]);
+        XCTAssertTrue([set containsObject:inputs[idx]]);
     }];
 }
 
@@ -97,7 +87,7 @@
         });
     }];
     
-   [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+    [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             [set anyObject];
         });
@@ -106,7 +96,7 @@
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
     //Does the set have the right number of items?
     XCTAssertTrue(set.count == inputs.count);
-     //Does the set have each of our items?
+    //Does the set have each of our items?
     [inputs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         XCTAssertTrue([set containsObject:inputs[idx]]);
     }];
@@ -138,7 +128,6 @@
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
     //Have all items been removed
     XCTAssertTrue(set.count == 0);
-    
 }
 
 - (void)testConcurrentReadsAndRemoveAll {
@@ -165,6 +154,6 @@
     dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
     //Have all items been removed
     XCTAssertTrue(set.count == 0);
-    
 }
+
 @end


### PR DESCRIPTION
**Changes**
- Fix minor formatting issues in both Swift and Objective-C test codes
- Use `@testable import` in Swift tests
- Deleted empty setup or teardown methods
- Got rid of unnecessary `throws`