### PR TITLE
Beacon app support

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		4F7EB4AC1BFFCF0F00768720 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7EB4A01BFFCEF600768720 /* main.m */; };
 		4F7EB4AD1BFFCF2300768720 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7EB4A41BFFCEF600768720 /* ViewController.m */; };
 		4F8A3B012CEC202F00ECDC76 /* JwtAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A3B002CEC202F00ECDC76 /* JwtAccessToken.swift */; };
+		4F9E05322DD6A08000548985 /* SFSDKOAuthTokenEndpointResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */; };
 		4FE5332A1BFFE70600814D2A /* Main_iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB4981BFFCEF600768720 /* Main_iPad.storyboard */; };
 		4FE5332B1BFFE70600814D2A /* Main_iPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB49A1BFFCEF600768720 /* Main_iPhone.storyboard */; };
 		6900B62C24B64DD800500923 /* NSURLResponse+SFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6900B62A24B64DD800500923 /* NSURLResponse+SFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -654,6 +655,7 @@
 		4F96FD471BFD32140022F021 /* SFSDKResourceUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKResourceUtils.m; sourceTree = "<group>"; };
 		4F96FD481BFD32140022F021 /* SFSDKWebUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKWebUtils.h; sourceTree = "<group>"; };
 		4F96FD491BFD32140022F021 /* SFSDKWebUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKWebUtils.m; sourceTree = "<group>"; };
+		4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKOAuthTokenEndpointResponseTests.m; sourceTree = "<group>"; };
 		4FEE438A1BFD488900F09C43 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		4FF945BD1BFFF47D005368C5 /* NSData+SFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+SFAdditions.h"; sourceTree = "<group>"; };
 		4FF945BE1BFFF47D005368C5 /* NSData+SFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+SFAdditions.m"; sourceTree = "<group>"; };
@@ -988,6 +990,7 @@
 		4F7EB3F61BFFC84700768720 /* SalesforceSDKCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */,
 				238AA57F2D827AF80036667C /* PushNotificationManagerTests.swift */,
 				2394F4712D930C5400B9686A /* WebViewStateManagerTests.swift */,
 				23A4C7472D0CAFCF00DF55EB /* JwtAccessTokenTests.swift */,
@@ -2178,6 +2181,7 @@
 				69CEBC7E22F368CF00F16218 /* SFNetworkTests.m in Sources */,
 				4F7EB41B1BFFC8D700768720 /* SFSDKCryptoUtilsTests.m in Sources */,
 				69848CB82364035300893E57 /* SFSDKEncryptedPushNotificationTests.m in Sources */,
+				4F9E05322DD6A08000548985 /* SFSDKOAuthTokenEndpointResponseTests.m in Sources */,
 				4F06AF8D1C49A18E00F70798 /* SalesforceSDKManagerTests.m in Sources */,
 				4F06AF8F1C49A18E00F70798 /* SFOAuthSessionRefresherTests.m in Sources */,
 				CEB98EE31F86E7DC0083AB9C /* SFSDKURLHandlerManagerTest.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		4F7EB4AD1BFFCF2300768720 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7EB4A41BFFCEF600768720 /* ViewController.m */; };
 		4F8A3B012CEC202F00ECDC76 /* JwtAccessToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F8A3B002CEC202F00ECDC76 /* JwtAccessToken.swift */; };
 		4F9E05322DD6A08000548985 /* SFSDKOAuthTokenEndpointResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */; };
