### PR TITLE
Revert CI is_pr removal.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -113,6 +113,7 @@ jobs:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      is_pr: true
     secrets: inherit
 
   native-samples-pr:
@@ -131,4 +132,5 @@ jobs:
       app: ${{ matrix.app }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      is_pr: true
     secrets: inherit

--- a/.github/workflows/reusable-build-workflow.yaml
+++ b/.github/workflows/reusable-build-workflow.yaml
@@ -16,17 +16,20 @@ on:
         default: macos-latest
         required: false
         type: string
+      is_pr:
+        type: boolean
+        default: false
 
 jobs:
   build-sample-app:
     runs-on: ${{ inputs.macos }}
     steps:
       - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request'
+        if: ${{ inputs.is_pr }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/checkout@v4
-        if: github.event_name != 'pull_request'
+        if: ${{ !inputs.is_pr }}
         with:
           ref: ${{ github.head_ref }}
       - name: Install Dependencies

--- a/.github/workflows/reusable-test-workflow.yaml
+++ b/.github/workflows/reusable-test-workflow.yaml
@@ -16,17 +16,20 @@ on:
         default: macos-latest
         required: false
         type: string
+      is_pr:
+        type: boolean
+        default: false
 
 jobs:
   test-ios:
     runs-on: ${{ inputs.macos }}
     steps:
       - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request'
+        if: ${{ inputs.is_pr }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/checkout@v4
-        if: github.event_name != 'pull_request'
+        if: ${{ !inputs.is_pr }}
         with:
           ref: ${{ github.head_ref }}
       - name: Install Dependencies


### PR DESCRIPTION
I _think_ this could be fixed by wrapping `github.event_name == 'pull_request'` in `${{ }}` instead, but I am not 100% sure that github passes the original `event_name` to the child jobs that are created by the matrix strategy.  I tried several times to  test this on my fork by adding the base branch to the `branches` list of `pull_request_target` it never triggered the workflow.  

This is the safe option to unlock PRs now.