### PR TITLE
Bulk checking last modified date during collection sync up

### DIFF
--- a/libs/MobileSync/MobileSync/Classes/BatchSyncUpTarget.swift
+++ b/libs/MobileSync/MobileSync/Classes/BatchSyncUpTarget.swift
@@ -39,7 +39,7 @@ extension BatchSyncUpTarget {
 
     @objc
     func sendRecordRequests(_ syncManager:SyncManager,
-                            recordRequests: Array<CompositeRequestHelper.RecordRequest>,
+                            recordRequests: [RecordRequest],
                             onComplete: @escaping OnSendCompleteCallback,
                             onFail: @escaping OnFailCallback) {
         

--- a/libs/MobileSync/MobileSync/Classes/CollectionSyncUpTarget.swift
+++ b/libs/MobileSync/MobileSync/Classes/CollectionSyncUpTarget.swift
@@ -158,16 +158,17 @@ public class CollectionSyncUpTarget: BatchSyncUpTarget {
                                 recordIdToLastModifiedDate[storeId] = SFRecordModDate(timestamp: nil, isDeleted: true)
                             }
                         }
+                        print("--> leaving group")
                         group.leave()
                     } else {
 //                        errorBlock(nil)
                     }
                 }
             }
+        }
                 
-            group.notify(queue: DispatchQueue.global()) {
-                completeBlock(recordIdToLastModifiedDate)
-            }
+        group.notify(queue: DispatchQueue.global()) {
+            completeBlock(recordIdToLastModifiedDate)
         }
     }
 }