+		4F9E05342DD7BE1500548985 /* SFOAuthCredentialsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9E05332DD7BE0A00548985 /* SFOAuthCredentialsTests.m */; };
 		4FE5332A1BFFE70600814D2A /* Main_iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB4981BFFCEF600768720 /* Main_iPad.storyboard */; };
 		4FE5332B1BFFE70600814D2A /* Main_iPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB49A1BFFCEF600768720 /* Main_iPhone.storyboard */; };
 		6900B62C24B64DD800500923 /* NSURLResponse+SFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6900B62A24B64DD800500923 /* NSURLResponse+SFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -656,6 +657,7 @@
 		4F96FD481BFD32140022F021 /* SFSDKWebUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKWebUtils.h; sourceTree = "<group>"; };
 		4F96FD491BFD32140022F021 /* SFSDKWebUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKWebUtils.m; sourceTree = "<group>"; };
 		4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKOAuthTokenEndpointResponseTests.m; sourceTree = "<group>"; };
+		4F9E05332DD7BE0A00548985 /* SFOAuthCredentialsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFOAuthCredentialsTests.m; sourceTree = "<group>"; };
 		4FEE438A1BFD488900F09C43 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		4FF945BD1BFFF47D005368C5 /* NSData+SFAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+SFAdditions.h"; sourceTree = "<group>"; };
 		4FF945BE1BFFF47D005368C5 /* NSData+SFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+SFAdditions.m"; sourceTree = "<group>"; };
@@ -990,6 +992,7 @@
 		4F7EB3F61BFFC84700768720 /* SalesforceSDKCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				4F9E05332DD7BE0A00548985 /* SFOAuthCredentialsTests.m */,
 				4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */,
 				238AA57F2D827AF80036667C /* PushNotificationManagerTests.swift */,
 				2394F4712D930C5400B9686A /* WebViewStateManagerTests.swift */,
@@ -2184,6 +2187,7 @@
 				4F9E05322DD6A08000548985 /* SFSDKOAuthTokenEndpointResponseTests.m in Sources */,
 				4F06AF8D1C49A18E00F70798 /* SalesforceSDKManagerTests.m in Sources */,
 				4F06AF8F1C49A18E00F70798 /* SFOAuthSessionRefresherTests.m in Sources */,
+				4F9E05342DD7BE1500548985 /* SFOAuthCredentialsTests.m in Sources */,
 				CEB98EE31F86E7DC0083AB9C /* SFSDKURLHandlerManagerTest.m in Sources */,
 				CED452F01D808E0F009266EB /* SalesforceRestAPITests.m in Sources */,
 				2394F4722D930C5400B9686A /* WebViewStateManagerTests.swift in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
@@ -42,6 +42,8 @@ extern NSString * _Nonnull const kSFOAuthServiceVfSid;
 extern NSString * _Nonnull const kSFOAuthServiceContentSid;
 extern NSString * _Nonnull const kSFOAuthServiceCsrf;
 extern NSString * _Nonnull const kSFOAuthServiceParentSid;
+extern NSString * _Nonnull const kSFOAuthServiceBeaconChildConsumerKey;
+extern NSString * _Nonnull const kSFOAuthServiceBeaconChildConsumerSecret;
 
 extern NSException * _Nullable SFOAuthInvalidIdentifierException(void);
 
@@ -78,7 +80,8 @@ extern NSException * _Nullable SFOAuthInvalidIdentifierException(void);
 @property (nonatomic, readwrite, nullable) NSString *sidCookieName;
 @property (nonatomic, readwrite, nullable) NSString *parentSid;
 @property (nonatomic, readwrite, nullable) NSString *tokenFormat;
-
+@property (nonatomic, readwrite, nullable) NSString *beaconChildConsumerKey;
+@property (nonatomic, readwrite, nullable) NSString *beaconChildConsumerSecret;
 
 - (void)setPropertyForKey:(NSString *_Nonnull) key withValue:(id _Nullable ) newValue;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
@@ -138,6 +138,8 @@ NS_SWIFT_NAME(OAuthCredentials)
 @property (nonatomic, readonly, nullable) NSString *sidCookieName;
 @property (nonatomic, readonly, nullable) NSString *parentSid;
 @property (nonatomic, readonly, nullable) NSString *tokenFormat;
+@property (nonatomic, readonly, nullable) NSString *beaconChildConsumerKey;
+@property (nonatomic, readonly, nullable) NSString *beaconChildConsumerSecret;
 
 
 /** A readonly convenience property returning the Salesforce Organization ID provided in the path component of the identityUrl.
@@ -271,6 +273,11 @@ NS_SWIFT_NAME(OAuthCredentials)
 - (NSURL *)overrideDomainIfNeeded;
 
 - (void)updateCredentials:(NSDictionary *)params;
+
+/** Returns the oauth client id to use for refresh
+ In the case of beacon app, the beacon child consumer key returned during login should be used instead of the configured consumer key
+ */
+- (NSString*)getClientIdForRefresh;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -37,6 +37,8 @@ NSString * const kSFOAuthServiceVfSid           = @"com.salesforce.mobilesdk.oau
 NSString * const kSFOAuthServiceContentSid      = @"com.salesforce.mobilesdk.oauth.contentSid";
 NSString * const kSFOAuthServiceCsrf            = @"com.salesforce.mobilesdk.oauth.csrf";
 NSString * const kSFOAuthServiceParentSid       = @"com.salesforce.mobilesdk.oauth.parentSid";
