### PR TITLE
@W-18250537 Add support for direct URLRequest support to MSDK REST client

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		23B2FDEC2DB03496006ADC07 /* NotificationCategoryFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B2FDE62DB03486006ADC07 /* NotificationCategoryFactory.swift */; };
 		23CAB1312DD515B500B8929B /* SFLoginViewController+Deep-Linking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23CAB1302DD515B500B8929B /* SFLoginViewController+Deep-Linking.swift */; };
 		23CAB0F92DCBE51F00B8929B /* MockRestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23CAB0F72DCBE51F00B8929B /* MockRestClient.swift */; };
+		23EDDEFE2DE0F7620024AD39 /* URLRequest+RestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDDEF82DE0F7480024AD39 /* URLRequest+RestRequest.swift */; };
+		23EDDF022DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDDF012DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift */; };
 		444B95D01E83251900908C61 /* UIColor+SFColorsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */; };
 		4F06AF731C49A16A00F70798 /* NSURL+SFStringUtilsTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F06AF5D1C49A16A00F70798 /* NSURL+SFStringUtilsTests.h */; };
 		4F06AF751C49A16A00F70798 /* SalesforceOAuthUnitTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F06AF5F1C49A16A00F70798 /* SalesforceOAuthUnitTests.h */; };
@@ -542,6 +544,8 @@
 		23B2FDE62DB03486006ADC07 /* NotificationCategoryFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCategoryFactory.swift; sourceTree = "<group>"; };
 		23CAB1302DD515B500B8929B /* SFLoginViewController+Deep-Linking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SFLoginViewController+Deep-Linking.swift"; path = "Login/SFLoginViewController+Deep-Linking.swift"; sourceTree = "<group>"; };
 		23CAB0F72DCBE51F00B8929B /* MockRestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRestClient.swift; sourceTree = "<group>"; };
+		23EDDEF82DE0F7480024AD39 /* URLRequest+RestRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+RestRequest.swift"; sourceTree = "<group>"; };
+		23EDDF012DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "URLRequest+RestRequestTests.swift"; path = "SalesforceSDKCoreTests/URLRequest+RestRequestTests.swift"; sourceTree = SOURCE_ROOT; };
 		444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+SFColorsTests.m"; path = "SalesforceSDKCoreTests/UIColor+SFColorsTests.m"; sourceTree = SOURCE_ROOT; };
 		4F06AF5D1C49A16A00F70798 /* NSURL+SFStringUtilsTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSURL+SFStringUtilsTests.h"; path = "SalesforceSDKCoreTests/NSURL+SFStringUtilsTests.h"; sourceTree = SOURCE_ROOT; };
 		4F06AF5E1C49A16A00F70798 /* NSURL+SFStringUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSURL+SFStringUtilsTests.m"; path = "SalesforceSDKCoreTests/NSURL+SFStringUtilsTests.m"; sourceTree = SOURCE_ROOT; };
@@ -1005,6 +1009,7 @@
 		4F7EB3F61BFFC84700768720 /* SalesforceSDKCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				23EDDF012DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift */,
 				4F9E05332DD7BE0A00548985 /* SFOAuthCredentialsTests.m */,
 				4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */,
 				696D6C3D2DD7E0AD00138888 /* NewLoginHostTests.swift */,
@@ -1541,6 +1546,7 @@
 		B722A702233C432E0089736E /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				23EDDEF82DE0F7480024AD39 /* URLRequest+RestRequest.swift */,
 				23350C552DCAB190009A10DE /* RestClient+Blocks.swift */,
 				B722A708233C437E0089736E /* RestClient.swift */,
 				B7A6ED31236A3F8600DBA451 /* UserAccountManager.swift */,
@@ -2191,6 +2197,7 @@
 				009D77521CA4A92200D5183A /* SFPushNotificationManagerTests.m in Sources */,
 				696E91472AD0A14A00205884 /* BiometricAuthenticationManagerTests.swift in Sources */,
 				B7E8A2AF1E77062E007C0D92 /* SFUserAccountManagerPersisterTests.m in Sources */,
+				23EDDF022DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift in Sources */,
 				CEB98EDF1F86E7CA0083AB9C /* SFSDKAuthErrorCommandTest.m in Sources */,
 				696E91482AD0A14A00205884 /* ScreenLockManagerTests.m in Sources */,
 				8263FED31E7336BF0038F694 /* SFSDKAppFeatureMarkersTests.m in Sources */,
@@ -2243,6 +2250,7 @@
 				2365097E2DAD6B1B002BCFA9 /* RemoteNotificationRegistering.swift in Sources */,
 				CE4CE3521C0E5252009F6029 /* SFOAuthSessionRefresher.m in Sources */,
 				CE4CE3681C0E526A009F6029 /* SFDefaultUserManagementListViewController.m in Sources */,