--- a/libs/MobileSync/MobileSync/Classes/CollectionSyncUpTarget.swift
+++ b/libs/MobileSync/MobileSync/Classes/CollectionSyncUpTarget.swift
@@ -146,8 +146,7 @@ public class CollectionSyncUpTarget: BatchSyncUpTarget {
                 let request = RestClient.shared.request(forCollectionRetrieve: objectType, objectIds: batchServerIds, fieldList: [modificationDateFieldName], apiVersion: nil)
                 
                 group.enter()
-                NetworkUtils.sendRequest(withMobileSyncUserAgent: request) { response, error, urlResponse in
-                    MobileSyncLogger.default.e(CollectionSyncUpTarget.self, message:"Request returned error \(response)")
+                NetworkUtils.sendRequest(withMobileSyncUserAgent: request) { response, error, urlResponse in                    
                     group.leave()
                 } successBlock: { response, urlResponse in
                     if let recordsFromResponse = response as? [Any] {

--- a/libs/MobileSync/MobileSync/Classes/Manager/SFAdvancedSyncUpTask.m
+++ b/libs/MobileSync/MobileSync/Classes/Manager/SFAdvancedSyncUpTask.m
@@ -24,6 +24,7 @@
 
 #import "SFAdvancedSyncUpTask.h"
 #import "SFAdvancedSyncUpTarget.h"
+#import <SmartStore/SFSmartStore.h>
 
 @implementation SFAdvancedSyncUpTask
 
@@ -32,72 +33,85 @@
 }
 
 - (void)syncUp:(SFSyncState*)sync recordIds:(NSArray*)recordIds {
-    [self syncUpMultipleEntries:sync recordIds:recordIds index:0 batch:[NSMutableArray new]];
-}
-
-- (void)syncUpMultipleEntries:(SFSyncState*)sync
-                    recordIds:(NSArray*)recordIds
-                        index:(NSUInteger)i
-                        batch:(NSMutableArray*)batch {
-
-    SFSyncStateMergeMode mergeMode = sync.mergeMode;
     SFSyncUpTarget *target = (SFSyncUpTarget *)sync.target;
     NSString* soupName = sync.soupName;
     sync.totalSize = recordIds.count;
+    
+    NSArray<NSDictionary*>* records = [target getFromLocalStore:self.syncManager
+                                                       soupName:soupName
+                                                       storeIds:recordIds];
+    
+    // Figuring out what records need to be synced up based on merge mode and last mod date on server
+    [self shouldSyncUpRecords:self.syncManager target:target records:records options:sync.options resultBlock:^(NSDictionary * _Nonnull recordIdToShouldSyncUp) {
+        [self syncUpMultipleEntries:sync
+                            records:records
+             recordIdToShouldSyncUp:recordIdToShouldSyncUp
+                              index:0
+                              batch:[NSMutableArray new]];
+    }];
+}
+
+- (void) shouldSyncUpRecords:(SFMobileSyncSyncManager *)syncManager
+                      target:(SFSyncUpTarget*)target
+                     records:(NSArray<NSDictionary*>*)records
+                     options:(SFSyncOptions*)options
+                 resultBlock:(SFSyncUpRecordsNewerThanServerBlock)resultBlock {
+        
+    if (options.mergeMode == SFSyncStateMergeModeOverwrite) {
+        NSMutableDictionary* result = [NSMutableDictionary new];
+        
+        for (NSDictionary* record in records) {
+            result[record[SOUP_ENTRY_ID]] = @YES;
+        }
+        
+        resultBlock(result);
+    } else {
+        [target areNewerThanServer:syncManager records:records resultBlock:resultBlock];
+    }
+}
+
+- (void)syncUpMultipleEntries:(SFSyncState*)sync
+                      records:(NSArray<NSDictionary*>*)records
+       recordIdToShouldSyncUp:(NSDictionary*)recordIdToShouldSyncUp
+                        index:(NSUInteger)i
+                        batch:(NSMutableArray*)batch {
+
+    SFSyncUpTarget *target = (SFSyncUpTarget *)sync.target;
+    NSUInteger maxBatchSize = ((SFSyncUpTarget<SFAdvancedSyncUpTarget>*) target).maxBatchSize;
+    sync.totalSize = records.count;
     [self updateSync:sync countSynched:i];
     
     if ([sync isDone] || [self shouldStop]) {
         return;
     }
 
-    NSMutableDictionary* record = [[target getFromLocalStore:self.syncManager soupName:soupName storeId:recordIds[i]] mutableCopy];
+    NSMutableDictionary* record = [records[i] mutableCopy];
     [SFSDKMobileSyncLogger d:[self class] format:@"syncUpMultipleEntries:%@", record];
     
-    if (mergeMode == SFSyncStateMergeModeLeaveIfChanged && ![target isLocallyCreated:record]) {
-        // Need to check the modification date on the server, against the local date.
-        __weak typeof(self) weakSelf = self;
-        [target isNewerThanServer:self.syncManager record:record resultBlock:^(BOOL isNewerThanServer) {
-            __strong typeof(weakSelf) strongSelf = weakSelf;
-            if (isNewerThanServer) {
-                [strongSelf addToSyncUpBatchAndProcessIfNeeded:sync recordIds:recordIds index:i record:record batch:batch];
-            }
-            else {
-                // Server date is newer than the local date.  Skip this update.
-                [SFSDKMobileSyncLogger d:[strongSelf class] format:@"syncUpMultipleEntries: Record not synced since client does not have the latest from server:%@", record];
-                // Calling addToSyncUpBatchAndProcessIfNeeded with nil for record - we don't want to add the current record to the batch
-                // but we do want the batch to be processed if needed
-                [strongSelf addToSyncUpBatchAndProcessIfNeeded:sync recordIds:recordIds index:i record:nil batch:batch];
-            }
-        }];
-    } else {
-        [self addToSyncUpBatchAndProcessIfNeeded:sync recordIds:recordIds index:i record:record batch:batch];
-    }
-}
-
-- (void)addToSyncUpBatchAndProcessIfNeeded:(SFSyncState*)sync
-                                 recordIds:(NSArray*)recordIds
-                                     index:(NSUInteger)i
-                                    record:(NSDictionary*)record
-                                     batch:(NSMutableArray*)batch {
-    
-    SFSyncUpTarget<SFAdvancedSyncUpTarget>* advancedTarget = (SFSyncUpTarget<SFAdvancedSyncUpTarget>*) sync.target;
-    NSUInteger maxBatchSize = advancedTarget.maxBatchSize;
-    
-    // Add record to batch unless nil
-    if (record) {
+    if (recordIdToShouldSyncUp[record[SOUP_ENTRY_ID]]) {
         [batch addObject:record];
     }
-    
+        
     // Process batch if max batch size reached or at the end of recordIds
-    if (batch.count == maxBatchSize || i == recordIds.count - 1) {
-        [self processSyncUpBatch:sync recordIds:recordIds index:i batch:batch];
+    if (batch.count == maxBatchSize || i == records.count - 1) {
+        
+        [self processSyncUpBatch:sync
+                         records:records
+          recordIdToShouldSyncUp:recordIdToShouldSyncUp
+                           index:i
+                           batch:batch];
     } else {
-        [self syncUpMultipleEntries:sync recordIds:recordIds index:i+1 batch:batch];
+        [self syncUpMultipleEntries:sync
+                            records:records
+             recordIdToShouldSyncUp:recordIdToShouldSyncUp
+                              index:i+1
+                              batch:batch];
     }
 }
 
 - (void)processSyncUpBatch:(SFSyncState*)sync
-                 recordIds:(NSArray*)recordIds
+                   records:(NSArray<NSDictionary*>*)records
+    recordIdToShouldSyncUp:(NSDictionary*)recordIdToShouldSyncUp
                      index:(NSUInteger)i
                      batch:(NSMutableArray*)batch {
     
@@ -108,7 +122,11 @@
     __weak typeof(self) weakSelf = self;
     void (^nextBlock)(NSDictionary *)=^(NSDictionary *syncUpResult) {
         [batch removeAllObjects];
-        [weakSelf syncUpMultipleEntries:sync recordIds:recordIds index:i+1 batch:batch];
+        [weakSelf syncUpMultipleEntries:sync
+                                records:records
+                 recordIdToShouldSyncUp:recordIdToShouldSyncUp
+                                  index:i+1
+                                  batch:batch];
     };
     
     SFSyncUpTargetErrorBlock failBlock = ^(NSError * err) {

--- a/libs/MobileSync/MobileSync/Classes/Manager/SFAdvancedSyncUpTask.m
+++ b/libs/MobileSync/MobileSync/Classes/Manager/SFAdvancedSyncUpTask.m
@@ -88,7 +88,9 @@
     NSMutableDictionary* record = [records[i] mutableCopy];
     [SFSDKMobileSyncLogger d:[self class] format:@"syncUpMultipleEntries:%@", record];
     
-    if (recordIdToShouldSyncUp[record[SOUP_ENTRY_ID]]) {
+    NSNumber* recordId = record[SOUP_ENTRY_ID];
+    BOOL shouldSyncUp =  [((NSNumber*) recordIdToShouldSyncUp[recordId]) boolValue];
+    if (shouldSyncUp) {
         [batch addObject:record];
     }
         

--- a/libs/MobileSync/MobileSync/Classes/Manager/SFAdvancedSyncUpTask.m
+++ b/libs/MobileSync/MobileSync/Classes/Manager/SFAdvancedSyncUpTask.m
@@ -88,8 +88,8 @@
     NSMutableDictionary* record = [records[i] mutableCopy];
     [SFSDKMobileSyncLogger d:[self class] format:@"syncUpMultipleEntries:%@", record];
     
-    NSNumber* recordId = record[SOUP_ENTRY_ID];
-    BOOL shouldSyncUp =  [((NSNumber*) recordIdToShouldSyncUp[recordId]) boolValue];
+    NSNumber* storeId = record[SOUP_ENTRY_ID];
+    BOOL shouldSyncUp =  [((NSNumber*) recordIdToShouldSyncUp[storeId]) boolValue];
     if (shouldSyncUp) {
         [batch addObject:record];
     }

--- a/libs/MobileSync/MobileSync/Classes/Target/BriefcaseSyncDownTarget.swift
+++ b/libs/MobileSync/MobileSync/Classes/Target/BriefcaseSyncDownTarget.swift
@@ -65,7 +65,7 @@ public class BriefcaseSyncDownTarget: SyncDownTarget {
     private static let briefcaseFeatureMarker = "BC"
     private static let countIdsPerRetrieve = "countIdsPerRetrieve"
     private static let infos = "infos"
-    private static let maxCountIdsPerRetrieve = 2000
+    private static let maxCountIdsPerRetrieve = SalesforceSDKCore.SFRestCollectionRetrieveMaxSize
     
     @objc let countIdsPerRetrieve: Int
     @objc private(set) var infosMap: [String: BriefcaseObjectInfo] = [:]

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.h
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.h
@@ -118,6 +118,15 @@ extern NSString * const kSyncTargetLastError;
 - (NSDictionary*) getFromLocalStore:(SFMobileSyncSyncManager *)syncManager soupName:(NSString*)soupName storeId:(NSNumber*)storeId;
 
 /**
+ * @param syncManager The sync manager
+ * @param soupName The soup
+ * @param storeIds The soup entry ids
+ * @return Records from local store by storeIds
+ */
+- (NSArray<NSDictionary*>*) getFromLocalStore:(SFMobileSyncSyncManager *)syncManager soupName:(NSString*)soupName storeIds:(NSArray<NSNumber*>*)storeIds;
+
+
+/**
  * Delete record from local store
  * @param syncManager The sync manager
  * @param soupName The soup

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
@@ -122,6 +122,10 @@ NSString * const kSyncTargetLastError = @"__last_error__";
     return [syncManager.store retrieveEntries:@[storeId] fromSoup:soupName][0];
 }
 
+- (NSArray<NSDictionary*>*) getFromLocalStore:(SFMobileSyncSyncManager *)syncManager soupName:(NSString*)soupName storeIds:(NSArray<NSNumber*>*)storeIds {
+    return [syncManager.store retrieveEntries:storeIds fromSoup:soupName];
+}
+
 - (void) deleteFromLocalStore:(SFMobileSyncSyncManager *)syncManager soupName:(NSString*)soupName record:(NSDictionary*)record {
     [SFSDKMobileSyncLogger d:[self class] format:@"deleteFromLocalStore:%@", record];
     [syncManager.store removeEntries:@[record[SOUP_ENTRY_ID]] fromSoup:soupName];

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.h
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.h
@@ -75,9 +75,14 @@ typedef NS_ENUM(NSUInteger, SFSyncUpTargetAction) {
 } NS_SWIFT_NAME(SyncUpTarget.Action);
 
 /**
- Block definition for returning whether a records changed on server.
+ Block definition for returning whether a record changed on server.
  */
 typedef void (^SFSyncUpRecordNewerThanServerBlock)(BOOL isNewerThanServer) NS_SWIFT_NAME(RecordNewerThanServerBlock);
+
+/**
+ Block definition for returning whether records changed on server.
+ */
+typedef void (^SFSyncUpRecordsNewerThanServerBlock)(NSDictionary* areNewerThanServer) NS_SWIFT_NAME(RecordsNewerThanServerBlock);
 
 /**
  Block definition for calling a sync up completion block.
@@ -163,6 +168,17 @@ NS_SWIFT_NAME(SyncUpTarget)
 - (void)isNewerThanServer:(SFMobileSyncSyncManager *)syncManager
                    record:(NSDictionary*)record
              resultBlock:(SFSyncUpRecordNewerThanServerBlock)resultBlock;
+
+
+/**
+Same as isNewerThanServer but operating over a list of records
+Return dictionary from record store id to boolean
+ @param records The records
+ @param resultBlock The block to execute
+*/
+ - (void)areNewerThanServer:(SFMobileSyncSyncManager *)syncManager
+                   records:(NSArray<NSDictionary*>*)records
+                resultBlock:(SFSyncUpRecordsNewerThanServerBlock)resultBlock;
 
 /**
  Save locally created record back to server

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.h
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.h
@@ -171,6 +171,14 @@ NS_SWIFT_NAME(SyncUpTarget)
 
 
 /**
+ Return true if local mod date is greater than remote mod date
+ NB: also return true if both were deleted or if local mod date is missing
+*/
+- (BOOL)isNewerThanServer:(nullable SFRecordModDate*)localModDate
+            remoteModDate:(nullable SFRecordModDate*)remoteModDate;
+
+
+/**
 Same as isNewerThanServer but operating over a list of records
 Return dictionary from record store id to boolean
  @param records The records

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.h
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.h
@@ -97,6 +97,7 @@ typedef void (^SFSyncUpTargetErrorBlock)(NSError *error) NS_SWIFT_NAME(SyncUpErr
 /**
  Helper class for isNewerThanServer
  */
+NS_SWIFT_NAME(RecordModDate)
 @interface SFRecordModDate : NSObject
 
 @property (nonatomic, strong) NSDate*  timestamp;   // time stamp - can be nil if unknown

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
@@ -344,6 +344,7 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
                                 }
     ];
 }
+
 /**
  Return true if local mod date is greater than remote mod date
  NB: also return true if both were deleted or if local mod date is missing

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
@@ -170,7 +170,8 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
         result[storeId] = [NSNumber numberWithBool:isNewerThanServer];
         if (i < records.count-1) {
             [strongSelf isNewerThanServer:syncManager
-                                  records:records index:i+1
+                                  records:records
+                                    index:i+1
                                    result:result
                               resultBlock:resultBlock];
         } else {

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncUpTarget.m
@@ -345,10 +345,6 @@ typedef void (^SFSyncUpRecordModDateBlock)(SFRecordModDate *remoteModDate);
     ];
 }
 
-/**
- Return true if local mod date is greater than remote mod date
- NB: also return true if both were deleted or if local mod date is missing
-*/
 - (BOOL)isNewerThanServer:(SFRecordModDate*)localModDate
         remoteModDate:(SFRecordModDate*)remoteModDate
 {

--- a/libs/MobileSync/MobileSync/Classes/Util/CompositeRequestHelper.swift
+++ b/libs/MobileSync/MobileSync/Classes/Util/CompositeRequestHelper.swift
@@ -312,11 +312,13 @@ class RecordRequest: NSObject {
                 let externalIdFieldNames = getExternalIdFieldName(recordRequests: recordRequests, requestType: .UPSERT)
                 
                 if (objectTypes.isEmpty || externalIdFieldNames.isEmpty) {
-                    // throw new SyncManager.MobileSyncException("Missing sobjectType or externalIdFieldName")
+                    MobileSyncLogger.default.e(CompositeRequestHelper.self, message:"Missing sobjectType or externalIdFieldName")
+                    return nil
                 }
                 
                 if (Set(objectTypes).count > 1) {
-                    // throw new SyncManager.MobileSyncException("All records must have same sobjectType");
+                    MobileSyncLogger.default.e(CompositeRequestHelper.self, message:"All records must have same sobjectType")
+                    return nil
                 }
                 
                 let objectType = objectTypes.first!

--- a/libs/MobileSync/MobileSync/Classes/Util/CompositeRequestHelper.swift
+++ b/libs/MobileSync/MobileSync/Classes/Util/CompositeRequestHelper.swift
@@ -28,238 +28,14 @@
 import Foundation
 import SalesforceSDKCore
 
-typealias OnSendCompleteCallback =  (Dictionary<String, CompositeRequestHelper.RecordResponse>) -> ()
+typealias OnSendCompleteCallback =  ([String: RecordResponse]) -> ()
 typealias OnFailCallback = (Error) -> ()
 
 @objc(SFCompositeRequestHelper)
 class CompositeRequestHelper:NSObject {
-    //
-    // Types of request
-    //
-    @objc
-    enum RequestType: Int, CaseIterable {
-       case CREATE, UPDATE, UPSERT, DELETE
-    }
-    
-    //
-    // Response object abstracting away differences between /composite/batch and /commposite/sobject sub-responses
-    //
-    @objc(SFSDKRecordResponse)
-    class RecordResponse: NSObject {
-        @objc let success: Bool
-        @objc let objectId: String?
-        @objc let recordDoesNotExist: Bool
-        @objc let relatedRecordDoesNotExist: Bool
-        @objc let errorJson: Dictionary<String, Any>?
-        @objc let json: Any
-        
-        private init(success:Bool, objectId:String?, recordDoesNotExist:Bool, relatedRecordDoesNotExist:Bool, errorJson: Dictionary<String, Any>?, json:Any) {
-            self.success = success
-            self.objectId = objectId
-            self.recordDoesNotExist = recordDoesNotExist
-            self.relatedRecordDoesNotExist = relatedRecordDoesNotExist
-            self.errorJson = errorJson
-            self.json = json
-        }
-        
-        func description() ->  String {
-            return SFJsonUtils.jsonRepresentation(json)
-        }
-        
-        static func fromCompositeSubResponse(compositeSubResponse: CompositeSubResponse) -> RecordResponse {
-            let success = RestClient.isStatusCodeSuccess(UInt(compositeSubResponse.httpStatusCode))
-            var objectId:String? = nil
-            var recordDoesNotExist = false
-            var relatedRecordDoesNotExist = false
-            var errorJson:Dictionary<String, Any>? = nil
-            
-            if (success) {
-                if let body = compositeSubResponse.body as? Dictionary<String, Any> {
-                    objectId = body["id"] as? String
-                }
-            } else {
-                recordDoesNotExist = RestClient.isStatusCodeNotFound(UInt(compositeSubResponse.httpStatusCode))
-                if let bodyArray = compositeSubResponse.body as? Array<Dictionary<String, Any>> {
-                    errorJson = bodyArray[0]
-                    let firstError = errorJson?["errorCode"] as? String
-                    relatedRecordDoesNotExist = firstError == "ENTITY_IS_DELETED"
-                }
-            }
-            
-            return RecordResponse(success:success, objectId: objectId, recordDoesNotExist: recordDoesNotExist, relatedRecordDoesNotExist: relatedRecordDoesNotExist, errorJson: errorJson, json: compositeSubResponse.dict)
-            
-        }
-        
-        static func fromCollectionSubResponse(collectionSubResponse: CollectionSubResponse) -> RecordResponse {
-            let success = collectionSubResponse.success
-            let objectId = collectionSubResponse.objectId
-            var recordDoesNotExist = false
-            var relatedRecordDoesNotExist = false
-            var errorJson:Dictionary<String, Any>? = nil
-
-            if (!success && !collectionSubResponse.errors.isEmpty) {
-                errorJson = collectionSubResponse.errors[0].json
-                let error = collectionSubResponse.errors[0].statusCode
-                recordDoesNotExist = error == "INVALID_CROSS_REFERENCE_KEY" || error == "ENTITY_IS_DELETED"
-                relatedRecordDoesNotExist = error == "ENTITY_IS_DELETED" // XXX ambiguous
-            }
-            
-            return RecordResponse(success:success, objectId: objectId, recordDoesNotExist: recordDoesNotExist, relatedRecordDoesNotExist: relatedRecordDoesNotExist, errorJson: errorJson, json: collectionSubResponse.json)
-        }
-    }
-
-    //
-    // Request object abstracting away differences between /composite/batch and /commposite/sobject sub-requests
-    //
-    @objc(SFSDKRecordRequest)
-    class RecordRequest: NSObject {
-        @objc var referenceId: String?
-        @objc let requestType: RequestType
-        @objc let objectType: String
-        @objc let fields: Dictionary<String, Any>?
-        @objc let objectId: String?
-        @objc let externalId: String?
-        @objc let externalIdFieldName: String?
-        
-        private init(requestType:RequestType, objectType:String, fields:Dictionary<String, Any>?, objectId: String?, externalId: String?, externalIdFieldName: String?) {
-            self.requestType = requestType
-            self.objectType = objectType
-            self.fields = fields
-            self.objectId = objectId
-            self.externalId = externalId
-            self.externalIdFieldName = externalIdFieldName
-        }
-        
-        func asRestRequest() -> RestRequest? {
-            // If object type is missing, we don't want to send request to parent path otherwise error will be
-            // hard to understand
-            let objectType = self.objectType == "" ? "null" : self.objectType
-            
-            switch (requestType) {
-            case .CREATE:
-                return RestClient.shared.requestForCreate(withObjectType: objectType, fields: fields, apiVersion: nil)
-            case .UPDATE:
-                return RestClient.shared.requestForUpdate(withObjectType: objectType, objectId: objectId!, fields: fields, apiVersion: nil)
-            case .UPSERT:
-                return RestClient.shared.requestForUpsert(withObjectType: objectType, externalIdField: externalIdFieldName!, externalId: externalId, fields: fields!, apiVersion: nil)
-            case .DELETE:
-                return RestClient.shared.requestForDelete(withObjectType: objectType, objectId: objectId!, apiVersion: nil)
-            }
-        }
-        
-        func  asDictForCollectionRequest() -> Dictionary<String, Any> {
-            var record:Dictionary<String, Any> = Dictionary()
-            record["attributes"] = ["type": objectType == "" ? "null" : objectType]
-            if let fields = fields {
-                for (fieldName, fieldValue) in fields {
-                    record[fieldName] = fieldValue
-                }
-            }
-            
-            if (requestType == .UPDATE) {
-                record["Id"] = objectId
-            }
-            
-            if (requestType == .UPSERT) {
-                if let externalIdFieldName = externalIdFieldName {
-                    record[externalIdFieldName] = externalId
-                }
-            }
-            
-            return record
-        }
-        
-        @objc
-        static func requestForCreate(objectType:String, fields:Dictionary<String, Any>) -> RecordRequest {
-            return RecordRequest(requestType:.CREATE, objectType: objectType, fields: fields, objectId: nil, externalId: nil, externalIdFieldName: nil)
-        }
-
-        @objc
-        static func requestForUpdate(objectType:String, objectId:String, fields:Dictionary<String, Any>) -> RecordRequest {
-            return RecordRequest(requestType:.UPDATE, objectType: objectType, fields: fields, objectId: objectId, externalId: nil, externalIdFieldName: nil)
-        }
-
-        @objc
-        static func requestForUpsert(objectType:String, externalIdFieldName:String, externalId:String, fields:Dictionary<String, Any>) -> RecordRequest {
-            return RecordRequest(requestType:.UPSERT, objectType: objectType, fields: fields, objectId: nil, externalId: externalId, externalIdFieldName: externalIdFieldName)
-        }
-
-        @objc
-        static func requestForDelete(objectType:String, objectId: String) -> RecordRequest {
-            return RecordRequest(requestType:.DELETE, objectType: objectType, fields: nil, objectId: objectId, externalId: nil, externalIdFieldName: nil)
-        }
-        
-        static func getRefIds(recordRequests:Array<RecordRequest>, requestType:RequestType) -> Array<String> {
-            return recordRequests
-                .filter { $0.requestType == requestType }
-                .map { $0.referenceId! }
-        }
-
-        static func getIds(recordRequests:Array<RecordRequest>, requestType:RequestType) -> Array<String> {
-            return recordRequests
-                .filter { $0.requestType == requestType && $0.objectId != nil }
-                .map { $0.objectId! }
-        }
-
-        static func getObjectTypes(recordRequests:Array<RecordRequest>, requestType:RequestType) -> Array<String> {
-            return recordRequests
-                .filter { $0.requestType == requestType }
-                .map { $0.objectType }
-        }
-        
-        static func getExternalIdFieldName(recordRequests:Array<RecordRequest>, requestType:RequestType) -> Array<String> {
-            return recordRequests
-                .filter { $0.requestType == requestType && $0.externalIdFieldName != nil }
-                .map { $0.externalIdFieldName! }
-        }
-        
-        static func getArrayForCollectionRequest(recordRequests:Array<RecordRequest>, requestType:RequestType) -> Array<Dictionary<String, Any>> {
-            return recordRequests
-                .filter { $0.requestType == requestType }
-                .map { $0.asDictForCollectionRequest() }
-        }
-        
-        static func getCollectionRequest(recordRequests:Array<RecordRequest>, requestType:RequestType, allOrNone: Bool) -> RestRequest? {
-            switch (requestType) {
-            case .CREATE:
-                return RestClient.shared.request(forCollectionCreate: allOrNone,
-                                                 records: getArrayForCollectionRequest(recordRequests: recordRequests, requestType: .CREATE),
-                                                 apiVersion: nil)
-            case .UPDATE:
-                return RestClient.shared.request(forCollectionUpdate: allOrNone,
-                                                 records: getArrayForCollectionRequest(recordRequests: recordRequests, requestType: .UPDATE),
-                                                 apiVersion: nil)
-            case .UPSERT:
-                let records = getArrayForCollectionRequest(recordRequests: recordRequests, requestType: .UPSERT)
-                if (!records.isEmpty) {
-                    let objectTypes = getObjectTypes(recordRequests: recordRequests, requestType: .UPSERT)
-                    let externalIdFieldNames = getExternalIdFieldName(recordRequests: recordRequests, requestType: .UPSERT)
-                    
-                    if (objectTypes.isEmpty || externalIdFieldNames.isEmpty) {
-                        // throw new SyncManager.MobileSyncException("Missing sobjectType or externalIdFieldName")
-                    }
-                    
-                    if (Set(objectTypes).count > 1) {
-                        // throw new SyncManager.MobileSyncException("All records must have same sobjectType");
-                    }
-                    
-                    let objectType = objectTypes.first!
-                    let externalIdFieldName = externalIdFieldNames.first!
-                    
-                    return RestClient.shared.request(forCollectionUpsert: objectType, externalIdField: externalIdFieldName, allOrNone: allOrNone, records: records, apiVersion: nil)
-                }
-            case .DELETE:
-                return RestClient.shared.request(forCollectionDelete: getIds(recordRequests: recordRequests, requestType: .DELETE),
-                                                 apiVersion: nil)
-            }
-            
-            return nil
-        }
-    }
-
     // Send record requests using a composite batch request
     @objc
-    static func sendAsCompositeBatchRequest(_ syncManager: SyncManager, allOrNone: Bool, recordRequests: Array<RecordRequest>, onComplete: @escaping OnSendCompleteCallback, onFail: @escaping OnFailCallback) {
+    static func sendAsCompositeBatchRequest(_ syncManager: SyncManager, allOrNone: Bool, recordRequests: [RecordRequest], onComplete: @escaping OnSendCompleteCallback, onFail: @escaping OnFailCallback) {
         
         let request = RestClient.shared.compositeRequest(recordRequests.map { $0.asRestRequest()! },
                                                          refIds: recordRequests.map { $0.referenceId! },
@@ -269,8 +45,8 @@ class CompositeRequestHelper:NSObject {
         NetworkUtils.sendRequest(withMobileSyncUserAgent: request) { response, error, urlResponse in
             onFail(error!)
         } successBlock: { response, urlResponse in
-            if let response  = response as? Dictionary<String, Any> {
-                var refIdToRecordResponse = Dictionary<String, RecordResponse>()
+            if let response  = response as? [String:Any] {
+                var refIdToRecordResponse = [String:RecordResponse]()
                 let compositeResponse = CompositeResponse(response)
                 compositeResponse.subResponses.forEach {
                     refIdToRecordResponse[$0.referenceId] = RecordResponse.fromCompositeSubResponse(compositeSubResponse:$0)
@@ -282,7 +58,7 @@ class CompositeRequestHelper:NSObject {
         
     // Send record requests using sobject collection requests
     @objc
-    static func sendAsCollectionRequests(_ syncManager: SyncManager, allOrNone: Bool, recordRequests: Array<RecordRequest>, onComplete: @escaping OnSendCompleteCallback, onFail: @escaping OnFailCallback)  {
+    static func sendAsCollectionRequests(_ syncManager: SyncManager, allOrNone: Bool, recordRequests: [RecordRequest], onComplete: @escaping OnSendCompleteCallback, onFail: @escaping OnFailCallback)  {
         
 
         let group = DispatchGroup()
@@ -295,7 +71,7 @@ class CompositeRequestHelper:NSObject {
                 NetworkUtils.sendRequest(withMobileSyncUserAgent: request) { response, error, urlResponse in
                     onFail(error!)
                 } successBlock: { response, urlResponse in
-                    if let response  = response as? Array<Dictionary<String, Any>> {
+                    if let response  = response as? [[String:Any]] {
                         let collectionResponse = CollectionResponse(response)
                         for (i, subResponse) in collectionResponse.subResponses.enumerated() {
                             let refId = refIds[i]
@@ -314,7 +90,7 @@ class CompositeRequestHelper:NSObject {
     
     // Return ref id to server id map if successful
     @objc
-    static func parseIdsFromResponses(_ refIdToRecordResponse:Dictionary<String, RecordResponse>) -> Dictionary<String, String> {
+    static func parseIdsFromResponses(_ refIdToRecordResponse:Dictionary<String, RecordResponse>) -> [String: String] {
         return refIdToRecordResponse
             .filter { _, response in response.objectId != nil }
             .mapValues { $0.objectId! }
@@ -322,7 +98,7 @@ class CompositeRequestHelper:NSObject {
     
     // Update id field with server id
     @objc
-    static func updateReferences(_ record: Dictionary<String, Any>, fieldWithRefId:String, refIdToServerId:Dictionary<String, String>) -> Dictionary<String, Any> {
+    static func updateReferences(_ record: [String:Any], fieldWithRefId:String, refIdToServerId:[String: String]) -> [String:Any] {
         var updatedRecord = record // copy
         
         if let refId = record[fieldWithRefId] as? String, let serverId = refIdToServerId[refId] {
@@ -330,5 +106,229 @@ class CompositeRequestHelper:NSObject {
         }
 
         return updatedRecord
+    }
+}
+
+//
+// Response object abstracting away differences between /composite/batch and /commposite/sobject sub-responses
+//
+@objc(SFSDKRecordResponse)
+class RecordResponse: NSObject {
+    @objc let success: Bool
+    @objc let objectId: String?
+    @objc let recordDoesNotExist: Bool
+    @objc let relatedRecordDoesNotExist: Bool
+    @objc let errorJson: [String:Any]?
+    @objc let json: Any
+    
+    private init(success:Bool, objectId:String?, recordDoesNotExist:Bool, relatedRecordDoesNotExist:Bool, errorJson: [String:Any]?, json:Any) {
+        self.success = success
+        self.objectId = objectId
+        self.recordDoesNotExist = recordDoesNotExist
+        self.relatedRecordDoesNotExist = relatedRecordDoesNotExist
+        self.errorJson = errorJson
+        self.json = json
+    }
+    
+    func description() ->  String {
+        return SFJsonUtils.jsonRepresentation(json)
+    }
+    
+    static func fromCompositeSubResponse(compositeSubResponse: CompositeSubResponse) -> RecordResponse {
+        let success = RestClient.isStatusCodeSuccess(UInt(compositeSubResponse.httpStatusCode))
+        var objectId:String? = nil
+        var recordDoesNotExist = false
+        var relatedRecordDoesNotExist = false
+        var errorJson:[String:Any]? = nil
+        
+        if (success) {
+            if let body = compositeSubResponse.body as? [String:Any] {
+                objectId = body["id"] as? String
+            }
+        } else {
+            recordDoesNotExist = RestClient.isStatusCodeNotFound(UInt(compositeSubResponse.httpStatusCode))
+            if let bodyArray = compositeSubResponse.body as? [[String:Any]] {
+                errorJson = bodyArray[0]
+                let firstError = errorJson?["errorCode"] as? String
+                relatedRecordDoesNotExist = firstError == "ENTITY_IS_DELETED"
+            }
+        }
+        
+        return RecordResponse(success:success, objectId: objectId, recordDoesNotExist: recordDoesNotExist, relatedRecordDoesNotExist: relatedRecordDoesNotExist, errorJson: errorJson, json: compositeSubResponse.dict)
+        
+    }
+    
+    static func fromCollectionSubResponse(collectionSubResponse: CollectionSubResponse) -> RecordResponse {
+        let success = collectionSubResponse.success
+        let objectId = collectionSubResponse.objectId
+        var recordDoesNotExist = false
+        var relatedRecordDoesNotExist = false
+        var errorJson:[String:Any]? = nil
+
+        if (!success && !collectionSubResponse.errors.isEmpty) {
+            errorJson = collectionSubResponse.errors[0].json
+            let error = collectionSubResponse.errors[0].statusCode
+            recordDoesNotExist = error == "INVALID_CROSS_REFERENCE_KEY" || error == "ENTITY_IS_DELETED"
+            relatedRecordDoesNotExist = error == "ENTITY_IS_DELETED" // XXX ambiguous
+        }
+        
+        return RecordResponse(success:success, objectId: objectId, recordDoesNotExist: recordDoesNotExist, relatedRecordDoesNotExist: relatedRecordDoesNotExist, errorJson: errorJson, json: collectionSubResponse.json)
+    }
+}
+
+//
+// Types of request
+//
+@objc
+enum RequestType: Int, CaseIterable {
+   case CREATE, UPDATE, UPSERT, DELETE
+}
+
+//
+// Request object abstracting away differences between /composite/batch and /commposite/sobject sub-requests
+//
+@objc(SFSDKRecordRequest)
+class RecordRequest: NSObject {
+    @objc var referenceId: String?
+    @objc let requestType: RequestType
+    @objc let objectType: String
+    @objc let fields: [String:Any]?
+    @objc let objectId: String?
+    @objc let externalId: String?
+    @objc let externalIdFieldName: String?
+    
+    private init(requestType:RequestType, objectType:String, fields:[String:Any]?, objectId: String?, externalId: String?, externalIdFieldName: String?) {
+        self.requestType = requestType
+        self.objectType = objectType
+        self.fields = fields
+        self.objectId = objectId
+        self.externalId = externalId
+        self.externalIdFieldName = externalIdFieldName
+    }
+    
+    func asRestRequest() -> RestRequest? {
+        // If object type is missing, we don't want to send request to parent path otherwise error will be
+        // hard to understand
+        let objectType = self.objectType == "" ? "null" : self.objectType
+        
+        switch (requestType) {
+        case .CREATE:
+            return RestClient.shared.requestForCreate(withObjectType: objectType, fields: fields, apiVersion: nil)
+        case .UPDATE:
+            return RestClient.shared.requestForUpdate(withObjectType: objectType, objectId: objectId!, fields: fields, apiVersion: nil)
+        case .UPSERT:
+            return RestClient.shared.requestForUpsert(withObjectType: objectType, externalIdField: externalIdFieldName!, externalId: externalId, fields: fields!, apiVersion: nil)
+        case .DELETE:
+            return RestClient.shared.requestForDelete(withObjectType: objectType, objectId: objectId!, apiVersion: nil)
+        }
+    }
+    
+    func  asDictForCollectionRequest() -> [String:Any] {
+        var record:[String:Any] = [:]
+        record["attributes"] = ["type": objectType == "" ? "null" : objectType]
+        if let fields = fields {
+            for (fieldName, fieldValue) in fields {
+                record[fieldName] = fieldValue
+            }
+        }
+        
+        if (requestType == .UPDATE) {
+            record["Id"] = objectId
+        }
+        
+        if (requestType == .UPSERT) {
+            if let externalIdFieldName = externalIdFieldName {
+                record[externalIdFieldName] = externalId
+            }
+        }
+        
+        return record
+    }
+    
+    @objc
+    static func requestForCreate(objectType:String, fields:[String:Any]) -> RecordRequest {
+        return RecordRequest(requestType:.CREATE, objectType: objectType, fields: fields, objectId: nil, externalId: nil, externalIdFieldName: nil)
+    }
+
+    @objc
+    static func requestForUpdate(objectType:String, objectId:String, fields:[String:Any]) -> RecordRequest {
+        return RecordRequest(requestType:.UPDATE, objectType: objectType, fields: fields, objectId: objectId, externalId: nil, externalIdFieldName: nil)
+    }
+
+    @objc
+    static func requestForUpsert(objectType:String, externalIdFieldName:String, externalId:String, fields:[String:Any]) -> RecordRequest {
+        return RecordRequest(requestType:.UPSERT, objectType: objectType, fields: fields, objectId: nil, externalId: externalId, externalIdFieldName: externalIdFieldName)
+    }
+
+    @objc
+    static func requestForDelete(objectType:String, objectId: String) -> RecordRequest {
+        return RecordRequest(requestType:.DELETE, objectType: objectType, fields: nil, objectId: objectId, externalId: nil, externalIdFieldName: nil)
+    }
+    
+    static func getRefIds(recordRequests:[RecordRequest], requestType:RequestType) -> [String] {
+        return recordRequests
+            .filter { $0.requestType == requestType }
+            .map { $0.referenceId! }
+    }
+
+    static func getIds(recordRequests:[RecordRequest], requestType:RequestType) -> [String] {
+        return recordRequests
+            .filter { $0.requestType == requestType && $0.objectId != nil }
+            .map { $0.objectId! }
+    }
+
+    static func getObjectTypes(recordRequests:[RecordRequest], requestType:RequestType) -> [String] {
+        return recordRequests
+            .filter { $0.requestType == requestType }
+            .map { $0.objectType }
+    }
+    
+    static func getExternalIdFieldName(recordRequests:[RecordRequest], requestType:RequestType) -> [String] {
+        return recordRequests
+            .filter { $0.requestType == requestType && $0.externalIdFieldName != nil }
+            .map { $0.externalIdFieldName! }
+    }
+    
+    static func getArrayForCollectionRequest(recordRequests:[RecordRequest], requestType:RequestType) -> [[String:Any]] {
+        return recordRequests
+            .filter { $0.requestType == requestType }
+            .map { $0.asDictForCollectionRequest() }
+    }
+    
+    static func getCollectionRequest(recordRequests:[RecordRequest], requestType:RequestType, allOrNone: Bool) -> RestRequest? {
+        switch (requestType) {
+        case .CREATE:
+            return RestClient.shared.request(forCollectionCreate: allOrNone,
+                                             records: getArrayForCollectionRequest(recordRequests: recordRequests, requestType: .CREATE),
+                                             apiVersion: nil)
+        case .UPDATE:
+            return RestClient.shared.request(forCollectionUpdate: allOrNone,
+                                             records: getArrayForCollectionRequest(recordRequests: recordRequests, requestType: .UPDATE),
+                                             apiVersion: nil)
+        case .UPSERT:
+            let records = getArrayForCollectionRequest(recordRequests: recordRequests, requestType: .UPSERT)
+            if (!records.isEmpty) {
+                let objectTypes = getObjectTypes(recordRequests: recordRequests, requestType: .UPSERT)
+                let externalIdFieldNames = getExternalIdFieldName(recordRequests: recordRequests, requestType: .UPSERT)
+                
+                if (objectTypes.isEmpty || externalIdFieldNames.isEmpty) {
+                    // throw new SyncManager.MobileSyncException("Missing sobjectType or externalIdFieldName")
+                }
+                
+                if (Set(objectTypes).count > 1) {
+                    // throw new SyncManager.MobileSyncException("All records must have same sobjectType");
+                }
+                
+                let objectType = objectTypes.first!
+                let externalIdFieldName = externalIdFieldNames.first!
+                
+                return RestClient.shared.request(forCollectionUpsert: objectType, externalIdField: externalIdFieldName, allOrNone: allOrNone, records: records, apiVersion: nil)
+            }
+        case .DELETE:
+            return RestClient.shared.request(forCollectionDelete: getIds(recordRequests: recordRequests, requestType: .DELETE),
+                                             apiVersion: nil)
+        }
+        
+        return nil
     }
 }

--- a/libs/MobileSync/MobileSync/Classes/Util/CompositeRequestHelper.swift
+++ b/libs/MobileSync/MobileSync/Classes/Util/CompositeRequestHelper.swift
@@ -28,14 +28,14 @@
 import Foundation
 import SalesforceSDKCore
 
-typealias OnSendCompleteCallback =  ([String: RecordResponse]) -> ()
-typealias OnFailCallback = (Error) -> ()
+public typealias OnSendCompleteCallback =  ([String: RecordResponse]) -> ()
+public typealias OnFailCallback = (Error) -> ()
 
 @objc(SFCompositeRequestHelper)
-class CompositeRequestHelper:NSObject {
+public class CompositeRequestHelper:NSObject {
     // Send record requests using a composite batch request
     @objc
-    static func sendAsCompositeBatchRequest(_ syncManager: SyncManager, allOrNone: Bool, recordRequests: [RecordRequest], onComplete: @escaping OnSendCompleteCallback, onFail: @escaping OnFailCallback) {
+    public static func sendAsCompositeBatchRequest(_ syncManager: SyncManager, allOrNone: Bool, recordRequests: [RecordRequest], onComplete: @escaping OnSendCompleteCallback, onFail: @escaping OnFailCallback) {
         
         let request = RestClient.shared.compositeRequest(recordRequests.map { $0.asRestRequest()! },
                                                          refIds: recordRequests.map { $0.referenceId! },
@@ -58,7 +58,7 @@ class CompositeRequestHelper:NSObject {
         
     // Send record requests using sobject collection requests
     @objc
-    static func sendAsCollectionRequests(_ syncManager: SyncManager, allOrNone: Bool, recordRequests: [RecordRequest], onComplete: @escaping OnSendCompleteCallback, onFail: @escaping OnFailCallback)  {
+    public static func sendAsCollectionRequests(_ syncManager: SyncManager, allOrNone: Bool, recordRequests: [RecordRequest], onComplete: @escaping OnSendCompleteCallback, onFail: @escaping OnFailCallback)  {
         
 
         let group = DispatchGroup()
@@ -90,7 +90,7 @@ class CompositeRequestHelper:NSObject {
     
     // Return ref id to server id map if successful
     @objc
-    static func parseIdsFromResponses(_ refIdToRecordResponse:Dictionary<String, RecordResponse>) -> [String: String] {
+    public static func parseIdsFromResponses(_ refIdToRecordResponse:Dictionary<String, RecordResponse>) -> [String: String] {
         return refIdToRecordResponse
             .filter { _, response in response.objectId != nil }
             .mapValues { $0.objectId! }
@@ -98,7 +98,7 @@ class CompositeRequestHelper:NSObject {
     
     // Update id field with server id
     @objc
-    static func updateReferences(_ record: [String:Any], fieldWithRefId:String, refIdToServerId:[String: String]) -> [String:Any] {
+    public static func updateReferences(_ record: [String:Any], fieldWithRefId:String, refIdToServerId:[String: String]) -> [String:Any] {
         var updatedRecord = record // copy
         
         if let refId = record[fieldWithRefId] as? String, let serverId = refIdToServerId[refId] {
@@ -113,12 +113,12 @@ class CompositeRequestHelper:NSObject {
 // Response object abstracting away differences between /composite/batch and /commposite/sobject sub-responses
 //
 @objc(SFSDKRecordResponse)
-class RecordResponse: NSObject {
-    @objc let success: Bool
+public class RecordResponse: NSObject {
+    @objc public let success: Bool
     @objc let objectId: String?
-    @objc let recordDoesNotExist: Bool
-    @objc let relatedRecordDoesNotExist: Bool
-    @objc let errorJson: [String:Any]?
+    @objc public let recordDoesNotExist: Bool
+    @objc public let relatedRecordDoesNotExist: Bool
+    @objc public let errorJson: [String:Any]?
     @objc let json: Any
     
     private init(success:Bool, objectId:String?, recordDoesNotExist:Bool, relatedRecordDoesNotExist:Bool, errorJson: [String:Any]?, json:Any) {
@@ -188,8 +188,8 @@ enum RequestType: Int, CaseIterable {
 // Request object abstracting away differences between /composite/batch and /commposite/sobject sub-requests
 //
 @objc(SFSDKRecordRequest)
-class RecordRequest: NSObject {
-    @objc var referenceId: String?
+public class RecordRequest: NSObject {
+    @objc public var referenceId: String?
     @objc let requestType: RequestType
     @objc let objectType: String
     @objc let fields: [String:Any]?
@@ -246,22 +246,22 @@ class RecordRequest: NSObject {
     }
     
     @objc
-    static func requestForCreate(objectType:String, fields:[String:Any]) -> RecordRequest {
+    public static func requestForCreate(objectType:String, fields:[String:Any]) -> RecordRequest {
         return RecordRequest(requestType:.CREATE, objectType: objectType, fields: fields, objectId: nil, externalId: nil, externalIdFieldName: nil)
     }
 
     @objc
-    static func requestForUpdate(objectType:String, objectId:String, fields:[String:Any]) -> RecordRequest {
+    public static func requestForUpdate(objectType:String, objectId:String, fields:[String:Any]) -> RecordRequest {
         return RecordRequest(requestType:.UPDATE, objectType: objectType, fields: fields, objectId: objectId, externalId: nil, externalIdFieldName: nil)
     }
 
     @objc
-    static func requestForUpsert(objectType:String, externalIdFieldName:String, externalId:String, fields:[String:Any]) -> RecordRequest {
+    public static func requestForUpsert(objectType:String, externalIdFieldName:String, externalId:String, fields:[String:Any]) -> RecordRequest {
         return RecordRequest(requestType:.UPSERT, objectType: objectType, fields: fields, objectId: nil, externalId: externalId, externalIdFieldName: externalIdFieldName)
     }
 
     @objc
-    static func requestForDelete(objectType:String, objectId: String) -> RecordRequest {
+    public static func requestForDelete(objectType:String, objectId: String) -> RecordRequest {
         return RecordRequest(requestType:.DELETE, objectType: objectType, fields: nil, objectId: objectId, externalId: nil, externalIdFieldName: nil)
     }
     

--- a/libs/MobileSync/MobileSyncTests/SFSyncUpdateCallbackQueue.m
+++ b/libs/MobileSync/MobileSyncTests/SFSyncUpdateCallbackQueue.m
@@ -24,7 +24,7 @@
 
 #import "SFSyncUpdateCallbackQueue.h"
 
-#define MAX_WAIT_TIME 5.0
+#define MAX_WAIT_TIME 10.0
 
 @interface SFMobileSyncSyncManager()
 - (void) runSync:(SFSyncState*) sync updateBlock:(SFSyncSyncManagerUpdateBlock)updateBlock;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
@@ -61,6 +61,11 @@ extern NSInteger const kSFRestSOQLDefaultBatchSize NS_SWIFT_NAME(SFRestSOQLDefau
 extern NSString* const kSFRestQueryOptions NS_SWIFT_NAME(SFRestQueryOptions);
 
 /**
+ Other constants
+ */
+extern NSInteger const kSFRestCollectionRetrieveMaxSize NS_SWIFT_NAME(SFRestCollectionRetrieveMaxSize);
+
+/**
  * Main class used to issue REST requests to the standard Force.com REST API.
  * See the [Force.com REST API Developer's Guide](http://www.salesforce.com/us/developer/docs/api_rest/index.htm)
  * for more information regarding the Force.com REST API.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -46,6 +46,8 @@ NSInteger const kSFRestSOQLMinBatchSize = 200;
 NSInteger const kSFRestSOQLMaxBatchSize = 2000;
 NSInteger const kSFRestSOQLDefaultBatchSize = 2000;
 NSString* const kSFRestQueryOptions = @"Sforce-Query-Options";
+NSInteger const kSFRestCollectionRetrieveMaxSize = 2000;
+
 
 
 static BOOL kIsTestRun;

--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
@@ -393,7 +393,6 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
 
 - (NSString*)computeFieldReference:(NSString*) field {
     NSString* fieldRef = [@[@"{", self.soupName, @":", field, @"}"] componentsJoinedByString:@""];
-    [SFSDKSmartStoreLogger d:[self class] format:@"computeFieldReference: %@ --> %@", field, fieldRef];
     return fieldRef;
 }
 


### PR DESCRIPTION
During collection sync up, we no longer check records last modified date one at a time.
Instead we leverage sobject collection retrieve to get last modified date by batches of up to 2000.

SFAdvancedSyncUpTask and its super classes are project objective-c classes. So I made the changes needed there in objective-c. However CollectionSyncUpTarget is written in Swift so the new code to get last modified date using sobject collection retrieve is written in Swift.

Other changes in this PR:
- using short hand notations for array and dictionary (e.g. [String:String] instead of Dictionary<String, String>),
- RecordRequest and RecordResponse are no longer inner classes of CompositeRequestHelper,
- made changes in CompositeRequestHelper (from last PR) to fix compilation errors in templates.