### PR TITLE
@W-17676299: Resolve memory leaks in SFNetwork.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
@@ -118,11 +118,15 @@ static SFSDKMetricsCollectedBlock _metricsCollectedAction = nil;
 
 + (void)removeSharedInstanceForIdentifier:(nullable NSString *)identifier {
     if (identifier) {
+        [[(SFNetwork *)sharedInstances[identifier] activeSession] invalidateAndCancel];
         [sharedInstances removeObject:identifier];
     }
 }
 
 + (void)removeAllSharedInstances {
+    for (SFNetwork * network in sharedInstances.allValues) {
+        [network.activeSession invalidateAndCancel];
+    }
     [sharedInstances removeAllObjects];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFNetwork.m
@@ -124,7 +124,7 @@ static SFSDKMetricsCollectedBlock _metricsCollectedAction = nil;
 }
 
 + (void)removeAllSharedInstances {
-    for (SFNetwork * network in sharedInstances.allValues) {
+    for (SFNetwork *network in sharedInstances.allValues) {
         [network.activeSession invalidateAndCancel];
     }
     [sharedInstances removeAllObjects];


### PR DESCRIPTION
WI: [W-17676299](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000028aP2eYAE/view)

Strong retain cycle is created as SFNetwork holds reference of URLSession as activeSession and URLSession holds reference of URLSessionDelegate which is SFNetwork.

Solution: https://salesforce.quip.com/XvWlAdixW1RJ