### PR TITLE
@W-18670439 Modernize import statements using @import syntax in MobileSyncExplorer

### DIFF
--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/AppDelegate.m
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/AppDelegate.m
@@ -25,18 +25,12 @@
 #import "AppDelegate.h"
 #import "InitialViewController.h"
 #import "ContactListViewController.h"
-#import <SalesforceSDKCore/SalesforceSDKManager.h>
-#import <SalesforceSDKCore/SFSDKAppConfig.h>
-#import <SalesforceSDKcore/SFSDKWindowManager.h>
-#import <SalesforceSDKCore/SFSDKAuthHelper.h>
-#import <MobileSync/MobileSyncSDKManager.h>
-#import <SalesforceSDKCommon/SFSDKDatasharingHelper.h>
-#import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
 #import <MobileSyncExplorerCommon/MobileSyncExplorerConfig.h>
-#import <SalesforceSDKCore/SFSDKNavigationController.h>
-#import <SalesforceSDKCore/SFUserAccountManager.h>
 #import <UserNotifications/UserNotifications.h>
-#import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
+
+@import SalesforceSDKCommon;
+@import SalesforceSDKCore;
+@import MobileSync;
 
 @interface AppDelegate ()
 

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/ContactListViewController.m
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/ContactListViewController.m
@@ -25,10 +25,9 @@
 #import "ContactListViewController.h"
 #import "ActionsPopupController.h"
 #import "ContactDetailViewController.h"
-#import <SalesforceSDKCore/SFDefaultUserManagementViewController.h>
-#import <SalesforceSDKCore/SFUserAccountManager.h>
-#import <SalesforceSDKCore/SalesforceSDKManager.h>
-#import <SmartStore/SFSmartStoreInspectorViewController.h>
+
+@import SalesforceSDKCore;
+@import SmartStore;
 
 static NSString * const kNavBarTitleText                = @"Contacts";
 static NSUInteger const kNavBarTintColor                = 0xf10000;

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/ContactSObjectData.m
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/ContactSObjectData.m
@@ -25,7 +25,8 @@
 #import "ContactSObjectData.h"
 #import "ContactSObjectDataSpec.h"
 #import "SObjectData+Internal.h"
-#import <MobileSync/SFMobileSyncConstants.h>
+
+@import MobileSync;
 
 @implementation ContactSObjectData
 

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/SObjectData.m
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/SObjectData.m
@@ -23,7 +23,8 @@
  */
 
 #import "SObjectData+Internal.h"
-#import <SalesforceSDKCore/NSDictionary+SFAdditions.h>
+
+@import SalesforceSDKCore;
 
 @implementation SObjectData
 

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/SObjectDataManager.h
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/SObjectDataManager.h
@@ -23,10 +23,10 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <MobileSync/SFMobileSyncSyncManager.h>
 #import <MobileSyncExplorerCommon/SObjectDataSpec.h>
 #import <MobileSyncExplorerCommon/SObjectData.h>
 
+@import MobileSync;
 
 @interface SObjectDataManager : NSObject
 

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/SObjectDataManager.m
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/SObjectDataManager.m
@@ -23,14 +23,9 @@
  */
 
 #import "SObjectDataManager.h"
-#import <SmartStore/SFSmartStore.h>
-#import <SmartStore/SFQuerySpec.h>
-#import <SalesforceSDKCore/SFUserAccountManager.h>
-#import <MobileSync/SFSDKMobileSyncLogger.h>
 
-// Will go away once we are done refactoring SFSyncTarget
-#import <SalesforceSDKCore/SalesforceSDKManager.h>
-#import <MobileSync/MobileSyncSDKManager.h>
+@import SalesforceSDKCore;
+@import SmartStore;
 
 static NSUInteger kMaxQueryPageSize = 1000;
 static char* const kSearchFilterQueueName = "com.salesforce.mobileSyncExplorer.searchFilterQueue";

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/SObjectDataSpec.h
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/SObjectDataSpec.h
@@ -23,8 +23,9 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <SmartStore/SFSoupIndex.h>
 #import <MobileSyncExplorerCommon/SObjectDataFieldSpec.h>
+
+@import SmartStore;
 
 extern NSString * const kSObjectIdField;
 

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/SObjectDataSpec.m
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorerCommon/SObjectDataSpec.m
@@ -23,7 +23,8 @@
  */
 
 #import "SObjectDataSpec.h"
-#import <MobileSync/SFMobileSyncSyncManager.h>
+
+@import MobileSync;
 
 NSString * const kSObjectIdField = @"Id";
 


### PR DESCRIPTION
Modernizes module imports in the MobileSyncExplorer sample app by replacing legacy #import statements with @import directives for supported Salesforce SDK modules.

# Affected Modules:
	•	SalesforceSDKCore
	•	SalesforceSDKCommon
	•	MobileSync
	•	SmartStore

# Benefits
	•	Aligns with modern Objective-C module import practices
	•	Reduces repetitive and brittle individual header imports
	•	Improves maintainability and readability
	•	Prepares codebase for future SDK modularization and Swift interop

# Scope
	•	Updated .m and .h files in:
	•	AppDelegate
	•	ContactListViewController
	•	All files under MobileSyncExplorerCommon

# Note:

`Ensure CLANG_ENABLE_MODULES = YES remains enabled in Xcode project settings.`
