### PR TITLE
Using prompt=login during advanced authentication so that user must re-enter credentials

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -171,7 +171,7 @@
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 strongSelf.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];
                 [strongSelf notifyDelegateOfBeginAuthentication];
-                [strongSelf beginNativeBrowserFlow];
+                [strongSelf beginNativeBrowserFlowWithSharedBrowserSessionEnabled:false];
             });
         } else {
             [SFSDKAuthConfigUtil getMyDomainAuthConfig:^(SFOAuthOrgAuthConfiguration *authConfig, NSError *error) {
@@ -183,7 +183,7 @@
                         [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureSafariBrowserForLogin];
                         strongSelf.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];
                         [strongSelf notifyDelegateOfBeginAuthentication];
-                        [strongSelf beginNativeBrowserFlow];
+                        [strongSelf beginNativeBrowserFlowWithSharedBrowserSessionEnabled:authConfig.shareBrowserSession];
                     } else {
                         [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureSafariBrowserForLogin];
                         [strongSelf notifyDelegateOfBeginAuthentication];
@@ -341,24 +341,24 @@
     }
 }
 
-- (void)beginNativeBrowserFlow {
+- (void)beginNativeBrowserFlowWithSharedBrowserSessionEnabled:(BOOL)shareBrowserSession {
     if ([self.delegate respondsToSelector:@selector(oauthCoordinator:willBeginBrowserAuthentication:)]) {
         __weak typeof(self) weakSelf = self;
         [self.delegate oauthCoordinator:self willBeginBrowserAuthentication:^(BOOL proceed) {
             if (proceed) {
-                [weakSelf continueNativeBrowserFlow];
+                [weakSelf continueNativeBrowserFlowWithSharedBrowserSessionEnabled:shareBrowserSession];
             }
         }];
     } else {
         // If delegate does not implement the method, simply continue with the browser flow.
-        [self continueNativeBrowserFlow];
+        [self continueNativeBrowserFlowWithSharedBrowserSessionEnabled:shareBrowserSession];
     }
 }
 
-- (void)continueNativeBrowserFlow {
+- (void)continueNativeBrowserFlowWithSharedBrowserSessionEnabled:(BOOL)shareBrowserSession {
     if (![NSThread isMainThread]) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self continueNativeBrowserFlow];
+            [self continueNativeBrowserFlowWithSharedBrowserSessionEnabled:shareBrowserSession];
         });
         return;
     }
@@ -369,6 +369,9 @@
                                                   domain:nil];
     approvalUrl = [NSString stringWithFormat:@"%@&state=%@", approvalUrl, self.credentials.identifier];
     
+    if (!shareBrowserSession) {
+        approvalUrl = [NSString stringWithFormat:@"%@&prompt=login", approvalUrl];
+    }
     
     // Launch the native browser.
     [SFSDKCoreLogger d:[self class] format:@"%@: Initiating native browser flow with URL %@", NSStringFromSelector(_cmd), approvalUrl];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.h
@@ -35,6 +35,11 @@
 @property (nonatomic, readonly) BOOL useNativeBrowserForAuth;
 
 /**
+ Tells Mobile SDK  to share the native browser session for authentication.
+ */
+@property (nonatomic, readonly) BOOL shareBrowserSession;
+
+/**
  List of configured SSO URLs.
  */
 @property (nonatomic, strong, readonly, nullable) NSArray<NSString *> *ssoUrls;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthOrgAuthConfiguration.m
@@ -26,6 +26,7 @@
 
 static NSString * const kAuthConfigMobileSDKKey        = @"MobileSDK";
 static NSString * const kAuthConfigUseNativeBrowserKey = @"UseiOSNativeBrowserForAuthentication";
+static NSString * const kAuthConfigShareBrowserSession = @"shareBrowserSessionIOS";
 static NSString * const kAuthConfigSamlProvidersKey    = @"SamlProviders";
 static NSString * const kAuthConfigAuthProvidersKey    = @"AuthProviders";
 static NSString * const kAuthConfigSSOUrlKey           = @"SsoUrl";
@@ -52,6 +53,15 @@ static NSString * const kAuthConfigLoginPageUrlKey     = @"LoginPageUrl";
 
 - (BOOL)useNativeBrowserForAuth {
     return [self.authConfigDict[kAuthConfigMobileSDKKey][kAuthConfigUseNativeBrowserKey] boolValue];
+}
+
+- (BOOL)shareBrowserSession {
+    if ([self.authConfigDict[kAuthConfigMobileSDKKey] objectForKey:kAuthConfigShareBrowserSession] != nil) {
+        return [self.authConfigDict[kAuthConfigMobileSDKKey][kAuthConfigShareBrowserSession] boolValue];
+    } else {
+        // return false which means prompt=login being appended to login url
+        return false;
+    }
 }
 
 - (NSArray<NSString *> *)ssoUrls {


### PR DESCRIPTION
Previously if a user did a logout followed by a login, they would go straight to the allow/deny screen. 

Changes were made initially in the internal fork of the Mobile SDK (see [here](https://git.soma.salesforce.com/iOS/SalesforceMobileSDK-iOS/pull/892)).

Configurable through auth config.