### PR TITLE
@W-14212091 Remove userLogout AILTN event

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -254,7 +254,6 @@ static dispatch_once_t pred;
             NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
             attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
             attributes[@"errorDescription"] = error.localizedDescription;
-            [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:nil className:NSStringFromClass([strongSelf class]) attributes:attributes];
             [[SFUserAccountManager sharedInstance] logout:SFLogoutReasonUnexpected];
         }];
     } else {
@@ -494,7 +493,6 @@ static dispatch_once_t pred;
     NSMutableDictionary *attributes = [[NSMutableDictionary alloc] init];
     attributes[@"errorCode"] = [NSNumber numberWithInteger:error.code];
     attributes[@"errorDescription"] = error.localizedDescription;
-    [SFSDKEventBuilderHelper createAndStoreEvent:@"userLogout" userAccount:user className:NSStringFromClass([self class]) attributes:attributes];
 }
 
 #pragma mark - SFRestRequest factory methods


### PR DESCRIPTION
Based on discussion [here](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001akoOhYAI/view) and in stand up, the event doesn't work and it wouldn't be possible to use AILTN to log the scenario where the user's token is revoked because we need the token to publish to AILTN



What to change

Remove this line: https://github.com/forcedotcom/SalesforceMobileSDK-iOS/blob/821bc4f0eab189fb62d979e041f8715c3f3b13dc/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m#L257