### PR TITLE
 @W-17964622 - Add notification types fetching

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		009D77521CA4A92200D5183A /* SFPushNotificationManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 009D77511CA4A92200D5183A /* SFPushNotificationManagerTests.m */; };
 		010A9B551CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 010A9B511CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h */; };
 		010A9B591CC1A147002AF4D3 /* SFCryptoStreamTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 010A9B521CC1A131002AF4D3 /* SFCryptoStreamTestUtils.m */; };
+		23945B712D78E4A60060B195 /* NotificationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23945B702D78E4A60060B195 /* NotificationType.swift */; };
+		23945B782D7A4C370060B195 /* PushNotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23945B772D7A4AF40060B195 /* PushNotificationManagerTests.swift */; };
 		23A4C7462D0CAFA000DF55EB /* ScreenLockManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A4C7452D0CAFA000DF55EB /* ScreenLockManagerTests.swift */; };
 		23A4C7492D0CAFCF00DF55EB /* NativeLoginManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A4C7482D0CAFCF00DF55EB /* NativeLoginManagerTests.swift */; };
 		23A4C74A2D0CAFCF00DF55EB /* JwtAccessTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A4C7472D0CAFCF00DF55EB /* JwtAccessTokenTests.swift */; };
@@ -519,6 +521,8 @@
 		009D77511CA4A92200D5183A /* SFPushNotificationManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFPushNotificationManagerTests.m; path = SalesforceSDKCoreTests/SFPushNotificationManagerTests.m; sourceTree = SOURCE_ROOT; };
 		010A9B511CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFCryptoStreamTestUtils.h; path = SalesforceSDKCoreTests/SFCryptoStreamTestUtils.h; sourceTree = SOURCE_ROOT; };
 		010A9B521CC1A131002AF4D3 /* SFCryptoStreamTestUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFCryptoStreamTestUtils.m; path = SalesforceSDKCoreTests/SFCryptoStreamTestUtils.m; sourceTree = SOURCE_ROOT; };
+		23945B702D78E4A60060B195 /* NotificationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationType.swift; sourceTree = "<group>"; };
+		23945B772D7A4AF40060B195 /* PushNotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManagerTests.swift; sourceTree = "<group>"; };
 		23A4C7452D0CAFA000DF55EB /* ScreenLockManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ScreenLockManagerTests.swift; path = SalesforceSDKCoreTests/ScreenLockManagerTests.swift; sourceTree = SOURCE_ROOT; };
 		23A4C7472D0CAFCF00DF55EB /* JwtAccessTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JwtAccessTokenTests.swift; path = SalesforceSDKCoreTests/JwtAccessTokenTests.swift; sourceTree = SOURCE_ROOT; };
 		23A4C7482D0CAFCF00DF55EB /* NativeLoginManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NativeLoginManagerTests.swift; path = SalesforceSDKCoreTests/NativeLoginManagerTests.swift; sourceTree = SOURCE_ROOT; };
@@ -1027,6 +1031,7 @@
 				010A9B521CC1A131002AF4D3 /* SFCryptoStreamTestUtils.m */,
 				4F7EB4571BFFC9D900768720 /* Supporting Files */,
 				009D77511CA4A92200D5183A /* SFPushNotificationManagerTests.m */,
+				23945B772D7A4AF40060B195 /* PushNotificationManagerTests.swift */,
 				8263FED21E7336BF0038F694 /* SFSDKAppFeatureMarkersTests.m */,
 				444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */,
 				B7E8A2AE1E77062E007C0D92 /* SFUserAccountManagerPersisterTests.m */,
@@ -1178,6 +1183,7 @@
 				69848CB12363FA1000893E57 /* SFSDKPushNotificationEncryptionConstants.h */,
 				69848CB32363FA3E00893E57 /* SFSDKPushNotificationError.h */,
 				69848CB42363FA3E00893E57 /* SFSDKPushNotificationError.m */,
+				23945B702D78E4A60060B195 /* NotificationType.swift */,
 			);
 			path = PushNotification;
 			sourceTree = "<group>";
@@ -2127,6 +2133,7 @@
 			files = (
 				6975869F23296D7500574148 /* SFSDKURLCacheTests.m in Sources */,
 				4F06AF911C49A18E00F70798 /* SFOAuthTestFlowCoordinatorDelegate.m in Sources */,
+				23945B782D7A4C370060B195 /* PushNotificationManagerTests.swift in Sources */,
 				6931EA49248F000600417362 /* SFUserIdUpgradeTests.m in Sources */,
 				CEB98EE21F86E7D70083AB9C /* SFSDKIDPLoginRequestCommandTest.m in Sources */,
 				B7E1A50E1F43B0FE007AC36A /* SFSDKWindowManagerTests.m in Sources */,
@@ -2351,6 +2358,7 @@
 				E1C80CF01C5AEE31001B3A21 /* SFSDKLoginHostListViewController.m in Sources */,
 				B773CCF81F8200BD00D2D1B2 /* SFSDKIDPLoginRequestCommand.m in Sources */,
 				CE4CE3931C0E526A009F6029 /* SFUserAccountIdentity.m in Sources */,
+				23945B712D78E4A60060B195 /* NotificationType.swift in Sources */,
 				CE4CE32D1C0E523B009F6029 /* SalesforceSDKManager.m in Sources */,
 				CE4CE3101C0E523B009F6029 /* NSDictionary+SFAdditions.m in Sources */,
 				B7FB26DD1F78096300FB25A2 /* SFSDKIDPLoginRequestHandler.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -24,8 +24,8 @@
 		009D77521CA4A92200D5183A /* SFPushNotificationManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 009D77511CA4A92200D5183A /* SFPushNotificationManagerTests.m */; };
 		010A9B551CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 010A9B511CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h */; };
 		010A9B591CC1A147002AF4D3 /* SFCryptoStreamTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 010A9B521CC1A131002AF4D3 /* SFCryptoStreamTestUtils.m */; };
+		238AA5802D827AF80036667C /* PushNotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 238AA57F2D827AF80036667C /* PushNotificationManagerTests.swift */; };
 		23945B712D78E4A60060B195 /* NotificationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23945B702D78E4A60060B195 /* NotificationType.swift */; };
-		23945B782D7A4C370060B195 /* PushNotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23945B772D7A4AF40060B195 /* PushNotificationManagerTests.swift */; };
 		23A4C7462D0CAFA000DF55EB /* ScreenLockManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A4C7452D0CAFA000DF55EB /* ScreenLockManagerTests.swift */; };
 		23A4C7492D0CAFCF00DF55EB /* NativeLoginManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A4C7482D0CAFCF00DF55EB /* NativeLoginManagerTests.swift */; };
 		23A4C74A2D0CAFCF00DF55EB /* JwtAccessTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A4C7472D0CAFCF00DF55EB /* JwtAccessTokenTests.swift */; };
