### PR TITLE
Fix for static analysis

### DIFF
--- a/.github/DangerFiles/StaticAnalysis.rb
+++ b/.github/DangerFiles/StaticAnalysis.rb
@@ -26,7 +26,7 @@ for file in files;
 
     if modified_file_names.include?(report_file_name) || added_file_names.include?(report_file_name)
         issues = report['diagnostics']
-        print "File modified in PR: #{file}, has #{issue.count} issues.\n"
+        print "File modified in PR: #{file}, has #{issues.count} issues.\n"
         for i in 0..issues.count-1
             unless issues[i].nil?
                 message << "#{report_file_name} | #{issues[i]['type']} | #{issues[i]['category']} | #{issues[i]['description']} | #{issues[i]['location']['line']} | #{issues[i]['location']['col']}\n"


### PR DESCRIPTION
I got this error on a run and I think it's just a small typo (haven't tried testing on a fork): 
```
[!] Invalid `StaticAnalysis.rb` file: undefined local variable or method `issue' for an instance of Danger::Dangerfile
 #  from StaticAnalysis.rb:29
 #  -------------------------------------------
 #          issues = report['diagnostics']
 >          print "File modified in PR: #{file}, has #{issue.count} issues.\n"
 #          for i in 0..issues.count-1
 #  -------------------------------------------
 ```