### PR TITLE
Make jwt access token init public

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/JwtAccessToken.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/JwtAccessToken.swift
@@ -76,7 +76,7 @@ public class JwtAccessToken : NSObject {
     let payload: JwtPayload
 
     /// Initializer to parse and decode the JWT string
-    @objc init(jwt: String) throws {
+    @objc public init(jwt: String) throws {
         self.rawJwt = jwt
         self.header = try JwtAccessToken.parseJwtHeader(jwt: jwt)
         self.payload = try JwtAccessToken.parseJwtPayload(jwt: jwt)


### PR DESCRIPTION
Ran into this when building one of the templates with dev
<img width="428" alt="Screenshot 2024-12-23 at 1 24 26 PM" src="https://github.com/user-attachments/assets/5cd0ae07-157c-4990-8b9b-85ec981f8212" />