@@ -521,8 +521,8 @@
 		009D77511CA4A92200D5183A /* SFPushNotificationManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFPushNotificationManagerTests.m; path = SalesforceSDKCoreTests/SFPushNotificationManagerTests.m; sourceTree = SOURCE_ROOT; };
 		010A9B511CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFCryptoStreamTestUtils.h; path = SalesforceSDKCoreTests/SFCryptoStreamTestUtils.h; sourceTree = SOURCE_ROOT; };
 		010A9B521CC1A131002AF4D3 /* SFCryptoStreamTestUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFCryptoStreamTestUtils.m; path = SalesforceSDKCoreTests/SFCryptoStreamTestUtils.m; sourceTree = SOURCE_ROOT; };
+		238AA57F2D827AF80036667C /* PushNotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PushNotificationManagerTests.swift; path = SalesforceSDKCoreTests/PushNotificationManagerTests.swift; sourceTree = SOURCE_ROOT; };
 		23945B702D78E4A60060B195 /* NotificationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationType.swift; sourceTree = "<group>"; };
-		23945B772D7A4AF40060B195 /* PushNotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationManagerTests.swift; sourceTree = "<group>"; };
 		23A4C7452D0CAFA000DF55EB /* ScreenLockManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ScreenLockManagerTests.swift; path = SalesforceSDKCoreTests/ScreenLockManagerTests.swift; sourceTree = SOURCE_ROOT; };
 		23A4C7472D0CAFCF00DF55EB /* JwtAccessTokenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JwtAccessTokenTests.swift; path = SalesforceSDKCoreTests/JwtAccessTokenTests.swift; sourceTree = SOURCE_ROOT; };
 		23A4C7482D0CAFCF00DF55EB /* NativeLoginManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NativeLoginManagerTests.swift; path = SalesforceSDKCoreTests/NativeLoginManagerTests.swift; sourceTree = SOURCE_ROOT; };
@@ -986,6 +986,7 @@
 		4F7EB3F61BFFC84700768720 /* SalesforceSDKCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				238AA57F2D827AF80036667C /* PushNotificationManagerTests.swift */,
 				23A4C7472D0CAFCF00DF55EB /* JwtAccessTokenTests.swift */,
 				23A4C7482D0CAFCF00DF55EB /* NativeLoginManagerTests.swift */,
 				23A4C7452D0CAFA000DF55EB /* ScreenLockManagerTests.swift */,
@@ -1031,7 +1032,6 @@
 				010A9B521CC1A131002AF4D3 /* SFCryptoStreamTestUtils.m */,
 				4F7EB4571BFFC9D900768720 /* Supporting Files */,
 				009D77511CA4A92200D5183A /* SFPushNotificationManagerTests.m */,
-				23945B772D7A4AF40060B195 /* PushNotificationManagerTests.swift */,
 				8263FED21E7336BF0038F694 /* SFSDKAppFeatureMarkersTests.m */,
 				444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */,
 				B7E8A2AE1E77062E007C0D92 /* SFUserAccountManagerPersisterTests.m */,
