### PR TITLE
Support for JWT-based access token

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		4F7EB4AB1BFFCF0000768720 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7EB4961BFFCEF600768720 /* AppDelegate.m */; };
 		4F7EB4AC1BFFCF0F00768720 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7EB4A01BFFCEF600768720 /* main.m */; };
 		4F7EB4AD1BFFCF2300768720 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7EB4A41BFFCEF600768720 /* ViewController.m */; };
+		4F8A3B012CEC202F00ECDC76 /* JwtAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A3B002CEC202F00ECDC76 /* JwtAccessToken.swift */; };
+		4F8A3B082CEC213400ECDC76 /* JwtAccessTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A3B072CEC212B00ECDC76 /* JwtAccessTokenTests.swift */; };
 		4FE5332A1BFFE70600814D2A /* Main_iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB4981BFFCEF600768720 /* Main_iPad.storyboard */; };
 		4FE5332B1BFFE70600814D2A /* Main_iPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB49A1BFFCEF600768720 /* Main_iPhone.storyboard */; };
 		6900B62C24B64DD800500923 /* NSURLResponse+SFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6900B62A24B64DD800500923 /* NSURLResponse+SFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -547,6 +549,8 @@
 		4F7EB4A21BFFCEF600768720 /* SalesforceSDKCoreTestApp-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SalesforceSDKCoreTestApp-Prefix.pch"; path = "SalesforceSDKCoreTestApp/SalesforceSDKCoreTestApp-Prefix.pch"; sourceTree = SOURCE_ROOT; };
 		4F7EB4A31BFFCEF600768720 /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ViewController.h; path = SalesforceSDKCoreTestApp/ViewController.h; sourceTree = SOURCE_ROOT; };
 		4F7EB4A41BFFCEF600768720 /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ViewController.m; path = SalesforceSDKCoreTestApp/ViewController.m; sourceTree = SOURCE_ROOT; };
+		4F8A3B002CEC202F00ECDC76 /* JwtAccessToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JwtAccessToken.swift; sourceTree = "<group>"; };
+		4F8A3B072CEC212B00ECDC76 /* JwtAccessTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JwtAccessTokenTests.swift; sourceTree = "<group>"; };
 		4F96FC521BFD32130022F021 /* NSData+SFSDKUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+SFSDKUtils.h"; sourceTree = "<group>"; };
 		4F96FC531BFD32130022F021 /* NSData+SFSDKUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+SFSDKUtils.m"; sourceTree = "<group>"; };
 		4F96FC541BFD32130022F021 /* NSData+SFSDKUtils_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+SFSDKUtils_Internal.h"; sourceTree = "<group>"; };
@@ -960,6 +964,7 @@
 		4F7EB3F61BFFC84700768720 /* SalesforceSDKCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				4F8A3B072CEC212B00ECDC76 /* JwtAccessTokenTests.swift */,
 				69DEF9DF2CBED60700D80D80 /* ScreenLockManagerTests.swift */,
 				69DFE0682B969C1D000906E4 /* CryptoUtilsTests.swift */,
 				69DFE0672B969C1D000906E4 /* PushNotificationDecryptionTests.swift */,
@@ -1115,6 +1120,7 @@
 		4F96FCC41BFD32130022F021 /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
+				4F8A3B002CEC202F00ECDC76 /* JwtAccessToken.swift */,
 				B7E1A77D1F4C8844007AC36A /* SFSDKAuthViewHandler.h */,
 				B7E1A77E1F4C8844007AC36A /* SFSDKAuthViewHandler.m */,
 				4F96FCC51BFD32130022F021 /* SFOAuthCoordinator+Internal.h */,
@@ -2139,6 +2145,7 @@
 				69CEBC7E22F368CF00F16218 /* SFNetworkTests.m in Sources */,
 				4F7EB41B1BFFC8D700768720 /* SFSDKCryptoUtilsTests.m in Sources */,
 				69848CB82364035300893E57 /* SFSDKEncryptedPushNotificationTests.m in Sources */,
