### PR TITLE
Don't add default hosts if host selection is disabled

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostStorage.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostStorage.m
@@ -31,6 +31,7 @@
 #import "SFManagedPreferences.h"
 #import "SFSDKResourceUtils.h"
 #import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
+#import "SFUserAccountManager.h"
 
 @interface SFSDKLoginHostStorage ()
 
@@ -104,8 +105,10 @@ static NSString * const SFSDKLoginHostNameKey = @"SalesforceLoginHostNameKey";
              */
             if (![self loginHostForHostAddress:customHost]) {
                 [self.loginHostList removeAllObjects];
-                [self.loginHostList addObject:production];
-                [self.loginHostList addObject:sandbox];
+                if ([SFUserAccountManager sharedInstance].loginViewControllerConfig.showSettingsIcon) {
+                    [self.loginHostList addObject:production];
+                    [self.loginHostList addObject:sandbox];
+                }
                 NSString *sanitizedCustomHost = [customHost stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
                 SFSDKLoginHost *customLoginHost = [SFSDKLoginHost hostWithName:customHost host:sanitizedCustomHost deletable:NO];
                 [self.loginHostList addObject:customLoginHost];


### PR DESCRIPTION
For issue #3501

- the app has a custom host configured through SFDCOAuthLoginHost and disabled the settings through the login view controller config
- when getting an error on the login screen, the generic error handler switches to the first host in the list which is production and retries
- since the settings icon is disabled the user can't get back to the intended custom host without uninstalling/reinstalling

This change would only add the default hosts for the SFDCOAuthLoginHost case if the settings icon is available (similar to the managed preferences case and onlyShowAuthorizedHosts)