### PR TITLE
Using resources by version call to rehydrate session

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
@@ -154,6 +154,11 @@ NS_SWIFT_NAME(RestClient)
 - (SFRestRequest *)requestForLimits:(nullable NSString *)apiVersion;
 
 /**
+ * Returns an `SFRestRequest` object for a cheap request to re-hydrate the access token
+ */
+- (SFRestRequest *)cheapRequest:(nullable NSString *)apiVersion;
+
+/**
  * Returns an `SFRestRequest` object that lists available resources for the
  * client's API version, including resource name and URI.
  * @param apiVersion API version.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -499,6 +499,11 @@ static dispatch_once_t pred;
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];
 }
 
+- (SFRestRequest *)cheapRequest:(NSString *)apiVersion {
+    return [self requestForResources:apiVersion];
+}
+
+
 - (SFRestRequest *)requestForResources:(NSString *)apiVersion {
     NSString *path = [NSString stringWithFormat:@"/%@", [self computeAPIVersion:apiVersion]];
     return [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -962,7 +962,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     // Make sure access token is not expired
     __weak typeof (self) weakSelf = self;
     SFOAuthCredentials *spAppCredentials = [self spAppCredentials:spAppOptions];
-    SFRestRequest *request = [[SFRestAPI sharedInstanceWithUser:user] requestForLimits:nil];
+    SFRestRequest *request = [[SFRestAPI sharedInstanceWithUser:user] cheapRequest:nil];
     [[SFRestAPI sharedInstanceWithUser:user] sendRequest:request failureBlock:^(id response, NSError *error, NSURLResponse *rawResponse) {
         failureBlock(error);
     } successBlock:^(id response, NSURLResponse *rawResponse) {


### PR DESCRIPTION
It's faster than limits and is also available to all API users