### PR TITLE
Fix two factor login with screen lock.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
@@ -372,7 +372,7 @@ static NSString *const kSFScreenLockWindowKey = @"screenlock";
     UIScene *scene = window.window.windowScene;
     SFSDKWindowContainer *fallbackWindow = [self mainWindow:scene];
    
-    if (window.isSnapshotWindow) {
+    if (window.isSnapshotWindow || window.isScreenLockWindow) {
         NSString *sceneId = scene.session.persistentIdentifier;
         if ([_lastActiveWindows objectForKey:sceneId]) {
             fallbackWindow = [_lastActiveWindows objectForKey:sceneId];


### PR DESCRIPTION
This fixes the issue by correctly setting the fallback window to the last active window instead of the main window.  In this instance we will return to the auth webview after unlocking instead of going straight to the app and not being able to finish the login flow.  

The only awkwardness is you will see the lock screen twice in the fixed scenario: once for the original user on foreground and then again for the new user if they also require the lock.  I don't think it is worth adding extra logic to avoid this for what should be a one time flow.  Overall this is a much cleaner solution than the hack we added to the old system to never lock on auth screen and always lock after.  