+				4F8A3B082CEC213400ECDC76 /* JwtAccessTokenTests.swift in Sources */,
 				4F06AF8D1C49A18E00F70798 /* SalesforceSDKManagerTests.m in Sources */,
 				4F06AF8F1C49A18E00F70798 /* SFOAuthSessionRefresherTests.m in Sources */,
 				CEB98EE31F86E7DC0083AB9C /* SFSDKURLHandlerManagerTest.m in Sources */,
@@ -2251,6 +2258,7 @@
 				CE4CE34B1C0E5252009F6029 /* SFOAuthInfo.m in Sources */,
 				69EA56CC264B1FAA007FE339 /* SFSDKMacDetectUtil.m in Sources */,
 				CED452BA1D808D0C009266EB /* SFRestAPI+Files.m in Sources */,
+				4F8A3B012CEC202F00ECDC76 /* JwtAccessToken.swift in Sources */,
 				CE4CE38F1C0E526A009F6029 /* SFUserAccount.m in Sources */,
 				CE4CE3B21C0E5279009F6029 /* SFSDKWebUtils.m in Sources */,
 				B7A4AE4722E8C77C0060E737 /* SFSDKOAuth2.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -494,6 +494,7 @@ SFNativeLoginManagerInternal *nativeLogin;
             @"IDP Enabled", [self idpEnabled] ? @"YES" : @"NO",
             @"Identity Provider", [self isIdentityProvider] ? @"YES" : @"NO",
             @"Current User", [self userToString:userAccountManager.currentUser],
+            @"Access Token Expiration", [self accessTokenExpiration],
             @"Authenticated Users", [self usersToString:userAccountManager.allUserAccounts],
             @"User Key-Value Stores", [self safeJoin:[SFSDKKeyValueEncryptedFileStore allStoreNames] separator:@", "],
             @"Global Key-Value Stores", [self safeJoin:[SFSDKKeyValueEncryptedFileStore allGlobalStoreNames] separator:@", "]
@@ -506,8 +507,27 @@ SFNativeLoginManagerInternal *nativeLogin;
     if ([managedPreferences hasManagedPreferences]) {
         [devInfos addObjectsFromArray:[self dictToDevInfos:managedPreferences.rawPreferences keyPrefix:@"Managed Pref"]];
     }
-
+    
     return devInfos;
+}
+
+- (NSString *) accessTokenExpiration {
+    SFOAuthCredentials* creds = [SFUserAccountManager sharedInstance].currentUser.credentials;
+    NSString* expiration = @"Unknown";
+    
+    if ([creds.tokenFormat isEqualToString:@"jwt"]) {
+        SFSDKJwtAccessToken* jwtAccessToken = [[SFSDKJwtAccessToken alloc] initWithJwt:creds.accessToken error:nil];
+        if (jwtAccessToken) {
+            NSDate* expirationDate = jwtAccessToken.expirationDate;
+            if (expirationDate) {
+                NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+                [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
+                expiration = [dateFormatter stringFromDate:expirationDate];
+            }
+        }
+    }
+    
+    return expiration;
 }
 
 - (NSString*) userToString:(SFUserAccount*)user {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/JwtAccessToken.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/JwtAccessToken.swift
@@ -1,0 +1,130 @@
+//
+//  JwtAccessToken.swift
+//  SalesforceSDKCore
+//
+//  Created by Wolfgang Mathurin on 11/18/24.
+//  Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+// 
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+// 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import Foundation
+
+/// Struct representing a JWT Header
+public struct JwtHeader: Codable {
+    let algorithm: String?
+    let type: String?
+    let keyId: String?
+    let tokenType: String?
+    let tenantKey: String?
+    let version: String?
+
+    enum CodingKeys: String, CodingKey {
+        case algorithm = "alg"
+        case type = "typ"
+        case keyId = "kid"
+        case tokenType = "tty"
+        case tenantKey = "tnk"
+        case version = "ver"
+    }
+}
+
+/// Struct representing a JWT Payload
+public struct JwtPayload: Codable {
+    let audience: [String]?
+    let expirationTime: Int?
+    let issuer: String?
+    let notBeforeTime: Int?
+    let subject: String?
+    let scopes: String?
+    let clientId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case audience = "aud"
+        case expirationTime = "exp"
+        case issuer = "iss"
+        case notBeforeTime = "nbf"
+        case subject = "sub"
+        case scopes = "scp"
+        case clientId = "client_id"
+    }
+}
+
+/// Class representing a JWT Access Token
+public class JwtAccessToken {
+    let rawJwt: String
+    let header: JwtHeader
+    let payload: JwtPayload
+
+    /// Initializer to parse and decode the JWT string
+    init(jwt: String) throws {
+        self.rawJwt = jwt
+        self.header = try JwtAccessToken.parseJwtHeader(jwt: jwt)
+        self.payload = try JwtAccessToken.parseJwtPayload(jwt: jwt)
+    }
+
+    /// Helper method to decode the JWT Header
+    private static func parseJwtHeader(jwt: String) throws -> JwtHeader {
+        let parts = jwt.split(separator: ".")
+        guard parts.count >= 2 else {
+            throw JwtError.invalidFormat
+        }
+
+        let headerJson = try decodeBase64Url(String(parts[0]))
+        let data = Data(headerJson.utf8)
+        return try JSONDecoder().decode(JwtHeader.self, from: data)
+    }
+
+    /// Helper method to decode the JWT Payload
+    private static func parseJwtPayload(jwt: String) throws -> JwtPayload {
+        let parts = jwt.split(separator: ".")
+        guard parts.count >= 2 else {
+            throw JwtError.invalidFormat
+        }
+
+        let payloadJson = try decodeBase64Url(String(parts[1]))
+        let data = Data(payloadJson.utf8)
+        return try JSONDecoder().decode(JwtPayload.self, from: data)
+    }
+
+    /// Helper method to decode Base64 URL-encoded strings
+    private static func decodeBase64Url(_ string: String) throws -> String {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let paddingLength = 4 - (base64.count % 4)
+        if paddingLength < 4 {
+            base64 += String(repeating: "=", count: paddingLength)
+        }
+
+        guard let data = Data(base64Encoded: base64),
+              let decodedString = String(data: data, encoding: .utf8) else {
+            throw JwtError.invalidBase64
+        }
+        return decodedString
+    }
+
+    /// Custom errors for JWT decoding
+    enum JwtError: Error {
+        case invalidFormat
+        case invalidBase64
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/JwtAccessToken.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/JwtAccessToken.swift
@@ -69,17 +69,27 @@ public struct JwtPayload: Codable {
 }
 
 /// Class representing a JWT Access Token
-public class JwtAccessToken {
+@objc(SFSDKJwtAccessToken)
+public class JwtAccessToken : NSObject {
     let rawJwt: String
     let header: JwtHeader
     let payload: JwtPayload
 
     /// Initializer to parse and decode the JWT string
-    init(jwt: String) throws {
+    @objc init(jwt: String) throws {
         self.rawJwt = jwt
         self.header = try JwtAccessToken.parseJwtHeader(jwt: jwt)
         self.payload = try JwtAccessToken.parseJwtPayload(jwt: jwt)
     }
+    
+    /// Returns the expiration time as a Date, or nil if not available
+    @objc public func expirationDate() -> Date? {
+        guard let expirationTime = payload.expirationTime else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: TimeInterval(expirationTime))
+    }
+    
 
     /// Helper method to decode the JWT Header
     private static func parseJwtHeader(jwt: String) throws -> JwtHeader {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
@@ -41,6 +41,7 @@ extern NSString * _Nonnull const kSFOAuthServiceLightningSid;
 extern NSString * _Nonnull const kSFOAuthServiceVfSid;
 extern NSString * _Nonnull const kSFOAuthServiceContentSid;
 extern NSString * _Nonnull const kSFOAuthServiceCsrf;
+extern NSString * _Nonnull const kSFOAuthServiceParentSid;
 
 extern NSException * _Nullable SFOAuthInvalidIdentifierException(void);
 
@@ -75,6 +76,9 @@ extern NSException * _Nullable SFOAuthInvalidIdentifierException(void);
 @property (nonatomic, readwrite, nullable) NSString *cookieClientSrc;
 @property (nonatomic, readwrite, nullable) NSString *cookieSidClient;
 @property (nonatomic, readwrite, nullable) NSString *sidCookieName;
+@property (nonatomic, readwrite, nullable) NSString *parentSid;
+@property (nonatomic, readwrite, nullable) NSString *tokenFormat;
+
 
 - (void)setPropertyForKey:(NSString *_Nonnull) key withValue:(id _Nullable ) newValue;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
@@ -136,6 +136,9 @@ NS_SWIFT_NAME(OAuthCredentials)
 @property (nonatomic, readonly, nullable) NSString *cookieClientSrc;
 @property (nonatomic, readonly, nullable) NSString *cookieSidClient;
 @property (nonatomic, readonly, nullable) NSString *sidCookieName;
+@property (nonatomic, readonly, nullable) NSString *parentSid;
+@property (nonatomic, readonly, nullable) NSString *tokenFormat;
+
 
 /** A readonly convenience property returning the Salesforce Organization ID provided in the path component of the identityUrl.
  

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -36,6 +36,7 @@ NSString * const kSFOAuthServiceLightningSid    = @"com.salesforce.mobilesdk.oau
 NSString * const kSFOAuthServiceVfSid           = @"com.salesforce.mobilesdk.oauth.vfSid";
 NSString * const kSFOAuthServiceContentSid      = @"com.salesforce.mobilesdk.oauth.contentSid";
 NSString * const kSFOAuthServiceCsrf            = @"com.salesforce.mobilesdk.oauth.csrf";
+NSString * const kSFOAuthServiceParentSid       = @"com.salesforce.mobilesdk.oauth.parentSid";
 
 NSString * const kSFOAuthServiceLegacyAccess    = @"com.salesforce.oauth.access";
 NSString * const kSFOAuthServiceLegacyRefresh   = @"com.salesforce.oauth.refresh";
@@ -109,6 +110,7 @@ NSException * SFOAuthInvalidIdentifierException() {
             self.cookieClientSrc  = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthClientSrc"];
             self.cookieSidClient  = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthCookieSidClient"];
             self.sidCookieName  = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthSidCookieName"];
+            self.tokenFormat  = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthTokenFormat"];
 
             if ([self isMemberOfClass:[SFOAuthCredentials class]]) {
                 // Otherwise they are stored in keychain
@@ -118,6 +120,7 @@ NSException * SFOAuthInvalidIdentifierException() {
                 self.vfSid  = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthVFSID"];
                 self.contentSid  = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthContentSID"];
                 self.csrfToken  = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthCSRFToken"];
+                self.parentSid = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthParentSID"];
             }
         }
     } else {
@@ -140,15 +143,12 @@ NSException * SFOAuthInvalidIdentifierException() {
     [coder encodeObject:self.issuedAt           forKey:@"SFOAuthIssuedAt"];
     [coder encodeObject:self.protocol           forKey:@"SFOAuthProtocol"];
     [coder encodeObject:self.lightningDomain    forKey:@"SFOAuthLightningDomain"];
-    [coder encodeObject:self.lightningSid       forKey:@"SFOAuthLightningSID"];
     [coder encodeObject:self.vfDomain           forKey:@"SFOAuthVFDomain"];
-    [coder encodeObject:self.vfSid              forKey:@"SFOAuthVFSID"];
     [coder encodeObject:self.contentDomain      forKey:@"SFOAuthContentDomain"];
-    [coder encodeObject:self.contentSid         forKey:@"SFOAuthContentSID"];
-    [coder encodeObject:self.csrfToken          forKey:@"SFOAuthCSRFToken"];
     [coder encodeObject:self.cookieClientSrc    forKey:@"SFOAuthClientSrc"];
     [coder encodeObject:self.cookieSidClient    forKey:@"SFOAuthCookieSidClient"];
     [coder encodeObject:self.sidCookieName      forKey:@"SFOAuthSidCookieName"];
+    [coder encodeObject:self.tokenFormat        forKey:@"SFOAuthTokenFormat"];
     [coder encodeObject:kSFOAuthArchiveVersion  forKey:@"SFOAuthArchiveVersion"];
     [coder encodeObject:@(self.isEncrypted)     forKey:@"SFOAuthEncrypted"];
     [coder encodeObject:self.additionalOAuthFields forKey:@"SFOAuthAdditionalFields"];
@@ -215,6 +215,8 @@ NSException * SFOAuthInvalidIdentifierException() {
     copyCreds.cookieClientSrc = self.cookieClientSrc;
     copyCreds.cookieSidClient = self.cookieSidClient;
     copyCreds.sidCookieName = self.sidCookieName;
+    copyCreds.parentSid = self.parentSid;
+    copyCreds.tokenFormat = self.tokenFormat;
     copyCreds.additionalOAuthFields = [self.additionalOAuthFields copy];
     return copyCreds;
 }
@@ -323,6 +325,8 @@ NSException * SFOAuthInvalidIdentifierException() {
     self.cookieClientSrc = nil;
     self.cookieSidClient = nil;
     self.sidCookieName = nil;
+    self.parentSid = nil;
+    self.tokenFormat = nil;
 }
 
 - (void)setPropertyForKey:(NSString *) propertyName withValue:(id) newValue {
@@ -415,6 +419,12 @@ NSException * SFOAuthInvalidIdentifierException() {
     }
     if (params[kSFOAuthSidCookieName]) {
         self.sidCookieName = params[kSFOAuthSidCookieName];
+    }
+    if (params[kSFOAuthParentSid]) {
+        self.parentSid = params[kSFOAuthParentSid];
+    }
+    if (params[kSFOAuthTokenFormat]) {
+        self.tokenFormat = params[kSFOAuthTokenFormat];
     }
 
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthKeychainCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthKeychainCredentials.m
@@ -98,6 +98,14 @@
     [self encryptToken:token forService:kSFOAuthServiceCsrf];
 }
 
+- (NSString *)parentSid {
+    return [self decryptedTokenForService:kSFOAuthServiceParentSid];
+}
+
+- (void)setParentSid:(NSString *)sid {
+    [self encryptToken:sid forService:kSFOAuthServiceParentSid];
+}
+
 
 #pragma mark - Private Keychain Methods
 - (NSData *)tokenForService:(NSString *)service

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -124,6 +124,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *cookieClientSrc;
 @property (nonatomic, readonly, nullable) NSString *cookieSidClient;
 @property (nonatomic, readonly, nullable) NSString *sidCookieName;
+@property (nonatomic, readonly, nullable) NSString *parentSid;
+@property (nonatomic, readonly, nullable) NSString *tokenFormat;
 - (NSDictionary *)asDictionary;
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -188,6 +188,14 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     return self.values[kSFOAuthSidCookieName];
 }
 
+- (NSString *)parentSid {
+    return self.values[kSFOAuthParentSid];
+}
+
+- (NSString *)tokenFormat {
+    return self.values[kSFOAuthTokenFormat];
+}
+
 - (NSURL *)communityUrl {
     if (_values[kSFOAuthCommunityUrl]) {
         return [NSURL URLWithString:self.values[kSFOAuthCommunityUrl]];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -75,6 +75,8 @@ static NSString * const kSFOAuthCSRFToken                       = @"csrf_token";
 static NSString * const kSFOAuthCookieClientSrc                 = @"cookie-clientSrc";
 static NSString * const kSFOAuthCookieSidClient                 = @"cookie-sid_Client";
 static NSString * const kSFOAuthSidCookieName                   = @"sidCookieName";
+static NSString * const kSFOAuthParentSid                       = @"parentSid";
+static NSString * const kSFOAuthTokenFormat                     = @"tokenFormat";
 
 // Used for the IP bypass flow, Advanced auth flow
 static NSString * const kSFOAuthApprovalCode                     = @"code";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -75,8 +75,8 @@ static NSString * const kSFOAuthCSRFToken                       = @"csrf_token";
 static NSString * const kSFOAuthCookieClientSrc                 = @"cookie-clientSrc";
 static NSString * const kSFOAuthCookieSidClient                 = @"cookie-sid_Client";
 static NSString * const kSFOAuthSidCookieName                   = @"sidCookieName";
-static NSString * const kSFOAuthParentSid                       = @"parentSid";
-static NSString * const kSFOAuthTokenFormat                     = @"tokenFormat";
+static NSString * const kSFOAuthParentSid                       = @"parent_sid";
+static NSString * const kSFOAuthTokenFormat                     = @"token_format";
 
 // Used for the IP bypass flow, Advanced auth flow
 static NSString * const kSFOAuthApprovalCode                     = @"code";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/JwtAccessTokenTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/JwtAccessTokenTests.swift
@@ -1,0 +1,80 @@
+//
+//  JwtAccessTokenTests.swift
+//  SalesforceSDKCore
+//
+//  Created by Wolfgang Mathurin on 11/18/24.
+//  Copyright (c) 2024-present, salesforce.com, inc. All rights reserved.
+//
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+import XCTest
+@testable import SalesforceSDKCore
+
+class JwtAccessTokenTests: XCTestCase {
+    private let testRawJwt = "eyJ0bmsiOiJjb3JlL2ZhbGNvbnRlc3QxLWNvcmU0c2RiNi8wMERTRzAwMDAwOUZZVmQyQU8iLCJ2ZXIiOiIxLjAiLCJraWQiOiJDT1JFX0FUSldULjAwRFNHMDAwMDA5RllWZC4xNzI1NTc5NDIwMTI1IiwidHR5Ijoic2ZkYy1jb3JlLXRva2VuIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzY3AiOiJyZWZyZXNoX3Rva2VuIHdlYiBhcGkiLCJhdWQiOlsiaHR0cHM6Ly9tb2JpbGVzZGthdHNkYjYudGVzdDEubXkucGMtcm5kLnNhbGVzZm9yY2UuY29tIl0sInN1YiI6InVpZDowMDVTRzAwMDAwOGVpQWJZQUkiLCJuYmYiOjE3MzAzODY2MjAsIm10eSI6Im9hdXRoIiwic2ZpIjoiYTZjZjk1MjY2NjYzM2Q4ZDUxMDUzNjkzNDcwZDczYzVhOTY4ZTA4NmQ1OGQ2NzlmYTVjMzY1ZmNhMGZiZjhkYyIsInJvbGVzIjpbXSwiaXNzIjoiaHR0cHM6Ly9tb2JpbGVzZGthdHNkYjYudGVzdDEubXkucGMtcm5kLnNhbGVzZm9yY2UuY29tIiwiaHNjIjpmYWxzZSwiZXhwIjoxNzMwMzg2Njk1LCJpYXQiOjE3MzAzODY2MzUsImNsaWVudF9pZCI6IjNNVkc5LkFnd3RvSXZFUlNkOGk4bGVQcnFmczdDYXpSeDJsbGJMOHViTm9HNlIzSHNZb21RRlJwYmF5YU1INEh0ekgzemowTkRFbUMwUElvaHcwUGYifQ.R8RDUDlRD-6LIzV2epi8y7m1_zWBwfvmTAhUiGOjg1fDWGxsX48hSi95WITHtZ-D-gDQEjVl1GBGKsIe7jEBdGkhoFhbUuYFEnd15bcYlmLBIpmRdSbSvImusaeGVBx2hLhv4Icl7md_BuNoiz6BpuV-T_0a0QxRkpo97sGN1MghO6m9ItzXY9ldR7m5_pOORy3eZ1q4JZ1aj49pphom_O_ZQAeWYX7Gp9dZjhxlLFYgk0XrarC689LOhfSAyBhJO-OvtgKrvUY1XiWEaZR3A2FAk-AK1ZrNenKB_76JGEppuODCpRyqiUUlLmFkzcx897KeTQGoC_QDrdn0y4speA"
+
+    func testDecodeValidJwtAndParseHeader() {
+        do {
+            let decodedJwt = try JwtAccessToken(jwt: testRawJwt)
+            XCTAssertNotNil(decodedJwt)
+
+            let jwtHeader = decodedJwt.header
+            XCTAssertNotNil(jwtHeader)
+
+            XCTAssertEqual(jwtHeader.algorithm, "RS256")
+            XCTAssertEqual(jwtHeader.type, "JWT")
+            XCTAssertEqual(jwtHeader.keyId, "CORE_ATJWT.00DSG000009FYVd.1725579420125")
+            XCTAssertEqual(jwtHeader.tokenType, "sfdc-core-token")
+            XCTAssertEqual(jwtHeader.tenantKey, "core/falcontest1-core4sdb6/00DSG000009FYVd2AO")
+            XCTAssertEqual(jwtHeader.version, "1.0")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testDecodeValidJwtAndParsePayload() {
+        do {
+            let decodedJwt = try JwtAccessToken(jwt: testRawJwt)
+            XCTAssertNotNil(decodedJwt)
+
+            let jwtPayload = decodedJwt.payload
+            XCTAssertNotNil(jwtPayload)
+
+            XCTAssertEqual(jwtPayload.audience, ["https://mobilesdkatsdb6.test1.my.pc-rnd.salesforce.com"])
+            XCTAssertEqual(jwtPayload.expirationTime, 1730386695)
+            XCTAssertEqual(jwtPayload.issuer, "https://mobilesdkatsdb6.test1.my.pc-rnd.salesforce.com")
+            XCTAssertEqual(jwtPayload.notBeforeTime, 1730386620)
+            XCTAssertEqual(jwtPayload.subject, "uid:005SG000008eiAbYAI")
+            XCTAssertEqual(jwtPayload.scopes, "refresh_token web api")
+            XCTAssertEqual(jwtPayload.clientId, "3MVG9.AgwtoIvERSd8i8lePrqfs7CazRx2llbL8ubNoG6R3HsYomQFRpbayaMH4HtzH3zj0NDEmC0PIohw0Pf")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testInvalidJwt() {
+        let invalidRawJwt = "invalid-jwt-string"
+        XCTAssertThrowsError(try JwtAccessToken(jwt: invalidRawJwt)) { error in
+            XCTAssertEqual(error as? JwtAccessToken.JwtError, JwtAccessToken.JwtError.invalidFormat)
+        }
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
@@ -140,6 +140,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     credsIn.cookieClientSrc = @"cookie-client-src-test";
     credsIn.cookieSidClient = @"cookie-sid-client";
     credsIn.sidCookieName   = @"sid-cookie-name";
+    credsIn.parentSid       = @"parent-sid";
+    credsIn.tokenFormat     = @"token-format";
 
     credsIn.additionalOAuthFields = @{
         @"abc": @"def"
@@ -178,6 +180,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     XCTAssertEqualObjects(credsIn.cookieClientSrc,     credsOut.cookieClientSrc,     @"cookieClientSrc mismatch");
     XCTAssertEqualObjects(credsIn.cookieSidClient,     credsOut.cookieSidClient,     @"cookieSidClient mismatch");
     XCTAssertEqualObjects(credsIn.sidCookieName,       credsOut.sidCookieName,       @"sidCookieName mismatch");
+    XCTAssertEqualObjects(credsIn.parentSid,           credsOut.parentSid,           @"parentSid mismatch");
+    XCTAssertEqualObjects(credsIn.tokenFormat,         credsOut.tokenFormat,         @"tokenFormat mismatch");
     XCTAssertEqualObjects(credsIn.additionalOAuthFields, credsOut.additionalOAuthFields, @"additionalFields mismatch");
     
     credsIn = nil;
@@ -206,6 +210,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     NSString *cookieClientSrcToCheck = @"cookie-client-src-test";
     NSString *cookieSidClientToCheck = @"cookie-sid-client";
     NSString *sidCookieNameToCheck = @"sid-cookie-name";
+    NSString *parentSidToCheck = @"parent-sid";
+    NSString *tokenFormatToCheck = @"token-format";
     NSDictionary *additionalFieldsToCheck = @{ @"field1": @"field1Val" };
     
     SFOAuthCredentials *origCreds = [[SFOAuthCredentials alloc] initWithIdentifier:kIdentifier clientId:kClientId encrypted:YES];
@@ -228,6 +234,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     origCreds.cookieClientSrc = cookieClientSrcToCheck;
     origCreds.cookieSidClient = cookieSidClientToCheck;
     origCreds.sidCookieName = sidCookieNameToCheck;
+    origCreds.parentSid = parentSidToCheck;
+    origCreds.tokenFormat = tokenFormatToCheck;
     
     // NB: Intentionally ordering the setting of these, because setting the identity URL automatically
     // sets the OrgID and UserID.  This ensures the values stay in sync.
@@ -261,6 +269,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     origCreds.cookieClientSrc = nil;
     origCreds.cookieSidClient = nil;
     origCreds.sidCookieName = nil;
+    origCreds.parentSid = nil;
+    origCreds.tokenFormat = nil;
     origCreds.additionalOAuthFields = nil;
     
     XCTAssertNotEqual(origCreds, copiedCreds);
@@ -284,6 +294,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     XCTAssertEqual(origCreds.contentSid, copiedCreds.contentSid);
     XCTAssertNotEqual(copiedCreds.csrfToken, csrfTokenToCheck);
     XCTAssertEqual(origCreds.csrfToken, copiedCreds.csrfToken);
+    XCTAssertNotEqual(copiedCreds.parentSid, parentSidToCheck);
+    XCTAssertEqual(origCreds.parentSid, copiedCreds.parentSid);
 
     XCTAssertEqual(copiedCreds.organizationId, orgIdToCheck);
     XCTAssertNotEqual(origCreds.organizationId, copiedCreds.organizationId);
@@ -311,6 +323,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     XCTAssertNotEqual(origCreds.cookieSidClient, copiedCreds.cookieSidClient);
     XCTAssertEqual(copiedCreds.sidCookieName, sidCookieNameToCheck);
     XCTAssertNotEqual(origCreds.sidCookieName, copiedCreds.sidCookieName);
+    XCTAssertEqual(copiedCreds.tokenFormat, tokenFormatToCheck);
+    XCTAssertNotEqual(origCreds.tokenFormat, copiedCreds.tokenFormat);
     XCTAssertEqual(copiedCreds.additionalOAuthFields, additionalFieldsToCheck);
     XCTAssertNotEqual(origCreds.additionalOAuthFields, copiedCreds.additionalOAuthFields);
 }


### PR DESCRIPTION
## Overview
Connected app / external client app can be configured to issue JWT-based access token (for more information see [here](https://help.salesforce.com/s/articleView?id=sf.connected_app_enable_jwt.htm&type=5)).

The mobile application does not need to know if it is using a JWT-based access token or an opaque token **in most cases**.
Login and refresh will just work as before.

However, front door URL cannot be built directly using the JWT-based access token. Instead the [single access API](https://help.salesforce.com/s/articleView?id=sf.frontdoor_singleaccess.htm&type=5) should be called to generate front door URL.

We already made changes in the Mobile SDK to be JWT-based access token ready:
- We introduced a REST wrapper for single access API and leveraged it in the IDP-SP flow (see https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3758)
- We moved away from front-door and hydrated the web view session in hybrid remote apps using the cookies returned by the oauth hybrid flow (https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Hybrid/pull/256)

## Changes in this PR
- We are saving the token format and parent sid returned by the token end point during login and refresh in the user account.
- We added a class `JwtAccessToken` to allow apps to inspect the JWT encoded in the JWT-based access token.

## Testing
- We added tests to check that token format and parent sid are properly captured and saved.
- We added tests for `JwtAccessToken`.
- We manually verified that login/refresh works in native applications.
- We manually verified that the IDP-SP flows work when JWT-based access token are being used.

## TODO 
Will happen in a separate PR on the [SalesforceMobileSDK-iOS-Hybrid repo](https://github.com/forcedotcom/SalesforceMobileSDK-ios-hybrid)
- Modify `SalesforceWebViewCookieManager` i.e. the class responsible for hydrating the web view sessions in hybrid remote apps when JWT-based access token are in use.
- Manually verify that login/refresh works in hybrid remote applications.


