### PR TITLE
Add CodeCov Components feature.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,31 +12,26 @@ coverage:
     project:
       default: false  # disable the default status that measures entire project
       SalesforceAnalytics:
-        target: auto
         paths: 
           - "libs/SalesforceAnalytics/SalesforceAnalytics/"
         flags: 
           - SalesforceAnalytics
       SalesforceSDKCommon:
-        target: auto
         paths: 
           - "libs/SalesforceSDKCore/SalesforceSDKCommon/"
         flags: 
           - SalesforceSDKCommon
       SalesforceSDKCore:
-        target: auto
         paths: 
           - "libs/SalesforceSDKCore/SalesforceSDKCore/"
         flags: 
           - SalesforceSDKCore
       SmartStore:
-        target: auto
         paths: 
           - "libs/SmartStore/SmartStore/"
         flags: 
           - SmartStore
       MobileSync:
-        target: auto
         paths: 
           - "libs/MobileSync/MobileSync/"
         flags: 
@@ -51,7 +46,29 @@ flag_management:
   default_rules: # the rules that will be followed for any flag added, generally
     carryforward: true
 
+# PR comment layout
 comment:
-  layout: "diff, flags, files"
+  layout: "diff, components, files"
   behavior: default
   require_changes: false
+
+component_management:
+  individual_components:
+    - component_id: SalesforceAnalytics  # this is an identifier that should not be changed
+      name: Analytics  # this is a display name, and can be changed freely
+      paths: 
+        - "libs/SalesforceAnalytics/SalesforceAnalytics/"
+    - component_id: SalesforceSDKCommon
+      name: Common
+      paths: 
+        - "libs/SalesforceSDKCommon/SalesforceSDKCommon/"
+    - component_id: SalesforceSDKCore
+      name: Core
+      paths: 
+        - "libs/SalesforceSDKCore/SalesforceSDKCore/"
+    - component_id: SmartStore
+      paths: 
+        - "libs/SmartStore/SmartStore/"
+    - component_id: MobileSync
+      paths: 
+        - "libs/MobileSync/MobileSync/"


### PR DESCRIPTION
"Components" is a relatively new feature that lets you get an isolated view of a specific part of your code base, perfect for our libraries.  

This differs from the "Flags" feature because filtering by a flag in the UI will show you its coverage as a percentage of the entire project which isn't helpful at all.  Flags are still needed because they are required for uploading partial coverage that gets merged into the full project report.  The two features sound similar but serve different purposes.  