+				23EDDEFE2DE0F7620024AD39 /* URLRequest+RestRequest.swift in Sources */,
 				B7FB26D91F78096300FB25A2 /* SFSDKAdvancedAuthURLHandler.m in Sources */,
 				A315F84326EAAFF800B94428 /* ScreenLockUIView.swift in Sources */,
 				4F2410B1282DCA4B00E5EFE3 /* SFSDKCollectionResponse.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -115,11 +115,15 @@ extension RestClient {
     
     /// Sends a URLRequest
     /// - Parameter urlRequest: The URLRequest to send
+    /// - Parameter networkServiceType: Specify a service type or use the default.
+    /// - Parameter requiresAuthentication: Specify requires auth, default to true.
     /// - Returns: A RestResponse containing the response data and metadata
     /// - Throws: A RestClientError if the request fails
-    @objc(sendURLRequest:completion:)
-    public func send(urlRequest: URLRequest) async throws -> (Data, URLResponse) {
-        guard let restRequest = urlRequest.toRestRequest() else {
+    @objc(sendURLRequest:networkServiceType:requiresAuthentication:completion:)
+    public func send(urlRequest: URLRequest,
+                     networkServiceType: RestRequest.NetWorkServiceType = RestRequest.NetWorkServiceType.SFNetworkServiceTypeDefault,
+                     requiresAuthentication: Bool = true) async throws -> (Data, URLResponse) {
+        guard let restRequest = urlRequest.toRestRequest(networkServiceType, requiresAuthentication) else {
             throw RestClientError.invalidRequest("Request is not a valid MSDK REST request.")
         }
         let response = try await send(request: restRequest)

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -113,6 +113,19 @@ extension RestClient {
         var records: [Record]?
     }
     
+    /// Sends a URLRequest
+    /// - Parameter urlRequest: The URLRequest to send
+    /// - Returns: A RestResponse containing the response data and metadata
+    /// - Throws: A RestClientError if the request fails
+    @objc(sendURLRequest:completion:)
+    public func send(urlRequest: URLRequest) async throws -> (Data, URLResponse) {
+        guard let restRequest = urlRequest.toRestRequest() else {
+            throw RestClientError.invalidRequest("Request is not a query request.")
+        }
+        let response = try await send(request: restRequest)
+        return (response.data, response.urlResponse)
+    }
+    
     /// Execute a prebuilt request.
     /// - Parameter request: The `RestRequest` object containing the request details.
     /// - Returns: A `RestResponse` object containing the response data and metadata.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/RestClient.swift
@@ -120,7 +120,7 @@ extension RestClient {
     @objc(sendURLRequest:completion:)
     public func send(urlRequest: URLRequest) async throws -> (Data, URLResponse) {
         guard let restRequest = urlRequest.toRestRequest() else {
-            throw RestClientError.invalidRequest("Request is not a query request.")
+            throw RestClientError.invalidRequest("Request is not a valid MSDK REST request.")
         }
         let response = try await send(request: restRequest)
         return (response.data, response.urlResponse)

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/URLRequest+RestRequest.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/URLRequest+RestRequest.swift
@@ -1,0 +1,66 @@
+//
+//  URLRequest+RestRequest.swift
+//  SalesforceSDKCore
+//
+//  Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
+// 
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+// 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+
+extension URLRequest {
+    
+    /// Converts a URLRequest to an SFRestRequest
+    /// - Returns: A new SFRestRequest instance populated with the URLRequest's properties
+    public func toRestRequest() -> RestRequest? {
+        guard let url = self.url else { return nil }
+        
+        let path = url.path
+        var queryParams: [String: Any] = [:]
+        if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+           let queryItems = components.queryItems {
+            for item in queryItems {
+                queryParams[item.name] = item.value
+            }
+        }
+        
+        let method = RestRequest.sfRestMethod(fromHTTPMethod: httpMethod ?? "GET")
+        
+        let baseURL = "\(url.scheme ?? "https")://\(url.host ?? "")"
+        let request = RestRequest(method: method, baseURL: baseURL, path: path, queryParams: queryParams)
+        
+        if let headers = allHTTPHeaderFields {
+            for (key, value) in headers {
+                request.setHeaderValue(value, forHeaderName: key)
+            }
+        }
+        
+        request.timeoutInterval = timeoutInterval
+        
+        if let body = httpBody {
+            let contentType = allHTTPHeaderFields?["Content-Type"] ?? "application/octet-stream"
+            request.setCustomRequestBodyData(body, contentType: contentType)
+        }
+        
+        request.endpoint = url.path
+        return request
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/URLRequest+RestRequest.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/URLRequest+RestRequest.swift
@@ -30,7 +30,8 @@ extension URLRequest {
     
     /// Converts a URLRequest to an SFRestRequest
     /// - Returns: A new SFRestRequest instance populated with the URLRequest's properties
-    public func toRestRequest() -> RestRequest? {
+    public func toRestRequest(_ networkServiceType: RestRequest.NetWorkServiceType = RestRequest.NetWorkServiceType.SFNetworkServiceTypeDefault,
+                              _ requiresAuthentication: Bool = true) -> RestRequest? {
         guard let url = self.url else { return nil }
         
         let path = url.path
@@ -61,6 +62,8 @@ extension URLRequest {
         }
         
         request.endpoint = url.path
+        request.networkServiceType = networkServiceType
+        request.requiresAuthentication = requiresAuthentication
         return request
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestRequest.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSInteger, SFRestMethod) {
 } NS_SWIFT_NAME(RestRequest.Method);
 
 /**
- * HTTP methods for requests.
+ * Network Service Types.
  */
 typedef NS_ENUM(NSInteger, SFSDKNetworkServiceType) {
     SFNetworkServiceTypeDefault,

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/URLRequest+RestRequestTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/URLRequest+RestRequestTests.swift
@@ -1,0 +1,218 @@
+/*
+ Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
+ 
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+  * Redistributions of source code must retain the above copyright notice, this list of conditions
+    and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice, this list of
+    conditions and the following disclaimer in the documentation and/or other materials provided
+    with the distribution.
+  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+    endorse or promote products derived from this software without specific prior written
+    permission of salesforce.com, inc.
+ 
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+@testable import SalesforceSDKCore
+
+class URLRequestRestRequestTests: XCTestCase {
+    
+    func testBasicURLRequestConversion() {
+        // Given
+        let url = URL(string: "https://example.com/api/v1/resource")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        
+        // When
+        let restRequest = request.toRestRequest()
+        
+        // Then
+        XCTAssertNotNil(restRequest)
+        XCTAssertEqual(restRequest?.method, .GET)
+        XCTAssertEqual(restRequest?.path, "/api/v1/resource")
+        XCTAssertEqual(restRequest?.baseURL, "https://example.com")
+        XCTAssertEqual(restRequest?.queryParams?.count, 0)
+    }
+    
+    func testURLRequestWithQueryParameters() {
+        // Given
+        let url = URL(string: "https://example.com/api/v1/resource?param1=value1&param2=value2")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        
+        // When
+        let restRequest = request.toRestRequest()
+        
+        // Then
+        XCTAssertNotNil(restRequest)
+        XCTAssertEqual(restRequest?.queryParams?["param1"] as? String, "value1")
+        XCTAssertEqual(restRequest?.queryParams?["param2"] as? String, "value2")
+    }
+    
+    func testURLRequestWithHeaders() {
+        // Given
+        let url = URL(string: "https://example.com/api/v1/resource")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer token123", forHTTPHeaderField: "Authorization")
+        
+        // When
+        let restRequest = request.toRestRequest()
+        
+        // Then
+        XCTAssertNotNil(restRequest)
+        XCTAssertEqual(restRequest?.customHeaders?["Content-Type"] as! String, "application/json")
+        XCTAssertEqual(restRequest?.customHeaders?["Authorization"] as! String, "Bearer token123")
+    }
+    
+    func testURLRequestWithBody() {
+        // Given
+        let url = URL(string: "https://example.com/api/v1/resource")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body = "{\"key\":\"value\"}".data(using: .utf8)
+        request.httpBody = body
+        
+        // When
+        let restRequest = request.toRestRequest()
+        
+        // Then
+        XCTAssertNotNil(restRequest)
+        XCTAssertEqual(restRequest?.method, .POST)
+    }
+    
+    func testURLRequestWithTimeout() {
+        // Given
+        let url = URL(string: "https://example.com/api/v1/resource")!
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 30
+        
+        // When
+        let restRequest = request.toRestRequest()
+        
+        // Then
+        XCTAssertNotNil(restRequest)
+        XCTAssertEqual(restRequest?.timeoutInterval, 30)
+    }
+    
+    func testInvalidURLRequest() {
+        // Given
+        var request = URLRequest(url: URL(string: "https://example.com")!)
+        request.url = nil
+        
+        // When
+        let restRequest = request.toRestRequest()
+        
+        // Then
+        XCTAssertNil(restRequest)
+    }
+    
+    func testDifferentHTTPMethods() {
+        // Test all supported HTTP methods
+        let methods = ["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"]
+        let expectedRestMethods: [RestRequest.Method] = [.GET, .POST, .PUT, .DELETE, .HEAD, .PATCH]
+        
+        for (index, method) in methods.enumerated() {
+            // Given
+            let url = URL(string: "https://example.com/api/v1/resource")!
+            var request = URLRequest(url: url)
+            request.httpMethod = method
+            
+            // When
+            let restRequest = request.toRestRequest()
+            
+            // Then
+            XCTAssertNotNil(restRequest)
+            XCTAssertEqual(restRequest?.method, expectedRestMethods[index])
+        }
+    }
+
+    func testURLRequestWithCustomEndpoint() {
+        // Create a URLRequest with a custom endpoint
+        let url = URL(string: "https://example.com/items/info/details")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        
+        // Convert to RestRequest
+        let restRequest = request.toRestRequest()
+        
+        // Verify conversion
+        XCTAssertNotNil(restRequest)
+        XCTAssertEqual(restRequest?.method, .GET)
+        XCTAssertEqual(restRequest?.path, "/items/info/details")
+        XCTAssertEqual(restRequest?.endpoint, "/items/info/details")
+    }
+
+    func testRoundTripConversion() {
+        // Given
+        let url = URL(string: "https://example.com/services/data/v57.0/sobjects/Account")!
+        var originalRequest = URLRequest(url: url)
+        originalRequest.httpMethod = "POST"
+        originalRequest.timeoutInterval = 30
+
+        originalRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        originalRequest.setValue("Bearer token123", forHTTPHeaderField: "Authorization")
+        originalRequest.setValue("custom-value", forHTTPHeaderField: "X-Custom-Header")
+        
+        let bodyDict = [
+            "Name": "Test Account",
+            "Type": "Prospect",
+            "Industry": "Technology",
+            "BillingCity": "San Francisco"
+        ]
+        let bodyData = try? JSONSerialization.data(withJSONObject: bodyDict)
+        originalRequest.httpBody = bodyData
+        
+        // When
+        let restRequest = originalRequest.toRestRequest()
+        let mockUser = UserAccount()
+        let convertedRequest = restRequest?.prepare(forSend: mockUser)
+        
+        // Then
+        XCTAssertNotNil(convertedRequest)
+        
+        XCTAssertEqual(convertedRequest?.url?.scheme, originalRequest.url?.scheme)
+        XCTAssertEqual(convertedRequest?.url?.host, originalRequest.url?.host)
+        XCTAssertEqual(convertedRequest?.url?.path, originalRequest.url?.path)
+
+        XCTAssertEqual(convertedRequest?.httpMethod, originalRequest.httpMethod)
+        
+        XCTAssertEqual(convertedRequest?.value(forHTTPHeaderField: "Content-Type"), originalRequest.value(forHTTPHeaderField: "Content-Type"))
+        XCTAssertEqual(convertedRequest?.value(forHTTPHeaderField: "Authorization"), originalRequest.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertEqual(convertedRequest?.value(forHTTPHeaderField: "X-Custom-Header"), originalRequest.value(forHTTPHeaderField: "X-Custom-Header"))
+
+        XCTAssertEqual(convertedRequest?.timeoutInterval, originalRequest.timeoutInterval)
+        
+        if let bodyStream = convertedRequest?.httpBodyStream {
+            let bufferSize = 1024
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+            defer { buffer.deallocate() }
+            
+            bodyStream.open()
+            let bytesRead = bodyStream.read(buffer, maxLength: bufferSize)
+            bodyStream.close()
+            
+            XCTAssertGreaterThan(bytesRead, 0)
+            if bytesRead > 0 {
+                let data = Data(bytes: buffer, count: bytesRead)
+                let streamDict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                XCTAssertEqual(streamDict?["Name"] as? String, bodyDict["Name"])
+                XCTAssertEqual(streamDict?["Type"] as? String, bodyDict["Type"])
+                XCTAssertEqual(streamDict?["Industry"] as? String, bodyDict["Industry"])
+                XCTAssertEqual(streamDict?["BillingCity"] as? String, bodyDict["BillingCity"])
+            }
+        }
+    }
+} 


### PR DESCRIPTION
🚀 Summary

This PR adds support for sending native URLRequest instances directly through the Salesforce Mobile SDK REST client. This feature simplifies networking for developers who already use URLRequest, eliminating the need to wrap requests in SFRestRequest for basic use cases.


✅ What’s Included

# New Async Await
```
public func send(urlRequest: URLRequest) async throws -> (Data, URLResponse)
```
# New Objc block equivalent 
```
- (void)sendURLRequest:(NSURLRequest *)urlRequest
            completion:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completion;
```

See [Test Plan: Direct URLRequest to MSDK](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/compare/link-if-applicable) for full details.

⸻

🛡️ Compatibility
	•	SFRestRequest support remains unchanged and continues to be the default abstraction.
