### PR TITLE
@W-18250548 add deprecation marker for signpost removal in upcoming release of 14.0

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFSDKInstrumentationHelper.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFSDKInstrumentationHelper.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(SalesforceInstrumentationHelper)
 /// @deprecated Signpost logging is deprecated and this helper will be removed in version 14.0.
-__attribute__((deprecated("Signpost logging is deprecated and will be removed in version 14.0")));
+SFSDK_DEPRECATED(13.1, 14.0, "Signpost logging is deprecated and will be removed.");
 @interface SFSDKInstrumentationHelper : NSObject
 @property (class,nonatomic,readonly) BOOL isEnabled;
 + (void)swizzleMethod:(SEL)originalSelector with:(SEL)swizzledSelector forClass:(Class)clazz isInstanceMethod:(BOOL)isInstanceMethod;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFSDKInstrumentationHelper.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Instrumentation/SFSDKInstrumentationHelper.h
@@ -30,6 +30,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(SalesforceInstrumentationHelper)
+/// @deprecated Signpost logging is deprecated and this helper will be removed in version 14.0.
+__attribute__((deprecated("Signpost logging is deprecated and will be removed in version 14.0")));
 @interface SFSDKInstrumentationHelper : NSObject
 @property (class,nonatomic,readonly) BOOL isEnabled;
 + (void)swizzleMethod:(SEL)originalSelector with:(SEL)swizzledSelector forClass:(Class)clazz isInstanceMethod:(BOOL)isInstanceMethod;


### PR DESCRIPTION
🔧 Deprecate SFSDKInstrumentationHelper Ahead of Removal in v14.0

This PR marks SFSDKInstrumentationHelper as deprecated in preparation for its removal in version 14.0.

📌 Context
	•	The class was originally introduced to support internal signpost-based debugging/logging.
	•	There is no known customer usage of this functionality.
	•	We’re moving to remove unnecessary internal tooling from the SDK surface.

🧱 Changes
	•	Added __attribute__((deprecated)) to the SFSDKInstrumentationHelper interface.
	•	Included an Xcode-friendly doc comment (@deprecated) for visibility in IDEs.

✅ Why This Matters
	•	Prevents client teams from relying on an internal-only utility.
	•	Provides a clear warning and migration window before permanent removal.
	•	Keeps the public API lean and maintainable.

🚫 No Breaking Changes
	•	This class was not meant for external use.
	•	Client apps not referencing SFSDKInstrumentationHelper will see no impact.
