### PR TITLE
@W-16580504: [iOS] Hook to propagate MSDK logs to other systems

### DIFF
--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SFLogger.h
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SFLogger.h
@@ -28,6 +28,8 @@
 #import <Foundation/Foundation.h>
 #import <os/log.h>
 
+@protocol SFLogReceiverFactory;
+
 typedef NS_ENUM(NSUInteger, SFLogLevel){
     SFLogLevelDefault =  OS_LOG_TYPE_DEFAULT,
     SFLogLevelInfo    =  OS_LOG_TYPE_INFO,
@@ -364,6 +366,12 @@ NS_SWIFT_NAME(SalesforceLogger)
  * @param logger Class.
  */
 + (void)setInstanceClass:(Class<SFLogging>)logger;
+
+/**
+ * Sets the log receiver factory which creates log receivers.
+ * @param logReceiverFactory The log receiver factory
+ */
++ (void)setLogReceiverFactory:(id<SFLogReceiverFactory>)logReceiverFactory;
 
 /**
  * Get the default Logger.

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SFLogger.m
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SFLogger.m
@@ -103,43 +103,45 @@ static SFSDKSafeMutableDictionary *loggerList = nil;
 -(void)setLogLevel:(SFLogLevel) logLevel {
     [self.logger setLogLevel:logLevel];
 }
+
+- (void)submitLogEntryWithClass:(nonnull Class)cls level:(SFLogLevel)level message:(nonnull NSString *)message {
+    [self.logger log:cls level:level message:message];
+    [self.logReceiver receiveWithLevel:level cls:cls component:self.logger.componentName message:message];
+}
+
+/**
+ * Submits a log entry with the provided properties to the logger and log receiver.
+ */
+- (void)submitLogEntryWithClass:(nonnull Class)cls level:(SFLogLevel)level format:(nonnull NSString *)format args:(va_list)args {
+    [self.logger log:cls level:level format:format args:args];
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
+    [self.logReceiver receiveWithLevel:level cls:cls component:self.logger.componentName message:formattedMessage];
+}
+
 - (void)log:(nonnull Class)cls message:(nonnull NSString *)message {
-    [self.logger log:cls level:SFLogLevelDefault message:message];
-    
-    [self.logReceiver receiveWithLevel:SFLogLevelDefault cls:cls component:self.logger.componentName message:message];
+    [self submitLogEntryWithClass:cls level:SFLogLevelDefault message:message];
 }
 
 - (void)log:(nonnull Class)cls format:(nonnull NSString *)format, ... {
     va_list args;
     va_start(args, format);
-    [self.logger log:cls level:SFLogLevelDefault format:format args:args];
-    
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
-    [self.logReceiver receiveWithLevel:SFLogLevelDefault cls:cls component:self.logger.componentName message:formattedMessage];
-    
+    [self submitLogEntryWithClass:cls level:SFLogLevelDefault format:format args:args];
     va_end(args);
 }
 
 - (void)log:(Class)cls level:(SFLogLevel)level message:(NSString *)message {
-    [self.logger log:cls level:level message:message];
-    
-    [self.logReceiver receiveWithLevel:level cls:cls component:self.logger.componentName message:message];
-}
+    [self submitLogEntryWithClass:cls level:level message:message];}
 
 - (void)log:(Class)cls level:(SFLogLevel)level format:(NSString *)format, ... {
     va_list args;
     va_start(args, format);
-    [self.logger log:cls level:level format:format args:args];
-    
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
-    [self.logReceiver receiveWithLevel:level cls:cls component:self.logger.componentName message:formattedMessage];
-    
+    [self submitLogEntryWithClass:cls level:level format:format args:args];
     va_end(args);
 }
 
 - (void)log:(Class)cls level:(SFLogLevel)level format:(NSString *)format args:(va_list)args {
     va_list args_copy;
-    va_copy(args_copy, args);
+    va_copy(args_copy, args); // Note: This log convenience cannot use the common submit log entry methods since it requires this local memory copy due to the caller already having run `va_start` on `args`.
     
     [self.logger log:cls level:level format:format args:args];
     
@@ -150,87 +152,57 @@ static SFSDKSafeMutableDictionary *loggerList = nil;
 }
 
 - (void)e:(nonnull Class)cls message:(nonnull NSString *)message {
-    [self.logger log:cls level:SFLogLevelError message:message];
-    
-    [self.logReceiver receiveWithLevel:SFLogLevelError cls:cls component:self.logger.componentName message:message];
+    [self submitLogEntryWithClass:cls level:SFLogLevelError message:message];
 }
 
 - (void)e:(nonnull Class)cls format:(nonnull NSString *)format, ... {
     va_list args;
     va_start(args, format);
-    [self.logger log:cls level:SFLogLevelError format:format args:args];
-    
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
-    [self.logReceiver receiveWithLevel:SFLogLevelError cls:cls component:self.logger.componentName message:formattedMessage];
-    
+    [self submitLogEntryWithClass:cls level:SFLogLevelError format:format args:args];
     va_end(args);
 }
 
 - (void)f:(nonnull Class)cls message:(nonnull NSString *)message {
-    [self.logger log:cls level:SFLogLevelFault message:message];
-    
-    [self.logReceiver receiveWithLevel:SFLogLevelFault cls:cls component:self.logger.componentName message:message];
+    [self submitLogEntryWithClass:cls level:SFLogLevelFault message:message];
 }
 
 - (void)f:(nonnull Class)cls format:(nonnull NSString *)format, ... {
     va_list args;
     va_start(args, format);
-    [self.logger log:cls level:SFLogLevelFault format:format args:args];
-    
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
-    [self.logReceiver receiveWithLevel:SFLogLevelFault cls:cls component:self.logger.componentName message:formattedMessage];
-    
+    [self submitLogEntryWithClass:cls level:SFLogLevelFault format:format args:args];
     va_end(args);
 }
 
 - (void)i:(nonnull Class)cls message:(nonnull NSString *)message {
-    [self.logger log:cls level:SFLogLevelInfo message:message];
-    
-    [self.logReceiver receiveWithLevel:SFLogLevelInfo cls:cls component:self.logger.componentName message:message];
+    [self submitLogEntryWithClass:cls level:SFLogLevelInfo message:message];
 }
 
 - (void)i:(nonnull Class)cls format:(nonnull NSString *)format, ... {
     va_list args;
     va_start(args, format);
-    [self.logger log:cls level:SFLogLevelInfo format:format args:args];
-    
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
-    [self.logReceiver receiveWithLevel:SFLogLevelInfo cls:cls component:self.logger.componentName message:formattedMessage];
-    
+    [self submitLogEntryWithClass:cls level:SFLogLevelInfo format:format args:args];
     va_end(args);
 }
 
 - (void)d:(nonnull Class)cls message:(nonnull NSString *)message {
-    [self.logger log:cls level:SFLogLevelDebug message:message];
-    
-    [self.logReceiver receiveWithLevel:SFLogLevelDebug cls:cls component:self.logger.componentName message:message];
+    [self submitLogEntryWithClass:cls level:SFLogLevelDebug message:message];
 }
 
 - (void)d:(nonnull Class)cls format:(nonnull NSString *)format, ... {
     va_list args;
     va_start(args, format);
-    [self.logger log:cls level:SFLogLevelDebug format:format args:args];
-    
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
-    [self.logReceiver receiveWithLevel:SFLogLevelDebug cls:cls component:self.logger.componentName message:formattedMessage];
-    
+    [self submitLogEntryWithClass:cls level:SFLogLevelDebug format:format args:args];
     va_end(args);
 }
 
 - (void)w:(nonnull Class)cls message:(nonnull NSString *)message {
-    [self.logger log:cls level:SFLogLevelDefault message:message];
-    
-    [self.logReceiver receiveWithLevel:SFLogLevelDefault cls:cls component:self.logger.componentName message:message];
+    [self submitLogEntryWithClass:cls level:SFLogLevelDefault message:message];
 }
 
 - (void)w:(nonnull Class)cls format:(nonnull NSString *)format, ... {
     va_list args;
     va_start(args, format);
-    [self.logger log:cls level:SFLogLevelDefault format:format args:args];
-    
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
-    [self.logReceiver receiveWithLevel:SFLogLevelDefault cls:cls component:self.logger.componentName message:formattedMessage];
-    
+    [self submitLogEntryWithClass:cls level:SFLogLevelDefault format:format args:args];
     va_end(args);
 }
 

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SalesforceLogReceiver.swift
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SalesforceLogReceiver.swift
@@ -1,0 +1,52 @@
+/*
+ SalesforceLogReceiver.swift
+ SalesforceSDKCommon
+ 
+ Created by Eric Johnson on 11/12/24.
+ 
+ Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Foundation
+
+/**
+ * Any object that can be registered with Salesforce logger and receive issued log entries.
+ */
+@objc(SFLogReceiver)
+public protocol SalesforceLogReceiver {
+    
+    /**
+     * Receives a log entry.
+     * - Parameters
+     *   - level:  The log entry's level
+     *   - cls: The log entry's associated class
+     *   - component: The log entry's associated component name
+     *   - message: The log entry's message
+     */
+    func receive(
+        level: SalesforceLogger.Level,
+        cls: AnyClass,
+        component: String,
+        message: String
+    )
+}

