### PR TITLE
Analytics Warnings Bug Fixes

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.h
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.h
@@ -71,7 +71,7 @@ typedef NSData * _Nullable (^ _Nullable DataDecryptorBlock)(NSData * _Nullable d
  *
  * @return List of event files.
  */
-- (NSArray<SFSDKInstrumentationEvent *> *) eventFiles;
+- (nullable NSArray<SFSDKInstrumentationEvent *> *) eventFiles;
 
 /**
  * Returns a specific event stored on the filesystem.

--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
@@ -120,7 +120,7 @@
     }
 }
 
-- (NSArray<SFSDKInstrumentationEvent *> *) eventFiles {
+- (NSArray<NSString *> *) eventFiles {
     return [[NSFileManager defaultManager] contentsOfDirectoryAtPath:self.storeDirectory error:nil];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -219,7 +219,7 @@ static SInt32 kBatchProcessCount = 100;
         } else {
             NSArray *eventFiles = [self.eventStoreManager eventFiles];
             SInt32 i = 0;
-            SInt32 remainingEvents = eventFiles.count;
+            NSUInteger remainingEvents = eventFiles.count;
             
             while (i < eventFiles.count) {
                 NSArray *subEvents = [eventFiles subarrayWithRange:NSMakeRange(i, MIN(kBatchProcessCount, remainingEvents))];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -254,7 +254,6 @@ static dispatch_once_t pred;
             NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
             attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
             attributes[@"errorDescription"] = error.localizedDescription;
-            [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:nil className:NSStringFromClass([strongSelf class]) attributes:attributes];
             [[SFUserAccountManager sharedInstance] logout];
         }];
     } else {


### PR DESCRIPTION
Analytics Warnings Fixed:
1. Nullability warning in SalesforceAnalytics
2. Incompatible pointer types in SalesforceAnalytics
3. Integer precision warning in SalesforceSDKCore