### PR TITLE
CI hide passed tests.

### DIFF
--- a/.github/DangerFiles/Gemfile.lock
+++ b/.github/DangerFiles/Gemfile.lock
@@ -64,7 +64,6 @@ GEM
     uri (1.0.2)
 
 PLATFORMS
-  arm64-darwin-23
   ruby
 
 DEPENDENCIES

--- a/.github/workflows/reusable-workflow.yaml
+++ b/.github/workflows/reusable-workflow.yaml
@@ -53,6 +53,7 @@ jobs:
           title: "${{ inputs.lib }} iOS ${{ inputs.ios }}"
           show-code-coverage: false
           upload-bundles: false
+          show-passed-tests: false
         if: success() || failure()
       - uses: codecov/codecov-action@v4
         with:

--- a/build/pre-build
+++ b/build/pre-build
@@ -1,6 +1,3 @@
 #!/bin/bash
 
 echo ${TEST_CREDENTIALS} > ./shared/test/test_credentials.json
-echo ${LOGINUSERS} > ./shared/test/ui_test_credentials.json
-
-

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # Salesforce.com Mobile SDK for iOS
-[![Nightly Tests](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/actions/workflows/nightly.yaml/badge.svg)](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/actions/workflows/nightly.yaml)
+[![Tests](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/actions/workflows/nightly.yaml/badge.svg)](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/actions/workflows/nightly.yaml)
 [![Known Vulnerabilities](https://snyk.io/test/github/forcedotcom/SalesforceMobileSDK-iOS/badge.svg)](https://snyk.io/test/github/forcedotcom/SalesforceMobileSDK-iOS)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/forcedotcom/SalesforceMobileSDK-iOS?sort=semver)
 


### PR DESCRIPTION
This change should make it easier to spot failed tests in Nightly CI runs.