### PR TITLE
Set kdf_iter for current connection, not global default

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
@@ -199,12 +199,12 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
 
 + (FMDatabase*) unlockDatabase:(FMDatabase*)db key:(NSString*)key salt:(NSString *)salt {
     if ([db open]) {
-        // Using sqlcipher 2.x kdf iter because 3.x default (64000) and 4.x default (256000) are too slow
-        [[db executeQuery:@"PRAGMA cipher_default_kdf_iter = 4000"] close];
-       
         if (key)
            [db setKey:key];
         
+        // Using sqlcipher 2.x kdf iter because 3.x default (64000) and 4.x default (256000) are too slow
+        [[db executeQuery:@"PRAGMA kdf_iter = 4000"] close];
+
         // No longer doing pragma cipher_migrate - so a jump from Mobile SDK 7.0 (last version using 3.x) to Mobile SDK 10.0 won't work
         // Motivation: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3463#issuecomment-1006844543
         
@@ -342,7 +342,9 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
         [manager removeItemAtPath:encDbPath error:nil];
         return db;
     }
-    
+
+    [[db executeQuery:@"PRAGMA encrypted.kdf_iter = 4000"] close];
+
     // Use sqlcipher_export() to move the data from the input DB over to the new one.
     if (salt) {
         [[db executeQuery:@"PRAGMA encrypted.cipher_plaintext_header_size = 32"] close];


### PR DESCRIPTION
Using `PRAGMA cipher_default_kdf_iter` changes the global default value, which affects all databases opened from that point forward. This is dangerous when Mobile SDK is used in an application where any other code uses SQLCipher directly, as connections to those databases will unexpectedly have a non-default value for `kdf_iter`.

This change sets `kdf_iter` only for the specific database connection being opened. Per the SQLCipher docs, this needs to happen after the key is set.