### PR TITLE
@W-17964653 Discovery endpoint to postpone OAuth flow

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		23CAB1312DD515B500B8929B /* SFLoginViewController+Deep-Linking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23CAB1302DD515B500B8929B /* SFLoginViewController+Deep-Linking.swift */; };
 		23CE44212DEE258800ADC770 /* RestClient+WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23CE44202DEE257900ADC770 /* RestClient+WebSocket.swift */; };
 		23D626992DF9DF2D00B898D0 /* URLSessionWebSocketTask+WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D626982DF9DF1E00B898D0 /* URLSessionWebSocketTask+WebSocketClient.swift */; };
+		23D96B6F2E145AC20004B06A /* DomainDiscoveryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D96B6E2E145AC20004B06A /* DomainDiscoveryCoordinator.swift */; };
+		23D96B762E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D96B752E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift */; };
 		23EDDEFE2DE0F7620024AD39 /* URLRequest+RestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDDEF82DE0F7480024AD39 /* URLRequest+RestRequest.swift */; };
 		23EDDF022DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDDF012DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift */; };
 		444B95D01E83251900908C61 /* UIColor+SFColorsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */; };
@@ -559,6 +561,8 @@
 		23CAB1302DD515B500B8929B /* SFLoginViewController+Deep-Linking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "SFLoginViewController+Deep-Linking.swift"; path = "Login/SFLoginViewController+Deep-Linking.swift"; sourceTree = "<group>"; };
 		23CE44202DEE257900ADC770 /* RestClient+WebSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RestClient+WebSocket.swift"; sourceTree = "<group>"; };
 		23D626982DF9DF1E00B898D0 /* URLSessionWebSocketTask+WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionWebSocketTask+WebSocketClient.swift"; sourceTree = "<group>"; };
+		23D96B6E2E145AC20004B06A /* DomainDiscoveryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainDiscoveryCoordinator.swift; sourceTree = "<group>"; };
+		23D96B752E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DomainDiscoveryCoordinatorTests.swift; path = SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift; sourceTree = SOURCE_ROOT; };
 		23EDDEF82DE0F7480024AD39 /* URLRequest+RestRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+RestRequest.swift"; sourceTree = "<group>"; };
 		23EDDF012DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "URLRequest+RestRequestTests.swift"; path = "SalesforceSDKCoreTests/URLRequest+RestRequestTests.swift"; sourceTree = SOURCE_ROOT; };
 		444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+SFColorsTests.m"; path = "SalesforceSDKCoreTests/UIColor+SFColorsTests.m"; sourceTree = SOURCE_ROOT; };
@@ -1025,6 +1029,7 @@
 		4F7EB3F61BFFC84700768720 /* SalesforceSDKCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				23D96B752E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift */,
 				230834872DF8A8F300C7CBF7 /* WebSocketClientTests.swift */,
 				230834852DF8938D00C7CBF7 /* URLSessionTask+RetryPolicyTests.swift */,
 				23EDDF012DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift */,
@@ -1187,6 +1192,7 @@
 		4F96FCC41BFD32130022F021 /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
+				23D96B6E2E145AC20004B06A /* DomainDiscoveryCoordinator.swift */,
 				4F8A3B002CEC202F00ECDC76 /* JwtAccessToken.swift */,
 				4F96FCC61BFD32130022F021 /* SFOAuthCoordinator.h */,
 				4F96FCC71BFD32130022F021 /* SFOAuthCoordinator.m */,
@@ -2209,6 +2215,7 @@
 				23CAB0F92DCBE51F00B8929B /* MockRestClient.swift in Sources */,
 				B7E66AE923763278005A652E /* RestClientPublisherTests.swift in Sources */,
 				697F5C4F267BE29A00F382A9 /* EncryptionTests.swift in Sources */,
+				23D96B762E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift in Sources */,
 				B7A4AE4922E8CA780060E737 /* SFSDKAuthUtilTests.swift in Sources */,
 				69DFE06C2B969C25000906E4 /* PushNotificationDecryptionTests.swift in Sources */,
 				4F7EB4161BFFC8D700768720 /* SDKCommonNSDataTests.m in Sources */,
@@ -2330,6 +2337,7 @@
 				CE4CE3A21C0E5279009F6029 /* NSURL+SFStringUtils.m in Sources */,
 				69BDD82F26F90AA400C26D77 /* DecryptStream.swift in Sources */,
 				23A4C74E2D0CB68B00DF55EB /* NativeLoginManagerInternal.swift in Sources */,
