### PR TITLE
Update CodeCov Requirements.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,32 +6,71 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "25...75"
+  range: "60...80"
 
   status:
+    # Overall Libarary Requirements
     project:
       default: false  # disable the default status that measures entire project
       SalesforceAnalytics:
+        threshold: 0%
         paths: 
           - "libs/SalesforceAnalytics/SalesforceAnalytics/"
         flags: 
           - SalesforceAnalytics
       SalesforceSDKCommon:
+        threshold: 0%
         paths: 
           - "libs/SalesforceSDKCore/SalesforceSDKCommon/"
         flags: 
           - SalesforceSDKCommon
       SalesforceSDKCore:
+        threshold: 0%
         paths: 
           - "libs/SalesforceSDKCore/SalesforceSDKCore/"
         flags: 
           - SalesforceSDKCore
       SmartStore:
+        threshold: 0%
         paths: 
           - "libs/SmartStore/SmartStore/"
         flags: 
           - SmartStore
       MobileSync:
+        threshold: 0%
+        paths: 
+          - "libs/MobileSync/MobileSync/"
+        flags: 
+          - MobileSync
+
+    # Pull Request Requirements
+    patch: 
+      SalesforceAnalytics:
+        target: 80%
+        paths: 
+          - "libs/SalesforceAnalytics/SalesforceAnalytics/"
+        flags: 
+          - SalesforceAnalytics
+      SalesforceSDKCommon:
+        target: 80%
+        paths: 
+          - "libs/SalesforceSDKCore/SalesforceSDKCommon/"
+        flags: 
+          - SalesforceSDKCommon
+      SalesforceSDKCore:
+        target: 80%
+        paths: 
+          - "libs/SalesforceSDKCore/SalesforceSDKCore/"
+        flags: 
+          - SalesforceSDKCore
+      SmartStore:
+        target: 80%
+        paths: 
+          - "libs/SmartStore/SmartStore/"
+        flags: 
+          - SmartStore
+      MobileSync:
+        target: 80%
         paths: 
           - "libs/MobileSync/MobileSync/"
         flags: 


### PR DESCRIPTION
- Add threshold: 0% to all libraries. This will fail a check if a PR lowers the overall coverage of a library by any amount.
- Add new patch section with target: 80% for each library. This will create a check per library that will ensures new code added in a PR has at least 80% coverage.

I could have required a specific coverage amount (like 80%) per library but most are no where near where we ideally want them. Instead, these rules should encourage us to organically work towards that goal.