### PR TITLE
Crashes in SFSDKCompositeResponse and SFSDKBatchResponse

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI+Blocks.m
@@ -63,15 +63,32 @@ static char SuccessBlockKey;
 
 - (void) sendCompositeRequest:(SFSDKCompositeRequest *)request failureBlock:(SFRestRequestFailBlock)failureBlock successBlock:(SFRestCompositeResponseBlock)successBlock {
     [self sendRequest:request failureBlock:failureBlock successBlock:^(id response, NSURLResponse * rawResponse) {
-        SFSDKCompositeResponse *compositeResponse = [[SFSDKCompositeResponse alloc] initWith:response];
-        successBlock(compositeResponse, rawResponse);
+        @try {
+            SFSDKCompositeResponse *compositeResponse = [[SFSDKCompositeResponse alloc] initWith:response];
+            successBlock(compositeResponse, rawResponse);
+        } @catch (NSException *exception) {
+            NSDictionary *userInfo = @{ @"Exception": exception.name, @"NSDebugDescription": exception.reason };
+            NSError *error = [[NSError alloc] initWithDomain: kSFRestErrorDomain
+                                                        code: kSFRestErrorCode
+                                                    userInfo:userInfo];
+            failureBlock(response, error, rawResponse);
+        }
     }];
 }
 
 - (void) sendBatchRequest:(SFSDKBatchRequest *)request failureBlock:(SFRestRequestFailBlock)failureBlock successBlock:(SFRestBatchResponseBlock)successBlock {
     [self sendRequest:request failureBlock:failureBlock successBlock:^(id response, NSURLResponse * rawResponse) {
-        SFSDKBatchResponse *compositeResponse = [[SFSDKBatchResponse alloc] initWith:response];
-        successBlock(compositeResponse, rawResponse);
+        @try {
+            SFSDKBatchResponse *compositeResponse = [[SFSDKBatchResponse alloc] initWith:response];
+            successBlock(compositeResponse, rawResponse);
+        } @catch (NSException *exception) {
+            
+            NSDictionary *userInfo = @{ @"Exception": exception.name, @"NSDebugDescription": exception.reason };
+            NSError *error = [[NSError alloc] initWithDomain: kSFRestErrorDomain
+                                                        code: kSFRestErrorCode
+                                                    userInfo:userInfo];
+            failureBlock(response, error, rawResponse);
+        }
     }];
 }
 


### PR DESCRIPTION
### What?
Fix invalid argument exception in SFSDKCompositeResponse and SFSDKBatchResponse.
Fixes: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/3568

### How?
Add try-catch block to handle invalid argument exceptions in SFSDKCompositeResponse and SFSDKBatchResponse.