+				23D96B6F2E145AC20004B06A /* DomainDiscoveryCoordinator.swift in Sources */,
 				23A4C74F2D0CB68B00DF55EB /* NativeLoginManager.swift in Sources */,
 				B7CD6D671F79CFC900F99F81 /* SFUserAccountManager+URLHandlers.m in Sources */,
 				69848CB62363FA3E00893E57 /* SFSDKPushNotificationError.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		23D96B762E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D96B752E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift */; };
 		23EDDEFE2DE0F7620024AD39 /* URLRequest+RestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDDEF82DE0F7480024AD39 /* URLRequest+RestRequest.swift */; };
 		23EDDF022DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDDF012DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift */; };
+		23EED88A2E2ACD3300646B10 /* SFOAuthCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EED8892E2ACD3300646B10 /* SFOAuthCoordinatorTests.swift */; };
+		23EED8912E2ACF3900646B10 /* MockNavigationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EED8902E2ACF3100646B10 /* MockNavigationAction.swift */; };
 		444B95D01E83251900908C61 /* UIColor+SFColorsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */; };
 		4F06AF731C49A16A00F70798 /* NSURL+SFStringUtilsTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F06AF5D1C49A16A00F70798 /* NSURL+SFStringUtilsTests.h */; };
 		4F06AF751C49A16A00F70798 /* SalesforceOAuthUnitTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F06AF5F1C49A16A00F70798 /* SalesforceOAuthUnitTests.h */; };
@@ -565,6 +567,8 @@
 		23D96B752E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DomainDiscoveryCoordinatorTests.swift; path = SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift; sourceTree = SOURCE_ROOT; };
 		23EDDEF82DE0F7480024AD39 /* URLRequest+RestRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+RestRequest.swift"; sourceTree = "<group>"; };
 		23EDDF012DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "URLRequest+RestRequestTests.swift"; path = "SalesforceSDKCoreTests/URLRequest+RestRequestTests.swift"; sourceTree = SOURCE_ROOT; };
+		23EED8892E2ACD3300646B10 /* SFOAuthCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SFOAuthCoordinatorTests.swift; path = SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift; sourceTree = SOURCE_ROOT; };
+		23EED8902E2ACF3100646B10 /* MockNavigationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationAction.swift; sourceTree = "<group>"; };
 		444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+SFColorsTests.m"; path = "SalesforceSDKCoreTests/UIColor+SFColorsTests.m"; sourceTree = SOURCE_ROOT; };
 		4F06AF5D1C49A16A00F70798 /* NSURL+SFStringUtilsTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSURL+SFStringUtilsTests.h"; path = "SalesforceSDKCoreTests/NSURL+SFStringUtilsTests.h"; sourceTree = SOURCE_ROOT; };
 		4F06AF5E1C49A16A00F70798 /* NSURL+SFStringUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSURL+SFStringUtilsTests.m"; path = "SalesforceSDKCoreTests/NSURL+SFStringUtilsTests.m"; sourceTree = SOURCE_ROOT; };
@@ -1020,6 +1024,7 @@
 		23CAB0F82DCBE51F00B8929B /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
+				23EED8902E2ACF3100646B10 /* MockNavigationAction.swift */,
 				23CAB0F72DCBE51F00B8929B /* MockRestClient.swift */,
 			);
 			name = Mocks;
@@ -1029,6 +1034,7 @@
 		4F7EB3F61BFFC84700768720 /* SalesforceSDKCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				23EED8892E2ACD3300646B10 /* SFOAuthCoordinatorTests.swift */,
 				23D96B752E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift */,
 				230834872DF8A8F300C7CBF7 /* WebSocketClientTests.swift */,
 				230834852DF8938D00C7CBF7 /* URLSessionTask+RetryPolicyTests.swift */,
@@ -2198,6 +2204,7 @@
 				B7E1A50E1F43B0FE007AC36A /* SFSDKWindowManagerTests.m in Sources */,
 				4F06AF8A1C49A18E00F70798 /* SalesforceOAuthUnitTests.m in Sources */,
 				23A4C7462D0CAFA000DF55EB /* ScreenLockManagerTests.swift in Sources */,
+				23EED88A2E2ACD3300646B10 /* SFOAuthCoordinatorTests.swift in Sources */,
 				B7A901BE228E4DFB0036D749 /* SFSDKLogoutBlocker.m in Sources */,
 				693E623B24A29B6B0017B222 /* SFSDKKeyValueEncryptedFileStoreTests.m in Sources */,
 				8214D955205316BA0007349E /* SFSDKSalesforceAnalyticsManagerTests.m in Sources */,