+NSString * const kSFOAuthServiceBeaconChildConsumerKey    = @"com.salesforce.mobilesdk.oauth.beaconChildConsumerKey";
+NSString * const kSFOAuthServiceBeaconChildConsumerSecret = @"com.salesforce.mobilesdk.oauth.beaconChildConsumerSecret";
 
 NSString * const kSFOAuthServiceLegacyAccess    = @"com.salesforce.oauth.access";
 NSString * const kSFOAuthServiceLegacyRefresh   = @"com.salesforce.oauth.refresh";
@@ -121,6 +123,8 @@ NSException * SFOAuthInvalidIdentifierException(void) {
                 self.contentSid  = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthContentSID"];
                 self.csrfToken  = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthCSRFToken"];
                 self.parentSid = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthParentSID"];
+                self.beaconChildConsumerKey  = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthBeaconChildConsumerKey"];
+                self.beaconChildConsumerSecret  = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthBeaconChildConsumerSecret"];
             }
         }
     } else {
@@ -217,6 +221,8 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     copyCreds.sidCookieName = self.sidCookieName;
     copyCreds.parentSid = self.parentSid;
     copyCreds.tokenFormat = self.tokenFormat;
+    copyCreds.beaconChildConsumerKey = self.beaconChildConsumerKey;
+    copyCreds.beaconChildConsumerSecret = self.beaconChildConsumerSecret;
     copyCreds.additionalOAuthFields = [self.additionalOAuthFields copy];
     return copyCreds;
 }
@@ -327,6 +333,8 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     self.sidCookieName = nil;
     self.parentSid = nil;
     self.tokenFormat = nil;
+    self.beaconChildConsumerKey = nil;
+    self.beaconChildConsumerSecret = nil;
 }
 
 - (void)setPropertyForKey:(NSString *) propertyName withValue:(id) newValue {
@@ -426,7 +434,16 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     if (params[kSFOAuthTokenFormat]) {
         self.tokenFormat = params[kSFOAuthTokenFormat];
     }
+    if (params[kSFOAuthBeaconChildConsumerKey]) {
+        self.beaconChildConsumerKey = params[kSFOAuthBeaconChildConsumerKey];
+    }
+    if (params[kSFOAuthBeaconChildConsumerSecret]) {
+        self.beaconChildConsumerSecret = params[kSFOAuthBeaconChildConsumerSecret];
+    }
+}
 
+- (NSString*)getClientIdForRefresh {
+    return self.beaconChildConsumerKey.length != 0 ? self.beaconChildConsumerKey : self.clientId;
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthKeychainCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthKeychainCredentials.m
@@ -106,6 +106,21 @@
     [self encryptToken:sid forService:kSFOAuthServiceParentSid];
 }
 
+- (NSString *)beaconChildConsumerKey {
+    return [self decryptedTokenForService:kSFOAuthServiceBeaconChildConsumerKey];
+}
+
+- (void)setBeaconChildConsumerKey:(NSString *)key {
+    [self encryptToken:key forService:kSFOAuthServiceBeaconChildConsumerKey];
+}
+
+- (NSString *)beaconChildConsumerSecret {
+    return [self decryptedTokenForService:kSFOAuthServiceBeaconChildConsumerSecret];
+}
+
+- (void)setBeaconChildConsumerSecret:(NSString *)secret {
+    [self encryptToken:secret forService:kSFOAuthServiceBeaconChildConsumerSecret];
+}
 
 #pragma mark - Private Keychain Methods
 - (NSData *)tokenForService:(NSString *)service

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -79,7 +79,7 @@
     SFSDKOAuthTokenEndpointRequest *request = [[SFSDKOAuthTokenEndpointRequest alloc] init];
     request.additionalOAuthParameterKeys = [SFUserAccountManager sharedInstance].additionalOAuthParameterKeys;
     request.additionalTokenRefreshParams = [SFUserAccountManager sharedInstance].additionalTokenRefreshParams;
