### PR TITLE
Revoke refresh token with a HTTP POST instead of a HTTP GET call

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -422,14 +422,20 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
 #pragma mark - Utilities
 
 + (NSMutableURLRequest *)requestForRevokeRefreshToken:(SFOAuthCredentials *)credentials reason:(SFLogoutReason)reason {
-    NSString *host = [NSString stringWithFormat:@"%@://%@%@?token=%@&revoke_reason=%@",
-                      credentials.protocol, credentials.domain,
-                      kSFRevokePath, credentials.refreshToken,
-                      [SFSDKOAuth2 stringValueForLogoutReason:reason]];
+    NSString *host = [NSString stringWithFormat:@"%@://%@%@",
+                      credentials.protocol, credentials.domain, kSFRevokePath];
     NSURL *url = [NSURL URLWithString:host];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:url];
-    [request setHTTPMethod:@"GET"];
+    [request setHTTPMethod:kHttpMethodPost];
+    [request setValue:kHttpPostContentType forHTTPHeaderField:kHttpHeaderContentType];
     [request setHTTPShouldHandleCookies:NO];
+    
+    NSString *params = [NSString stringWithFormat:@"token=%@&revoke_reason=%@",
+                        [credentials.refreshToken sfsdk_stringByURLEncoding],
+                        [SFSDKOAuth2 stringValueForLogoutReason:reason]];
+    NSData *encodedBody = [params dataUsingEncoding:NSUTF8StringEncoding];
+    [request setHTTPBody:encodedBody];
+    
     return request;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthUtilTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthUtilTests.swift
@@ -143,8 +143,19 @@ class SFSDKAuthUtilTests: XCTestCase {
     func testRevokeToken() throws {
         let credentials = try XCTUnwrap(currentUser?.credentials)
         let request = SFSDKOAuth2.request(forRevokeRefreshToken: credentials, reason: .userInitiated)
-        let url = try XCTUnwrap(request.url?.absoluteString)
-        let queryItems = try XCTUnwrap(URLComponents(string: url)?.queryItems)
+        
+        // Verify HTTP method is POST
+        XCTAssertEqual(request.httpMethod, "POST")
+        
+        // Verify content type header
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
+        
+        // Verify HTTP body contains expected parameters
+        let httpBody = try XCTUnwrap(request.httpBody)
+        let bodyString = try XCTUnwrap(String(data: httpBody, encoding: .utf8))
+        var bodyComponents = URLComponents()
+        bodyComponents.query = bodyString
+        let queryItems = try XCTUnwrap(bodyComponents.queryItems)
         
         XCTAssertEqual(queryItems.count, 2)
         XCTAssertTrue(queryItems.contains(where: { item in
@@ -153,5 +164,10 @@ class SFSDKAuthUtilTests: XCTestCase {
         XCTAssertTrue(queryItems.contains(where: { item in
             item.name == "revoke_reason" && item.value == "user_logout"
         }))
+        
+        // Verify URL has no query parameters
+        let url = try XCTUnwrap(request.url?.absoluteString)
+        let urlComponents = try XCTUnwrap(URLComponents(string: url))
+        XCTAssertNil(urlComponents.queryItems)
     }
 }


### PR DESCRIPTION
Manually tested by:

- stepping through debugger on the client
- watching the session management page in the browser at the same time to see the oauth2 session disappear