### PR TITLE
@W-15631761 - Fix for Privacy Manifest Warning (#905)

### DIFF
--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/PrivacyInfo.xcprivacy
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/PrivacyInfo.xcprivacy
@@ -12,14 +12,8 @@
 				<string>CA92.1</string>
 			</array>
 		</dict>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string></string>
-		</dict>
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
-	<key>NSPrivacyCollectedDataTypes</key>
-	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
(cherry picked from commit 3c55bdc3df06fa18617bb39fb466b7692d78a0e1)

Salesforce App received the following warning when submitting to the App Store: 
```
ITMS-91056: Invalid privacy manifest - The PrivacyInfo.xcprivacy file from the following path is invalid: 
“Frameworks/SalesforceSDKCommon.framework/PrivacyInfo.xcprivacy”. While no action is required at this time, 
starting May 1, 2024, when you upload a new app or app update, keys and values in your app’s privacy 
manifest must be in a valid format. For more details about privacy manifest files, visit: 
https://developer.apple.com/documentation/bundleresources/privacy_manifest_files.
```

The change in this PR was submitted to the App Store, and did not generate a warning for SalesforceSDKCommon.

I assume this warning was due to the second item in `NSPrivacyAccessedAPITypes` being an empty string.

I also removed the empty array of `NSPrivacyCollectedDataTypes` based on this StackOverflow answer: [Missing an expected key: 'NSPrivacyCollectedDataTypes'](https://stackoverflow.com/questions/78223324/missing-an-expected-key-nsprivacycollecteddatatypes)

cc: @bbirman 