### PR TITLE
Keep prior add connection functionality with removing scheme.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/NewLoginHostView.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/NewLoginHostView.swift
@@ -82,9 +82,9 @@ struct NewLoginHostView: View {
     
     func save() {
         var hostToSave = host.trimmingCharacters(in: .whitespaces)
-        if let httpsRange = hostToSave.range(of: "://"),
-           let components = URLComponents(string: hostToSave),
-           let scheme = components.scheme {
+        if hostToSave.contains("://"),
+           let components = URLComponents(string: hostToSave) {
+            let scheme = components.scheme ?? ""
             hostToSave = String(hostToSave.dropFirst("\(scheme)://".count))
         }
         saveAction(hostToSave, hostLabel.trimmingCharacters(in: .whitespaces))

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/NewLoginHostView.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/NewLoginHostView.swift
@@ -67,7 +67,7 @@ struct NewLoginHostField: View {
 
 struct NewLoginHostView: View {
     @State var host = ""
-    @State var hostName = ""
+    @State var hostLabel = ""
     private var saveAction: ((String, String?) -> Void)
     private var navBarTintColor: Color
     
@@ -82,10 +82,12 @@ struct NewLoginHostView: View {
     
     func save() {
         var hostToSave = host.trimmingCharacters(in: .whitespaces)
-        if let httpsRange = hostToSave.range(of: "://") {
-            hostToSave = String(host[...httpsRange.upperBound])
+        if let httpsRange = hostToSave.range(of: "://"),
+           let components = URLComponents(string: hostToSave),
+           let scheme = components.scheme {
+            hostToSave = String(hostToSave.dropFirst("\(scheme)://".count))
         }
-        saveAction(hostToSave, hostName.trimmingCharacters(in: .whitespaces))
+        saveAction(hostToSave, hostLabel.trimmingCharacters(in: .whitespaces))
     }
     
     var body: some View {
@@ -103,7 +105,7 @@ struct NewLoginHostView: View {
                               fieldLabelAccessibilityID: "addconn_nameLabel",
                               fieldPlaceholder: SFSDKResourceUtils.localizedString("LOGIN_SERVER_NAME_PLACEHOLDER"),
                               fieldInputAccessibilityID: "addconn_nameInput",
-                              fieldValue: $hostName)
+                              fieldValue: $hostLabel)
                 .listRowSeparator(.hidden)
                 .padding(.bottom)
         }


### PR DESCRIPTION
The current behavior if a scheme is included in the add connection host url:
Input: `https://test.salesforce.com`
Result: `https://t`
Expected: `test.salesforce.com`

Fix: 
If a scheme is included in the host input field, the scheme and "://" are removed from the host url variable.

@bbirman