### PR TITLE
@W-19388238: [iOS][QR Code] QR code login puts the app in an unrecoverable state.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AuthCoordinatorFrontdoorBridgeLoginOverride.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AuthCoordinatorFrontdoorBridgeLoginOverride.swift
@@ -75,7 +75,7 @@ public class AuthCoordinatorFrontdoorBridgeLoginOverride: NSObject {
         // Check if the front door URL host matches the app's selected login host
         self.matchesLoginHost = frontdoorBridgeUrl.host() == UserAccountManager.shared.loginHost
         
-        // Only set the properties if the front door URL host and the start URL consumer key matche the app's current values.
+        // Only set the properties if the front door URL host and the start URL consumer key match the app's current values.
         if self.matchesLoginHost && self.matchesConsumerKey {
             self.codeVerifier = codeVerifier
             self.frontdoorBridgeUrl = frontdoorBridgeUrl

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AuthCoordinatorFrontdoorBridgeLoginOverride.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AuthCoordinatorFrontdoorBridgeLoginOverride.swift
@@ -33,8 +33,11 @@ public class AuthCoordinatorFrontdoorBridgeLoginOverride: NSObject {
     /// For Salesforce Identity UI Bridge API support, the optional web server flow code verifier accompanying the front door bridge URL.  This can only be used with `overrideWithfrontDoorBridgeUrl`.
     @objc public var codeVerifier: String?
     
-    /// For Salesforce Identity UI Bridge API support, indicates if overriding front door bridge URL has a consumer key value that matches the app config, which is also known as the boot config.
+    /// For Salesforce Identity UI Bridge API support, indicates if the overriding front door bridge URL has a consumer key value that matches the app config, which is also known as the boot config.
     @objc public var matchesConsumerKey: Bool = false
+    
+    /// For Salesforce Identity UI Bridge API support, indicates if the overriding front door bridge URL has a host that matches the app's selected login host.
+    @objc public var matchesLoginHost: Bool = false
     
     @objc public init(frontdoorBridgeUrl: URL, codeVerifier: String?) {
         super.init()
@@ -69,10 +72,13 @@ public class AuthCoordinatorFrontdoorBridgeLoginOverride: NSObject {
         }
         self.matchesConsumerKey = frontdoorBridgeUrlClientId == appConsumerKey
         
-        // Only set the properties if the consumer key matches
-        if self.matchesConsumerKey {
+        // Check if the front door URL host matches the app's selected login host
+        self.matchesLoginHost = frontdoorBridgeUrl.host() == UserAccountManager.shared.loginHost
+        
+        // Only set the properties if the front door URL host and the start URL consumer key matche the app's current values.
+        if self.matchesLoginHost && self.matchesConsumerKey {
             self.codeVerifier = codeVerifier
             self.frontdoorBridgeUrl = frontdoorBridgeUrl
         }
     }
-} 
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -931,7 +931,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
                                                       alertControllerWithTitle:errorTitle
                                                       message:errorMessage
                                                       preferredStyle:UIAlertControllerStyleAlert];
-                [alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+                [alertController addAction:[UIAlertAction actionWithTitle:[SFSDKResourceUtils localizedString:@"OK"] style:UIAlertActionStyleDefault handler:nil]];
                 [loginViewController
                  presentViewController:alertController
                  animated:true

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -920,10 +920,10 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             NSString *errorTitle = nil;
             NSString *errorMessage = nil;
             if (!coordinator.frontdoorBridgeLoginOverride.matchesConsumerKey) {
-                errorTitle = @"Error";
+                errorTitle = [SFSDKResourceUtils localizedString:@"Error"];
                 errorMessage = [SFSDKResourceUtils localizedString:@"authAlertFrontdoorLoginUrlConsumerKeyMismatch"];
             } else if (!coordinator.frontdoorBridgeLoginOverride.matchesLoginHost) {
-                errorTitle = @"Error";
+                errorTitle = [SFSDKResourceUtils localizedString:@"Error"];
                 errorMessage = [SFSDKResourceUtils localizedString:@"authAlertFrontdoorLoginUrlLoginHostMismatch"];
             }
             if (errorTitle && errorMessage) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -916,16 +916,27 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     void (^authViewDisplayBlock)(void) = ^{
         
         self.authViewHandler.authViewDisplayBlock(viewHolder);
-        if (coordinator.frontdoorBridgeLoginOverride && !coordinator.frontdoorBridgeLoginOverride.matchesConsumerKey) {
-            UIAlertController* alertController = [UIAlertController
-                                                  alertControllerWithTitle:@"Error"
-                                                  message:[SFSDKResourceUtils localizedString:@"authAlertFrontdoorLoginUrlConsumerKeyMismatch"]
-                                                  preferredStyle:UIAlertControllerStyleAlert];
-            [alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
-            [loginViewController
-             presentViewController:alertController
-             animated:true
-             completion:nil];
+        if (coordinator.frontdoorBridgeLoginOverride) {
+            NSString *errorTitle = nil;
+            NSString *errorMessage = nil;
+            if (!coordinator.frontdoorBridgeLoginOverride.matchesConsumerKey) {
+                errorTitle = @"Error";
+                errorMessage = [SFSDKResourceUtils localizedString:@"authAlertFrontdoorLoginUrlConsumerKeyMismatch"];
+            } else if (!coordinator.frontdoorBridgeLoginOverride.matchesLoginHost) {
+                errorTitle = @"Error";
+                errorMessage = [SFSDKResourceUtils localizedString:@"authAlertFrontdoorLoginUrlLoginHostMismatch"];
+            }
+            if (errorTitle && errorMessage) {
+                UIAlertController* alertController = [UIAlertController
+                                                      alertControllerWithTitle:errorTitle
+                                                      message:errorMessage
+                                                      preferredStyle:UIAlertControllerStyleAlert];
+                [alertController addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil]];
+                [loginViewController
+                 presentViewController:alertController
+                 animated:true
+                 completion:nil];
+            }
         }
     };
     

--- a/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
+++ b/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
@@ -53,6 +53,7 @@
 "authAlertVersionMismatchError" = "Your app has been updated, and you will need to log in again to continue using the app.";
 "authAlertBrowserFlowTitle" = "Log In";
 "authAlertFrontdoorLoginUrlConsumerKeyMismatch" = "Cannot use another app's login QR Code.  Please log in to this app.";
+"authAlertFrontdoorLoginUrlLoginHostMismatch" = "Cannot use another login host's login QR Code.  Please log in to this app.";
 
 // LoginViewController
 "TITLE_LOGIN" = "Log In";

--- a/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
+++ b/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
@@ -129,3 +129,6 @@
 "Copy key to clipboard" = "Copy key to clipboard";
 "Key-Value Store Inspector" = "Key-Value Store Inspector";
 " (global)" = " (global)";
+
+// General
+"Error" = "Error"

--- a/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
+++ b/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
@@ -132,3 +132,4 @@
 
 // General
 "Error" = "Error"
+"OK" = "OK"


### PR DESCRIPTION
🎸 _*Ready For Review*_ 🥁

  This adds a comparison of the UI Bridge API front door URL's `host` to the app's selected login host before allowing the use of a front door URL for login.  This follows the pattern that recently used for the consumer key validation.