--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SalesforceLogReceiverFactory.swift
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Logger/SalesforceLogReceiverFactory.swift
@@ -1,0 +1,45 @@
+/*
+ SalesforceLogReceiverFactory.swift
+ SalesforceSDKCommon
+ 
+ Created by Eric Johnson on 11/12/24.
+ 
+ Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Foundation
+
+/**
+ * Any object that can be registered with Salesforce logger to create log receivers.
+ */
+@objc(SFLogReceiverFactory)
+public protocol SalesforceLogReceiverFactory {
+    
+    /**
+     * Creates a log receiver for the named component.
+     * - Parameters
+     *   - componentName: The logger's named component
+     */
+    @objc
+    func create(componentName: String) -> SalesforceLogReceiver
+}


### PR DESCRIPTION
🎸 _*Ready For Review!*_ 🥁

  This is a counterpart to MSDK Android's [logging update](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2635).  Everything about MSDK's current logging API and support for file logging in downstream repositories remains the same.  What's new is the app can register "log receivers" via a new factory interface.  These will receive every log issued by MSDK in parallel with the existing logging infrastructure, if the app so desires.

  The big discussion topic here is if this meets both the requirements we have in the work item _plus_ those we may also know of in other threads.  @bbirman gave me quite a bit of the context, so I believe this is an abstract enough solution that most any app need could be met with this API.  I'd be really curious to see if that still looks like that case once we get eyes on this code update.

 Thanks, as always, for reading and I'll incorporate any updates we'll need based on our reviews.