### PR TITLE
Fix for snapshot dismissal

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
@@ -195,7 +195,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     UIScene *scene = UIApplication.sharedApplication.connectedScenes.allObjects.firstObject;
     [[NSNotificationCenter defaultCenter] postNotificationName:UISceneDidEnterBackgroundNotification object:scene];
     XCTAssertTrue(presentOnBackground, @"Did not respond to scene background.");
-    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillEnterForegroundNotification object:scene];
+    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneDidActivateNotification object:scene];
     XCTAssertTrue(dismissOnDidBecomeActive, @"Did not respond to app did become active.");
 }
 
@@ -241,7 +241,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     // This will simulate that the snapshot view is being presented
     UIView* fakeView = [UIView new];
     [fakeView addSubview:defaultViewControllerOnPresentation.view];
-    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillEnterForegroundNotification
+    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneDidActivateNotification
                                                         object:scene];
     XCTAssertEqual(defaultViewControllerOnPresentation, defaultViewControllerOnDismissal, @"Default snapshot view controller on dismissal is different than the one provided on presentation!");
 }
@@ -288,7 +288,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     // This will simulate that the snapshot view is being presented
     UIView* fakeView = [UIView new];
     [fakeView addSubview:customSnapshot.view];
-    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneWillEnterForegroundNotification object:scene];
+    [[NSNotificationCenter defaultCenter] postNotificationName:UISceneDidActivateNotification object:scene];
     XCTAssertEqual(customSnapshot, snapshotOnDismissal, @"Custom snapshot view controller was not used on dismissal!");
 }
 


### PR DESCRIPTION
In https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3679 I changed the notification we use to dismiss snapshot from `UISceneDidActivateNotification` to `UISceneWillEnterForegroundNotification` because `UISceneDidActivateNotification` isn't called for screen mirroring and I thought `UISceneWillEnterForegroundNotification` could cover both cases.  There's a new issue with using `UISceneWillEnterForegroundNotification` so this PR separates it into using `UISceneDidActivateNotification` for the main flow like it was originally and `UISceneWillEnterForegroundNotification` for the non-interactive/mirrored case