### PR TITLE
Using Single Access API to get front door URL

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class SFOAuthCoordinator;
 @class SFOAuthInfo;
+@class SFUserAccount;
 
 /**
  Callback block used for the browser flow authentication.
@@ -350,7 +351,7 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
 
 - (BOOL)handleIDPAuthenticationResponse:(NSURL *)appUrlResponse;
 
-- (void)beginIDPFlow;
+- (void)beginIDPFlow:(SFUserAccount *)user success:(void(^)(void))successBlock failure:(void(^)(NSError *))failureBlock;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.h
@@ -134,10 +134,18 @@ NS_SWIFT_NAME(RestClient)
 ///---------------------------------------------------------------------------------------
 
 /**
- * Returns an `SFRestRequest` object that contains information associated with the current user.
+ * Returns an `SFRestRequest` object that returns information associated with the current user.
  * @see https://help.salesforce.com/articleView?id=remoteaccess_using_userinfo_endpoint.htm
  */
 - (SFRestRequest *)requestForUserInfo;
+
+/**
+ * Returns an `SFRestRequest` object that returns URL to bridge into UI sessions (a front door URL).
+ * @param redirectUri A relative path that points to where the user is redirected when their new session begins.
+ * @see https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm
+ */
+- (SFRestRequest *)requestForSingleAccess:(NSString *)redirectUri;
+
 
 /**
  * Returns an `SFRestRequest` object that lists summary information about each

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -312,9 +312,7 @@ static dispatch_once_t pred;
                 id dataForDelegate = [strongSelf prepareDataForDelegate:data request:request response:response];
                 [strongSelf notifyDelegateOfSuccess:requestDelegate request:request data:dataForDelegate rawResponse:response];
             } else {
-                // Do not refresh token if biometric authentiction lock is enabled
-                if (shouldRetry && statusCode == 401 && ![[SFBiometricAuthenticationManagerInternal shared] locked]) {
-                    // 401 indicates refresh is required.
+                if (shouldRetry && [self shouldRefresh:statusCode responseData:data request:request]) {
                     [strongSelf replayRequest:request response:response requestDelegate:requestDelegate];
                 } else {
                     // Other status codes indicate failure.
@@ -327,6 +325,27 @@ static dispatch_once_t pred;
         request.sessionDataTask = dataTask;
     }
 }
+
+- (BOOL)shouldRefresh:(NSInteger)statusCode responseData:(NSData *)responseData request:(SFRestRequest *)request {
+    // most calls return 401 if oauth access token is not valid
+    BOOL isNotAuthorized = statusCode == 401;
+    
+    // service/oauth2 calls return 403 with Bad_OAuth_Token response if oauth access is not valid
+    BOOL hasBadOAuthToken = statusCode == 403
+    && [request.path hasPrefix:@"/services/oauth2"]
+    && [[[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding] isEqualToString:@"Bad_OAuth_Token"];
+    
+    if (isNotAuthorized || hasBadOAuthToken) {
+        [SFSDKCoreLogger d:[self class] format:@"response request path: %@", request.path];
+        [SFSDKCoreLogger i:[self class] format:@"response code: %ld", (long) statusCode];
+        
+        // Do not refresh token if biometric authentiction lock is enabled
+        return ![[SFBiometricAuthenticationManagerInternal shared] locked];
+    } else {
+        return false;
+    }
+}
+
 
 - (SFNetwork *)networkForRequest:(SFRestRequest *)request {
     if (request.networkServiceType == SFNetworkServiceTypeBackground) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -487,6 +487,16 @@ static dispatch_once_t pred;
     return request;
 }
 
+- (SFRestRequest *)requestForSingleAccess:(NSString*) redirectUri {
+    NSString *path = @"/services/oauth2/singleaccess";
+    NSString *bodyStr = [@"redirect_uri=" stringByAppendingString:[redirectUri sfsdk_stringByURLEncoding]];
+    SFRestRequest *request = [SFRestRequest requestWithMethod:SFRestMethodPOST serviceHostType:SFSDKRestServiceHostTypeInstance path:path queryParams:nil];
+    [request setCustomRequestBodyString:bodyStr contentType:kHttpPostContentType];
+    request.endpoint = @"";
+    return request;
+}
+
+
 - (SFRestRequest *)requestForVersions {
     NSString *path = @"/";
     SFRestRequest* request = [SFRestRequest requestWithMethod:SFRestMethodGET path:path queryParams:nil];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceRestAPITests.m
@@ -261,6 +261,16 @@ static NSException *authException = nil;
     self.dataCleanupRequired = NO;
 }
 
+// simple: just invoke requestForSingleAccess
+- (void)testGetSingleAccess {
+    SFRestRequest* request = [[SFRestAPI sharedInstance] requestForSingleAccess:@"abc/def"];
+    SFNativeRestRequestListener *listener = [self sendSyncRequest:request];
+    XCTAssertEqualObjects(listener.returnStatus, kTestRequestStatusDidLoad, @"request failed");
+    [self checkKeysInJsonObject:listener.dataResponse expectedKeys:@[@"frontdoor_uri"]];
+    self.dataCleanupRequired = NO;
+}
+
+
 // simple: just invoke requestForLimits
 - (void)testGetLimits {
     SFRestRequest* request = [[SFRestAPI sharedInstance] requestForLimits:kSFRestDefaultAPIVersion];
@@ -3055,6 +3065,14 @@ static NSException *authException = nil;
     NSDictionary *requestBody = request.requestBodyAsDictionary;
     NSString *requestNotificationIds = requestBody[@"notificationIds"];
     XCTAssertEqualObjects(notificationIds, requestNotificationIds);
+}
+
+#pragma mark - Helper methods
+
+- (void)checkKeysInJsonObject:(NSDictionary *)jsonObject expectedKeys:(NSArray<NSString *> *)expectedKeys {
+    for (NSString *expectedKey in expectedKeys) {
+        NSAssert([jsonObject objectForKey:expectedKey] != nil, @"Object should have key: %@", expectedKey);
+    }
 }
 
 @end


### PR DESCRIPTION
- Added `SFRestAPI requestForSingleAccess` (with new test in `SalesforceRestAPITests`) which calls `/services/oauth2/singleaccess` to generate a frontdoor URL to bridge into UI sessions.
- Added `shouldRefresh` method in `SFRestAPI: it now refreshes when getting either a 401 or a 403 with reason `Bad_OAuth_Token` while going to `/services/oauth2` (as long as the biometric is not enabled and locked).
- Using `requestForSingleAccess` in `SFOAuthCoordinator beginIDPFlow` instead of building 
a frontdoor URL directly
