### PR TITLE
Handle shareBrowserSessionIOS flag

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.h
@@ -35,6 +35,11 @@
 @property (nonatomic, readonly) BOOL useNativeBrowserForAuth;
 
 /**
+ Tells Mobile SDK  to share the native browser session for authentication.
+ */
+@property (nonatomic, readonly) BOOL shareBrowserSession;
+
+/**
  List of configured SSO URLs.
  */
 @property (nonatomic, strong, readonly, nullable) NSArray<NSString *> *ssoUrls;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.m
@@ -26,6 +26,7 @@
 
 static NSString * const kAuthConfigMobileSDKKey        = @"MobileSDK";
 static NSString * const kAuthConfigUseNativeBrowserKey = @"UseiOSNativeBrowserForAuthentication";
+static NSString * const kAuthConfigShareBrowserSession = @"shareBrowserSessionIOS";
 static NSString * const kAuthConfigSamlProvidersKey    = @"SamlProviders";
 static NSString * const kAuthConfigAuthProvidersKey    = @"AuthProviders";
 static NSString * const kAuthConfigSSOUrlKey           = @"SsoUrl";
@@ -52,6 +53,16 @@ static NSString * const kAuthConfigLoginPageUrlKey     = @"LoginPageUrl";
 
 - (BOOL)useNativeBrowserForAuth {
     return [self.authConfigDict[kAuthConfigMobileSDKKey][kAuthConfigUseNativeBrowserKey] boolValue];
+}
+
+- (BOOL)shareBrowserSession {
+    if ([self.authConfigDict[kAuthConfigMobileSDKKey] objectForKey:kAuthConfigShareBrowserSession] != nil) {
+        return [self.authConfigDict[kAuthConfigMobileSDKKey][kAuthConfigShareBrowserSession] boolValue];
+    } else {
+        // W-11606434 if shareBrowserSession value does not exist:
+        // - return true which ensures fallback behavior of prompt=login not being appended to login url
+        return true;
+    }
 }
 
 - (NSArray<NSString *> *)ssoUrls {


### PR DESCRIPTION
**Background:**

- For MyDomain an additional Auth Config: "shareBrowserSessionIOS" was added in: [W-11606434](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000014FkazYAC/view)

**Changes:**
To handle "shareBrowserSessionIOS",  `prompt=login` should be added to the approvalUrl when this setting is false, when setting is true nothing should be added to url. If `shareBrowserSessionIOS` is not present treat as true. 