### PR TITLE
Fixing MobileSyncExplorer crash when running on device

### DIFF
--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
@@ -1161,7 +1161,7 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		4F6852722E7CE50800D37B27 /* XCRemoteSwiftPackageReference "fmdb" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/wmathurin/fmdb";
+			repositoryURL = "https://github.com/forcedotcom/fmdb";
 			requirement = {
 				kind = exactVersion;
 				version = "2.7.12-sqlcipher";


### PR DESCRIPTION
**Problem:**
- App crashes on iOS 18.5 device or iOS 26 device with `Library not loaded: @rpath/SQLCipher.framework/SQLCipher`
- SmartStore depends on SQLCipher and FMDB via Swift Package Manager, but Xcode doesn't automatically embed transitive SPM dependencies in the app bundle
- Works on simulator due to different framework search paths, fails on device

**Solution:**
- Add SQLCipher and FMDB as direct Swift Package Manager dependencies to MobileSyncExplorer
- This ensures both frameworks are properly embedded in the app bundle for device deployment

**Note:**
There are no issues with the templates apps (both the ones that use Cocoapods and the one using Swift Package Manager).