### PR TITLE
Aligning logout reasons with Android

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -1574,8 +1574,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             NSArray *keys = [self.userAccountMap allKeys];
             for (SFUserAccountIdentity *identity in keys) {
                 // Logout any other user with Biometric Authentication
+                // This is an unexpected logout(s) because we only support one Bio Auth user.
                 if ([bioAuthManager checkForPolicyWithUserId:identity.userId] && ![identity isEqual:[self currentUserIdentity]]) {
-                    [self logoutUser:[self userAccountForUserIdentity:identity] reason:SFLogoutReasonRefreshTokenRotated];
+                    [self logoutUser:[self userAccountForUserIdentity:identity] reason:SFLogoutReasonUnexpected];
                 }
             }
         }
@@ -1821,7 +1822,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
                 if (preLoginCredentials != nil && ![preLoginCredentials.refreshToken isEqualToString:self.currentUser.credentials.refreshToken]) {
                     
                     id<SFSDKOAuthProtocol> authClient = self.authClient();
-                    [authClient revokeRefreshToken:preLoginCredentials reason:SFLogoutReasonUnknown];
+                    [authClient revokeRefreshToken:preLoginCredentials reason:SFLogoutReasonRefreshTokenRotated];
                 }
             } else if (hasMobilePolicy) {
                 [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureScreenLock];


### PR DESCRIPTION
* during login when signout out an existing user matching the newly logged in user, Android uses REFRESH_TOKEN_ROTATED while iOS was using SFLogoutReasonUnknown See [AuthenticationUtilities](https://github.com/forcedotcom/SalesforceMobileSDK-Android/blob/dev/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt#L163) and [OAuthWebviewHelper](https://github.com/forcedotcom/SalesforceMobileSDK-Android/blob/dev/libs/SalesforceSDK/src/com/salesforce/androidsdk/ui/OAuthWebviewHelper.kt#L529)

* on login with bio auth enabled, when signing out existing users (which should not happen because we only support one bio auth user) Android uses UNEXPECTED while iOS was using SFLogoutReasonRefreshTokenRotated See [AuthenticationUtilities](https://github.com/forcedotcom/SalesforceMobileSDK-Android/blob/dev/libs/SalesforceSDK/src/com/salesforce/androidsdk/auth/AuthenticationUtilities.kt#L176)