### PR TITLE
Resize navigation title for accessibility + IDs for UI automation

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/NewLoginHostView.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/NewLoginHostView.swift
@@ -37,7 +37,9 @@ class NewLoginHostViewController: NSObject {
 
 struct NewLoginHostField: View {
     let fieldLabel: String
+    let fieldLabelAccessibilityID: String
     let fieldPlaceholder: String
+    let fieldInputAccessibilityID: String
     @Binding var fieldValue: String
     
     func placeholderText() -> Text {
@@ -50,7 +52,9 @@ struct NewLoginHostField: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             Text(fieldLabel)
+                .accessibilityIdentifier(fieldLabelAccessibilityID)
             TextField("", text: $fieldValue, prompt: placeholderText())
+                .accessibilityIdentifier(fieldInputAccessibilityID)
                 .autocorrectionDisabled()
                 .padding()
                 .background(
@@ -87,14 +91,18 @@ struct NewLoginHostView: View {
     var body: some View {
         List {
             NewLoginHostField(fieldLabel: SFSDKResourceUtils.localizedString("LOGIN_SERVER_URL"),
+                              fieldLabelAccessibilityID: "addconn_hostLabel",
                               fieldPlaceholder: SFSDKResourceUtils.localizedString("LOGIN_SERVER_URL_PLACEHOLDER"),
+                              fieldInputAccessibilityID: "addconn_hostInput",
                               fieldValue: $host)
                 .keyboardType(.URL)
                 .autocapitalization(.none)
                 .listRowSeparator(.hidden)
 
             NewLoginHostField(fieldLabel: SFSDKResourceUtils.localizedString("LOGIN_SERVER_NAME"),
+                              fieldLabelAccessibilityID: "addconn_nameLabel",
                               fieldPlaceholder: SFSDKResourceUtils.localizedString("LOGIN_SERVER_NAME_PLACEHOLDER"),
+                              fieldInputAccessibilityID: "addconn_nameInput",
                               fieldValue: $label)
                 .listRowSeparator(.hidden)
                 .padding(.bottom)

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -95,6 +95,8 @@
     if (bioAuthManager.locked && bioAuthManager.hasBiometricOptedIn) {
         [bioAuthManager presentBiometricWithScene:self.view.window.windowScene];
     }
+    
+    [self registerForTraitChanges:@[UITraitDisplayScale.class] withAction:@selector(setupNavigationBar)];
 }
 
 - (CGFloat) belowFrame:(CGRect) frame {
@@ -195,34 +197,35 @@
 #pragma mark - Setup Navigation bar
 
 - (void)setupNavigationBar {
-    
-    self.navBar = self.navigationController.navigationBar;
-    self.navBar.topItem.titleView = [self createTitleItem];
-    // Hides the gear icon if there are no hosts to switch to.
-    SFManagedPreferences *managedPreferences = [SFManagedPreferences sharedPreferences];
-    if (managedPreferences.onlyShowAuthorizedHosts && managedPreferences.loginHosts.count == 0) {
-        self.config.showSettingsIcon = NO;
-    }
-    if(self.showSettingsIcon) {
-        // Setup right bar button.
-       UIBarButtonItem *button = [self createSettingsButton];
-       if (!button.target){
-           [button setTarget:self];
-       }
-       if (!button.action){
-           [button setAction:@selector(showLoginHost:)];
-       }
-       self.navBar.topItem.rightBarButtonItem = button;
-    }
-    [self styleNavigationBar:self.navBar];
-    
-    if (self.navigationController == nil) {
-        [self.view addSubview:self.navBar];
-    }
-    
-    #if !TARGET_OS_VISION
+    if (self.showNavbar) {
+        self.navBar = self.navigationController.navigationBar;
+        self.navBar.topItem.titleView = [self createTitleItem];
+        // Hides the gear icon if there are no hosts to switch to.
+        SFManagedPreferences *managedPreferences = [SFManagedPreferences sharedPreferences];
+        if (managedPreferences.onlyShowAuthorizedHosts && managedPreferences.loginHosts.count == 0) {
+            self.config.showSettingsIcon = NO;
+        }
+        if(self.showSettingsIcon) {
+            // Setup right bar button.
+            UIBarButtonItem *button = [self createSettingsButton];
+            if (!button.target){
+                [button setTarget:self];
+            }
+            if (!button.action){
+                [button setAction:@selector(showLoginHost:)];
+            }
+            self.navBar.topItem.rightBarButtonItem = button;
+        }
+        [self styleNavigationBar:self.navBar];
+        
+        if (self.navigationController == nil) {
+            [self.view addSubview:self.navBar];
+        }
+        
+        #if !TARGET_OS_VISION
         [self setNeedsStatusBarAppearanceUpdate];
-    #endif
+        #endif
+    }
 }
 
 - (void)setupBackButton {
@@ -277,9 +280,13 @@
     }
     if (self.config.navBarFont) {
         item.font = self.config.navBarFont;
+    } else {
+        item.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
     }
+    
     item.text = title;
-    [item sizeToFit];
+    item.textAlignment = NSTextAlignmentCenter;
+    item.adjustsFontForContentSizeCategory = YES;
     return item;
 }
 


### PR DESCRIPTION
Example of default and big below. The default is a little bolder than it was before but it actually matches the nav bar titles that we're already had on "Add Connection" and "Choose Connection".

Tested on iPhone + iPad in portrait and landscape

<img width="300" alt="default" src="https://github.com/user-attachments/assets/4a5f9ac2-85e9-4e0e-85f7-1fd68452e6cd" />
<img width="300" alt="big" src="https://github.com/user-attachments/assets/a0726d7c-ca03-47ec-8219-98381a041ff7" />
