### PR TITLE
iOS 15 window crash

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
@@ -235,6 +235,19 @@
     [self waitForExpectations:@[delegate.before,delegate.after] timeout:2];
     
     XCTAssertTrue(delegate.notificationWindow.isAuthWindow);
-    
 }
+
+- (void)testDealloc {
+    __weak SFSDKWindowContainer *container;
+    @autoreleasepool {
+        container = [[SFSDKWindowManager sharedManager] createNewNamedWindow:@"customWindow"];
+        [container presentWindow];
+        [[SFSDKWindowManager sharedManager] removeNamedWindow:@"customWindow"];
+    }
+
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"window == nil"];
+    XCTNSPredicateExpectation *expectation = [[XCTNSPredicateExpectation alloc] initWithPredicate:predicate object:container];
+    [self waitForExpectations:@[expectation] timeout:10];
+}
+
 @end


### PR DESCRIPTION
There's a crash reported on iOS 15 where `[UIWindow dealloc]` triggers `[SFSDKUIWindow disableWindow]` and then looks like it hits [this check](https://github.com/apple-oss-distributions/objc4/blob/8701d5672d3fd3cd817aeb84db1077aafe1a1604/runtime/objc-weak.mm#L420) when setting `super.rootViewController = nil` which crashes because UIWindow is deallocating. We don't have any repro steps with an app but I could hit the same crash point using the unit test in this PR on iOS 15 while it runs successfully on iOS 14 without any SDK changes. Adding a guard for now until we can get more information

