### PR TITLE
Nightly will run on iOS 17 (Xcode 15) / iOS 18 (Xcode 16 and 26) / iOS 26 (Xcode 26)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,12 +12,19 @@ jobs:
       fail-fast: false
       matrix:
         lib: [SalesforceSDKCommon, SalesforceAnalytics, SalesforceSDKCore, SmartStore, MobileSync]
-        macos: [macos-15]
-        ios: [^18]
-        xcode: [^26, ^16]
-        # Valid combinations that will run:
-        # - iOS ^18 + Xcode ^26
-        # - iOS ^18 + Xcode ^16
+        include:
+          - macos: macos-15
+            ios: ^18
+            xcode: ^16
+          - macos: macos-15
+            ios: ^18
+            xcode: ^26
+          - macos: macos-15
+            ios: ^26
+            xcode: ^26
+          - macos: macos-14
+            ios: ^17
+            xcode: ^15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
@@ -31,12 +38,19 @@ jobs:
       fail-fast: false
       matrix:
         app: [RestAPIExplorer, MobileSyncExplorer]
-        macos: [macos-15]
-        ios: [^18]
-        xcode: [^26, ^16]
-        # Valid combinations that will run:
-        # - iOS ^18 + Xcode ^26
-        # - iOS ^18 + Xcode ^16
+        include:
+          - macos: macos-15
+            ios: ^18
+            xcode: ^16
+          - macos: macos-15
+            ios: ^18
+            xcode: ^26
+          - macos: macos-15
+            ios: ^26
+            xcode: ^26
+          - macos: macos-14
+            ios: ^17
+            xcode: ^15
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.app }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -102,12 +102,13 @@ jobs:
       fail-fast: false
       matrix:
         lib: ${{ fromJson(needs.test-orchestrator.outputs.libs) }}
-        macos: [macos-15]
-        ios: [^18]
-        xcode: [^16, ^26]
-        # Valid combinations that will run:
-        # - iOS ^18 + Xcode ^16
-        # - iOS ^18 + Xcode ^26
+        include:
+          - macos: macos-15
+            ios: ^18
+            xcode: ^16
+          - macos: macos-15
+            ios: ^26
+            xcode: ^26
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.lib }}
@@ -122,12 +123,13 @@ jobs:
       fail-fast: false
       matrix:
         app: [RestAPIExplorer, MobileSyncExplorer]
-        macos: [macos-15]
-        ios: [^18]
-        xcode: [^16, ^26]
-        # Valid combinations that will run:
-        # - iOS ^18 + Xcode ^16
-        # - iOS ^18 + Xcode ^26
+        include:
+          - macos: macos-15
+            ios: ^18
+            xcode: ^16
+          - macos: macos-15
+            ios: ^26
+            xcode: ^26
     uses: ./.github/workflows/reusable-workflow.yaml
     with:
       lib: ${{ matrix.app }}


### PR DESCRIPTION
PRs will run on iOS 18 (Xcode 16) and iOS 26 (Xcode 26)