### PR TITLE
Move off of deprecated openURL method

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthHelper.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKIDPAuthHelper.m
@@ -63,8 +63,9 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
     
     NSURL *url = [command requestURL];
     dispatch_async(dispatch_get_main_queue(), ^{
-        BOOL launched  = [SFApplicationHelper openURL:url];
-        completionBlock(launched);
+        [SFApplicationHelper openURL:url options:@{} completionHandler:^(BOOL success) {
+            completionBlock(success);
+        }];
     });
 }
 
@@ -95,8 +96,9 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
             [authWindow dismissWindow];
             [[[SFSDKWindowManager sharedManager] mainWindow:nil] presentWindow];
         }];
-        BOOL launched  = [SFApplicationHelper openURL:url];
-        completionBlock(launched);
+        [SFApplicationHelper openURL:url options:@{} completionHandler:^(BOOL success) {
+            completionBlock(success);
+        }];
     });
 }
 
@@ -111,12 +113,15 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
             [authWindow dismissWindow];
             [[[SFSDKWindowManager sharedManager] mainWindow:nil] presentWindow];
         }];
-        BOOL launched  = [SFApplicationHelper openURL:url];
-        if (!launched) {
-            [SFSDKCoreLogger e:[self class] format:@"Could not launch spAPP to handle error %@",[error description]];
-        }
-        [[SFUserAccountManager sharedInstance] stopCurrentAuthentication:^(BOOL result) {
-            [SFSDKCoreLogger d:[self class] format:@"Completed idp authentication with error, %@",error];
+        
+        [SFApplicationHelper openURL:url options:@{} completionHandler:^(BOOL success) {
+            if (!success) {
+                [SFSDKCoreLogger e:[self class] format:@"Could not launch spAPP to handle error %@", [error description]];
+            }
+            
+            [[SFUserAccountManager sharedInstance] stopCurrentAuthentication:^(BOOL result) {
+                [SFSDKCoreLogger d:[self class] format:@"Completed idp authentication with error, %@", error];
+            }];
         }];
     });
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKStartURLHandler.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/URLHandlers/SFSDKStartURLHandler.m
@@ -38,10 +38,11 @@
 - (BOOL)processRequest:(NSURL *)url options:(NSDictionary *)options {
     if (url) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            BOOL success = [SFApplicationHelper openURL:url];
-            if (!success) {
-                 [SFSDKCoreLogger d:[self class] format:@"Could not launch  %@", url];
-            }
+            [SFApplicationHelper openURL:url options:options completionHandler:^(BOOL success) {
+                if (!success) {
+                     [SFSDKCoreLogger d:[self class] format:@"Could not launch  %@", url];
+                }
+            }];
         });
     }
     return NO;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFApplicationHelper.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFApplicationHelper.h
@@ -23,6 +23,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -43,7 +44,9 @@ NS_ASSUME_NONNULL_BEGIN
  @param url The URL to be opened.
  @return YES if the URL is successfully opened.
  */
-+ (BOOL)openURL:(NSURL*)url;
++ (BOOL)openURL:(NSURL*)url SFSDK_DEPRECATED(12.2, 13.0, "Use openURL:options:completionHandler: instead.");
+
++ (void)openURL:(NSURL*)url options:(NSDictionary<UIApplicationOpenExternalURLOptionsKey, id> *)options completionHandler:(void (^ __nullable)(BOOL success))completion;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFApplicationHelper.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFApplicationHelper.m
@@ -51,4 +51,19 @@
     return success;
 }
 
++ (void)openURL:(NSURL*)url options:(NSDictionary<UIApplicationOpenExternalURLOptionsKey, id> *)options completionHandler:(void (^ __nullable)(BOOL success))completion {
+    UIApplication *app = [self sharedApplication];
+    
+    if (app) {
+        SEL selector = @selector(openURL:options:completionHandler:);
+        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[[app class] instanceMethodSignatureForSelector:selector]];
+        [invocation setTarget:app];
+        [invocation setSelector:selector];
+        [invocation setArgument:&url atIndex:2];
+        [invocation setArgument:&options atIndex:3];
+        [invocation setArgument:&completion atIndex:4];
+        [invocation invoke];
+    }
+}
+
 @end

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -44,7 +44,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         SalesforceManager.shared.appDisplayName = "Rest API Explorer"
         UserAccountManager.shared.navigationPolicyForAction = { webView, action in
             if let url = action.request.url, url.absoluteString == "https://www.salesforce.com/us/company/privacy" {
-                SFApplicationHelper.open(url)
+                SFApplicationHelper.open(url, options: [:], completionHandler: nil)
                 return .cancel
             }
             return .allow


### PR DESCRIPTION
Using the old `openURL` is failing during IDP on iOS 18 with this error: 
```
BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(_:) needs to migrate to the 
non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO). 
```