### PR TITLE
@W-19345684: [iOS][QRCode] Shows Unsupported URL on FreshLogin using QRCode

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -851,13 +851,12 @@
                                            myDomain:discoveryResult.myDomain];
         decisionHandler(WKNavigationActionPolicyCancel);
     } else if ([self isRedirectURL:requestUrl]) {
-        // First, choose user agent or web server authentication from Salesforce SDK's properties.
-        BOOL isUsingWebServerAuthentication = [[SalesforceSDKManager sharedManager] useWebServerAuthentication];
-        // Second, switch authentication based on the in-use Salesforce Identity API UI Bridge front-door URL and code verifier.
-        if (self.frontdoorBridgeLoginOverride.frontdoorBridgeUrl) {
-            isUsingWebServerAuthentication = self.frontdoorBridgeLoginOverride.codeVerifier;
-        }
-        if (isUsingWebServerAuthentication) {
+        // If a front door bridge URL override is present, use its code verifier to choose between user agent or web server authentication.
+        if (self.frontdoorBridgeLoginOverride.frontdoorBridgeUrl // Check if an override is provided
+            ? self.frontdoorBridgeLoginOverride.codeVerifier != nil // If yes, only proceed if it's a web server flow as indicated by a code verifier.
+            : [[SalesforceSDKManager sharedManager] useWebServerAuthentication] // If there's no override use the default SDK setting.
+            )
+        {
             [self handleWebServerResponse:url]; // Web server flow/URLs with query string parameters.
         } else {
             [self handleUserAgentResponse:url]; // User agent flow/URLs with the fragment component.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -851,9 +851,13 @@
                                            myDomain:discoveryResult.myDomain];
         decisionHandler(WKNavigationActionPolicyCancel);
     } else if ([self isRedirectURL:requestUrl]) {
-        // Determine if presence of override parameters require the user agent flow.
-        BOOL overrideWithUserAgentFlow = self.frontdoorBridgeLoginOverride.frontdoorBridgeUrl && !self.frontdoorBridgeLoginOverride.codeVerifier;
-        if ( [[SalesforceSDKManager sharedManager] useWebServerAuthentication] && !overrideWithUserAgentFlow) {
+        // First, choose user agent or web server authentication from Salesforce SDK's properties.
+        BOOL isUsingWebServerAuthentication = [[SalesforceSDKManager sharedManager] useWebServerAuthentication];
+        // Second, switch authentication based on the in-use Salesforce Identity API UI Bridge front-door URL and code verifier.
+        if (self.frontdoorBridgeLoginOverride.frontdoorBridgeUrl) {
+            isUsingWebServerAuthentication = self.frontdoorBridgeLoginOverride.codeVerifier;
+        }
+        if (isUsingWebServerAuthentication) {
             [self handleWebServerResponse:url]; // Web server flow/URLs with query string parameters.
         } else {
             [self handleUserAgentResponse:url]; // User agent flow/URLs with the fragment component.


### PR DESCRIPTION
🥁 _*Ready For Review*_ 🎸

  This simple fix makes the iOS side of QR Code Log In override the user-agent or web server flows just as Android now does.  The error in the video was caused by the web server flow oriented QR code getting handled like a user agent one.