### PR TITLE
Fix nav bar color for RestAPIExplorer

### DIFF
--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/RootViewController.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/ViewControllers/RootViewController.swift
@@ -140,13 +140,18 @@ class RootViewController: UIViewController {
                                                name: NSNotification.Name(rawValue: kSFScreenLockFlowWillBegin),
                                                object: nil)
         
-        self.navigationController?.navigationBar.barTintColor = UIColor.appDarkBlue
-        self.navigationController?.navigationBar.isTranslucent = false
-        
         guard let font = UIFont.appRegularFont(20) else {
             return
         }
-        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white, NSAttributedString.Key.font: font]
+        let navBarAppearance = UINavigationBarAppearance()
+        navBarAppearance.backgroundColor = UIColor.appDarkBlue
+        navBarAppearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white, NSAttributedString.Key.font: font]
+
+        self.navigationController?.navigationBar.scrollEdgeAppearance = navBarAppearance;
+        self.navigationController?.navigationBar.compactAppearance = navBarAppearance;
+        self.navigationController?.navigationBar.standardAppearance = navBarAppearance;
+        self.navigationController?.navigationBar.compactScrollEdgeAppearance = navBarAppearance;
+     
         self.title = "RestAPI Explorer"
         
         guard let leftImage = UIImage(named: "list")?.withRenderingMode(.alwaysOriginal), let _ = UIImage(named: "search")?.withRenderingMode(.alwaysOriginal) else {


### PR DESCRIPTION
Before:
<img width="568" alt="nav bar before" src="https://github.com/forcedotcom/SalesforceMobileSDK-iOS/assets/840431/45d7453f-2612-468d-9f6d-241d74c6397f">

After:
<img width="568" alt="nav bar after" src="https://github.com/forcedotcom/SalesforceMobileSDK-iOS/assets/840431/8b3b88f5-edba-45a3-b329-b258dccde753">
