### PR TITLE
@W-18542896 Provide a way for the application to specify notification types / actions it actually supports

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/PushNotificationManager+ActionableNotifications.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/PushNotificationManager+ActionableNotifications.swift
@@ -141,7 +141,15 @@ internal extension PushNotificationManager {
     }
     
     func setNotificationCategories(types: [NotificationType]) {
-        let categories = types
+        
+        let filterTypes: [NotificationType]
+        if let filter = UserAccountManager.shared.filterSupportedNotificationTypes {
+            filterTypes = filter(types)
+        } else {
+            filterTypes = types
+        }
+        
+        let categories = filterTypes
             .flatMap { createNotificationCategories(from: $0) }
         UNUserNotificationCenter.current().setNotificationCategories(Set(categories))
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
@@ -25,6 +25,21 @@ public class NotificationType: NSObject, Codable {
         self.actionGroups = actionGroups
     }
     
+    /** Creates a new NotificationType with only the specified actions
+     * - Parameter allowedActionNames: Set of action names to keep
+     * - Returns: A new NotificationType with filtered actions
+     **/
+    @objc
+    public func filteredCopy(keepingActions allowedActionNames: Set<String>) -> NotificationType {
+        let filteredGroups = actionGroups?.map { group in
+            let filteredActions = group.actions.filter { action in
+                allowedActionNames.contains(action.name)
+            }
+            return ActionGroup(name: group.name, actions: filteredActions)
+        }
+        return NotificationType(type: type, apiName: apiName, label: label, actionGroups: filteredGroups)
+    }
+    
     @objc public class func from(jsonData: Data) -> [NotificationType] {
         let decoder = JSONDecoder()
         do {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -381,6 +381,13 @@ NS_SWIFT_NAME(UserAccountManager)
 @property (class,nonatomic,readonly) SFUserAccountManager *sharedInstance NS_SWIFT_NAME(shared);
 
 /**
+ * Use this to provide a custom filter for supported notification types.
+ * The app can use this to return only the notification types it supports,
+ * so that unsupported types are not registered with the system.
+ */
+@property (nonatomic, copy, nullable) NSArray<NotificationType*>* (^filterSupportedNotificationTypes)(NSArray<NotificationType*>* notificationTypes);
+
+/**
  Adds a delegate to this user account manager.
  @param delegate The delegate to add.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
@@ -645,6 +645,90 @@ class PushNotificationManagerTests: XCTestCase {
         XCTAssertEqual(mockUserAccount.notificationTypes?.count, 1)
         XCTAssertEqual(mockUserAccount.notificationTypes?.first?.apiName, "cached_type")
     }
+
+    func testSetNotificationCategories_WithFilter() {
+        // Given
+        let mockTypes = [
+            NotificationType(type: "supported_type", apiName: "supported_type", label: "Supported Type", actionGroups: [
+                ActionGroup(name: "group1", actions: [
+                    Action(name: "action1", identifier: "group1__action1", label: "Action 1", type: .notificationApiAction)
+                ])
+            ]),
+            NotificationType(type: "unsupported_type", apiName: "unsupported_type", label: "Unsupported Type", actionGroups: [
+                ActionGroup(name: "group2", actions: [
+                    Action(name: "action2", identifier: "group2__action2", label: "Action 2", type: .notificationApiAction)
+                ])
+            ])
+        ]
+        
+        // When
+        UserAccountManager.shared.filterSupportedNotificationTypes = { types in
+            return types.filter { $0.apiName == "supported_type" }
+        }
+        pushNotificationManager.setNotificationCategories(types: mockTypes)
+        
+        // Then
+        let expectation = XCTestExpectation(description: "Get notification categories")
+        UNUserNotificationCenter.current().getNotificationCategories { categories in
+            XCTAssertEqual(categories.count, 1, "Should only register one category")
+            
+            let category = categories.first
+            XCTAssertEqual(category?.identifier, "group1", "Category identifier should match the supported type's group")
+            XCTAssertEqual(category?.actions.count, 1, "Should have one action")
+            
+            let action = category?.actions.first
+            XCTAssertEqual(action?.identifier, "group1__action1", "Action identifier should match")
+            XCTAssertEqual(action?.title, "Action 1", "Action title should match")
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testSetNotificationCategories_NoFilter() {
+        // Given
+        let mockTypes = [
+            NotificationType(type: "type1", apiName: "type1", label: "Type 1", actionGroups: [
+                ActionGroup(name: "group1", actions: [
+                    Action(name: "action1", identifier: "group1__action1", label: "Action 1", type: .notificationApiAction)
+                ])
+            ]),
+            NotificationType(type: "type2", apiName: "type2", label: "Type 2", actionGroups: [
+                ActionGroup(name: "group2", actions: [
+                    Action(name: "action2", identifier: "group2__action2", label: "Action 2", type: .notificationApiAction)
+                ])
+            ])
+        ]
+        
+        // When
+        UserAccountManager.shared.filterSupportedNotificationTypes = nil
+        pushNotificationManager.setNotificationCategories(types: mockTypes)
+        
+        // Then
+        let expectation = XCTestExpectation(description: "Get notification categories")
+        UNUserNotificationCenter.current().getNotificationCategories { categories in
+            XCTAssertEqual(categories.count, 2, "Should register both categories")
+            
+            let category1 = categories.first { $0.identifier == "group1" }
+            XCTAssertNotNil(category1, "Should have category for type1")
+            XCTAssertEqual(category1?.actions.count, 1, "Should have one action for type1")
+            let action1 = category1?.actions.first
+            XCTAssertEqual(action1?.identifier, "group1__action1", "Action identifier should match")
+            XCTAssertEqual(action1?.title, "Action 1", "Action title should match")
+            
+            let category2 = categories.first { $0.identifier == "group2" }
+            XCTAssertNotNil(category2, "Should have category for type2")
+            XCTAssertEqual(category2?.actions.count, 1, "Should have one action for type2")
+            let action2 = category2?.actions.first
+            XCTAssertEqual(action2?.identifier, "group2__action2", "Action identifier should match")
+            XCTAssertEqual(action2?.title, "Action 2", "Action title should match")
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
 }
 
 class NotificationCategoryFactoryTests: XCTestCase {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
@@ -729,6 +729,83 @@ class PushNotificationManagerTests: XCTestCase {
         
         wait(for: [expectation], timeout: 1.0)
     }
+
+    func testSetNotificationCategories_WithActionFilter() {
+        // Given
+        let mockTypes = [
+            NotificationType(type: "approval_type", apiName: "approval_type", label: "Approval Type", actionGroups: [
+                ActionGroup(name: "approval_actions", actions: [
+                    Action(name: "approve", identifier: "approval_actions__approve", label: "Approve", type: .notificationApiAction),
+                    Action(name: "deny", identifier: "approval_actions__deny", label: "Deny", type: .notificationApiAction),
+                    Action(name: "delegate", identifier: "approval_actions__delegate", label: "Delegate", type: .notificationApiAction)
+                ])
+            ])
+        ]
+        
+        // When
+        UserAccountManager.shared.filterSupportedNotificationTypes = { types in
+            return types.map { type in
+                // Use the helper method to filter actions
+                return type.filteredCopy(keepingActions: ["approve", "deny"])
+            }
+        }
+        pushNotificationManager.setNotificationCategories(types: mockTypes)
+        
+        // Then
+        let expectation = XCTestExpectation(description: "Get notification categories")
+        UNUserNotificationCenter.current().getNotificationCategories { categories in
+
+            XCTAssertEqual(categories.count, 1, "Should register one category")
+            
+            let category = categories.first
+            XCTAssertEqual(category?.identifier, "approval_actions", "Category identifier should match")
+            XCTAssertEqual(category?.actions.count, 2, "Should have only approve and deny actions")
+            
+            let approveAction = category?.actions.first { $0.identifier == "approval_actions__approve" }
+            XCTAssertNotNil(approveAction, "Should have approve action")
+            XCTAssertEqual(approveAction?.title, "Approve", "Action title should match")
+            
+            let denyAction = category?.actions.first { $0.identifier == "approval_actions__deny" }
+            XCTAssertNotNil(denyAction, "Should have deny action")
+            XCTAssertEqual(denyAction?.title, "Deny", "Action title should match")
+            
+            let delegateAction = category?.actions.first { $0.identifier == "approval_actions__delegate" }
+            XCTAssertNil(delegateAction, "Should not have delegate action")
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testNotificationTypeFilteredCopy() {
+        // Given
+        let originalType = NotificationType(type: "test_type", apiName: "test_type", label: "Test Type", actionGroups: [
+            ActionGroup(name: "test_group", actions: [
+                Action(name: "action1", identifier: "test_group__action1", label: "Action 1", type: .notificationApiAction),
+                Action(name: "action2", identifier: "test_group__action2", label: "Action 2", type: .notificationApiAction),
+                Action(name: "action3", identifier: "test_group__action3", label: "Action 3", type: .notificationApiAction)
+            ])
+        ])
+        
+        // When
+        let filteredType = originalType.filteredCopy(keepingActions: ["action1", "action3"])
+        
+        // Then
+        XCTAssertEqual(filteredType.type, originalType.type, "Type should be preserved")
+        XCTAssertEqual(filteredType.apiName, originalType.apiName, "API name should be preserved")
+        XCTAssertEqual(filteredType.label, originalType.label, "Label should be preserved")
+        
+        // Verify action groups
+        XCTAssertEqual(filteredType.actionGroups?.count, 1, "Should have one action group")
+        let filteredGroup = filteredType.actionGroups?.first
+        XCTAssertEqual(filteredGroup?.name, "test_group", "Group name should be preserved")
+        
+        // Verify actions
+        XCTAssertEqual(filteredGroup?.actions.count, 2, "Should have two actions")
+        let actionNames = filteredGroup?.actions.map { $0.name }
+        XCTAssertEqual(actionNames, ["action1", "action3"], "Should only keep specified actions")
+    }
 }
 
 class NotificationCategoryFactoryTests: XCTestCase {


### PR DESCRIPTION
# Add Support for Filtering Notification Types and Actions

## Problem
Currently, all notification types and actions received from the server are automatically registered with the system, even if the app doesn't support or handle them. This can lead to a poor user experience where users see notification actions that don't work or aren't relevant to the app's functionality.

## Solution
Added a new property `filterSupportedNotificationTypes` to `UserAccountManager` that allows apps to specify which notification types they support. This filter is applied when creating notification categories, ensuring that only supported types and their actions are registered with the system.

### Key Changes
- Added `filterSupportedNotificationTypes` property to `UserAccountManager`
- Modified `setNotificationCategories` in `PushNotificationManager` to apply the filter
- Added unit tests to verify filtering behavior

### Usage
Apps can now filter notification types by setting the filter property:

```swift
// Only allow specific notification types
UserAccountManager.shared.filterSupportedNotificationTypes = { types in
    return types.filter { $0.apiName == "supported_type" }
}

// Or allow all types (default behavior)
UserAccountManager.shared.filterSupportedNotificationTypes = nil
```

### Testing
Added comprehensive test coverage:
- `testSetNotificationCategories_WithFilter`: Verifies that only supported notification types are registered
- `testSetNotificationCategories_NoFilter`: Verifies that all types are registered when no filter is set

## Impact
This change improves the user experience by ensuring that only relevant notification actions are displayed to users. It also provides apps with more control over which notification types they support and handle.
