### PR TITLE
Fix Nightly Test Runs

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,15 +13,16 @@ jobs:
       matrix:
         lib: [SalesforceSDKCommon, SalesforceAnalytics, SalesforceSDKCore, SmartStore, MobileSync]
         ios: [^18, ^17]
+        macos: [macos-15]
         include:
           - ios: ^18
-            macos: macos-15
+            xcode: ^16
           - ios: ^17
-            macos: macos-14
-
+            xcode: ^15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
+      xcode: ${{ matrix.xcode }}
       macos: ${{ matrix.macos }}
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Report Static Analysis
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bundle exec danger --dangerfile=.github/DanagerFiles/StaticAnalysis.rb --danger_id=StaticAnalysis
+        run: bundle exec danger --dangerfile=.github/DangerFiles/StaticAnalysis.rb --danger_id=StaticAnalysis
 
   test-orchestrator:
     runs-on: macos-15

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -36,7 +36,6 @@ jobs:
         env: 
           TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
         run: |
-          npm install shelljs@0.8.5
           ./install.sh
           echo $TEST_CREDENTIALS > ./shared/test/test_credentials.json
       - uses: mxcl/xcodebuild@v3
@@ -52,6 +51,9 @@ jobs:
       - uses: slidoapp/xcresulttool@v3.1.0
         with:
           path: test.xcresult
+          title: "${{ inputs.lib }} iOS ${{ inputs.ios }}"
+          show-code-coverage: false
+          upload-bundles: false
         if: success() || failure()
       - uses: codecov/codecov-action@v4
         with:


### PR DESCRIPTION
Use Xcode 15 and 16 on macos-15 instead of macos-14 and and macos-15 to run tests on iOS 17 and 18 for Nightly test runs.