### PR TITLE
Use my domain from 'Use custom domain'

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly, nullable) NSURLSession *session;
 @property (nonatomic, strong , nullable) NSMutableData *responseData;
 @property (nonatomic, assign) BOOL initialRequestLoaded;
+@property (nonatomic, assign) BOOL domainUpdated;
 @property (nonatomic, copy) NSString *approvalCode;
 @property (nonatomic, strong, nullable) WKWebView *view;
 @property (nonatomic, strong, nullable) NSString *codeVerifier;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -763,9 +763,22 @@
         if (bioAuthManager.locked && bioAuthManager.hasBiometricOptedIn) {
             [bioAuthManager presentBiometricWithScene:self.view.window.windowScene];
         }
+    } else if (!self.domainUpdated && [self shouldUpdateDomain:url]) {
+        // To support case where my domain is entered through "Use Custom Domain"
+        self.domainUpdated = YES;
+        decisionHandler(WKNavigationActionPolicyCancel);
+        [self stopAuthentication];
+        self.credentials.domain = url.host;
+        [self authenticate];
     } else {
         decisionHandler(WKNavigationActionPolicyAllow);
     }
+}
+
+- (BOOL)shouldUpdateDomain:(NSURL *)webviewURL {
+    NSURL *currentDomain = [NSURL URLWithString:self.credentials.domain];
+    NSString *myDomainSuffix = @".my.salesforce.com";
+    return (![currentDomain.host hasSuffix:myDomainSuffix] && [webviewURL.host hasSuffix:myDomainSuffix]);
 }
 
 - (void)webView:(WKWebView *)webView decidePolicyForNavigationResponse:(WKNavigationResponse *)navigationResponse decisionHandler:(void (^)(WKNavigationResponsePolicy))decisionHandler {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -330,8 +330,8 @@ NSException * SFOAuthInvalidIdentifierException() {
 }
 
 - (NSURL *)overrideDomainIfNeeded {
-    NSString *refreshDomain = self.communityId ? self.communityUrl.absoluteString : self.domain;
-    NSString *protocolHost = self.communityId ? refreshDomain : [NSString stringWithFormat:@"%@://%@", self.protocol, refreshDomain];
+    NSString *domain = self.communityId ? self.communityUrl.absoluteString : self.domain;
+    NSString *protocolHost = self.communityId ? domain : [NSString stringWithFormat:@"%@://%@", self.protocol, domain];
     return [NSURL URLWithString:protocolHost];
 }
 


### PR DESCRIPTION


https://github.com/forcedotcom/SalesforceMobileSDK-iOS/assets/840431/ee643b7d-d85f-4cf7-ace3-4b49dfda6d60



Test cases so far: 
- “Use custom domain” with advanced auth enabled
- “Use custom domain” with  advanced auth disabled
- “Use custom domain” with invalid my domain
- Host picker with advanced auth enabled
- Host picker with advanced auth disabled
- Host picker with invalid my domain