### PR TITLE
@W-18892644 Change Action to String to match Android implementation

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationCategoryFactory.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationCategoryFactory.swift
@@ -34,7 +34,7 @@ public class NotificationCategoryFactory: NSObject {
         }
         
         return actionGroup.actions.compactMap { action in
-            let options: UNNotificationActionOptions = action.type == .notificationApiAction ? [.authenticationRequired] : [.foreground]
+            let options: UNNotificationActionOptions = action.type == "NotificationApiAction" ? [.authenticationRequired] : [.foreground]
             return UNNotificationAction(
                 identifier: action.identifier,
                 title: action.label,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
@@ -26,14 +26,14 @@ public class NotificationType: NSObject, Codable {
     }
     
     /** Creates a new NotificationType with only the specified actions
-     * - Parameter allowedActionNames: Set of action names to keep
+     * - Parameter allowedActionTypes: Set of action types to keep
      * - Returns: A new NotificationType with filtered actions
      **/
     @objc
-    public func filteredCopy(keepingActions allowedActionNames: Set<String>) -> NotificationType {
+    public func filteredCopy(keepingActions allowedActionTypes: Set<String>) -> NotificationType {
         let filteredGroups = actionGroups?.map { group in
             let filteredActions = group.actions.filter { action in
-                allowedActionNames.contains(action.name)
+                allowedActionTypes.contains(action.type)
             }
             return ActionGroup(name: group.name, actions: filteredActions)
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/NotificationType.swift
@@ -70,45 +70,18 @@ public class Action: NSObject, Codable {
     public let name: String
     public let identifier: String
     public let label: String
-    public let type: NotificationActionType
+    public let type: String
     
     enum CodingKeys: String, CodingKey {
         case name, label, type
         case identifier = "actionKey"
     }
     
-    public init(name: String, identifier: String, label: String, type: NotificationActionType) {
+    public init(name: String, identifier: String, label: String, type: String) {
         self.name = name
         self.identifier = identifier
         self.label = label
         self.type = type
-    }
-}
-
-@objc(SFSDKNotificationActionType)
-public enum NotificationActionType: Int, Codable {
-    case notificationApiAction = 0
-    case foregroundAction = 1
-    
-    var stringValue: String {
-        switch self {
-        case .notificationApiAction: return "NotificationApiAction"
-        case .foregroundAction: return "ForegroundAction"
-        }
-    }
-    
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let rawValue = try container.decode(String.self)
-        switch rawValue {
-        case "NotificationApiAction": self = .notificationApiAction
-        default: self = .foregroundAction
-        }
-    }
-    
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(stringValue)
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
@@ -735,9 +735,9 @@ class PushNotificationManagerTests: XCTestCase {
         let mockTypes = [
             NotificationType(type: "approval_type", apiName: "approval_type", label: "Approval Type", actionGroups: [
                 ActionGroup(name: "approval_actions", actions: [
-                    Action(name: "approve", identifier: "approval_actions__approve", label: "Approve", type: "NotificationApiAction"),
-                    Action(name: "deny", identifier: "approval_actions__deny", label: "Deny", type: "NotificationApiAction"),
-                    Action(name: "delegate", identifier: "approval_actions__delegate", label: "Delegate", type: "NotificationApiAction")
+                    Action(name: "approve", identifier: "approval_actions__approve", label: "Approve", type: "approve_type"),
+                    Action(name: "deny", identifier: "approval_actions__deny", label: "Deny", type: "deny_type"),
+                    Action(name: "delegate", identifier: "approval_actions__delegate", label: "Delegate", type: "delegate_type")
                 ])
             ])
         ]
@@ -746,7 +746,7 @@ class PushNotificationManagerTests: XCTestCase {
         UserAccountManager.shared.filterSupportedNotificationTypes = { types in
             return types.map { type in
                 // Use the helper method to filter actions
-                return type.filteredCopy(keepingActions: ["approve", "deny"])
+                return type.filteredCopy(keepingActions: ["approve_type", "deny_type"])
             }
         }
         pushNotificationManager.setNotificationCategories(types: mockTypes)
@@ -782,14 +782,14 @@ class PushNotificationManagerTests: XCTestCase {
         // Given
         let originalType = NotificationType(type: "test_type", apiName: "test_type", label: "Test Type", actionGroups: [
             ActionGroup(name: "test_group", actions: [
-                Action(name: "action1", identifier: "test_group__action1", label: "Action 1", type: "NotificationApiAction"),
-                Action(name: "action2", identifier: "test_group__action2", label: "Action 2", type: "NotificationApiAction"),
-                Action(name: "action3", identifier: "test_group__action3", label: "Action 3", type: "NotificationApiAction")
+                Action(name: "action1", identifier: "test_group__action1", label: "Action 1", type: "action1_type"),
+                Action(name: "action2", identifier: "test_group__action2", label: "Action 2", type: "action2_type"),
+                Action(name: "action3", identifier: "test_group__action3", label: "Action 3", type: "action3_type")
             ])
         ])
         
         // When
-        let filteredType = originalType.filteredCopy(keepingActions: ["action1", "action3"])
+        let filteredType = originalType.filteredCopy(keepingActions: ["action1_type", "action3_type"])
         
         // Then
         XCTAssertEqual(filteredType.type, originalType.type, "Type should be preserved")

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
@@ -651,12 +651,12 @@ class PushNotificationManagerTests: XCTestCase {
         let mockTypes = [
             NotificationType(type: "supported_type", apiName: "supported_type", label: "Supported Type", actionGroups: [
                 ActionGroup(name: "group1", actions: [
-                    Action(name: "action1", identifier: "group1__action1", label: "Action 1", type: .notificationApiAction)
+                    Action(name: "action1", identifier: "group1__action1", label: "Action 1", type: "NotificationApiAction")
                 ])
             ]),
             NotificationType(type: "unsupported_type", apiName: "unsupported_type", label: "Unsupported Type", actionGroups: [
                 ActionGroup(name: "group2", actions: [
-                    Action(name: "action2", identifier: "group2__action2", label: "Action 2", type: .notificationApiAction)
+                    Action(name: "action2", identifier: "group2__action2", label: "Action 2", type: "NotificationApiAction")
                 ])
             ])
         ]
@@ -691,12 +691,12 @@ class PushNotificationManagerTests: XCTestCase {
         let mockTypes = [
             NotificationType(type: "type1", apiName: "type1", label: "Type 1", actionGroups: [
                 ActionGroup(name: "group1", actions: [
-                    Action(name: "action1", identifier: "group1__action1", label: "Action 1", type: .notificationApiAction)
+                    Action(name: "action1", identifier: "group1__action1", label: "Action 1", type: "NotificationApiAction")
                 ])
             ]),
             NotificationType(type: "type2", apiName: "type2", label: "Type 2", actionGroups: [
                 ActionGroup(name: "group2", actions: [
-                    Action(name: "action2", identifier: "group2__action2", label: "Action 2", type: .notificationApiAction)
+                    Action(name: "action2", identifier: "group2__action2", label: "Action 2", type: "NotificationApiAction")
                 ])
             ])
         ]
@@ -735,9 +735,9 @@ class PushNotificationManagerTests: XCTestCase {
         let mockTypes = [
             NotificationType(type: "approval_type", apiName: "approval_type", label: "Approval Type", actionGroups: [
                 ActionGroup(name: "approval_actions", actions: [
-                    Action(name: "approve", identifier: "approval_actions__approve", label: "Approve", type: .notificationApiAction),
-                    Action(name: "deny", identifier: "approval_actions__deny", label: "Deny", type: .notificationApiAction),
-                    Action(name: "delegate", identifier: "approval_actions__delegate", label: "Delegate", type: .notificationApiAction)
+                    Action(name: "approve", identifier: "approval_actions__approve", label: "Approve", type: "NotificationApiAction"),
+                    Action(name: "deny", identifier: "approval_actions__deny", label: "Deny", type: "NotificationApiAction"),
+                    Action(name: "delegate", identifier: "approval_actions__delegate", label: "Delegate", type: "NotificationApiAction")
                 ])
             ])
         ]
@@ -782,9 +782,9 @@ class PushNotificationManagerTests: XCTestCase {
         // Given
         let originalType = NotificationType(type: "test_type", apiName: "test_type", label: "Test Type", actionGroups: [
             ActionGroup(name: "test_group", actions: [
-                Action(name: "action1", identifier: "test_group__action1", label: "Action 1", type: .notificationApiAction),
-                Action(name: "action2", identifier: "test_group__action2", label: "Action 2", type: .notificationApiAction),
-                Action(name: "action3", identifier: "test_group__action3", label: "Action 3", type: .notificationApiAction)
+                Action(name: "action1", identifier: "test_group__action1", label: "Action 1", type: "NotificationApiAction"),
+                Action(name: "action2", identifier: "test_group__action2", label: "Action 2", type: "NotificationApiAction"),
+                Action(name: "action3", identifier: "test_group__action3", label: "Action 3", type: "NotificationApiAction")
             ])
         ])
         
@@ -990,7 +990,7 @@ class ActionTypeTests: XCTestCase {
         let action = try JSONDecoder().decode(Action.self, from: jsonData)
         
         // Then
-        XCTAssertEqual(action.type, .notificationApiAction)
+        XCTAssertEqual(action.type, "NotificationApiAction")
     }
     
     func testActionTypeDecodingForeground() throws {
@@ -1009,17 +1009,7 @@ class ActionTypeTests: XCTestCase {
         let action = try JSONDecoder().decode(Action.self, from: jsonData)
         
         // Then
-        XCTAssertEqual(action.type, .foregroundAction)
-    }
-    
-    func testActionTypeStringValue() {
-        // Test notificationApiAction
-        let apiAction = NotificationActionType.notificationApiAction
-        XCTAssertEqual(apiAction.stringValue, "NotificationApiAction")
-        
-        // Test foregroundAction
-        let foregroundAction = NotificationActionType.foregroundAction
-        XCTAssertEqual(foregroundAction.stringValue, "ForegroundAction")
+        XCTAssertEqual(action.type, "foreground")
     }
     
     func testActionTypeDecodingInvalidType() throws {
@@ -1036,25 +1026,6 @@ class ActionTypeTests: XCTestCase {
         
         // When, Then
         XCTAssertThrowsError(try JSONDecoder().decode(Action.self, from: jsonData))
-    }
-    
-    func testActionTypeDecodingDefaultCase() throws {
-        // Given
-        let json = """
-        {
-            "name": "test",
-            "actionKey": "test_key",
-            "label": "Test Label",
-            "type": "dismiss"
-        }
-        """
-        let jsonData = json.data(using: .utf8)!
-        
-        // When
-        let action = try JSONDecoder().decode(Action.self, from: jsonData)
-        
-        // Then
-        XCTAssertEqual(action.type, .foregroundAction, "Unknown type should default to foregroundAction")
     }
 }
 


### PR DESCRIPTION
Matching Android Action types to just be strings to have it match server side and match Android handling as well. 