### PR TITLE
Reduce loading of AILTN events at app background

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.h
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.h
@@ -67,6 +67,13 @@ typedef NSData * _Nullable (^ _Nullable DataDecryptorBlock)(NSData * _Nullable d
 - (void) storeEvents:(nullable NSArray<SFSDKInstrumentationEvent *> *) events;
 
 /**
+ * Returns all the event files stored on the filesystem for that unique identifier.
+ *
+ * @return List of event files.
+ */
+- (NSArray<SFSDKInstrumentationEvent *> *) eventFiles;
+
+/**
  * Returns a specific event stored on the filesystem.
  *
  * @param eventId Unique identifier for the event.
@@ -98,5 +105,10 @@ typedef NSData * _Nullable (^ _Nullable DataDecryptorBlock)(NSData * _Nullable d
  * Deletes all the events stored on the filesystem for that unique identifier.
  */
 - (void) deleteAllEvents;
+
+/**
+ * Lets callers know if they _can_ store an event (optimization, so they wouldn't have to build and call -store: unnecessarily).
+ */
+- (BOOL) shouldStoreEvent;
 
 @end

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
@@ -120,6 +120,10 @@
     }
 }
 
+- (NSArray<SFSDKInstrumentationEvent *> *) eventFiles {
+    return [[NSFileManager defaultManager] contentsOfDirectoryAtPath:self.storeDirectory error:nil];
+}
+
 - (SFSDKInstrumentationEvent *) fetchEvent:(NSString *) eventId {
     if (!eventId) {
         return nil;
@@ -129,7 +133,7 @@
 }
 
 - (NSArray<SFSDKInstrumentationEvent *> *) fetchAllEvents {
-    NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:self.storeDirectory error:nil];
+    NSArray *files = [self eventFiles];
     NSMutableArray *events = [[NSMutableArray alloc] init];
     for (NSString *file in files) {
         SFSDKInstrumentationEvent *event = [self fetchEventFromFile:[self filenameForEvent:file]];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.h
@@ -47,6 +47,14 @@
 @property (nonatomic, readwrite, assign, getter=isLoggingEnabled) BOOL loggingEnabled;
 
 /**
+ * Disables or enables batch processing of events.
+ *
+ * @discussion If batching is enabled, publishing of events will happen in smaller chunks
+ */
+@property (nonatomic, readwrite, assign, getter=isBatchingEnabled) BOOL batchingEnabled;
+
+
+/**
  * Returns an instance of this class associated with the specified user account.
  *
  * @param userAccount User account.
@@ -115,5 +123,11 @@
  * Updates the preferences of this library.
  */
 - (void) updateLoggingPrefs;
+
+
+/**
+ * Clears unpublished events.
+ */
+- (void) clearAllEvents;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.h
@@ -124,10 +124,4 @@
  */
 - (void) updateLoggingPrefs;
 
-
-/**
- * Clears unpublished events.
- */
-- (void) clearAllEvents;
-
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -52,6 +52,8 @@ static NSString * const kEventStoreGCMEncryptedKey = @"com.salesforce.eventStore
 
 static NSMutableDictionary *analyticsManagerList = nil;
 
+static SInt32 kBatchProcessCount = 100;
+
 @implementation SFSDKSalesforceAnalyticsManager
 
 + (void)initialize {
@@ -209,16 +211,56 @@ static NSMutableDictionary *analyticsManagerList = nil;
 
 - (void) publishAllEvents {
     @synchronized (self) {
-        NSArray<SFSDKInstrumentationEvent *> *events = [self.eventStoreManager fetchAllEvents];
-        [self publishEvents:events];
+        dispatch_group_t publishEventsGroup = dispatch_group_create();
+
+        if (self.batchingEnabled == NO) {
+            NSArray<SFSDKInstrumentationEvent *> *events = [self.eventStoreManager fetchAllEvents];
+            [self publishEvents:events dispatchGroup:publishEventsGroup];
+        } else {
+            NSArray *eventFiles = [self.eventStoreManager eventFiles];
+            SInt32 i = 0;
+            SInt32 remainingEvents = eventFiles.count;
+            
+            while (i < eventFiles.count) {
+                NSArray *subEvents = [eventFiles subarrayWithRange:NSMakeRange(i, MIN(kBatchProcessCount, remainingEvents))];
+                //MIN() used because array must be larger than or equal to range size, else exception will be thrown
+                
+                // batch process and use autorelease pool to best manage memory usage in processsing events
+                @autoreleasepool {
+                    NSMutableArray * eventsArray = [NSMutableArray arrayWithCapacity:kBatchProcessCount];
+                    for (SInt32 subCount = 0; subCount < subEvents.count; subCount++) {
+                        
+                        NSString *eventFile = subEvents[subCount];
+                        [eventsArray addObject:[self.eventStoreManager fetchEvent:eventFile]];
+                    }
+                    [self publishEvents:eventsArray dispatchGroup:publishEventsGroup];
+                    i += subEvents.count;
+                    remainingEvents = remainingEvents - subEvents.count;
+                }
+                
+            }
+        }
+        
+        dispatch_group_notify(publishEventsGroup, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),^{
+            [self cleanupBackgroundTask];
+        });
     }
 }
 
 - (void) publishEvents:(NSArray<SFSDKInstrumentationEvent *> *) events {
+    [self publishEvents:events dispatchGroup:nil];
+}
+
+- (void) publishEvents:(NSArray<SFSDKInstrumentationEvent *> *) events dispatchGroup:(nullable dispatch_group_t) dispatchGroup {
     if (events.count == 0 || self.remotes.count == 0) {
         return;
     }
     @synchronized (self) {
+        
+        if (dispatchGroup != nil) {
+            dispatch_group_enter(dispatchGroup);
+        }
+        
         NSMutableArray<NSString *> *eventIds = [[NSMutableArray alloc] init];
         for (SFSDKInstrumentationEvent *event in events) {
             [eventIds addObject:event.eventId];
@@ -260,7 +302,10 @@ static NSMutableDictionary *analyticsManagerList = nil;
                 }
                 publishCompleteBlock = nil;
             }
-            [self cleanupBackgroundTask];
+            
+            if (dispatchGroup != nil) {
+                dispatch_group_leave(dispatchGroup);
+            }
         };
         [self applyTransformAndPublish:currentTpp events:events publishCompleteBlock:publishCompleteBlock];
     }
@@ -346,11 +391,14 @@ static NSMutableDictionary *analyticsManagerList = nil;
     if (tpp) {
         NSMutableArray *eventsArray = [[NSMutableArray alloc] init];
         for (SFSDKInstrumentationEvent *event in events) {
-            id transformedEvent = [tpp.transform transform:event];
-            if (transformedEvent != nil) {
-                [eventsArray addObject:transformedEvent];
+            @autoreleasepool {
+                id transformedEvent = [tpp.transform transform:event];
+                if (transformedEvent != nil) {
+                    [eventsArray addObject:transformedEvent];
+                }
             }
         }
+
         id<SFSDKAnalyticsPublisher> networkPublisher = tpp.publisher;
         if (networkPublisher) {
             [networkPublisher publish:eventsArray user:self.userAccount publishCompleteBlock:publishCompleteBlock];


### PR DESCRIPTION
Based on work necessary for Salesforce Field Service, this PR encompasses work to enable batch processing of AILTN events, as well as strategic usage of `@autoreleasepool` blocks to more effectively manage runtime memory allocations while processing.

Doing so significantly reduces the memory profile of the host application when processing AILTN events stored at runtime.

As you can see below, the biggest improvement comes from autorelease support, with batching being a more effective means to attempt to submit these metrics before a background task terminates (fewer submissions, although concurrently, may succeed better than one giant one).

Memory analysis

Test 1:
1000 events (single "batch")
Autorelease disabled
AILTN start: 445Mb
AILTN end: 1.25Gb <------

Test 2:
1000 events (single "batch")
Autorelease enabled
AILTN start: 443Mb
AILTN end: 451Mb

Test 3:
1000 events, processed 100 x 10
Autorelease disabled
AILTN start: 437Mb
AILTN end: 447Mb

Test 4:
1000 events, processed 100 x 10
Autorelease enabled
AILTN start: 433Mb
AILTN end: 441Mb