### PR TITLE
@W-11296703 - Crash when writing event in analytics event store manager.

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
@@ -96,14 +96,26 @@
     if (encryptedData) {
         NSString *filename = [self filenameForEvent:eventCopy.eventId];
         NSString *parentDir = [filename stringByDeletingLastPathComponent];
-        [[NSFileManager defaultManager] createDirectoryAtPath:parentDir withIntermediateDirectories:YES attributes: @{ NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication } error:&error];
-        [encryptedData writeToFile:filename options:NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication error:&error];
+        NSFileManager *fileManager = [NSFileManager defaultManager];        
+        [fileManager createDirectoryAtPath:parentDir withIntermediateDirectories:YES attributes: @{ NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication } error:&error];
+        
         if (error) {
-            [SFSDKAnalyticsLogger w:[self class] format:@"Error occurred while writing to file: %@", error.localizedDescription];
-        } else {
-            @synchronized (self.eventCountMutex) {
-                self.numStoredEvents++;
+            [SFSDKAnalyticsLogger w:[self class] format:@"Error occurred while trying to create directory: %@", error.localizedDescription];
+            return;
+        }
+        
+        @try {
+            [encryptedData writeToFile:filename options:NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication error:&error];
+            if (error) {
+                [SFSDKAnalyticsLogger w:[self class] format:@"Error occurred while writing to file: %@", error.localizedDescription];
+            } else {
+                @synchronized (self.eventCountMutex) {
+                    self.numStoredEvents++;
+                }
             }
+        }
+        @catch (NSException *e) {
+            [SFSDKAnalyticsLogger w:[self class] format:@"Exception occurred while writing to file: %@", e.reason];
         }
     }
 }


### PR DESCRIPTION
Crash that is being reported through AppCenter with 179 users and 208 reports:

```
0   CoreFoundation          __exceptionPreprocess + 220
1   libobjc.A.dylib         objc_exception_throw + 56
2   Foundation              -[NSData(NSData) writeToFile:options:error:] + 308
3   SalesforceAnalytics     -[SFSDKEventStoreManager storeEvent:] (SFSDKEventStoreManager.m:100)
4   SalesforceSDKCore       +[SFSDKEventBuilderHelper createAndStoreEvent:userAccount:className:attributes:] (SFSDKEventBuilderHelper.m:64)
5   SalesforceSDKCore       -[SFUserAccountManager handleAnalyticsAddUserEvent:account:] (SFUserAccountManager.m:1707)
6   SalesforceSDKCore       -[SFUserAccountManager finalizeAuthCompletion:] (SFUserAccountManager.m:1637)
7   SalesforceSDKCore       __46-[SFUserAccountManager retrievedIdentityData:]_block_invoke (SFUserAccountManager.m:1553)
8   SalesforceSDKCore       -[SFSDKWindowManager makeTransparentWithCompletion:completion:] (SFSDKWindowManager.m:400)
9   SalesforceSDKCore       -[SFSDKWindowManager dismissWindow:animated:withCompletion:] (SFSDKWindowManager.m:359)
10  SalesforceSDKCore       -[SFSDKWindowContainer dismissWindowAnimated:withCompletion:] (SFSDKWindowContainer.m:101)
11  SalesforceSDKCore       -[SFUserAccountManager dismissAuthViewControllerIfPresentForScene:completion:] (SFUserAccountManager.m:621)
12  SalesforceSDKCore       -[SFUserAccountManager retrievedIdentityData:] (SFUserAccountManager.m:1551)
13  SalesforceSDKCore       -[SFUserAccountManager identityCoordinatorRetrievedData:] (SFUserAccountManager.m:773)
14  SalesforceSDKCore       __48-[SFIdentityCoordinator notifyDelegateOfSuccess]_block_invoke (SFIdentityCoordinator.m:200)
```

@bbirman @wmathurin @bhariharan 