### PR TITLE
Fix SalesforceSDKCommon release compile issue for Carthage

### DIFF
--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/xcshareddata/xcschemes/SalesforceSDKCommon.xcscheme
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon.xcodeproj/xcshareddata/xcschemes/SalesforceSDKCommon.xcscheme
@@ -22,7 +22,7 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">


### PR DESCRIPTION
`SalesforceSDKCommonTests` do not need to be built for running `SalesforceSDKCommon`.  