-    request.clientID = self.credentials.clientId;
+    request.clientID = [self.credentials getClientIdForRefresh];
     request.refreshToken = self.credentials.refreshToken;
     request.redirectURI = self.credentials.redirectUri;
     request.serverURL = [self.credentials overrideDomainIfNeeded];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -131,6 +131,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *sidCookieName;
 @property (nonatomic, readonly, nullable) NSString *parentSid;
 @property (nonatomic, readonly, nullable) NSString *tokenFormat;
+@property (nonatomic, readonly, nullable) NSString *beaconChildConsumerKey;
+@property (nonatomic, readonly, nullable) NSString *beaconChildConsumerSecret;
+
 - (NSDictionary *)asDictionary;
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -196,6 +196,14 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     return self.values[kSFOAuthTokenFormat];
 }
 
+- (NSString *)beaconChildConsumerKey {
+    return self.values[kSFOAuthBeaconChildConsumerKey];
+}
+
+- (NSString *)beaconChildConsumerSecret {
+    return self.values[kSFOAuthBeaconChildConsumerSecret];
+}
+
 - (NSURL *)communityUrl {
     if (_values[kSFOAuthCommunityUrl]) {
         return [NSURL URLWithString:self.values[kSFOAuthCommunityUrl]];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -77,6 +77,9 @@ static NSString * const kSFOAuthCookieSidClient                 = @"cookie-sid_C
 static NSString * const kSFOAuthSidCookieName                   = @"sidCookieName";
 static NSString * const kSFOAuthParentSid                       = @"parent_sid";
 static NSString * const kSFOAuthTokenFormat                     = @"token_format";
+static NSString * const kSFOAuthBeaconChildConsumerKey          = @"beacon_child_consumer_key";
+static NSString * const kSFOAuthBeaconChildConsumerSecret       = @"beacon_child_consumer_secret";
+
 
 // Used for the IP bypass flow, Advanced auth flow
 static NSString * const kSFOAuthApprovalCode                     = @"code";

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/SFOAuthCredentialsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/SFOAuthCredentialsTests.m
@@ -1,0 +1,105 @@
+/*
+ SFOAuthCredentialsTests.m
+ SalesforceSDKCoreTests
+ 
+ Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "SFOAuthCredentials.h"
+
+@interface SFOAuthCredentialsTests : XCTestCase
+
+@end
+
+@implementation SFOAuthCredentialsTests
+
+- (void)testUpdateCredentialsNotEncryptedNotStored {
+    [self tryUpdateCredentials:FALSE storageType:SFOAuthCredentialsStorageTypeNone];
+}
+
+- (void)testUpdateCredentialsEncryptedNotStored {
+    [self tryUpdateCredentials:TRUE storageType:SFOAuthCredentialsStorageTypeNone];
+}
+
+- (void)testUpdateCredentialsNotEncryptedStored {
+    [self tryUpdateCredentials:FALSE storageType:SFOAuthCredentialsStorageTypeKeychain];
+}
+
+- (void)testUpdateCredentialsEncryptedStored {
+    [self tryUpdateCredentials:TRUE storageType:SFOAuthCredentialsStorageTypeKeychain];
+}
+
+
+- (void)tryUpdateCredentials:(BOOL)encrypted storageType:(SFOAuthCredentialsStorageType)storageType {
+    // Creating SFOAuthCredentials
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"test_auth_creds" clientId:@"test_client_id" encrypted:encrypted storageType:storageType];
+
+    // Prepare dictionary with credentials
+    NSMutableDictionary<NSString *, NSString *> *params = [NSMutableDictionary dictionary];
+    [params setObject:@"test-auth-token" forKey:@"access_token"];
+    [params setObject:@"test-refresh-token" forKey:@"refresh_token"];
+    [params setObject:@"https://instance.salesforce.com" forKey:@"instance_url"];
+    [params setObject:@"https://id.salesforce.com" forKey:@"id"];
+    [params setObject:@"test-community-id" forKey:@"sfdc_community_id"];
+    [params setObject:@"https://community.salesforce.com" forKey:@"sfdc_community_url"];
+    [params setObject:@"test-lightning-domain" forKey:@"lightning_domain"];
+    [params setObject:@"test-lightning-sid" forKey:@"lightning_sid"];
+    [params setObject:@"test-vf-domain" forKey:@"visualforce_domain"];
+    [params setObject:@"test-vf-sid" forKey:@"visualforce_sid"];
+    [params setObject:@"test-content-domain" forKey:@"content_domain"];
+    [params setObject:@"test-content-sid" forKey:@"content_sid"];
+    [params setObject:@"test-csrf-token" forKey:@"csrf_token"];
+    [params setObject:@"test-cookie-client-src" forKey:@"cookie-clientSrc"];
+    [params setObject:@"test-cookie-sid-client" forKey:@"cookie-sid_Client"];
+    [params setObject:@"test-sid-cookie-name" forKey:@"sidCookieName"];
+    [params setObject:@"test-parent-sid" forKey:@"parent_sid"];
+    [params setObject:@"test-token-format" forKey:@"token_format"];
+    [params setObject:@"test-beacon-child-consumer-key" forKey:@"beacon_child_consumer_key"];
+    [params setObject:@"test-beacon-child-consumer-secret" forKey:@"beacon_child_consumer_secret"];
+    [creds updateCredentials:params];
+    
+    // Check updated SFOAuthCredentials
+    XCTAssertEqualObjects(creds.accessToken, @"test-auth-token");
+    XCTAssertEqualObjects(creds.refreshToken, @"test-refresh-token");
+    XCTAssertEqualObjects(creds.instanceUrl.absoluteString, @"https://instance.salesforce.com");
+    XCTAssertEqualObjects(creds.identityUrl.absoluteString, @"https://id.salesforce.com");
+    XCTAssertEqualObjects(creds.communityId, @"test-community-id");
+    XCTAssertEqualObjects(creds.communityUrl.absoluteString, @"https://community.salesforce.com");
+    XCTAssertEqualObjects(creds.lightningDomain, @"test-lightning-domain");
+    XCTAssertEqualObjects(creds.lightningSid, @"test-lightning-sid");
+    XCTAssertEqualObjects(creds.vfDomain, @"test-vf-domain");
+    XCTAssertEqualObjects(creds.vfSid, @"test-vf-sid");
+    XCTAssertEqualObjects(creds.contentDomain, @"test-content-domain");
+    XCTAssertEqualObjects(creds.contentSid, @"test-content-sid");
+    XCTAssertEqualObjects(creds.csrfToken, @"test-csrf-token");
+    XCTAssertEqualObjects(creds.cookieClientSrc, @"test-cookie-client-src");
+    XCTAssertEqualObjects(creds.cookieSidClient, @"test-cookie-sid-client");
+    XCTAssertEqualObjects(creds.sidCookieName, @"test-sid-cookie-name");
+    XCTAssertEqualObjects(creds.parentSid, @"test-parent-sid");
+    XCTAssertEqualObjects(creds.tokenFormat, @"test-token-format");
+    XCTAssertEqualObjects(creds.beaconChildConsumerKey, @"test-beacon-child-consumer-key");
+    XCTAssertEqualObjects(creds.beaconChildConsumerSecret, @"test-beacon-child-consumer-secret");
+}
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/SFSDKOAuthTokenEndpointResponseTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/SFSDKOAuthTokenEndpointResponseTests.m
@@ -1,0 +1,107 @@
+/*
+ SFSDKOAuthTokenEndpointResponseTests.m
+ SalesforceSDKCoreTests
+ 
+ Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "SFSDKOAuth2.h"
+
+@interface SFSDKOAuthTokenEndpointResponse ()
+
+- (instancetype)initWithDictionary:(NSDictionary *)nvPairs parseAdditionalFields:(NSArray<NSString *> *)additionalOAuthParameterKeys;
+
+@end
+
+@interface SFSDKOAuthTokenEndpointResponseTests : XCTestCase
+
+@end
+
+@implementation SFSDKOAuthTokenEndpointResponseTests
+
+- (void)testInitWithDictionary {
+    // Prepeare dictionary simulating response from token end point
+    NSMutableDictionary<NSString *, NSString *> *params = [NSMutableDictionary dictionary];
+    [params setObject:@"test-auth-token" forKey:@"access_token"];
+    [params setObject:@"test-refresh-token" forKey:@"refresh_token"];
+    [params setObject:@"https://instance.salesforce.com" forKey:@"instance_url"];
+    [params setObject:@"https://id.salesforce.com" forKey:@"id"];
+    [params setObject:@"test-community-id" forKey:@"sfdc_community_id"];
+    [params setObject:@"https://community.salesforce.com" forKey:@"sfdc_community_url"];
+    [params setObject:@"test-lightning-domain" forKey:@"lightning_domain"];
+    [params setObject:@"test-lightning-sid" forKey:@"lightning_sid"];
+    [params setObject:@"test-vf-domain" forKey:@"visualforce_domain"];
+    [params setObject:@"test-vf-sid" forKey:@"visualforce_sid"];
+    [params setObject:@"test-content-domain" forKey:@"content_domain"];
+    [params setObject:@"test-content-sid" forKey:@"content_sid"];
+    [params setObject:@"test-csrf-token" forKey:@"csrf_token"];
+    [params setObject:@"test-cookie-client-src" forKey:@"cookie-clientSrc"];
+    [params setObject:@"test-cookie-sid-client" forKey:@"cookie-sid_Client"];
+    [params setObject:@"test-sid-cookie-name" forKey:@"sidCookieName"];
+    [params setObject:@"test-parent-sid" forKey:@"parent_sid"];
+    [params setObject:@"test-token-format" forKey:@"token_format"];
+    [params setObject:@"test-beacon-child-consumer-key" forKey:@"beacon_child_consumer_key"];
+    [params setObject:@"test-beacon-child-consumer-secret" forKey:@"beacon_child_consumer_secret"];
+
+    // Additional fields
+    NSArray<NSString *>* additionalFields = @[ @"additional-1", @"additional-2" ];
+    for (NSString *field in additionalFields) {
+        NSString *value = [NSString stringWithFormat:@"test-%@", field];
+        [params setObject:value forKey:field];
+    }
+    
+    // Create SFSDKOAuthTokenEndpointResponse with initWithDictionary
+    SFSDKOAuthTokenEndpointResponse* response = [[SFSDKOAuthTokenEndpointResponse alloc] initWithDictionary:params parseAdditionalFields:additionalFields];
+    
+    // Check regular fields
+    XCTAssertEqualObjects(response.accessToken, @"test-auth-token");
+    XCTAssertEqualObjects(response.refreshToken, @"test-refresh-token");
+    XCTAssertEqualObjects(response.instanceUrl.absoluteString, @"https://instance.salesforce.com");
+    XCTAssertEqualObjects(response.identityUrl.absoluteString, @"https://id.salesforce.com");
+    XCTAssertEqualObjects(response.communityId, @"test-community-id");
+    XCTAssertEqualObjects(response.communityUrl.absoluteString, @"https://community.salesforce.com");
+    XCTAssertEqualObjects(response.lightningDomain, @"test-lightning-domain");
+    XCTAssertEqualObjects(response.lightningSid, @"test-lightning-sid");
+    XCTAssertEqualObjects(response.vfDomain, @"test-vf-domain");
+    XCTAssertEqualObjects(response.vfSid, @"test-vf-sid");
+    XCTAssertEqualObjects(response.contentDomain, @"test-content-domain");
+    XCTAssertEqualObjects(response.contentSid, @"test-content-sid");
+    XCTAssertEqualObjects(response.csrfToken, @"test-csrf-token");
+    XCTAssertEqualObjects(response.cookieClientSrc, @"test-cookie-client-src");
+    XCTAssertEqualObjects(response.cookieSidClient, @"test-cookie-sid-client");
+    XCTAssertEqualObjects(response.sidCookieName, @"test-sid-cookie-name");
+    XCTAssertEqualObjects(response.parentSid, @"test-parent-sid");
+    XCTAssertEqualObjects(response.tokenFormat, @"test-token-format");
+    XCTAssertEqualObjects(response.beaconChildConsumerKey, @"test-beacon-child-consumer-key");
+    XCTAssertEqualObjects(response.beaconChildConsumerSecret, @"test-beacon-child-consumer-secret");
+
+    // Check additional fields
+    for (NSString *field in additionalFields) {
+        NSString *value = [NSString stringWithFormat:@"test-%@", field];
+        XCTAssertEqualObjects(response.additionalOAuthFields[field], value);
+    }
+
+}
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
@@ -142,6 +142,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     credsIn.sidCookieName   = @"sid-cookie-name";
     credsIn.parentSid       = @"parent-sid";
     credsIn.tokenFormat     = @"token-format";
+    credsIn.beaconChildConsumerKey = @"beacon-child-consumer-key";
+    credsIn.beaconChildConsumerSecret = @"beacon-child-consumer-secret";
 
     credsIn.additionalOAuthFields = @{
         @"abc": @"def"
@@ -182,6 +184,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     XCTAssertEqualObjects(credsIn.sidCookieName,       credsOut.sidCookieName,       @"sidCookieName mismatch");
     XCTAssertEqualObjects(credsIn.parentSid,           credsOut.parentSid,           @"parentSid mismatch");
     XCTAssertEqualObjects(credsIn.tokenFormat,         credsOut.tokenFormat,         @"tokenFormat mismatch");
+    XCTAssertEqualObjects(credsIn.beaconChildConsumerKey,    credsOut.beaconChildConsumerKey,    @"beaconChildConsumerKey mismatch");
+    XCTAssertEqualObjects(credsIn.beaconChildConsumerSecret, credsOut.beaconChildConsumerSecret, @"beaconChildConsumerSecret mismatch");
     XCTAssertEqualObjects(credsIn.additionalOAuthFields, credsOut.additionalOAuthFields, @"additionalFields mismatch");
     
     credsIn = nil;
@@ -212,6 +216,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     NSString *sidCookieNameToCheck = @"sid-cookie-name";
     NSString *parentSidToCheck = @"parent-sid";
     NSString *tokenFormatToCheck = @"token-format";
+    NSString *beaconChildConsumerKeyCheck = @"beacon-child-consumer-key";
+    NSString *beaconChildConsumerSecretCheck = @"beacon-child-consumer-secret";
     NSDictionary *additionalFieldsToCheck = @{ @"field1": @"field1Val" };
     
     SFOAuthCredentials *origCreds = [[SFOAuthCredentials alloc] initWithIdentifier:kIdentifier clientId:kClientId encrypted:YES];
@@ -236,7 +242,9 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     origCreds.sidCookieName = sidCookieNameToCheck;
     origCreds.parentSid = parentSidToCheck;
     origCreds.tokenFormat = tokenFormatToCheck;
-    
+    origCreds.beaconChildConsumerKey = beaconChildConsumerKeyCheck;
+    origCreds.beaconChildConsumerSecret = beaconChildConsumerSecretCheck;
+
     // NB: Intentionally ordering the setting of these, because setting the identity URL automatically
     // sets the OrgID and UserID.  This ensures the values stay in sync.
     origCreds.identityUrl = identityUrlToCheck;
@@ -271,6 +279,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     origCreds.sidCookieName = nil;
     origCreds.parentSid = nil;
     origCreds.tokenFormat = nil;
+    origCreds.beaconChildConsumerKey = nil;
+    origCreds.beaconChildConsumerSecret = nil;
     origCreds.additionalOAuthFields = nil;
     
     XCTAssertNotEqual(origCreds, copiedCreds);
@@ -296,6 +306,10 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     XCTAssertEqual(origCreds.csrfToken, copiedCreds.csrfToken);
     XCTAssertNotEqual(copiedCreds.parentSid, parentSidToCheck);
     XCTAssertEqual(origCreds.parentSid, copiedCreds.parentSid);
+    XCTAssertNotEqual(copiedCreds.beaconChildConsumerKey, beaconChildConsumerKeyCheck);
+    XCTAssertEqual(origCreds.beaconChildConsumerKey, copiedCreds.beaconChildConsumerKey);
+    XCTAssertNotEqual(copiedCreds.beaconChildConsumerSecret, beaconChildConsumerSecretCheck);
+    XCTAssertEqual(origCreds.beaconChildConsumerSecret, copiedCreds.beaconChildConsumerSecret);
 
     XCTAssertEqual(copiedCreds.organizationId, orgIdToCheck);
     XCTAssertNotEqual(origCreds.organizationId, copiedCreds.organizationId);


### PR DESCRIPTION
- Saving beacon child consumer key and secret in keychain when returned in token end point response
- Using beacon child consumer key instead of configured consumer key if available during refresh
- Updated tests
- Tested manually with beacon app setup in test environment (na54)