### PR TITLE
New tests where we query soup elements with non-ascii characters

### DIFF
--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
@@ -390,6 +390,68 @@
     [self assertSameJSONArrayWithExpected:[SFJsonUtils objectFromJSONString:@"[[\"00020\"],[\"00060\"],[\"00070\"],[\"00310\"],[\"102\"]]"] actual:result message:@"Wrong result"];
 }
 
+ // Test running smart queries matching non-ASCII characters in String field
+- (void) testSmartQueryMachingNonAsciiInStringField
+{
+    // Creating another employee from a json string with first name using non-ascii characters (Turkish)
+    [self createEmployeeWithJsonString:@"{\"employeeId\":\"101\",\"firstName\":\"Göktuğ\"}"];
+
+    // Creating another employee from a json string with first name using non-ascii characters (Korean)
+    [self createEmployeeWithJsonString:@"{\"employeeId\":\"102\",\"firstName\":\"보배\"}"];
+
+    // Smart sql looking for first name containing a certain non-ASCII character (ğ)
+    SFQuerySpec* querySpec = [SFQuerySpec newSmartQuerySpec:@"select {employees:employeeId} from {employees} where {employees:firstName} like '%ğ%'" withPageSize:10];
+    NSArray* result = [self.store queryWithQuerySpec:querySpec pageIndex:0  error:nil];
+    [self assertSameJSONArrayWithExpected:[SFJsonUtils objectFromJSONString:@"[[\"101\"]]"] actual:result message:@"Wrong result"];
+
+    // Smart sql looking for first name containing a certain non-ASCII character (배)
+    querySpec = [SFQuerySpec newSmartQuerySpec:@"select {employees:employeeId} from {employees} where {employees:firstName} like '%배%'" withPageSize:10];
+    result = [self.store queryWithQuerySpec:querySpec pageIndex:0  error:nil];
+    [self assertSameJSONArrayWithExpected:[SFJsonUtils objectFromJSONString:@"[[\"102\"]]"] actual:result message:@"Wrong result"];
+}
+
+// Test running smart queries matching non-ASCII characters in Json1 field
+- (void) testSmartQueryMachingNonAsciiInJSON1Field
+{
+    // Creating another employee from a json string with education using non-ascii characters (Turkish)
+    [self createEmployeeWithJsonString:@"{\"employeeId\":\"101\",\"education\":\"latince uzmanı\"}"];
+
+    // Creating another employee from a json string with education using non-ascii characters (Korean)
+    [self createEmployeeWithJsonString:@"{\"employeeId\":\"102\",\"education\":\"라틴어 전문가\"}"];
+
+    // Smart sql looking for education containing a certain non-ASCII character (ı)
+    SFQuerySpec* querySpec = [SFQuerySpec newSmartQuerySpec:@"select {employees:employeeId} from {employees} where {employees:education} like '%ı%'" withPageSize:10];
+    NSArray* result = [self.store queryWithQuerySpec:querySpec pageIndex:0  error:nil];
+    [self assertSameJSONArrayWithExpected:[SFJsonUtils objectFromJSONString:@"[[\"101\"]]"] actual:result message:@"Wrong result"];
+
+    // Smart sql looking for education containing a certain non-ASCII character (문)
+    querySpec = [SFQuerySpec newSmartQuerySpec:@"select {employees:employeeId} from {employees} where {employees:education} like '%문%'" withPageSize:10];
+    result = [self.store queryWithQuerySpec:querySpec pageIndex:0  error:nil];
+    [self assertSameJSONArrayWithExpected:[SFJsonUtils objectFromJSONString:@"[[\"102\"]]"] actual:result message:@"Wrong result"];
+}
+
+
+ // Test running smart queries matching non-ASCII characters in non-indexed field
+- (void) testSmartQueryMachingNonAsciiInNonIndexedField
+{
+    // Creating another employee from a json string with country using non-ascii characters (Turkish)
+    [self createEmployeeWithJsonString:@"{\"employeeId\":\"101\",\"country\":\"Türkçe\"}"];
+
+    // Creating another employee from a json string with country using non-ascii characters (Korean)
+    [self createEmployeeWithJsonString:@"{\"employeeId\":\"102\",\"country\":\"한국\"}"];
+
+    // Smart sql looking for country containing a certain non-ASCII character (ç)
+    SFQuerySpec* querySpec = [SFQuerySpec newSmartQuerySpec:@"select {employees:employeeId} from {employees} where {employees:country} like '%ç%'" withPageSize:10];
+    NSArray* result = [self.store queryWithQuerySpec:querySpec pageIndex:0  error:nil];
+    [self assertSameJSONArrayWithExpected:[SFJsonUtils objectFromJSONString:@"[[\"101\"]]"] actual:result message:@"Wrong result"];
+
+    // Smart sql looking for country containing a certain non-ASCII character (국)
+    querySpec = [SFQuerySpec newSmartQuerySpec:@"select {employees:employeeId} from {employees} where {employees:country} like '%국%'" withPageSize:10];
+    result = [self.store queryWithQuerySpec:querySpec pageIndex:0  error:nil];
+    [self assertSameJSONArrayWithExpected:[SFJsonUtils objectFromJSONString:@"[[\"102\"]]"] actual:result message:@"Wrong result"];
+
+}
+
 - (void)testSmartQueryFilteringByNonIndexedField {
     [self createEmployeeWithJsonString:@"{\"employeeId\":\"101\",\"address\":{\"city\":\"San Francisco\", \"zipcode\":94105}}"];
     [self createEmployeeWithJsonString:@"{\"employeeId\":\"102\",\"address\":{\"city\":\"New York City\", \"zipcode\":10004}}"];


### PR DESCRIPTION
Three new tests:
- non-ascii characters in string indexed field, 
- non-ascii characters in json1 indexed field, 
- non-ascii characters in non-indexed field.