### PR TITLE
Add ability to provide SQLCipher license key

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore+Internal.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore+Internal.h
@@ -64,6 +64,8 @@ static NSString *const EXPLAIN_ROWS = @"rows";
 
 @interface SFSmartStore ()
 
++ (NSString *)licenseKey;
+
 @property (nonatomic, strong) FMDatabaseQueue *storeQueue;
 @property (nonatomic, strong) SFSmartStoreDatabaseManager *dbMgr;
 @property (nonatomic, assign) BOOL isGlobal;

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -229,6 +229,15 @@ NS_SWIFT_NAME(SmartStore)
  */
 + (void)setEncryptionKeyGenerator:(SFSmartStoreEncryptionKeyGenerator)newEncryptionKeyGenerator;
 
+/**
+ Set license key for SQLCipher
+ Needed when using commercial or enterprise editions of SQLCipher
+ Should be called before using SmartStore
+ 
+ @param licenseKey The license key string provided by Zetetic
+ */
++ (void)setLicenseKey:(NSString*)licenseKey;
+
 #pragma mark - Soup manipulation methods
 
 /**

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -477,9 +477,9 @@ NS_SWIFT_NAME(SmartStore)
 
 /**
  * Return SQLCipher FIPS status
- * @return 0 when using the community edition or the commercial edition and 1 when using the FIPS enabled enterprise edition
+ * @return true if using a FIPS enabled SQLCipher edition
  */
-- (NSString *)getCipherFIPSStatus NS_SWIFT_NAME(cipherFIPSStatus());
+- (BOOL)getCipherFIPSStatus NS_SWIFT_NAME(cipherFIPSStatus());
 
 #pragma mark - Long operations recovery methods
 

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.h
@@ -469,6 +469,18 @@ NS_SWIFT_NAME(SmartStore)
  */
 - (NSString *)getSQLCipherVersion NS_SWIFT_NAME(versionOfSQLCipher());
 
+/**
+ * Return SQLCipher provider version
+ * @return cipher provider version
+ */
+- (NSString *)getCipherProviderVersion NS_SWIFT_NAME(cipherProviderVersion());
+
+/**
+ * Return SQLCipher FIPS status
+ * @return 0 when using the community edition or the commercial edition and 1 when using the FIPS enabled enterprise edition
+ */
+- (NSString *)getCipherFIPSStatus NS_SWIFT_NAME(cipherFIPSStatus());
+
 #pragma mark - Long operations recovery methods
 
 /**

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -54,6 +54,7 @@ static SFSmartStoreEncryptionKeyGenerator _encryptionKeyGenerator = NULL;
 static SFSmartStoreEncryptionSaltBlock _encryptionSaltBlock = NULL;
 static BOOL _jsonSerializationCheckEnabled = NO;
 static BOOL _postRawJsonOnError = NO;
+static NSString* _licenseKey = NULL;
 
 // The name of the store name used by the SFSmartStorePlugin for hybrid apps
 NSString * const kDefaultSmartStoreName   = @"defaultStore";
@@ -718,6 +719,14 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     if (newEncryptionKeyGenerator != _encryptionKeyGenerator) {
         _encryptionKeyGenerator = newEncryptionKeyGenerator;
     }
+}
+
++ (NSString *)licenseKey {
+    return _licenseKey;
+}
+
++ (void)setLicenseKey:(NSString*)licenseKey {
+    _licenseKey = [licenseKey copy];
 }
 
 - (NSNumber *)currentTimeInMilliseconds {

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -2036,6 +2036,16 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     return [[self queryPragma:@"cipher_version"] componentsJoinedByString:@""];
 }
 
+- (NSString*) getCipherProviderVersion
+{
+    return [[self queryPragma:@"cipher_provider_version"] componentsJoinedByString:@""];
+}
+
+- (NSString*) getCipherFipsStatus
+{
+    return [[self queryPragma:@"cipher_fips_status"] componentsJoinedByString:@""];
+}
+
 - (NSArray*) queryPragma:(NSString*) pragma
 {
     __block NSMutableArray* result = [NSMutableArray new];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -2041,9 +2041,10 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
     return [[self queryPragma:@"cipher_provider_version"] componentsJoinedByString:@""];
 }
 
-- (NSString*) getCipherFipsStatus
+- (BOOL) getCipherFipsStatus
 {
-    return [[self queryPragma:@"cipher_fips_status"] componentsJoinedByString:@""];
+    NSString *cipherFIPSStatus = [[self queryPragma:@"cipher_fips_status"] componentsJoinedByString:@""];
+    return [cipherFIPSStatus isEqualToString:@"1"];
 }
 
 - (NSArray*) queryPragma:(NSString*) pragma

--- a/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.m
@@ -23,6 +23,7 @@
  */
 
 #import "SFSmartStoreDatabaseManager+Internal.h"
+#import "SFSmartStore+Internal.h"
 #import <SalesforceSDKCore/UIDevice+SFHardware.h>
 #import <SalesforceSDKCore/NSData+SFAdditions.h>
 #import <SalesforceSDKCore/NSString+SFAdditions.h>
@@ -199,6 +200,9 @@ static NSString * const kSFSmartStoreVerifyReadDbErrorDesc = @"Could not read fr
 
 + (FMDatabase*) unlockDatabase:(FMDatabase*)db key:(NSString*)key salt:(NSString *)salt {
     if ([db open]) {
+        if ([SFSmartStore licenseKey])
+            [[db executeQuery:[NSString stringWithFormat:@"PRAGMA cipher_license = '%@'", [SFSmartStore licenseKey]]] close];
+        
         if (key)
            [db setKey:key];
         

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -115,6 +115,18 @@
     XCTAssertEqualObjects(version, @"4.6.1 community");
 }
 
+- (void) testCipherProviderVersion
+{
+    NSString* cipherProviderVersion = [self.store getCipherProviderVersion];
+    XCTAssertEqualObjects(cipherProviderVersion, @"unknown");
+}
+
+- (void) testCipherFIPSStatus
+{
+    NSString* cipherFIPSStatus = [self.store getCipherFIPSStatus];
+    XCTAssertEqualObjects(cipherFIPSStatus, @"0");
+}
+
 /**
  * Test fts extension
  */

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -123,8 +123,8 @@
 
 - (void) testCipherFIPSStatus
 {
-    NSString* cipherFIPSStatus = [self.store getCipherFIPSStatus];
-    XCTAssertEqualObjects(cipherFIPSStatus, @"0");
+    BOOL cipherFIPSStatus = [self.store getCipherFIPSStatus];
+    XCTAssertFalse(cipherFIPSStatus);
 }
 
 /**


### PR DESCRIPTION
Needed in order to use commercial or enterprise editions of SQLCipher.

## Testing
- Put the SQLCipher.xcframework (and openssl.xcframework) for SQLCipher commercial or enterprise edition in the SmartStore project
- Change `libs/SmartStore/SmartStoreTestApp/AppDelegate.m b/libs/SmartStore/SmartStoreTestApp/AppDelegate.m`
```
#import "AppDelegate.h"
**#import <SmartStore/SmartStore.h>**

@implementation AppDelegate

- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
    // Override point for customization after application launch.
    [SFSmartStore setLicenseKey:@"--YOUR-SQLCIPHER-LICENSE-KEY--"];
    return YES;
}
```
## Expected Result
Only the testSQLCipherVersion should fail, it will report the SQLCipher edition you are using instead of community e.g.
```
SFSmartStoreTests.m:115: ((version) equal to (@"4.6.1 community")) failed: ("4.6.1 FIPS zetetic") is not equal to ("4.6.1 community")
``` 