@@ -2133,7 +2133,7 @@
 			files = (
 				6975869F23296D7500574148 /* SFSDKURLCacheTests.m in Sources */,
 				4F06AF911C49A18E00F70798 /* SFOAuthTestFlowCoordinatorDelegate.m in Sources */,
-				23945B782D7A4C370060B195 /* PushNotificationManagerTests.swift in Sources */,
+				238AA5802D827AF80036667C /* PushNotificationManagerTests.swift in Sources */,
 				6931EA49248F000600417362 /* SFUserIdUpgradeTests.m in Sources */,
 				CEB98EE21F86E7D70083AB9C /* SFSDKIDPLoginRequestCommandTest.m in Sources */,
 				B7E1A50E1F43B0FE007AC36A /* SFSDKWindowManagerTests.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/PushNotificationManager.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/PushNotificationManager.swift
@@ -32,6 +32,7 @@ public enum PushNotificationManagerError: Error {
     case registrationFailed
     case currentUserNotDetected
     case failedNotificationTypesRetrieval
+    case notificationActionInvocationFailed(String)
 }
 
 enum UserDefaultsKeys {
@@ -91,6 +92,30 @@ extension PushNotificationManager {
 }
 
 extension PushNotificationManager {
+    @objc
+    func getNotificationTypes(restClient: RestClient = RestClient.shared,
+                                 account: UserAccount? = UserAccountManager.shared.currentUserAccount) async throws -> [NotificationType] {
+        guard let account = account else {
+            throw PushNotificationManagerError.currentUserNotDetected as Error
+        }
+        
+        do {
+            let types = try await fetchNotificationTypesFromAPI(with: restClient)
+            storeNotification(types: types, with: account)
+            setNotificationCategories(types: types)
+            return (types)
+        } catch {
+            SFSDKCoreLogger().d(PushNotificationManager.self, message: "API fetch failed: \(error.localizedDescription). Trying cache...")
+            guard let cachedTypes = getCachedNotificationTypes(with: account) else {
+                SFSDKCoreLogger().e(PushNotificationManager.self, message: "No cached notification types available.")
+                throw PushNotificationManagerError.failedNotificationTypesRetrieval as Error
+            }
+            SFSDKCoreLogger().d(PushNotificationManager.self, message: "Using cached notification types.")
+            setNotificationCategories(types: cachedTypes)
+            return (cachedTypes)
+        }
+    }
+    
     private func fetchNotificationTypesFromAPI(with client: RestClient) async throws -> [NotificationType] {
         let request = RestRequest(method: .GET, path: "connect/notifications/types", queryParams: nil)
         let response = try await client.send(request: request)
@@ -127,38 +152,99 @@ extension PushNotificationManager {
                 }
             }
         }
+    
+    private func getNotificationType(apiName: String, account: UserAccount) -> NotificationType? {
+        guard let notificationTypes = account.notificationTypes else { return nil }
+        return notificationTypes.first { $0.apiName == apiName }
+    }
 }
 
 @objc
 extension PushNotificationManager {
-    /// Retrieves available notification types from the API or local cache if the API request fails.
+    
+    /// Retrieves all stored notification types for the current or specified user account.
+    ///
+    /// - Parameter account: The user account from which to retrieve notification types. Defaults to the current user.
+    /// - Returns: An array of `NotificationType` if available, otherwise `nil`.
+    func getNotificationTypes(account: UserAccount? = UserAccountManager.shared.currentUserAccount) -> [NotificationType]? {
+        return account?.notificationTypes
+    }
+    
+    /// Retrieves all action groups for a given notification type.
     ///
     /// - Parameters:
-    ///   - restClient: The `RestClient` instance used to fetch notification types from the API.
-    ///   - userDefaults: Stores and retrieves cached notification types. Defaults to `.standard`.
-    /// - Returns: A tuple containing:
-    ///   - `Bool`: `true` if notification types were successfully retrieved and stored; `false` if retrieval failed.
-    ///   - `Error?`: An error object if retrieval fails completely, or `nil` if successful.
-    ///
-    /// If the API fetch fails, the function attempts to retrieve notification types from the cache.
-    /// If neither source provides data, the function returns `false` with an appropriate error.
+    ///   - notificationTypeApiName: The API name of the notification type.
+    ///   - account: The user account from which to retrieve action groups. Defaults to the current user.
+    /// - Returns: An array of `ActionGroup` if found, otherwise `nil`.
     @objc
-    public func getNotificationTypes(restClient: RestClient = RestClient.shared,
-                                     account: UserAccount) async -> (Bool, Error?) {
+    public func getActionGroups(notificationTypeApiName: String,
+                                account: UserAccount? = UserAccountManager.shared.currentUserAccount) -> [ActionGroup]? {
+        guard let account = account,
+              let notificationType = getNotificationType(apiName: notificationTypeApiName, account: account) else {
+            return nil
+        }
+        return notificationType.actionGroups
+    }
+    
+    /// Retrieves a specific action group for a given notification type.
+    ///
+    /// - Parameters:
+    ///   - notificationTypeApiName: The API name of the notification type.
+    ///   - actionGroupName: The name of the action group.
+    ///   - account: The user account from which to retrieve the action group. Defaults to the current user.
+    /// - Returns: The `ActionGroup` if found, otherwise `nil`.
+    @objc
+    public func getActionGroup(notificationTypeApiName: String,
+                               actionGroupName: String,
+                               account: UserAccount? = UserAccountManager.shared.currentUserAccount) -> ActionGroup? {
+        guard let account = account,
+              let notificationType = getNotificationType(apiName: notificationTypeApiName, account: account) else {
+            return nil
+        }
+        return notificationType.actionGroups.first { $0.name == actionGroupName }
+    }
+    
+    /// Retrieves a specific action by its identifier within a given notification type.
+    ///
+    /// - Parameters:
+    ///   - notificationTypeApiName: The API name of the notification type.
+    ///   - actionIdentifier: The identifier of the action.
+    ///   - account: The user account from which to retrieve the action. Defaults to the current user.
+    /// - Returns: The `Action` if found, otherwise `nil`.
+    @objc
+    public func getAction(notificationTypeApiName: String,
+                          actionIdentifier: String,
+                          account: UserAccount? = UserAccountManager.shared.currentUserAccount) -> Action? {
+        guard let account = account,
+              let notificationType = getNotificationType(apiName: notificationTypeApiName, account: account) else {
+            return nil
+        }
+        return notificationType.actionGroups
+            .flatMap { $0.actions }
+            .first { $0.identifier == actionIdentifier }
+    }
+    
+    /// Invokes a server-side notification action for a specific notification.
+    ///
+    /// - Parameters:
+    ///   - client: The `RestClient` instance to use for the request. Defaults to `RestClient.shared`.
+    ///   - notificationId: The ID of the notification for which the action is invoked.
+    ///   - actionIdentifier: The identifier of the action to be performed.
+    /// - Throws: `PushNotificationManagerError.notificationActionInvocationFailed` if the action invocation fails.
+    /// - Returns: An `ActionResultRepresentation` containing the response from the server.
+    @objc
+    public func invokeServerNotificationAction(client: RestClient = RestClient.shared,
+                                               notificationId: String,
+                                               actionIdentifier: String
+    ) async throws -> ActionResultRepresentation {
+        let path = "/connect/notifications/\(notificationId)/actions/\(actionIdentifier)"
+        let request = RestRequest(method: .POST, path: path, queryParams: nil)
+        
         do {
-            let types = try await fetchNotificationTypesFromAPI(with: restClient)
-            storeNotification(types: types, with: account)
-            setNotificationCategories(types: types)
-            return (true, nil)
+            let response = try await client.send(request: request)
+            return try response.asDecodable(type: ActionResultRepresentation.self)
         } catch {
-            print("API fetch failed: \(error.localizedDescription). Trying cache...")
-            guard let cachedTypes = getCachedNotificationTypes(with: account) else {
-                print("No cached notification types available.")
-                return (false, PushNotificationManagerError.failedNotificationTypesRetrieval as Error)
-            }
-            print("Using cached notification types.")
-            setNotificationCategories(types: cachedTypes)
-            return (true, nil)
+            throw PushNotificationManagerError.notificationActionInvocationFailed(error.localizedDescription)
         }
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@objc(SFSDKNotificationTypesResponse)
 @objcMembers
 public class NotificationTypesResponse: NSObject, Codable {
     public let notificationTypes: [NotificationType]
@@ -9,6 +10,7 @@ public class NotificationTypesResponse: NSObject, Codable {
     }
 }
 
+@objc(SFSDKNotificationType)
 @objcMembers
 public class NotificationType: NSObject, Codable {
     public let type: String
@@ -29,12 +31,13 @@ public class NotificationType: NSObject, Codable {
             let response = try decoder.decode(NotificationTypesResponse.self, from: jsonData)
             return response.notificationTypes
         } catch {
-            print("Failed to decode NotificationType: \(error)")
+            SFSDKCoreLogger.e(NotificationType.self, message: "Failed to decode NotificationType: \(error)")
             return []
         }
     }
 }
 
+@objc(SFSDKActionGroup)
 @objcMembers
 public class ActionGroup: NSObject, Codable {
     public let name: String
@@ -46,6 +49,7 @@ public class ActionGroup: NSObject, Codable {
     }
 }
 
+@objc(SFSDKAction)
 @objcMembers
 public class Action: NSObject, Codable {
     public let name: String
@@ -61,6 +65,7 @@ public class Action: NSObject, Codable {
     }
 }
 
+@objc(SFSDKActionResultRepresentation)
 @objcMembers
 public class ActionResultRepresentation: NSObject, Codable {
     public let message: String

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct NotificationTypesResponse: Codable {
+    let notificationTypes: [NotificationType]
+}
+
+public struct NotificationType: Codable {
+    let type: String
+    let apiName: String
+    let label: String
+    let actionGroups: [ActionGroup]
+}
+
+struct ActionGroup: Codable {
+    let name: String
+    let actions: [Action]
+}
+
+struct Action: Codable {
+    let name: String
+    let identifier: String
+    let label: String
+    let type: String
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
@@ -60,3 +60,12 @@ public class Action: NSObject, Codable {
         self.type = type
     }
 }
+
+@objcMembers
+public class ActionResultRepresentation: NSObject, Codable {
+    public let message: String
+
+    public init(message: String) {
+        self.message = message
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
@@ -1,24 +1,62 @@
 import Foundation
 
-struct NotificationTypesResponse: Codable {
-    let notificationTypes: [NotificationType]
+@objcMembers
+public class NotificationTypesResponse: NSObject, Codable {
+    public let notificationTypes: [NotificationType]
+
+    public init(notificationTypes: [NotificationType]) {
+        self.notificationTypes = notificationTypes
+    }
 }
 
-public struct NotificationType: Codable {
-    let type: String
-    let apiName: String
-    let label: String
-    let actionGroups: [ActionGroup]
+@objcMembers
+public class NotificationType: NSObject, Codable {
+    public let type: String
+    public let apiName: String
+    public let label: String
+    public let actionGroups: [ActionGroup]
+
+    public init(type: String, apiName: String, label: String, actionGroups: [ActionGroup]) {
+        self.type = type
+        self.apiName = apiName
+        self.label = label
+        self.actionGroups = actionGroups
+    }
+
+    @objc public class func from(jsonData: Data) -> [NotificationType] {
+        let decoder = JSONDecoder()
+        do {
+            let response = try decoder.decode(NotificationTypesResponse.self, from: jsonData)
+            return response.notificationTypes
+        } catch {
+            print("Failed to decode NotificationType: \(error)")
+            return []
+        }
+    }
 }
 
-struct ActionGroup: Codable {
-    let name: String
-    let actions: [Action]
+@objcMembers
+public class ActionGroup: NSObject, Codable {
+    public let name: String
+    public let actions: [Action]
+
+    public init(name: String, actions: [Action]) {
+        self.name = name
+        self.actions = actions
+    }
 }
 
-struct Action: Codable {
-    let name: String
-    let identifier: String
-    let label: String
-    let type: String
+@objcMembers
+public class Action: NSObject, Codable {
+    public let name: String
+    public let identifier: String
+    public let label: String
+    public let type: String
+
+    public init(name: String, identifier: String, label: String, type: String) {
+        self.name = name
+        self.identifier = identifier
+        self.label = label
+        self.type = type
+    }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -183,14 +183,13 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
             [[SFPreferences currentUserLevelPreferences] setObject:strongSelf->_deviceSalesforceId forKey:kSFDeviceSalesforceId];
             [[SFPreferences currentUserLevelPreferences] synchronize];
             [SFSDKCoreLogger i:[strongSelf class] format:@"Response:%@", responseAsJson];
-            [strongSelf getNotificationTypesWithRestClient:[SFRestAPI sharedInstance]
-                                                   account:[[SFUserAccountManager sharedInstance] currentUser]
-                                         completionHandler:^(NSArray<NotificationType *> * _Nullable type, NSError * _Nullable error) {
+            [strongSelf fetchAndStoreNotificationTypesWithRestClient:[SFRestAPI sharedInstance] account:user completionHandler:^(NSError * _Nullable error) {
                 if (error != nil) {
                     [SFSDKCoreLogger e:[strongSelf class] format:@"Get Notification Types Error: %@", [error localizedDescription]];
                 }
                 [strongSelf postPushNotificationRegistration:completionBlock];
             }];
+            
         }
     }];
     return YES;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -184,7 +184,7 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
             [[SFPreferences currentUserLevelPreferences] synchronize];
             [SFSDKCoreLogger i:[strongSelf class] format:@"Response:%@", responseAsJson];
             [strongSelf getNotificationTypesWithRestClient:[SFRestAPI sharedInstance]
-                                              userDefaults:[NSUserDefaults standardUserDefaults]
+                                                   account:[[SFUserAccountManager sharedInstance] currentUser]
                                          completionHandler:^(BOOL passed, NSError * _Nullable error) {
                 if (error != nil) {
                     [SFSDKCoreLogger e:[strongSelf class] format:@"Get Notification Types Error: %@", [error localizedDescription]];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -185,7 +185,7 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
             [SFSDKCoreLogger i:[strongSelf class] format:@"Response:%@", responseAsJson];
             [strongSelf getNotificationTypesWithRestClient:[SFRestAPI sharedInstance]
                                                    account:[[SFUserAccountManager sharedInstance] currentUser]
-                                         completionHandler:^(BOOL passed, NSError * _Nullable error) {
+                                         completionHandler:^(NSArray<NotificationType *> * _Nullable type, NSError * _Nullable error) {
                 if (error != nil) {
                     [SFSDKCoreLogger e:[strongSelf class] format:@"Get Notification Types Error: %@", [error localizedDescription]];
                 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFPushNotificationManager.m
@@ -33,6 +33,7 @@
 #import "SFRestAPI+Blocks.h"
 #import "SFSDKPushNotificationEncryptionConstants.h"
 #import "SFSDKCryptoUtils.h"
+#import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 
 static NSString* const kSFDeviceToken = @"deviceToken";
 static NSString* const kSFDeviceSalesforceId = @"deviceSalesforceId";
@@ -182,7 +183,14 @@ static NSString * const kSFAppFeaturePushNotifications = @"PN";
             [[SFPreferences currentUserLevelPreferences] setObject:strongSelf->_deviceSalesforceId forKey:kSFDeviceSalesforceId];
             [[SFPreferences currentUserLevelPreferences] synchronize];
             [SFSDKCoreLogger i:[strongSelf class] format:@"Response:%@", responseAsJson];
-            [strongSelf postPushNotificationRegistration:completionBlock];
+            [strongSelf getNotificationTypesWithRestClient:[SFRestAPI sharedInstance]
+                                              userDefaults:[NSUserDefaults standardUserDefaults]
+                                         completionHandler:^(BOOL passed, NSError * _Nullable error) {
+                if (error != nil) {
+                    [SFSDKCoreLogger e:[strongSelf class] format:@"Get Notification Types Error: %@", [error localizedDescription]];
+                }
+                [strongSelf postPushNotificationRegistration:completionBlock];
+            }];
         }
     }];
     return YES;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class SFUserAccountIdentity;
 @class SFOAuthCredentials;
+@class NotificationType;
 
 /**
  Enumeration of the potential login states of the user account.
@@ -71,6 +72,10 @@ NS_SWIFT_NAME(UserAccount)
 /** The credentials associated with this user
  */
 @property (nonatomic, strong) SFOAuthCredentials *credentials;
+
+/** The notification types for this user
+ */
+@property (nonatomic, strong, nullable) NSArray<NotificationType *> *notificationTypes;
 
 /** The identity data associated with this user
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.m
@@ -38,6 +38,7 @@ static NSString * const kUser_CUSTOM_DATA         = @"customData";
 static NSString * const kUser_ACCESS_RESTRICTIONS = @"accessRestrictions";
 static NSString * const kCredentialsUserIdPropName = @"userId";
 static NSString * const kCredentialsOrgIdPropName = @"organizationId";
+static NSString * const kUser_NOTIFICATION_TYPES = @"notificationTypes";
 static NSString * const kSFAppFeatureOAuth = @"UA";
 
 static const char * kSyncQueue = "com.salesforce.mobilesdk.sfuseraccount.syncqueue";
@@ -62,6 +63,7 @@ NSString * const kUserAccountPhotoEncryptionKeyLabel = @"com.salesforce.userAcco
 @synthesize credentials = _credentials;
 @synthesize accessScopes = _accessScopes;
 @synthesize idData = _idData;
+@synthesize notificationTypes = _notificationTypes;
 
 + (BOOL)supportsSecureCoding {
     return YES;
@@ -99,6 +101,7 @@ NSString * const kUserAccountPhotoEncryptionKeyLabel = @"com.salesforce.userAcco
     [encoder encodeObject:_idData forKey:kUser_ID_DATA];
     [encoder encodeObject:_customData forKey:kUser_CUSTOM_DATA];
     [encoder encodeInteger:_accessRestrictions forKey:kUser_ACCESS_RESTRICTIONS];
+    [encoder encodeObject:_notificationTypes forKey:kUser_NOTIFICATION_TYPES];
 }
 
 - (id)initWithCoder:(NSCoder*)decoder {
@@ -116,6 +119,7 @@ NSString * const kUserAccountPhotoEncryptionKeyLabel = @"com.salesforce.userAcco
         if (_loginState == SFUserAccountLoginStateLoggedIn) {
             [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureOAuth];
         }
+        _notificationTypes = [decoder decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class], [NotificationType class], nil] forKey:kUser_NOTIFICATION_TYPES];
     }
     return self;
 }
@@ -133,6 +137,15 @@ NSString * const kUserAccountPhotoEncryptionKeyLabel = @"com.salesforce.userAcco
     dispatch_barrier_async(_syncQueue, ^{
         self->_accessScopes = accessScopes;
     });
+}
+
+
+- (NSArray<NotificationType *> *)notificationTypes {
+    return _notificationTypes;
+}
+
+- (void)setNotificationTypes:(NSArray<NotificationType *> *)notificationTypes {
+    _notificationTypes = [notificationTypes copy];
 }
 
 - (NSString *)userPhotoDirectory {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.m
@@ -119,7 +119,7 @@ NSString * const kUserAccountPhotoEncryptionKeyLabel = @"com.salesforce.userAcco
         if (_loginState == SFUserAccountLoginStateLoggedIn) {
             [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureOAuth];
         }
-        _notificationTypes = [decoder decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class], [NotificationType class], nil] forKey:kUser_NOTIFICATION_TYPES];
+        _notificationTypes = [decoder decodeObjectOfClasses:[NSSet setWithObjects:[NSArray class], [SFSDKNotificationType class], nil] forKey:kUser_NOTIFICATION_TYPES];
     }
     return self;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/PushNotificationManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/PushNotificationManagerTests.swift
@@ -1,0 +1,341 @@
+import XCTest
+@testable import SalesforceSDKCore
+
+class PushNotificationManagerTests: XCTestCase {
+
+    var pushNotificationManager: PushNotificationManager!
+    var mockRestClient: MockRestClient!
+    var mockUserDefaults: UserDefaults!
+    
+    override func setUp() {
+        super.setUp()
+        pushNotificationManager = PushNotificationManager.sharedInstance()
+        mockRestClient = MockRestClient()
+        mockUserDefaults = UserDefaults(suiteName: "TestDefaults")!
+    }
+
+    override func tearDown() {
+        mockUserDefaults.removePersistentDomain(forName: "TestDefaults")
+        pushNotificationManager = nil
+        mockRestClient = nil
+        mockUserDefaults = nil
+        super.tearDown()
+    }
+
+
+    func testGetNotificationTypes_SuccessfulAPIResponse() async {
+        // Setup
+        mockRestClient.jsonString = """
+        {
+            "notificationTypes": [
+                {
+                    "type": "chatter_mention",
+                    "apiName": "chatter_mention",
+                    "label": "Chatter Mention",
+                    "actionGroups": []
+                },
+                {
+                    "type": "approval_notification",
+                    "apiName": "approval_notification",
+                    "label": "Approval Notification",
+                    "actionGroups": [
+                        {
+                            "name": "approval_req",
+                            "actions": [
+                                {
+                                    "name": "approve",
+                                    "identifier": "approval_req__approve",
+                                    "label": "Approve",
+                                    "type": "NotificationApiAction"
+                                },
+                                {
+                                    "name": "deny",
+                                    "identifier": "approval_req__deny",
+                                    "label": "Deny",
+                                    "type": "NotificationApiAction"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "approval_pending",
+                            "actions": [
+                                {
+                                    "name": "escalate",
+                                    "identifier": "approval_pending__escalate",
+                                    "label": "Escalate",
+                                    "type": "NotificationApiAction"
+                                },
+                                {
+                                    "name": "reminder",
+                                    "identifier": "approval_pending__reminder",
+                                    "label": "Reminder",
+                                    "type": "NotificationApiAction"
+                                },
+                                {
+                                    "name": "approve",
+                                    "identifier": "approval_pending__approve",
+                                    "label": "Approval",
+                                    "type": "NotificationApiAction"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "0MLSG0000009oVR4AY",
+                    "apiName": "account_created",
+                    "label": "Account Created",
+                    "actionGroups": [
+                                     {
+                                         "name": "account_c",
+                                         "actions": [
+                                             {
+                                                 "name": "view",
+                                                 "identifier": "account_c__view",
+                                                 "label": "View",
+                                                 "type": "NotificationApiAction"
+                                             },
+                                             {
+                                                 "name": "dismiss",
+                                                 "identifier": "account_c__dismiss",
+                                                 "label": "Dismiss",
+                                                 "type": "NotificationApiAction"
+                                             }
+                                         ]
+                                     }
+                                     ]
+                }
+            ]
+        }
+        """
+
+        // Test
+        let (success, error) = await pushNotificationManager.getNotificationTypes(restClient: mockRestClient, userDefaults: mockUserDefaults)
+
+        // Validate
+        XCTAssertTrue(success)
+        XCTAssertNil(error)
+        let cachedData = mockUserDefaults.data(forKey: UserDefaultsKeys.cachedNotificationTypes)
+        XCTAssertNotNil(cachedData)
+    }
+
+    func testGetNotificationTypes_FallbackToCache() async {
+        // Setup
+        mockRestClient.mockError = NSError(domain: "MockRestClient", code: 500, userInfo: [NSLocalizedDescriptionKey: "Mock API failure"])
+        let cachedTypes = [
+            NotificationType(type: "cachedType",
+                             apiName: "cached_notification",
+                             label: "Cached Notification",
+                             actionGroups: [])
+        ]
+        let encodedData = try! JSONEncoder().encode(cachedTypes)
+        mockUserDefaults.set(encodedData, forKey: UserDefaultsKeys.cachedNotificationTypes)
+
+        // Test
+        let (success, error) = await pushNotificationManager.getNotificationTypes(
+            restClient: mockRestClient,
+            userDefaults: mockUserDefaults
+        )
+
+        // Validate
+        XCTAssertTrue(success, "Expected success even with API failure, since cache should be used.")
+        XCTAssertNil(error, "Expected no error when falling back to cache.")
+        let cachedData = mockUserDefaults.data(forKey:UserDefaultsKeys.cachedNotificationTypes)
+        XCTAssertNotNil(cachedData, "Expected cached notification types to be stored and retrieved.")
+    }
+
+    func testGetNotificationTypes_FailNoCache() async {
+        // Setup
+        mockRestClient.mockError = NSError(
+            domain: "MockRestClient",
+            code: 500,
+            userInfo: [NSLocalizedDescriptionKey: "Mock API failure"]
+        )
+        
+        // Test
+        mockUserDefaults.removeObject(forKey: UserDefaultsKeys.cachedNotificationTypes)
+        let (success, error) = await pushNotificationManager.getNotificationTypes(
+            restClient: mockRestClient,
+            userDefaults: mockUserDefaults
+        )
+
+        // Validate
+        XCTAssertFalse(success, "Expected failure since both API and cache are unavailable.")
+        XCTAssertNotNil(error, "Expected an error when API fails and cache is empty.")
+        XCTAssertEqual(error as? PushNotificationManagerError, .failedNotificationTypesRetrieval, "Expected a `failedNotificationTypesRetrieval` error.")
+    }
+
+    // MARK: - deleteNotificationTypes Tests
+
+    func testDeleteNotificationTypes_RemovesCache() {
+        // Setup
+        mockUserDefaults.set(Data(), forKey: UserDefaultsKeys.cachedNotificationTypes)
+
+        // Test
+        pushNotificationManager.deleteNotificationTypes(userDefaults: mockUserDefaults)
+
+        // Validate
+        XCTAssertNil(mockUserDefaults.data(forKey: UserDefaultsKeys.cachedNotificationTypes))
+    }
+
+    func testDeleteNotificationTypes_RemovesNotificationCategories() async {
+        // Setup
+        mockRestClient.jsonString = """
+        {
+            "notificationTypes": [
+                {
+                    "type": "chatter_mention",
+                    "apiName": "chatter_mention",
+                    "label": "Chatter Mention",
+                    "actionGroups": []
+                },
+                {
+                    "type": "approval_notification",
+                    "apiName": "approval_notification",
+                    "label": "Approval Notification",
+                    "actionGroups": [
+                        {
+                            "name": "approval_req",
+                            "actions": [
+                                {
+                                    "name": "approve",
+                                    "identifier": "approval_req__approve",
+                                    "label": "Approve",
+                                    "type": "NotificationApiAction"
+                                },
+                                {
+                                    "name": "deny",
+                                    "identifier": "approval_req__deny",
+                                    "label": "Deny",
+                                    "type": "NotificationApiAction"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "approval_pending",
+                            "actions": [
+                                {
+                                    "name": "escalate",
+                                    "identifier": "approval_pending__escalate",
+                                    "label": "Escalate",
+                                    "type": "NotificationApiAction"
+                                },
+                                {
+                                    "name": "reminder",
+                                    "identifier": "approval_pending__reminder",
+                                    "label": "Reminder",
+                                    "type": "NotificationApiAction"
+                                },
+                                {
+                                    "name": "approve",
+                                    "identifier": "approval_pending__approve",
+                                    "label": "Approval",
+                                    "type": "NotificationApiAction"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "0MLSG0000009oVR4AY",
+                    "apiName": "account_created",
+                    "label": "Account Created",
+                    "actionGroups": [
+                                     {
+                                         "name": "account_c",
+                                         "actions": [
+                                             {
+                                                 "name": "view",
+                                                 "identifier": "account_c__view",
+                                                 "label": "View",
+                                                 "type": "NotificationApiAction"
+                                             },
+                                             {
+                                                 "name": "dismiss",
+                                                 "identifier": "account_c__dismiss",
+                                                 "label": "Dismiss",
+                                                 "type": "NotificationApiAction"
+                                             }
+                                         ]
+                                     }
+                                     ]
+                }
+            ]
+        }
+        """
+        let (success, error) = await pushNotificationManager.getNotificationTypes(restClient: mockRestClient, userDefaults: mockUserDefaults)
+        XCTAssertTrue(success, "Expected success even with API failure, since cache should be used.")
+        XCTAssertNil(error, "Expected no error when falling back to cache.")
+        var categories = await UNUserNotificationCenter.current().notificationCategories()
+        XCTAssertFalse(categories.isEmpty, "Precondition: There should be existing categories before deletion")
+
+        // Test
+        pushNotificationManager.deleteNotificationTypes(userDefaults: mockUserDefaults)
+
+        // Validate
+        categories = await UNUserNotificationCenter.current().notificationCategories()
+        XCTAssertTrue(categories.isEmpty, "Notification categories should be empty after deletion")
+    }
+}
+
+// MARK: - Mock RestClient
+
+class MockRestClient: RestClient {
+    var mockError: Error?
+    weak var testDelegate: RestRequestDelegate?
+    // ✅ A customizable JSON string for test cases
+    var jsonString: String = """
+    {
+        "notificationTypes": [
+                              {
+                                  "type": "chatter_mention",
+                                  "apiName": "chatter_mention",
+                                  "label": "Chatter Mention",
+                                  "actionGroups": []
+                              }
+                              ]
+    }
+    """ // Default mock JSON response
+    
+    
+    override func send(_ request: RestRequest, requestDelegate: RestRequestDelegate?) {
+        print("called")
+        
+        let mockURLResponse = URLResponse(url: URL(string: "https://example.com")!,
+                                          mimeType: "application/json",
+                                          expectedContentLength: 0,
+                                          textEncodingName: "utf-8")
+        
+        if let error = mockError {
+            requestDelegate?.request?(request, didSucceed: error, rawResponse: mockURLResponse)
+            return
+        }
+        
+        if let jsonData = jsonString.data(using: .utf8) {
+            requestDelegate?.request?(request, didSucceed: jsonData, rawResponse: mockURLResponse)
+        }
+    }
+}
+
+class MockRestClientDelegate: NSObject, RestRequestDelegate {
+    var receivedResponse: Any?
+    var receivedError: Error?
+
+    func request(_ request: RestRequest, didLoadResponse jsonResponse: Any) {
+        receivedResponse = jsonResponse
+        print("Mock delegate received response: \(jsonResponse)")
+    }
+
+    func request(_ request: RestRequest, didFailLoadWithError error: Error, rawResponse: URLResponse?) {
+        receivedError = error
+        print("Mock delegate received error: \(error.localizedDescription)")
+    }
+
+    func requestDidCancelLoad(_ request: RestRequest) {
+        print("Mock delegate: request canceled")
+    }
+
+    func requestDidTimeout(_ request: RestRequest) {
+        print("Mock delegate: request timed out")
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/PushNotificationManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/PushNotificationManagerTests.swift
@@ -65,9 +65,7 @@ class PushNotificationManagerTests: XCTestCase {
             XCTAssertNotNil(error)
             return
         }
-        
-        // Should throw an assertion before we get here.
-        XCTFail()
+        XCTFail("Should throw an assertion before we get here.")
     }
     
     func testGetActionGroups_Success() {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/PushNotificationManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/PushNotificationManagerTests.swift
@@ -5,182 +5,82 @@ class PushNotificationManagerTests: XCTestCase {
 
     var pushNotificationManager: PushNotificationManager!
     var mockRestClient: MockRestClient!
-    var mockUserDefaults: UserDefaults!
+    var mockUserAccount: UserAccount!
     
     override func setUp() {
         super.setUp()
         pushNotificationManager = PushNotificationManager.sharedInstance()
         mockRestClient = MockRestClient()
-        mockUserDefaults = UserDefaults(suiteName: "TestDefaults")!
+        mockUserAccount = UserAccount()
     }
 
     override func tearDown() {
-        mockUserDefaults.removePersistentDomain(forName: "TestDefaults")
+        mockUserAccount = nil
         pushNotificationManager = nil
         mockRestClient = nil
-        mockUserDefaults = nil
         super.tearDown()
     }
 
-
     func testGetNotificationTypes_SuccessfulAPIResponse() async {
-        // Setup
-        mockRestClient.jsonString = """
-        {
-            "notificationTypes": [
-                {
-                    "type": "chatter_mention",
-                    "apiName": "chatter_mention",
-                    "label": "Chatter Mention",
-                    "actionGroups": []
-                },
-                {
-                    "type": "approval_notification",
-                    "apiName": "approval_notification",
-                    "label": "Approval Notification",
-                    "actionGroups": [
-                        {
-                            "name": "approval_req",
-                            "actions": [
-                                {
-                                    "name": "approve",
-                                    "identifier": "approval_req__approve",
-                                    "label": "Approve",
-                                    "type": "NotificationApiAction"
-                                },
-                                {
-                                    "name": "deny",
-                                    "identifier": "approval_req__deny",
-                                    "label": "Deny",
-                                    "type": "NotificationApiAction"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "approval_pending",
-                            "actions": [
-                                {
-                                    "name": "escalate",
-                                    "identifier": "approval_pending__escalate",
-                                    "label": "Escalate",
-                                    "type": "NotificationApiAction"
-                                },
-                                {
-                                    "name": "reminder",
-                                    "identifier": "approval_pending__reminder",
-                                    "label": "Reminder",
-                                    "type": "NotificationApiAction"
-                                },
-                                {
-                                    "name": "approve",
-                                    "identifier": "approval_pending__approve",
-                                    "label": "Approval",
-                                    "type": "NotificationApiAction"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "type": "0MLSG0000009oVR4AY",
-                    "apiName": "account_created",
-                    "label": "Account Created",
-                    "actionGroups": [
-                                     {
-                                         "name": "account_c",
-                                         "actions": [
-                                             {
-                                                 "name": "view",
-                                                 "identifier": "account_c__view",
-                                                 "label": "View",
-                                                 "type": "NotificationApiAction"
-                                             },
-                                             {
-                                                 "name": "dismiss",
-                                                 "identifier": "account_c__dismiss",
-                                                 "label": "Dismiss",
-                                                 "type": "NotificationApiAction"
-                                             }
-                                         ]
-                                     }
-                                     ]
-                }
-            ]
-        }
-        """
+        // Given
+        mockRestClient.jsonResponse = makeMockJSONResponse()
 
-        // Test
-        let (success, error) = await pushNotificationManager.getNotificationTypes(restClient: mockRestClient, userDefaults: mockUserDefaults)
+        // When
+        let (success, error) = await pushNotificationManager.getNotificationTypes(
+            restClient: mockRestClient,
+            account: mockUserAccount
+        )
 
-        // Validate
+        // Then
         XCTAssertTrue(success)
         XCTAssertNil(error)
-        let cachedData = mockUserDefaults.data(forKey: UserDefaultsKeys.cachedNotificationTypes)
-        XCTAssertNotNil(cachedData)
+        let cachedData = try? XCTUnwrap(mockUserAccount.notificationTypes)
+        XCTAssertFalse(cachedData!.isEmpty, "Expected notification types to be stored")
     }
 
     func testGetNotificationTypes_FallbackToCache() async {
-        // Setup
+        // Given
         mockRestClient.mockError = NSError(domain: "MockRestClient", code: 500, userInfo: [NSLocalizedDescriptionKey: "Mock API failure"])
-        let cachedTypes = [
-            NotificationType(type: "cachedType",
-                             apiName: "cached_notification",
-                             label: "Cached Notification",
-                             actionGroups: [])
-        ]
-        let encodedData = try! JSONEncoder().encode(cachedTypes)
-        mockUserDefaults.set(encodedData, forKey: UserDefaultsKeys.cachedNotificationTypes)
+        mockUserAccount.notificationTypes = [NotificationType(type: "cachedType", apiName: "cached_notification", label: "Cached Notification", actionGroups: [])]
 
-        // Test
+        // When
         let (success, error) = await pushNotificationManager.getNotificationTypes(
             restClient: mockRestClient,
-            userDefaults: mockUserDefaults
+            account: mockUserAccount
         )
 
-        // Validate
+        // Then
         XCTAssertTrue(success, "Expected success even with API failure, since cache should be used.")
         XCTAssertNil(error, "Expected no error when falling back to cache.")
-        let cachedData = mockUserDefaults.data(forKey:UserDefaultsKeys.cachedNotificationTypes)
-        XCTAssertNotNil(cachedData, "Expected cached notification types to be stored and retrieved.")
+        let cachedData = try? XCTUnwrap(mockUserAccount.notificationTypes)
+        XCTAssertFalse(cachedData!.isEmpty, "Expected cached notification types to be retrieved.")
     }
 
     func testGetNotificationTypes_FailNoCache() async {
-        // Setup
+        // Given
         mockRestClient.mockError = NSError(
             domain: "MockRestClient",
             code: 500,
             userInfo: [NSLocalizedDescriptionKey: "Mock API failure"]
         )
-        
-        // Test
-        mockUserDefaults.removeObject(forKey: UserDefaultsKeys.cachedNotificationTypes)
+        mockUserAccount.notificationTypes = nil
+
+        // When
         let (success, error) = await pushNotificationManager.getNotificationTypes(
             restClient: mockRestClient,
-            userDefaults: mockUserDefaults
+            account: mockUserAccount
         )
 
-        // Validate
+        // Then
         XCTAssertFalse(success, "Expected failure since both API and cache are unavailable.")
         XCTAssertNotNil(error, "Expected an error when API fails and cache is empty.")
         XCTAssertEqual(error as? PushNotificationManagerError, .failedNotificationTypesRetrieval, "Expected a `failedNotificationTypesRetrieval` error.")
     }
 
-    // MARK: - deleteNotificationTypes Tests
+    // MARK: - Helper Function
 
-    func testDeleteNotificationTypes_RemovesCache() {
-        // Setup
-        mockUserDefaults.set(Data(), forKey: UserDefaultsKeys.cachedNotificationTypes)
-
-        // Test
-        pushNotificationManager.deleteNotificationTypes(userDefaults: mockUserDefaults)
-
-        // Validate
-        XCTAssertNil(mockUserDefaults.data(forKey: UserDefaultsKeys.cachedNotificationTypes))
-    }
-
-    func testDeleteNotificationTypes_RemovesNotificationCategories() async {
-        // Setup
-        mockRestClient.jsonString = """
+    private func makeMockJSONResponse() -> Data {
+        let json = """
         {
             "notificationTypes": [
                 {
@@ -210,71 +110,13 @@ class PushNotificationManagerTests: XCTestCase {
                                     "type": "NotificationApiAction"
                                 }
                             ]
-                        },
-                        {
-                            "name": "approval_pending",
-                            "actions": [
-                                {
-                                    "name": "escalate",
-                                    "identifier": "approval_pending__escalate",
-                                    "label": "Escalate",
-                                    "type": "NotificationApiAction"
-                                },
-                                {
-                                    "name": "reminder",
-                                    "identifier": "approval_pending__reminder",
-                                    "label": "Reminder",
-                                    "type": "NotificationApiAction"
-                                },
-                                {
-                                    "name": "approve",
-                                    "identifier": "approval_pending__approve",
-                                    "label": "Approval",
-                                    "type": "NotificationApiAction"
-                                }
-                            ]
                         }
                     ]
-                },
-                {
-                    "type": "0MLSG0000009oVR4AY",
-                    "apiName": "account_created",
-                    "label": "Account Created",
-                    "actionGroups": [
-                                     {
-                                         "name": "account_c",
-                                         "actions": [
-                                             {
-                                                 "name": "view",
-                                                 "identifier": "account_c__view",
-                                                 "label": "View",
-                                                 "type": "NotificationApiAction"
-                                             },
-                                             {
-                                                 "name": "dismiss",
-                                                 "identifier": "account_c__dismiss",
-                                                 "label": "Dismiss",
-                                                 "type": "NotificationApiAction"
-                                             }
-                                         ]
-                                     }
-                                     ]
                 }
             ]
         }
         """
-        let (success, error) = await pushNotificationManager.getNotificationTypes(restClient: mockRestClient, userDefaults: mockUserDefaults)
-        XCTAssertTrue(success, "Expected success even with API failure, since cache should be used.")
-        XCTAssertNil(error, "Expected no error when falling back to cache.")
-        var categories = await UNUserNotificationCenter.current().notificationCategories()
-        XCTAssertFalse(categories.isEmpty, "Precondition: There should be existing categories before deletion")
-
-        // Test
-        pushNotificationManager.deleteNotificationTypes(userDefaults: mockUserDefaults)
-
-        // Validate
-        categories = await UNUserNotificationCenter.current().notificationCategories()
-        XCTAssertTrue(categories.isEmpty, "Notification categories should be empty after deletion")
+        return json.data(using: .utf8)!
     }
 }
 
@@ -283,59 +125,30 @@ class PushNotificationManagerTests: XCTestCase {
 class MockRestClient: RestClient {
     var mockError: Error?
     weak var testDelegate: RestRequestDelegate?
-    // ✅ A customizable JSON string for test cases
-    var jsonString: String = """
+    var jsonResponse: Data = """
     {
         "notificationTypes": [
-                              {
-                                  "type": "chatter_mention",
-                                  "apiName": "chatter_mention",
-                                  "label": "Chatter Mention",
-                                  "actionGroups": []
-                              }
-                              ]
+            {
+                "type": "chatter_mention",
+                "apiName": "chatter_mention",
+                "label": "Chatter Mention",
+                "actionGroups": []
+            }
+        ]
     }
-    """ // Default mock JSON response
-    
-    
+    """.data(using: .utf8)! // Default mock JSON response
+
     override func send(_ request: RestRequest, requestDelegate: RestRequestDelegate?) {
-        print("called")
-        
         let mockURLResponse = URLResponse(url: URL(string: "https://example.com")!,
                                           mimeType: "application/json",
                                           expectedContentLength: 0,
                                           textEncodingName: "utf-8")
-        
+
         if let error = mockError {
             requestDelegate?.request?(request, didSucceed: error, rawResponse: mockURLResponse)
             return
         }
         
-        if let jsonData = jsonString.data(using: .utf8) {
-            requestDelegate?.request?(request, didSucceed: jsonData, rawResponse: mockURLResponse)
-        }
-    }
-}
-
-class MockRestClientDelegate: NSObject, RestRequestDelegate {
-    var receivedResponse: Any?
-    var receivedError: Error?
-
-    func request(_ request: RestRequest, didLoadResponse jsonResponse: Any) {
-        receivedResponse = jsonResponse
-        print("Mock delegate received response: \(jsonResponse)")
-    }
-
-    func request(_ request: RestRequest, didFailLoadWithError error: Error, rawResponse: URLResponse?) {
-        receivedError = error
-        print("Mock delegate received error: \(error.localizedDescription)")
-    }
-
-    func requestDidCancelLoad(_ request: RestRequest) {
-        print("Mock delegate: request canceled")
-    }
-
-    func requestDidTimeout(_ request: RestRequest) {
-        print("Mock delegate: request timed out")
+        requestDelegate?.request?(request, didSucceed: jsonResponse, rawResponse: mockURLResponse)
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
@@ -11,6 +11,7 @@ class PushNotificationManagerTests: XCTestCase {
         super.setUp()
         pushNotificationManager = PushNotificationManager.sharedInstance()
         mockRestClient = MockRestClient()
+        mockRestClient.apiVersion = "v61.0"
         mockUserAccount = UserAccount()
     }
 
@@ -26,10 +27,9 @@ class PushNotificationManagerTests: XCTestCase {
         mockRestClient.jsonResponse = makeMockJSONResponse()
 
         // When
-        let types = try await pushNotificationManager.getNotificationTypes(restClient: mockRestClient, account: mockUserAccount)
+        try await pushNotificationManager.fetchAndStoreNotificationTypes(restClient: mockRestClient, account: mockUserAccount)
 
         // Then
-        XCTAssertFalse(types.isEmpty, "Expected notification types")
         let cachedData = try? XCTUnwrap(mockUserAccount.notificationTypes)
         XCTAssertFalse(cachedData!.isEmpty, "Expected notification types to be stored")
     }
@@ -40,10 +40,9 @@ class PushNotificationManagerTests: XCTestCase {
         mockUserAccount.notificationTypes = [NotificationType(type: "cachedType", apiName: "cached_notification", label: "Cached Notification", actionGroups: [])]
 
         // When
-        let types = try await pushNotificationManager.getNotificationTypes(restClient: mockRestClient, account: mockUserAccount)
+        try await pushNotificationManager.fetchAndStoreNotificationTypes(restClient: mockRestClient, account: mockUserAccount)
 
         // Then
-        XCTAssertFalse(types.isEmpty, "Expected success even with API failure, since cache should be used.")
         let cachedData = try? XCTUnwrap(mockUserAccount.notificationTypes)
         XCTAssertFalse(cachedData!.isEmpty, "Expected cached notification types to be retrieved.")
     }
@@ -59,7 +58,7 @@ class PushNotificationManagerTests: XCTestCase {
 
         // When
         do {
-            _ = try await pushNotificationManager.getNotificationTypes(restClient: mockRestClient, account: mockUserAccount)
+            try await pushNotificationManager.fetchAndStoreNotificationTypes(restClient: mockRestClient, account: mockUserAccount)
         } catch {
             // Then
             XCTAssertNotNil(error)


### PR DESCRIPTION
Adds support for fetching and caching Salesforce notification types, error handling, dependency injection, mock API simulations, and unit tests.

This doesn't have anyting to handle the action yet.  This is just all the regristration and logout support. 