### PR TITLE
Force transitive dependencies to an ARC compatible version + make internal swift public

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
@@ -28,17 +28,23 @@
 import Foundation
 import LocalAuthentication
 
+/*
+ * This class is internal to the Mobile SDK - don't instantiate in your application code
+ * It's only public to be visible from the obj-c code when the library is compiled as a framework
+ * See https://developer.apple.com/documentation/swift/importing-swift-into-objective-c#Import-Code-Within-a-Framework-Target
+ */
+
 @objc(SFBiometricAuthenticationManagerInternal)
-internal class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenticationManager {
-    @objc internal static let shared = BiometricAuthenticationManagerInternal()
+public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenticationManager {
+    @objc public static let shared = BiometricAuthenticationManagerInternal()
     
-    var enabled: Bool {
+    public var enabled: Bool {
         get {
             return readBioAuhPolicy()?.hasPolicy ?? false
         }
     }
     
-    var locked = false
+    public var locked = false
     
     internal var backgroundTimestamp: Double = 0
     // This is a local var so it can be stubbed for tests
@@ -57,7 +63,7 @@ internal class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthen
     }
     
     /// Locks the screen if necessary
-    @objc internal func handleAppForeground() {
+    @objc public func handleAppForeground() {
         if shouldLock() {
             lock()
         }
@@ -74,7 +80,7 @@ internal class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthen
         return false
     }
     
-    @objc func storePolicy(userAccount: UserAccount, hasMobilePolicy: Bool, sessionTimeout: Int32) {
+    @objc public func storePolicy(userAccount: UserAccount, hasMobilePolicy: Bool, sessionTimeout: Int32) {
         let policyData = try! JSONEncoder().encode(
             BioAuthPolicy(hasPolicy: hasMobilePolicy, timeout: sessionTimeout)
         )
@@ -121,7 +127,7 @@ internal class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthen
         return nil
     }
     
-    func lock() {
+    public func lock() {
         locked = true
         NotificationCenter.default.post(name: Notification.Name(rawValue: kSFBiometricAuthenticationFlowWillBegin), object: nil)
         
@@ -138,18 +144,18 @@ internal class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthen
         }
     }
     
-    func biometricOptIn(optIn: Bool) {
+    public func biometricOptIn(optIn: Bool) {
         if var policy = readBioAuhPolicy() {
             policy.optIn = optIn
             storePolicy(policy: policy)
         }
     }
     
-    func hasBiometricOptedIn() -> Bool {
+    public func hasBiometricOptedIn() -> Bool {
         return readBioAuhPolicy()?.optIn ?? false
     }
     
-    func presentOptInDialog(viewController: UIViewController) {
+    public func presentOptInDialog(viewController: UIViewController) {
         let dialog = UIAlertController(title: SFSDKResourceUtils.localizedString("bioOptInPromptTitle"), message: SFSDKResourceUtils.localizedString("bioOptInPromptMessage"), preferredStyle: .alert)
         let enableAction = UIAlertAction(title: SFSDKResourceUtils.localizedString("bioPromptEnable"), style: .default) { _ in
             self.biometricOptIn(optIn: true)
@@ -162,14 +168,14 @@ internal class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthen
         viewController.present(dialog, animated: true)
     }
     
-    func enableNativeBiometricLoginButton(enabled: Bool) {
+    public func enableNativeBiometricLoginButton(enabled: Bool) {
         if var policy = readBioAuhPolicy() {
             policy.nativeLoginButton = enabled
             storePolicy(policy: policy)
         }
     }
     
-    @objc func showNativeLoginButton() -> Bool {
+    @objc public func showNativeLoginButton() -> Bool {
         var error: NSError?
         if (!laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)) {
             return false
@@ -185,12 +191,12 @@ internal class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthen
         return false
     }
     
-    @objc func cleanup(user: UserAccount) {
+    @objc public func cleanup(user: UserAccount) {
         _ = KeychainHelper.remove(service: kBioAuthPolicyIdentifier, account: user.idData.userId)
         locked = false
     }
     
-    @objc func checkForPolicy(userId: String) -> Bool {
+    @objc public func checkForPolicy(userId: String) -> Bool {
         let result = KeychainHelper.read(service: kBioAuthPolicyIdentifier, account: userId)
         if let data = result.data, result.success {
             do {
@@ -203,7 +209,7 @@ internal class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthen
         return false
     }
     
-    @objc func presentBiometric(scene: UIScene) {
+    @objc public func presentBiometric(scene: UIScene) {
         laContext.localizedCancelTitle = SFSDKResourceUtils.localizedString("usePassword")
         var error: NSError?
         if (laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)) {
@@ -236,7 +242,7 @@ internal class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthen
         }
     }
     
-    @objc func unlockPostProcessing() {
+    @objc public func unlockPostProcessing() {
         self.locked = false
         NotificationCenter.default.post(name: Notification.Name(rawValue: kSFBiometricAuthenticationFlowCompleted), object: nil)
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockManagerInternal.swift
@@ -29,17 +29,23 @@ import Foundation
 import SwiftUI
 
 // Callback block used to launch the app when the screen is unlocked.
-internal typealias ScreenLockCallbackBlock = () -> Void
+public typealias ScreenLockCallbackBlock = () -> Void
+
+/*
+ * This class is internal to the Mobile SDK - don't instantiate in your application code
+ * It's only public to be visible from the obj-c code when the library is compiled as a framework
+ * See https://developer.apple.com/documentation/swift/importing-swift-into-objective-c#Import-Code-Within-a-Framework-Target
+ */
 
 @objc(SFScreenLockManagerInternal)
-internal class ScreenLockManagerInternal: NSObject, ScreenLockManager {
-    var enabled: Bool {
+public class ScreenLockManagerInternal: NSObject, ScreenLockManager {
+    public var enabled: Bool {
         get {
             return (getTimeout() != nil)
         }
     }
     
-    @objc internal static let shared = ScreenLockManagerInternal()
+    @objc public static let shared = ScreenLockManagerInternal()
     
     private let kScreenLockIdentifier = "com.salesforce.security.screenlock"
     private var callbackBlock: ScreenLockCallbackBlock? = nil
@@ -57,7 +63,7 @@ internal class ScreenLockManagerInternal: NSObject, ScreenLockManager {
     // MARK: Screen Lock Manager
     
     /// Locks the screen if necessary
-    @objc func handleAppForeground() {
+    @objc public func handleAppForeground() {
         if let policyTimeout = getTimeout(), lockTimeoutExpired(lockTimeout: policyTimeout) {
             lock()
         } else {
@@ -75,7 +81,7 @@ internal class ScreenLockManagerInternal: NSObject, ScreenLockManager {
     ///   - userAccount: The user account
     ///   - hasMobilePolicy: Whether the user has a mobile policy
     @available(*, deprecated, renamed: "storeMobilePolicy(userAccount:hasMobilePolicy:lockTimeout:)")
-    @objc func storeMobilePolicy(userAccount: UserAccount, hasMobilePolicy: Bool) {
+    @objc public func storeMobilePolicy(userAccount: UserAccount, hasMobilePolicy: Bool) {
         storeMobilePolicy(userAccount: userAccount, hasMobilePolicy: hasMobilePolicy, lockTimeout: 1)
     }
     
@@ -85,7 +91,7 @@ internal class ScreenLockManagerInternal: NSObject, ScreenLockManager {
     ///   - userAccount: The user account
     ///   - hasMobilePolicy: Whether the user has a mobile policy
     ///   - lockTimeout: The length of time in minutes before the app will be locked after backgrounding
-    @objc func storeMobilePolicy(userAccount: UserAccount, hasMobilePolicy: Bool, lockTimeout: Int32) {
+    @objc public func storeMobilePolicy(userAccount: UserAccount, hasMobilePolicy: Bool, lockTimeout: Int32) {
         let hasPolicyData = try! JSONEncoder().encode(MobilePolicy(hasPolicy: hasMobilePolicy, timeout: lockTimeout))
         let result = KeychainHelper.write(service: kScreenLockIdentifier, data: hasPolicyData, account: userAccount.idData.userId)
         if result.success {
@@ -109,12 +115,12 @@ internal class ScreenLockManagerInternal: NSObject, ScreenLockManager {
     ///
     /// - Parameters:
     ///   -  screenLockCallbackBlock: The block to be run upon unlock
-    @objc func setCallbackBlock(screenLockCallbackBlock: @escaping ScreenLockCallbackBlock) {
+    @objc public func setCallbackBlock(screenLockCallbackBlock: @escaping ScreenLockCallbackBlock) {
         callbackBlock = screenLockCallbackBlock
     }
     
     /// Checks all users for Screen Lock policy and removes global policy if none are found.
-    @objc func checkForScreenLockUsers() {
+    @objc public func checkForScreenLockUsers() {
         guard getTimeout() != nil else {
             return
         }
@@ -142,7 +148,7 @@ internal class ScreenLockManagerInternal: NSObject, ScreenLockManager {
     
     // TODO: Remove in Mobile SDK 12.0
     /// Upgrades from SFSecurityLockout to ScreenLockManager
-    @objc func upgradePasscode() {
+    @objc public func upgradePasscode() {
         let userAccounts = UserAccountManager.shared.userAccounts()
         
         userAccounts?.forEach({ account in
@@ -215,7 +221,7 @@ internal class ScreenLockManagerInternal: NSObject, ScreenLockManager {
         unlockPostProcessing()
     }
     
-    func lock() {
+    public func lock() {
         if !Thread.isMainThread {
             DispatchQueue.main.async {
                 self.lock()
@@ -238,7 +244,7 @@ internal class ScreenLockManagerInternal: NSObject, ScreenLockManager {
         }
     }
 
-    @objc func checkForPolicy(userId: String) -> Bool {
+    @objc public func checkForPolicy(userId: String) -> Bool {
         return readMobilePolicy(id: userId)?.hasPolicy ?? false
     }
     

--- a/mobilesdk_pods.rb
+++ b/mobilesdk_pods.rb
@@ -55,14 +55,26 @@ def signposts_post_install(installer)
   end
 end
 
-# Post Install: Keeping Mobile SDK deployement target at 14 (__apply_Xcode_12_5_M1_post_install_workaround changes it to 11)
+# Post Install: fix deployment targets
 def mobile_sdk_post_install(installer)
   installer.pods_project.targets.each do |target|
-    if ['SalesforceAnalytics', 'SalesforceSDKCommon', 'SalesforceSDKCore', 'SmartStore', 'MobileSync', 'SalesforceReact'].include?(target.name)
-      target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.0'
-      end
+    # ARC code targeting iOS 8 does not build on Xcode 14.3. Force to at least iOS 9.
+    force_to_arc_supported_min = target.deployment_target[/\d+/].to_i < 9
+    if force_to_arc_supported_min
+      change_deployment_target(target, '9.0')
     end
+    
+    # Mobile SDK targets
+    is_mobile_sdk_target = ['SalesforceAnalytics', 'SalesforceSDKCommon', 'SalesforceSDKCore', 'SmartStore', 'MobileSync', 'SalesforceReact', 'FMDB'].include?(target.name)
+    if is_mobile_sdk_target
+      change_deployment_target(target, '14.0')
+    end
+  end
+end
+
+def change_deployment_target(target, deployment_target)
+  target.build_configurations.each do |config|
+    config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = deployment_target
   end
 end
 


### PR DESCRIPTION
Xcode 14.3 (released March 30, 2023) stopped building automatic reference counted (ARC) code targeting < iOS 9 or < macOS 10.11 by removing a libarclite_* library from the toolchain that was needed to link for these older targets.

Force transitive dependencies to a minimum version of at least iOS 9 or macOS 10.11.