@@ -2205,6 +2212,7 @@
 				B759CD891F8BDBAC0081AA87 /* SDSDKAlertMessageTest.m in Sources */,
 				4F06AF8C1C49A18E00F70798 /* SalesforceSDKIdentityTests.m in Sources */,
 				4F06AF921C49A18E00F70798 /* SFPreferencesTests.m in Sources */,
+				23EED8912E2ACF3900646B10 /* MockNavigationAction.swift in Sources */,
 				4F755F5820D48F8600CE4E0E /* NSString+SFAdditionsTests.m in Sources */,
 				6990CBC029F5AF56004A5F8D /* SFSDKIDPAuthCodeLoginRequestCommandTest.m in Sources */,
 				CEB98EE01F86E7CF0083AB9C /* SFSDKAuthRequestCommandTest.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostStorage.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostStorage.m
@@ -67,7 +67,7 @@ static NSString * const SFSDKLoginHostNameKey = @"SalesforceLoginHostNameKey";
         SFManagedPreferences *managedPreferences = [SFManagedPreferences sharedPreferences];
         SFSDKLoginHost *production = [SFSDKLoginHost hostWithName:[SFSDKResourceUtils localizedString:@"LOGIN_SERVER_PRODUCTION"] host:@"login.salesforce.com" deletable:NO];
         SFSDKLoginHost *sandbox = [SFSDKLoginHost hostWithName:[SFSDKResourceUtils localizedString:@"LOGIN_SERVER_SANDBOX"] host:@"test.salesforce.com" deletable:NO];
-        SFSDKLoginHost *welcome = [SFSDKLoginHost hostWithName:[SFSDKResourceUtils localizedString:@"LOGIN_SERVER_WELCOME"] host:@"welcome.salesforce.com" deletable:NO];
+        SFSDKLoginHost *welcome = [SFSDKLoginHost hostWithName:[SFSDKResourceUtils localizedString:@"LOGIN_SERVER_WELCOME"] host:@"welcome.salesforce.com/discovery" deletable:NO];
 
         // Add the Production, Sandbox and Welcome login hosts, unless an MDM policy explicitly forbids this.
         if (!(managedPreferences.hasManagedPreferences && managedPreferences.onlyShowAuthorizedHosts)) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
@@ -1,0 +1,100 @@
+import Foundation
+import WebKit
+
+/// Coordinator for My Domain discovery via WebView before OAuth login.
+public enum DomainDiscoveryConstants {
+    public static let callbackURL = "sfdc://discocallback"
+}
+
+@objcMembers
+public class DomainDiscoveryCoordinator: NSObject {
+    private var webView: WKWebView
+    
+    @objc(init)
+    public convenience override init() {
+        let webView = WKWebView()
+        self.init(webView: webView)
+    }
+
+    public init(webView: WKWebView = WKWebView()) {
+        self.webView = webView
+        super.init()
+        self.webView.navigationDelegate = self
+    }
+
+    private var continuation: CheckedContinuation<(String, String), Error>?
+
+    @MainActor
+    @objc(runDomainDiscoveryWithCredentials:completion:)
+    public func runMyDomainDiscovery(
+        credentials: OAuthCredentials
+    ) async throws -> (String, String) {
+        
+        guard webView != nil else {
+            throw NSError(domain: "DomainDiscoveryCoordinator", code: 1000, userInfo: [NSLocalizedDescriptionKey: "Missing webView"])
+        }
+        // 1. Build the discovery URL
+        let discoveryHost = credentials.domain ?? "welcome.salesforce.com"
+        guard let clientId = credentials.clientId,
+              let clientVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else {
+            throw NSError(domain: "DomainDiscoveryCoordinator", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Missing required credentials"])
+        }
+
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = discoveryHost
+        components.path = ""
+        components.queryItems = [
+            URLQueryItem(name: "client_id", value: clientId),
+            URLQueryItem(name: "client_version", value: clientVersion),
+            URLQueryItem(name: "callback_url", value: DomainDiscoveryConstants.callbackURL)
+        ]
+        guard let url = components.url else {
+            throw NSError(domain: "DomainDiscoveryCoordinator", code: 1002, userInfo: [NSLocalizedDescriptionKey: "Failed to construct discovery URL"])
+        }
+
+        // 2. Load the URL in the webView and wait for callback
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            self.webView.load(URLRequest(url: url))
+        }
+    }
+}
+
+extension DomainDiscoveryCoordinator: WKNavigationDelegate {
+    /// Decides whether to allow or cancel a navigation action.
+    public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        defer { decisionHandler(.allow) }
+        guard let url = navigationAction.request.url else { return }
+
+        // Use the constant for callback URL matching
+        if url.absoluteString.hasPrefix(DomainDiscoveryConstants.callbackURL) {
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+            let myDomain = components?.queryItems?.first(where: { $0.name == "my_domain" })?.value?.removingPercentEncoding
+            let loginHint = components?.queryItems?.first(where: { $0.name == "login_hint" })?.value?.removingPercentEncoding
+
+            if let myDomain, let loginHint, !myDomain.isEmpty, !loginHint.isEmpty {
+                continuation?.resume(returning: (myDomain, loginHint))
+            } else {
+                let error = NSError(domain: "DomainDiscoveryCoordinator", code: 1003, userInfo: [NSLocalizedDescriptionKey: "Missing or malformed parameters in callback"])
+                continuation?.resume(throwing: error)
+            }
+            continuation = nil
+        }
+    }
+
+    /// Called when navigation starts.
+    public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        // TODO: Handle navigation start if needed
+    }
+
+    /// Called when navigation finishes successfully.
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        // TODO: Handle navigation finish if needed
+    }
+
+    /// Called when navigation fails.
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        // TODO: Handle navigation failure
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
@@ -49,7 +49,7 @@ public class DomainDiscoveryCoordinator: NSObject {
     ///
     /// - Parameters:
     ///   - webview: The WKWebView in which to load the discovery URL for domain discovery.
-    ///   - credentials: The OAuth credentials containing clientId, clientVersion, and domain.
+    ///   - credentials: The OAuth credentials containing clientId and domain.
     ///
     /// This method loads the discovery URL in the given webview. The result of the discovery should be handled by monitoring navigation actions and calling `handle(webAction:)`.
     @MainActor

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
@@ -87,7 +87,7 @@ public class DomainDiscoveryCoordinator: NSObject {
     }
     
     @objc
-    public func isDisoveryDomain(_ domain: String?, clientId: String?) -> Bool {
+    public func isDiscoveryDomain(_ domain: String?, clientId: String?) -> Bool {
         guard let domain = domain, let clientId = clientId else { return false }
         let isDiscovery = domain.lowercased().contains(DomainDiscovery.URLComponent.path.rawValue)
         let isSupportedClient = DomainDiscovery.supportedClientIds.contains(clientId)

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
@@ -4,6 +4,7 @@ import WebKit
 public enum DomainDiscoveryConstants {
     /// The callback URL used for domain discovery.
     public static let callbackURL = "sfdc://discocallback"
+    public static let discoveryDomain = "welcome.salesforce.com"
 }
 
 /// Represents the result of a domain discovery operation.
@@ -50,12 +51,12 @@ public class DomainDiscoveryCoordinator: NSObject {
     
     /// Handles a navigation action and checks if it matches the domain discovery callback URL.
     ///
-    /// - Parameter action: The WKNavigationAction to inspect.
+    /// - Parameter action: The action to inspect.
     /// - Returns: A `DomainDiscoveryResult` if the callback URL is detected and parsed; otherwise, `nil`.
     ///
     /// Call this from your WKNavigationDelegate when a navigation action occurs to detect and extract the result from the domain discovery callback URL.
     @objc(handleWithWebAction:)
-    public func handle(webAction action: WKNavigationAction) -> DomainDiscoveryResult? {
+    public func handle(action: WKNavigationAction) -> DomainDiscoveryResult? {
         guard let url = action.request.url else {
             return nil
         }
@@ -64,6 +65,12 @@ public class DomainDiscoveryCoordinator: NSObject {
             return result
         }
         return nil
+    }
+    
+    @objc
+    public func isDisoveryDomain(_ domain: String?) -> Bool {
+        guard let domain = domain else { return false }
+        return domain.lowercased().contains(DomainDiscoveryConstants.discoveryDomain)
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
@@ -15,6 +15,11 @@ enum DomainDiscovery: String {
             case callbackURL = "callback_url"
         }
     }
+
+    static let supportedClientIds: Set<String> = [
+        "SfdcMobileChatterAndroid",
+        "SfdcMobileChatteriOS"
+    ]
 }
 
 /// Represents the result of a domain discovery operation.
@@ -78,9 +83,11 @@ public class DomainDiscoveryCoordinator: NSObject {
     }
     
     @objc
-    public func isDisoveryDomain(_ domain: String?) -> Bool {
-        guard let domain = domain else { return false }
-        return domain.lowercased().contains(DomainDiscovery.URLComponent.path.rawValue)
+    public func isDisoveryDomain(_ domain: String?, clientId: String?) -> Bool {
+        guard let domain = domain, let clientId = clientId else { return false }
+        let isDiscovery = domain.lowercased().contains(DomainDiscovery.URLComponent.path.rawValue)
+        let isSupportedClient = DomainDiscovery.supportedClientIds.contains(clientId)
+        return isDiscovery && isSupportedClient
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
@@ -91,6 +91,9 @@ public class DomainDiscoveryCoordinator: NSObject {
         guard let domain = domain, let clientId = clientId else { return false }
         let isDiscovery = domain.lowercased().contains(DomainDiscovery.URLComponent.path.rawValue)
         let isSupportedClient = DomainDiscovery.supportedClientIds.contains(clientId)
+        if isDiscovery && !isSupportedClient {
+            SFSDKCoreLogger.e(classForCoder, message: "\(domain) is a discovery domain, but client ID '\(clientId)' is not supported.")
+        }
         return isDiscovery && isSupportedClient
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -83,6 +83,7 @@
 
 
 - (id)init {
+    _domainDiscoveryCoordinator = [[DomainDiscoveryCoordinator alloc] init];
     return [self initWithCredentials:nil];
 }
 
@@ -215,11 +216,10 @@
 }
 
 - (BOOL)isDiscoveryDomain:(NSString *)domain {
-    return [domain isEqualToString:@"gidruntime-cell2.sfproxy.gid.dev1-uswest2.aws.sfdc.cl"];
+    return [self.domainDiscoveryCoordinator isDisoveryDomain:domain];
 }
 
 - (void)runMyDomainDiscoveryAndAuthenticate {
-    self.domainDiscoveryCoordinator = [[DomainDiscoveryCoordinator alloc] initWith:self.view];
     [self startWebviewAuthenticationIfNeeded];
     [self.domainDiscoveryCoordinator runMyDomainsDiscoveryOn:self.view with:self.credentials];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -56,7 +56,7 @@
 @interface SFOAuthCoordinator()
 
 @property (nonatomic) NSString *networkIdentifier;
-@property (nonatomic, strong) DomainDiscoveryCoordinator *domainDiscoveryCoordinator;
+@property (nonatomic, strong) SFDomainDiscoveryCoordinator *domainDiscoveryCoordinator;
 
 @end
 
@@ -94,7 +94,7 @@
         _timeout = kSFOAuthDefaultTimeout;
         _view = nil;
         _authClient = [[SFSDKOAuth2 alloc] init];
-        _domainDiscoveryCoordinator = [[DomainDiscoveryCoordinator alloc] init];
+        _domainDiscoveryCoordinator = [[SFDomainDiscoveryCoordinator alloc] init];
     }
     return self;
 }
@@ -108,7 +108,7 @@
         _timeout = kSFOAuthDefaultTimeout;
         _view = nil;
         _authClient = [[SFSDKOAuth2 alloc] init];
-        _domainDiscoveryCoordinator = [[DomainDiscoveryCoordinator alloc] init];
+        _domainDiscoveryCoordinator = [[SFDomainDiscoveryCoordinator alloc] init];
     }
     return self;
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -210,15 +210,12 @@
 
 - (void)authenticateWithCredentials:(SFOAuthCredentials *)credentials {
     self.credentials = credentials;
-    if ([self isDiscoveryDomain:self.credentials.domain]) {
+    if ([self.domainDiscoveryCoordinator isDisoveryDomain:self.credentials.domain
+                                                 clientId:self.credentials.clientId]) {
         [self runMyDomainDiscoveryAndAuthenticate];
         return;
     }
     [self authenticate];
-}
-
-- (BOOL)isDiscoveryDomain:(NSString *)domain {
-    return [self.domainDiscoveryCoordinator isDisoveryDomain:domain];
 }
 
 - (void)runMyDomainDiscoveryAndAuthenticate {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -864,6 +864,7 @@
             [bioAuthManager presentBiometricWithScene:self.view.window.windowScene];
         }
     } else if ([self shouldUpdateDomain:url]) {
+        // To support case where my domain is entered through "Use Custom Domain"
         [self handleCustomDomainUpdateWithLoginHint:self.loginHint
                                            myDomain:url.host];
         decisionHandler(WKNavigationActionPolicyCancel);

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -83,7 +83,6 @@
 
 
 - (id)init {
-    _domainDiscoveryCoordinator = [[DomainDiscoveryCoordinator alloc] init];
     return [self initWithCredentials:nil];
 }
 
@@ -95,6 +94,7 @@
         _timeout = kSFOAuthDefaultTimeout;
         _view = nil;
         _authClient = [[SFSDKOAuth2 alloc] init];
+        _domainDiscoveryCoordinator = [[DomainDiscoveryCoordinator alloc] init];
     }
     return self;
 }
@@ -108,6 +108,7 @@
         _timeout = kSFOAuthDefaultTimeout;
         _view = nil;
         _authClient = [[SFSDKOAuth2 alloc] init];
+        _domainDiscoveryCoordinator = [[DomainDiscoveryCoordinator alloc] init];
     }
     return self;
 }
@@ -123,6 +124,7 @@
     _scopes = nil;
     _view = nil;
     _authSession = nil;
+    _domainDiscoveryCoordinator = nil;
 }
 
 - (void)authenticate {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -613,7 +613,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     
     dispatch_async(dispatch_get_main_queue(), ^{
         [SFSDKWebViewStateManager removeSessionForcefullyWithCompletionHandler:^{
-            [authSession.oauthCoordinator authenticate];
+            [authSession.oauthCoordinator authenticateWithCredentials:authSession.credentials];
         }];
             
     });

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
@@ -33,7 +33,7 @@
 static NSString * const kSFOAuthEndPointAuthConfiguration = @"/.well-known/auth-configuration";
 static NSString * const kSandboxLoginURL = @"test.salesforce.com";
 static NSString * const kProductionLoginURL = @"login.salesforce.com";
-static NSString * const kWelcomeLoginURL = @"welcome.salesforce.com";
+static NSString * const kWelcomeLoginURL = @"welcome.salesforce.com/discovery";
 
 @implementation SFSDKAuthConfigUtil
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
@@ -58,8 +58,7 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         let results = coordinator.handle(action: mockWebView.mockAction!)
         
         // Then
-        XCTAssertEqual(results?.myDomain, "")
-        XCTAssertEqual(results?.loginHint, expectedLoginHint)
+        XCTAssertNil(results)
     }
 
     func testMissingLoginHint() async throws {
@@ -78,8 +77,7 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         let results = coordinator.handle(action: mockWebView.mockAction!)
         
         // Then
-        XCTAssertEqual(results?.myDomain, expectedDomain)
-        XCTAssertEqual(results?.loginHint, "")
+        XCTAssertNil(results)
     }
 
     func testMalformedCallbackURL() async throws {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import SalesforceSDKCore
+import WebKit
+
+// Mock WKWebView to simulate navigation and callback
+class MockWKWebView: WKWebView {
+    var simulatedCallbackURL: URL?
+    override func load(_ request: URLRequest) -> WKNavigation? {
+        if let callbackURL = simulatedCallbackURL,
+           let delegate = self.navigationDelegate {
+            let navAction = MockNavigationAction(url: callbackURL)
+            delegate.webView?(self, decidePolicyFor: navAction, decisionHandler: { _ in })
+        }
+        return nil
+    }
+}
+
+class MockNavigationAction: WKNavigationAction {
+    private let _request: URLRequest
+    override var request: URLRequest { _request }
+    init(url: URL) {
+        self._request = URLRequest(url: url)
+        super.init()
+    }
+}
+
+@MainActor
+final class DomainDiscoveryCoordinatorTests: XCTestCase {
+
+    func testCallbackSuccess() async throws {
+        // Given
+        let mockWebView = MockWKWebView()
+        let coordinator = DomainDiscoveryCoordinator(webView: mockWebView)
+        let credentials = OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false)
+        let expectedDomain = "https://foo.my.salesforce.com"
+        let expectedLoginHint = "testuser@example.com"
+        let callbackURLString = "sfdc://discocallback?my_domain=\(expectedDomain.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)&login_hint=\(expectedLoginHint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)"
+        let callbackURL = URL(string: callbackURLString)!
+        mockWebView.simulatedCallbackURL = callbackURL
+        
+        // When
+        let results = try await coordinator.runMyDomainDiscovery(credentials: credentials!)
+        
+        // Then
+        XCTAssertEqual(results.0, expectedDomain)
+        XCTAssertEqual(results.1, expectedLoginHint)
+    }
+
+    func testMissingMyDomain() async throws {
+        // Given
+        let mockWebView = MockWKWebView()
+        let coordinator = DomainDiscoveryCoordinator(webView: mockWebView)
+        let credentials = OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false)
+        let expectedLoginHint = "testuser@example.com"
+        let callbackURLString = "sfdc://discocallback?login_hint=\(expectedLoginHint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)"
+        let callbackURL = URL(string: callbackURLString)!
+        mockWebView.simulatedCallbackURL = callbackURL
+        
+        // When/Then
+        do {
+            _ = try await coordinator.runMyDomainDiscovery(credentials: credentials!)
+            XCTFail("Expected error to be thrown, but got success")
+        } catch {
+            // Optionally, check error type or message here
+        }
+    }
+
+    func testMissingLoginHint() async throws {
+        // Given
+        let mockWebView = MockWKWebView()
+        let coordinator = DomainDiscoveryCoordinator(webView: mockWebView)
+        let credentials = OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false)
+        let expectedDomain = "https://foo.my.salesforce.com"
+        let callbackURLString = "sfdc://discocallback?my_domain=\(expectedDomain.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)"
+        let callbackURL = URL(string: callbackURLString)!
+        mockWebView.simulatedCallbackURL = callbackURL
+
+        // When/Then
+        do {
+            _ = try await coordinator.runMyDomainDiscovery(credentials: credentials!)
+            XCTFail("Expected error to be thrown, but got success")
+        } catch {
+            // Optionally, check error type or message here
+        }
+    }
+
+    func testMalformedCallbackURL() async throws {
+        // Given
+        let mockWebView = MockWKWebView()
+        let coordinator = DomainDiscoveryCoordinator(webView: mockWebView)
+        let credentials = OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false)
+        let callbackURLString = "sfdc://discocallback?my_domain=&login_hint="
+        let callbackURL = URL(string: callbackURLString)!
+        mockWebView.simulatedCallbackURL = callbackURL
+
+        // When/Then
+        do {
+            _ = try await coordinator.runMyDomainDiscovery(credentials: credentials!)
+            XCTFail("Expected error to be thrown, but got success")
+        } catch {
+            // Optionally, check error type or message here
+        }
+    }
+
+    func testNonCallbackURL() async throws {
+        // Given
+        let mockWebView = MockWKWebView()
+        let coordinator = DomainDiscoveryCoordinator(webView: mockWebView)
+        let credentials = OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false)
+        let nonCallbackURL = URL(string: "https://example.com")!
+        mockWebView.simulatedCallbackURL = nonCallbackURL
+
+        // When/Then
+        let expectation = XCTestExpectation(description: "Should not complete for non-callback URL")
+        expectation.isInverted = true // This means we expect it NOT to be fulfilled
+
+        let task = Task {
+            do {
+                _ = try await coordinator.runMyDomainDiscovery(credentials: credentials!)
+                XCTFail("Expected to hang or timeout, but got a result")
+            } catch {
+                // Optionally, check error type or message here
+            }
+            expectation.fulfill()
+        }
+
+        // Wait for a short period and then cancel
+        await fulfillment(of: [expectation], timeout: 0.5)
+        task.cancel()
+    }
+
+    func testSpecialCharactersInLoginHint() async throws {
+        // Given
+        let mockWebView = MockWKWebView()
+        let coordinator = DomainDiscoveryCoordinator(webView: mockWebView)
+        let credentials = OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false)
+        let expectedDomain = "https://foo.my.salesforce.com"
+        let expectedLoginHint = "user+test@example.com"
+        let callbackURLString = "sfdc://discocallback?my_domain=\(expectedDomain.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)&login_hint=\(expectedLoginHint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)"
+        let callbackURL = URL(string: callbackURLString)!
+        mockWebView.simulatedCallbackURL = callbackURL
+
+        // When
+        let results = try await coordinator.runMyDomainDiscovery(credentials: credentials!)
+
+        // Then
+        XCTAssertEqual(results.0, expectedDomain)
+        XCTAssertEqual(results.1, expectedLoginHint)
+    }
+
+    func testExtraQueryParameters() async throws {
+        // Given
+        let mockWebView = MockWKWebView()
+        let coordinator = DomainDiscoveryCoordinator(webView: mockWebView)
+        let credentials = OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false)
+        let expectedDomain = "https://foo.my.salesforce.com"
+        let expectedLoginHint = "testuser@example.com"
+        let callbackURLString = "sfdc://discocallback?my_domain=\(expectedDomain.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)&login_hint=\(expectedLoginHint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)&extra=foo&another=bar"
+        let callbackURL = URL(string: callbackURLString)!
+        mockWebView.simulatedCallbackURL = callbackURL
+
+        // When
+        let results = try await coordinator.runMyDomainDiscovery(credentials: credentials!)
+
+        // Then
+        XCTAssertEqual(results.0, expectedDomain)
+        XCTAssertEqual(results.1, expectedLoginHint)
+    }
+} 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/Mocks/MockNavigationAction.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/Mocks/MockNavigationAction.swift
@@ -1,0 +1,37 @@
+//
+//  MockNavigationAction.swift
+//  SalesforceSDKCore
+//
+//  Created by Riley Crebs on 7/18/25.
+//  Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
+// 
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+// 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+@testable import SalesforceSDKCore
+
+class MockNavigationAction: WKNavigationAction {
+    private let _request: URLRequest
+    override var request: URLRequest { _request }
+    init(url: URL) {
+        self._request = URLRequest(url: url)
+        super.init()
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import SalesforceSDKCore
+
+class SFOAuthCoordinatorTests: XCTestCase {
+    func testDecidePolicyForNavigationAction_DomainDiscoveryCallback() {
+        // Given
+        let expectedLoginHint = "testuser@example.com"
+        let mockDomain = "mydomain.example.com"
+        let callbackURLString = "sfdc://discocallback?my_domain=\(mockDomain.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)&login_hint=\(expectedLoginHint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)"
+        guard let callbackURL = URL(string: callbackURLString) else {
+            XCTFail("Failed to create callback URL")
+            return
+        }
+        let mockNavigationAction = MockNavigationAction(url: callbackURL)
+        let coordinator = SFOAuthCoordinator()
+        coordinator.delegate = self
+        let credentials = OAuthCredentials(identifier: "test",
+                                           clientId: "client",
+                                           encrypted: false)
+        credentials?.testDomain = DomainDiscoveryConstants.discoveryDomain
+        coordinator.credentials = credentials
+        
+        // When
+        coordinator.authenticate(with: credentials!)
+        
+        // Then
+        var didCallDecisionHandlerPolicy: WKNavigationActionPolicy = .allow
+        coordinator.webView(WKWebView(), decidePolicyFor: mockNavigationAction, decisionHandler: { policy in
+            didCallDecisionHandlerPolicy = policy
+        })
+        
+        // Assert
+        XCTAssertEqual(didCallDecisionHandlerPolicy, .cancel)
+        XCTAssertEqual(coordinator.testLoginHint, expectedLoginHint)
+        XCTAssertEqual(coordinator.credentials?.domain, mockDomain)
+    }
+}
+
+// MARK: - SFOAuthCoordinatorDelegate conformance for tests
+extension SFOAuthCoordinatorTests: SFOAuthCoordinatorDelegate {
+    func oauthCoordinator(_ coordinator: SFOAuthCoordinator, didBeginAuthenticationWith view: WKWebView) {}
+    func oauthCoordinator(_ coordinator: SFOAuthCoordinator, didBeginAuthenticationWith session: ASWebAuthenticationSession) {}
+    func oauthCoordinatorDidBeginNativeAuthentication(_ coordinator: SFOAuthCoordinator) {}
+    func oauthCoordinatorDidCancelBrowserAuthentication(_ coordinator: SFOAuthCoordinator) {}
+}
+
+// MARK: - Test-only extension for SFOAuthCredentials to set domain
+@testable import SalesforceSDKCore
+
+extension OAuthCredentials {
+    var testDomain: String? {
+        get { return self.domain }
+        set { self.setValue(newValue, forKey: "domain") }
+    }
+}
+
+// MARK: - Test-only extension for SFOAuthCoordinator to get loginHint
+extension SFOAuthCoordinator {
+    var testLoginHint: String? {
+        get { self.value(forKey: "loginHint") as? String }
+        set { self.setValue(newValue, forKey: "loginHint") }
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
@@ -17,7 +17,7 @@ class SFOAuthCoordinatorTests: XCTestCase {
         let credentials = OAuthCredentials(identifier: "test",
                                            clientId: "client",
                                            encrypted: false)
-        credentials?.testDomain = DomainDiscoveryConstants.discoveryDomain
+        credentials?.testDomain = "foo.bar.com/discovery"
         coordinator.credentials = credentials
         
         // When


### PR DESCRIPTION

- Refactored domain discovery to use a helper for building the discovery URL.
- Added a result object for parsing the callback URL.
- Improved async handling so the continuation always gets called.
- Tried letting DomainDiscoveryCoordinator own its own webview, but it caused issues with showing/dismissing the right webview and broke some flows.  
- To keep things simple, the webview is now just shared with SFOAuthCoordinator.
