### PR TITLE
Guards for analytics crash

### DIFF
--- a/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
+++ b/libs/SalesforceAnalytics/SalesforceAnalytics/Classes/Store/SFSDKEventStoreManager.m
@@ -97,7 +97,18 @@
         NSString *filename = [self filenameForEvent:eventCopy.eventId];
         NSString *parentDir = [filename stringByDeletingLastPathComponent];
         [[NSFileManager defaultManager] createDirectoryAtPath:parentDir withIntermediateDirectories:YES attributes: @{ NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication } error:&error];
-        [encryptedData writeToFile:filename options:NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication error:&error];
+        if (error) {
+            [SFSDKAnalyticsLogger w:[self class] format:@"Error occurred while trying to create directory: %@", error.localizedDescription];
+            return;
+        }
+        
+        @try {
+            [encryptedData writeToFile:filename options:NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication error:&error];
+        } @catch (NSException *e) {
+            [SFSDKAnalyticsLogger w:[self class] format:@"Exception thrown while writing to file: %@", e.reason];
+            return;
+        }
+        
         if (error) {
             [SFSDKAnalyticsLogger w:[self class] format:@"Error occurred while writing to file: %@", error.localizedDescription];
         } else {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Analytics/SFSDKSalesforceAnalyticsManager.m
@@ -82,7 +82,12 @@ static SInt32 kBatchProcessCount = 100;
                 return nil;
             }
             analyticsMgr = [[self alloc] initWithUser:userAccount];
-            analyticsManagerList[key] = analyticsMgr;
+            if (analyticsMgr) {
+                analyticsManagerList[key] = analyticsMgr;
+            } else {
+                [SFSDKCoreLogger w:[self class] format:@"%@ Unable to create a SFSDKSalesforceAnalyticsManager instance for a user.", NSStringFromSelector(_cmd)];
+                return nil;
+            }
         }
         return analyticsMgr;
     }
@@ -139,6 +144,11 @@ static SInt32 kBatchProcessCount = 100;
             rootStoreDir = [[SFDirectoryManager sharedManager] directoryForUser:userAccount type:NSDocumentDirectory components:@[ kEventStoresDirectory ]];
         } else {
             rootStoreDir = [[SFDirectoryManager sharedManager] globalDirectoryOfType:NSDocumentDirectory components:@[ kEventStoresDirectory ]];
+        }
+        
+        if (!rootStoreDir) {
+            [SFSDKCoreLogger e:[self class] format:@"Root directory path is nil"];
+            return nil;
         }
 
         NSError *error = nil;


### PR DESCRIPTION
Open to any ideas / changes to approach on this one

Backstory:
There's a crash with no repro steps that was originally reported on Sapp when `[encryptedData writeToFile:filename options:NSDataWritingFileProtectionCompleteUntilFirstUserAuthentication error:&error];` is called. @mbwimmer investigated and found that the fileName being nil could cause an exception but it was unclear how that scenario could happen ([more discussion here](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/3534/files)). That fix went into Sapp's fork but now MP is also seeing the same issue (still no repro steps). 

It looks like we do have a nullability conflict where SFSDKEventStoreManager's init method specifies a non-null storeDirectory but the method used to generate the directory that's eventually passed into that init method can return nil which would make the original `fileName` argument nil. Note: I still don't know what user scenario would cause that.

Two parts to the guards here:
- Fail initialization of the analytics manager earlier if a nil directory is provided since events will never successfully write without it, avoids invalid init with SFSDKEventStoreManager 
- Add a guard around the method to catch the exception like @mbwimmer originally had in case there's another cause





