### PR TITLE
Fix issue with LAContext.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
@@ -210,6 +210,7 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
     }
     
     @objc public func presentBiometric(scene: UIScene) {
+        let laContext = LAContext()
         laContext.localizedCancelTitle = SFSDKResourceUtils.localizedString("usePassword")
         var error: NSError?
         if (laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)) {


### PR DESCRIPTION
There appears to be a bug with iOS and/or `LAContext` where `evaluatePolicy` will instantly return success without actually prompting the user.  I have only ever seen this on iOS 17.1.2 (I cannot repro today on iOS 16) but there are reports online of this behavior going all the way back to iOS 13.  

This isn't a patch worthy issue in my opinion since it only occurs when `evaluatePolicy` was called recently and is still in memory.  The default timeout for Bio Auth (and shortest possible timeout for token refresh) of 15 minutes is too long for this bug to show.  The issue also never shows on cold boot, regardless of timing.  Passcode is unaffected.  