### PR TITLE
Use OauthCoordinator as source of truth for auth info & provide default value

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) NSString *approvalCode;
 @property (nonatomic, strong, nullable) WKWebView *view;
 @property (nonatomic, strong, nullable) NSString *codeVerifier;
-@property (nonatomic, strong, nullable) SFOAuthInfo *authInfo;
+@property (nonatomic, strong, nonnull) SFOAuthInfo *authInfo;
 @property (nonatomic, copy) NSString *origWebUserAgent;
 @property (nonatomic, strong ,nullable) SFOAuthCredentials *spAppCredentials;
 @property (nonatomic, weak, nullable) SFSDKAuthSession *authSession;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -335,6 +335,12 @@
     return _view;
 }
 
+- (SFOAuthInfo *)authInfo {
+    if (_authInfo == nil) {
+        _authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeUnknown];
+    }
+    return _authInfo;
+}
 
 #pragma mark - Private Methods
 
@@ -346,7 +352,7 @@
            [self.delegate oauthCoordinator:self didFailWithError:error authInfo:info];
         });
     }
-    self.authInfo = nil;
+    _authInfo = nil;
     [self clearFrontDoorBridgeLoginOverride];
 }
 
@@ -356,7 +362,7 @@
     if ([self.delegate respondsToSelector:@selector(oauthCoordinatorDidAuthenticate:authInfo:)]) {
         [self.delegate oauthCoordinatorDidAuthenticate:self authInfo:authInfo];
     }
-    self.authInfo = nil;
+    _authInfo = nil;
     [self clearFrontDoorBridgeLoginOverride];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.h
@@ -43,7 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) SFIdentityCoordinator *identityCoordinator;
 @property (nonatomic, assign) BOOL notifiesDelegatesOfFailure;
 @property (nonatomic, strong, nullable)NSError *authError;
-@property (nonatomic, strong) SFOAuthInfo *authInfo;
 @property (nonatomic, copy, nullable) void (^authCoordinatorBrowserBlock)(BOOL);
 @property (nonatomic) BOOL nativeLogin;
 //idp related


### PR DESCRIPTION
Background:
There's a crash log that looks it's coming from [this line](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/blob/f1be8efd1305cc2f43eff7a81bbe0008e9774d06/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m#L1993) because `authInfo` is nil
```
     NSDictionary *userInfo = @{kSFNotificationUserInfoAccountKey: userAccount,
                                kSFNotificationUserInfoAuthTypeKey: authInfo};
```
The change so far is to make authInfo non-null and use the existing `SFOAuthTypeUnknown` as the default value.  I noticed that there's an `authInfo` property on SFSDKAuthSession [here](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/blob/f1be8efd1305cc2f43eff7a81bbe0008e9774d06/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.h#L46) and another `authInfo` property on the SFOAuthCoordinator [here](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/blob/f1be8efd1305cc2f43eff7a81bbe0008e9774d06/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator%2BInternal.h#L46) and we update the one on the session based on the value from the coordinator. Since the session also has a reference to the coordinator, I think we could use the value on the coordinator as the source of truth and remove authInfo on the session. 