### PR TITLE
@W-14662360/W-15061210: [iOS] Add additional native login feature(s): forgot password/(user registration)

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/NativeLoginManager.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/NativeLoginManager.swift
@@ -116,10 +116,10 @@ public protocol NativeLoginManager {
     ///  See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_registration_public_clients.htm&type=5
     ///
     /// - Parameters:
-    ///    - otp A user-entered one-time-password
-    ///    - requestIdentifier The request identifier issued by the Salesforce Identity API headless
+    ///    - otp: A user-entered one-time-password
+    ///    - requestIdentifier: The request identifier issued by the Salesforce Identity API headless
     ///    registration flow in the start registration method
-    ///    - otpVerificationMethod The one-time-password verification method used to obtain the
+    ///    - otpVerificationMethod: The one-time-password verification method used to obtain the
     ///    OTP identifier
     ///  - Returns: A native login result indicating success or one of several possible failures, including
     ///  both in-app and Salesforce Identity API results
@@ -207,12 +207,6 @@ public protocol NativeLoginManager {
 // MARK: Salesforce Identity API Headless Registration Flow Data Types
 
 /// An Objective-C compatible start registration result.
-/// - Parameters:
-///   - nativeLoginResult: A native login result indicating success or one of several possible
-///   failures, including both in-app and Salesforce Identity API results
-///   - email: On success result, the email provided by the Salesforce Identity API
-///   - requestIdentifier: On success result, the request identifier provided by the Salesforce
-///   Identity API
 @objc(SFStartRegistrationResult)
 @objcMembers
 public class StartRegistrationResult: NSObject {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/NativeLoginManager.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/NativeLoginManager.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Brandon Page on 1/3/24.
 //  Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
-// 
+//
 //  Redistribution and use of this software in source and binary forms, with or without modification,
 //  are permitted provided that the following conditions are met:
 //  * Redistributions of source code must retain the above copyright notice, this list of conditions
@@ -15,7 +15,7 @@
 //  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
 //  endorse or promote products derived from this software without specific prior written
 //  permission of salesforce.com, inc.
-// 
+//
 //  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
 //  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
 //  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
@@ -26,12 +26,22 @@
 //  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
- 
+
 @objc public enum NativeLoginResult: Int {
-    case invalidUsername         // Username does not meet Salesforce criteria (length, email format, ect).
-    case invalidPassword         // Password does not meet the weakest Salesforce criteria.
-    case invalidCredentials      // Username/password combination is incorrect.
+    /// Email address is not a valid format
+    case invalidEmail
+    
+    /// Username does not meet Salesforce criteria (length, email format, ect)
+    case invalidUsername
+    
+    /// Password does not meet the weakest Salesforce criteria
+    case invalidPassword
+    
+    /// Username/password combination is incorrect
+    case invalidCredentials
+    
     case unknownError
+    
     case success
 }
 
@@ -72,15 +82,96 @@ public protocol NativeLoginManager {
     /// Note: this call will dismiss your login view controller.
     @objc func biometricAuthenticationSuccess()
     
-    // MARK: Headless, Password-Less Login Via One-Time-Passcode
+    // MARK: Salesforce Identity API Headless Registration Flow
     
-    /// Submits a request for a one-time-passcode to the Salesforce headless password-less login flow.
-    /// This fulfills step three of the headless password-less login flow.
+    ///  Submits a request to start a user registration to the Salesforce Identity API headless registration
+    ///  flow.  This fulfills step four of the headless registration flow.
+    ///
+    ///  See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_registration_public_clients.htm&type=5
+    ///
+    /// - Parameters:
+    ///   - email: The user-entered email address
+    ///   - firstName: The user-entered first name
+    ///   - lastName: The user-entered last name
+    ///   - username: A valid Salesforce username or email
+    ///   - newPassword: The user-entered new password
+    ///   - reCaptchaToken: A reCAPTCHA token provided by the reCAPTCHA SDK
+    ///   - otpVerificationMethod: The delivery method for the OTP
+    ///  - Returns: The start registration result with the request identifier returned by the Salesforce
+    ///  Identity API and a native login result indicating success or one of several possible failures,
+    ///  including both in-app and Salesforce Identity API results
+    @objc func startRegistration(
+        email: String,
+        firstName: String,
+        lastName: String,
+        username: String,
+        newPassword: String,
+        reCaptchaToken: String,
+        otpVerificationMethod: OtpVerificationMethod
+    ) async -> StartRegistrationResult
+    
+    ///  Submits a request to complete a user registration to the Salesforce Identity API headless
+    ///  registration flow.  This fulfills step eight of the headless registration flow.
+    ///
+    ///  See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_registration_public_clients.htm&type=5
+    ///
+    /// - Parameters:
+    ///    - otp A user-entered one-time-password
+    ///    - requestIdentifier The request identifier issued by the Salesforce Identity API headless
+    ///    registration flow in the start registration method
+    ///    - otpVerificationMethod The one-time-password verification method used to obtain the
+    ///    OTP identifier
+    ///  - Returns: A native login result indicating success or one of several possible failures, including
+    ///  both in-app and Salesforce Identity API results
+    @objc func completeRegistration(
+        otp: String,
+        requestIdentifier: String,
+        otpVerificationMethod: OtpVerificationMethod
+    ) async -> NativeLoginResult
+    
+    // MARK: Salesforce Identity API Headless Forgot Password Flow
+    
+    /// Submits a request to start a password reset to the Salesforce Identity API headless forgot password
+    /// flow.  This fulfills step one of the headless forgot password flow.
+    ///
+    /// See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_forgot_password_flow.htm&type=5
+    ///
+    /// - Parameters:
+    ///   - username: A valid Salesforce username or email
+    ///   - reCaptchaToken: A reCAPTCHA token provided by the reCAPTCHA SDK
+    /// - Returns: A native login result indicating success or one of several possible failures, including
+    ///  both in-app and Salesforce Identity API results
+    @objc func startPasswordReset(
+        username: String,
+        reCaptchaToken: String
+    ) async -> NativeLoginResult
+    
+    /// Submits a request to complete a password reset to the Salesforce Identity API headless forgot
+    /// password flow. This fulfills step four of the headless forgot password flow.
+    ///
+    /// See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_forgot_password_flow.htm&type=5
+    ///
+    /// - Parameters:
+    ///   - username: A valid Salesforce username or email
+    ///   - otp: A user-entered one-time-password
+    ///   - newPassword: The user-entered new password
+    /// - Returns: A native login result indicating success or one of several possible failures, including
+    /// both in-app and Salesforce Identity API results
+    @objc func completePasswordReset(
+        username: String,
+        otp: String,
+        newPassword: String
+    ) async -> NativeLoginResult
+    
+    // MARK: Salesforce Identity API Headless, Password-Less Login Via One-Time-Passcode
+    
+    /// Submits a request to start password-less login via one-time-passcode to the Salesforce Identity API
+    /// headless, password-less login flow. This fulfills step three of the headless, password-less login flow.
     ///
     /// See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_passwordless_login_public_clients.htm&type=5
     ///
     /// - Parameters:
-    ///   - username: A valid Salesforce username.  Note that email may be used for community users
+    ///   - username: A valid Salesforce username or email
     ///   - reCaptchaToken: A reCAPTCHA token provided by the reCAPTCHA SDK
     ///   - otpVerificationMethod: The delivery method for the OTP
     /// - Returns: An OTP request result with the overall login result and the OTP identifier for
@@ -91,16 +182,20 @@ public protocol NativeLoginManager {
         reCaptchaToken: String,
         otpVerificationMethod: OtpVerificationMethod) async -> OtpRequestResult
     
-    /// Submits a request for a one-time-passcode to the Salesforce headless password-less login flow.
-    /// This fulfills steps eight, eleven and thirteen of the headless password-less login flow.
+    /// Submits a request to complete a password-less login to the Salesforce Identity API headless,
+    /// password-less login flow. This fulfills steps eight, eleven and thirteen of the headless password-less
+    /// login flow.
     ///
     /// See https://help.salesforce.com/s/articleView?id=sf.remoteaccess_headless_passwordless_login_public_clients.htm&type=5
     ///
     /// - Parameters:
-    ///   - otp: A user-entered OTP
-    ///   - otpIdentifier: The OTP identifier issued by the Headless Identity API
-    ///   - otpVerificationMethod: The OTP verification method used to obtain the OTP identifier
-    /// - Returns: A login result indicating the outcome of the authorization and access token requests
+    ///   - otp: A user-entered one-time-password
+    ///   - otpIdentifier: The one-time-password identifier issued by the Salesforce Identity API
+    ///   headless, password-less login flow in the start password-less authorization method.
+    ///   - otpVerificationMethod: The one-time-password verification method used to obtain the
+    ///   OTP identifier
+    /// - Returns: A native login result indicating success or one of several possible failures, including
+    /// both in-app and Salesforce Identity API results
     ///
     @objc func submitPasswordlessAuthorizationRequest(
         otp: String,
@@ -109,12 +204,47 @@ public protocol NativeLoginManager {
     ) async -> NativeLoginResult
 }
 
+// MARK: Salesforce Identity API Headless Registration Flow Data Types
+
+/// An Objective-C compatible start registration result.
+/// - Parameters:
+///   - nativeLoginResult: A native login result indicating success or one of several possible
+///   failures, including both in-app and Salesforce Identity API results
+///   - email: On success result, the email provided by the Salesforce Identity API
+///   - requestIdentifier: On success result, the request identifier provided by the Salesforce
+///   Identity API
+@objc(SFStartRegistrationResult)
+@objcMembers
+public class StartRegistrationResult: NSObject {
+    
+    /// The overall result of the start registration request
+    public let nativeLoginResult: NativeLoginResult
+    
+    /// On success result, the email address provided by the Salesforce Identity API
+    public let email: String?
+    
+    /// On success result, the request identifier provided by the Salesforce Identity API
+    public let requestIdentifier: String?
+    
+    init(
+        nativeLoginResult: NativeLoginResult,
+        email: String? = nil,
+        requestIdentifier: String? = nil
+    ) {
+        self.nativeLoginResult = nativeLoginResult
+        self.email = email
+        self.requestIdentifier = requestIdentifier
+    }
+}
+
+// MARK: Salesforce Identity API Headless, Password-Less Login Via One-Time-Passcode Data Types
+
 /// An Objective-C compatible OTP request result
 @objc(SFOtpRequestResult)
 @objcMembers
 public class OtpRequestResult: NSObject {
     
-    /// The overall result of the OTP request.
+    /// The overall result of the OTP request
     public let nativeLoginResult: NativeLoginResult
     
     /// On success result, the OTP identifier provided by the API
@@ -128,6 +258,8 @@ public class OtpRequestResult: NSObject {
         self.otpIdentifier = otpIdentifier
     }
 }
+
+// MARK: Common Data Types
 
 /// The possible OTP verification methods.
 @objc public enum OtpVerificationMethod: Int {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/NativeLoginManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/NativeLoginManagerInternal.swift
@@ -431,7 +431,7 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
         // React to the start password reset response.
         switch startPasswordResetResponse {
             
-        case .success(let startPasswordResetResponse):
+        case .success:
             return .success
             
         case .failure(let error):
@@ -496,7 +496,7 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
         // React to the complete password reset response.
         switch completePasswordResetResponse {
             
-        case .success(let completePasswordResetResponse):
+        case .success:
             return .success
             
         case .failure(let error):

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/NativeLoginManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/NativeLoginManagerInternal.swift
@@ -242,7 +242,7 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
                 data: try JSONEncoder().encode(
                     StartRegistrationRequestBody(
                         recaptcha: reCaptchaParameterGenerationResult.nonEnterpriseReCaptchaToken,
-                        recaptchaevent: reCaptchaParameterGenerationResult.enterpriseReCaptchaEvent,
+                        recaptchaEvent: reCaptchaParameterGenerationResult.enterpriseReCaptchaEvent,
                         userData: UserData(
                             email: email,
                             username: username,
@@ -251,7 +251,7 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
                             lastName: lastName),
                         otpVerificationMethod: otpVerificationMethodString)
                 ),
-                encoding: .utf8)!
+                encoding: .utf8)
             } catch let error {
                 SFSDKCoreLogger().e(
                     classForCoder,
@@ -328,7 +328,7 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
         var recaptcha: String?
         
         /// The reCAPTCHA parameters for use with reCAPTCHA Enterprise
-        var recaptchaevent: ReCaptchaEventRequestParameter?
+        var recaptchaEvent: ReCaptchaEventRequestParameter?
         
         /// The start registration request user data
         var userData: UserData
@@ -338,7 +338,7 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
         
         enum CodingKeys: String, CodingKey {
             case recaptcha = "recaptcha"
-            case recaptchaevent = "recaptchaevent"
+            case recaptchaEvent = "recaptchaevent"
             case userData = "userdata"
             case otpVerificationMethod = "verificationMethod"
         }
@@ -396,10 +396,10 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
                 data: try JSONEncoder().encode(
                     StartPasswordResetRequestBody(
                         recaptcha: reCaptchaParameterGenerationResult.nonEnterpriseReCaptchaToken,
-                        recaptchaevent: reCaptchaParameterGenerationResult.enterpriseReCaptchaEvent,
+                        recaptchaEvent: reCaptchaParameterGenerationResult.enterpriseReCaptchaEvent,
                         username: trimmedUsername)
                 ),
-                encoding: .utf8)!
+                encoding: .utf8)
             } catch let error {
                 SFSDKCoreLogger().e(
                     classForCoder,
@@ -464,7 +464,7 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
                         otp: trimmedOtp,
                         newPassword: trimmedPassword)
                 ),
-                encoding: .utf8)!
+                encoding: .utf8)
             } catch let error {
                 SFSDKCoreLogger().e(
                     classForCoder,
@@ -537,11 +537,11 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
                 data: try JSONEncoder().encode(
                     OtpRequestBody(
                         recaptcha: reCaptchaParameterGenerationResult.nonEnterpriseReCaptchaToken,
-                        recaptchaevent: reCaptchaParameterGenerationResult.enterpriseReCaptchaEvent,
+                        recaptchaEvent: reCaptchaParameterGenerationResult.enterpriseReCaptchaEvent,
                         username: username,
                         verificationMethod: otpVerificationMethodString)
                 ),
-                encoding: .utf8)!
+                encoding: .utf8)
             } catch let error {
                 SFSDKCoreLogger().e(
                     classForCoder,
@@ -687,14 +687,14 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
         var recaptcha: String?
         
         /// The reCAPTCHA parameters for use with reCAPTCHA Enterprise
-        var recaptchaevent: ReCaptchaEventRequestParameter?
+        var recaptchaEvent: ReCaptchaEventRequestParameter?
         
         /// A valid Salesforce username or email
         var username: String
         
         enum CodingKeys: String, CodingKey {
             case recaptcha = "recaptcha"
-            case recaptchaevent = "recaptchaevent"
+            case recaptchaEvent = "recaptchaevent"
             case username = "username"
         }
     }
@@ -724,7 +724,7 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
         let recaptcha: String?
         
         /// The reCAPTCHA parameters for use with reCAPTCHA Enterprise
-        let recaptchaevent: ReCaptchaEventRequestParameter?
+        let recaptchaEvent: ReCaptchaEventRequestParameter?
         
         /// The Salesforce username
         let username: String
@@ -734,7 +734,7 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
         
         enum CodingKeys: String, CodingKey {
             case recaptcha = "recaptcha"
-            case recaptchaevent = "recaptchaevent"
+            case recaptchaEvent = "recaptchaevent"
             case verificationMethod = "verificationmethod"
             case username = "username"
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -88,6 +88,7 @@ static NSString * const kSFOAuthCodeCredentialsParamName        = @"code_credent
 static NSString * const kSFOAuthRequestTypeParamName            = @"Auth-Request-Type";
 static NSString * const kSFOAuthRequestTypeNamedUser            = @"Named-User";
 static NSString * const kSFOAuthRequestTypePasswordlessLogin    = @"passwordless-login";
+static NSString * const kSFOAuthRequestTypeUserRegistration     = @"user-registration";
 
 static NSString * const kSFOAuthAuthorizationTypeParamName      = @"Authorization";
 static NSString * const kSFOAuthAuthorizationTypeBasic          = @"Basic";
@@ -124,7 +125,13 @@ static NSString * const kOAuthUserAgentUserDefaultsKey              = @"UserAgen
 static NSString * const kSFAppFeatureSafariBrowserForLogin          = @"BW";
 static NSString * const kSFECParameter                              = @"ec";
 
-// Headless, password-less authentication constants
+// Endpoint path for Salesforce Identity API initialize headless, password-less login flow
 static NSString * const kSFOAuthEndPointHeadlessInitPasswordlessLogin = @"services/auth/headless/init/passwordless/login";
+
+/// Endpoint path for Salesforce Identity API initialize headless registration flow
+static NSString * const kSFOAuthEndPointHeadlessInitRegistration = @"services/auth/headless/init/registration";
+
+/// Endpoint path for Salesforce Identity API headless forgot password flow
+static NSString * const kSFOAuthEndPointHeadlessForgotPassword = @"services/auth/headless/forgot_password";
 
 #endif /* SFSDKOAuthConstants_h */


### PR DESCRIPTION
🎸 _*Ready For Review!_ 🥁

Here's a two-in-one: forgot password and user registration via the Salesforce Headless Identity API.  This will look really familiar to previous client implementations we've done for iOS for this API.  It will also look really familiar compared to the Android implementation since most of the logic is identical along with very similar naming conventions and code layout.

Keep an eye on the template implementation incubating in https://github.com/forcedotcom/SalesforceMobileSDK-Templates/pull/414

Thanks for reading!