### PR TITLE
Add user agent to token calls

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
@@ -265,7 +265,7 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
  the lifetime of the coordinator object, the user agent configured for the system will be reset back to
  its original value in between authentication requests.
  */
-@property (nonatomic, copy) NSString *userAgentForAuth;
+@property (nonatomic, copy) NSString *userAgentForAuth SFSDK_DEPRECATED(13.2, 14.0, "Not used, will be removed.");
 
 /**
  An array of additional keys (NSString) to parse during OAuth

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -617,8 +617,14 @@
     request.refreshToken = self.credentials.refreshToken;
     request.redirectURI = self.credentials.redirectUri;
     request.serverURL = [self.credentials overrideDomainIfNeeded];
+   
+    // TODO: Remove in Mobile SDK 14.0
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     request.userAgentForAuth = self.userAgentForAuth;
-     __weak typeof (self) weakSelf = self;
+    #pragma clang diagnostic pop
+    
+    __weak typeof (self) weakSelf = self;
     if (self.approvalCode) {
         [SFSDKCoreLogger i:[self class] format:@"%@: Initiating authorization code flow.", NSStringFromSelector(_cmd)];
         request.approvalCode = self.approvalCode;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.m
@@ -61,7 +61,13 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
     self.oauthCoordinator.scopes = self.oauthRequest.scopes;
     self.oauthCoordinator.brandLoginPath = self.oauthRequest.brandLoginPath;
     self.oauthCoordinator.useBrowserAuth = self.oauthRequest.useBrowserAuth;
+    
+    // TODO: Remove in Mobile SDK 14.0
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     self.oauthCoordinator.userAgentForAuth = self.oauthRequest.userAgentForAuth;
+    #pragma clang diagnostic pop
+    
     if (_spAppCredentials && _spAppCredentials.domain) {
         self.oauthCoordinator.credentials.domain = _spAppCredentials.domain;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -145,11 +145,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)revokeRefreshToken:(SFOAuthCredentials *)credentials reason:(SFLogoutReason)reason;
 @end
 
+SFSDK_DEPRECATED(13.2, 14.0, "Will be removed.")
 @protocol SFSDKOAuthSessionManaging<NSObject>
 - (NSURLSession *)createURLSessionWithIdentifier:(nonnull NSString *)identifier;
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 @interface SFSDKOAuth2 : NSObject<SFSDKOAuthProtocol, SFSDKOAuthSessionManaging>
+#pragma clang diagnostic pop
 
 + (NSMutableURLRequest *)requestForRevokeRefreshToken:(SFOAuthCredentials *)credentials reason:(SFLogoutReason)reason;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -235,11 +235,11 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     NSData *encodedBody = [params dataUsingEncoding:NSUTF8StringEncoding];
     [request setHTTPBody:encodedBody];
     
-    __block NSString *instanceIdentifier = [SFNetwork uniqueInstanceIdentifier];
-    NSURLSession *session = [self createURLSessionWithIdentifier:instanceIdentifier];
+    __block NSString *networkIdentifier = [SFNetwork uniqueInstanceIdentifier];
+    SFNetwork *network = [SFNetwork sharedEphemeralInstanceWithIdentifier:networkIdentifier];
     __weak typeof(self) weakSelf = self;
-    [[session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *urlResponse, NSError *error) {
-        [SFNetwork removeSharedInstanceForIdentifier:instanceIdentifier];
+    [network sendRequest:request dataResponseBlock:^(NSData * data, NSURLResponse *urlResponse, NSError *error) {
+        [SFNetwork removeSharedInstanceForIdentifier:networkIdentifier];
         __strong typeof(weakSelf) strongSelf = weakSelf;
         SFSDKOAuthTokenEndpointResponse *endpointResponse = nil;
         if (error) {
@@ -260,7 +260,7 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
             return;
         }
         [strongSelf handleTokenEndpointResponse:completionBlock request:endpointReq data:data urlResponse:urlResponse];
-    }] resume];
+    }];
 }
 
 /* Handle a 'token' endpoint (e.g. refresh, advanced auth) response.
@@ -290,11 +290,11 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     NSData *encodedBody = [params dataUsingEncoding:NSUTF8StringEncoding];
     [request setHTTPBody:encodedBody];
     __block NSString *instanceIdentifier = [SFNetwork uniqueInstanceIdentifier];
-    NSURLSession *session = [self createURLSessionWithIdentifier:instanceIdentifier];
+    SFNetwork *network = [SFNetwork sharedEphemeralInstanceWithIdentifier:instanceIdentifier];
 
     __weak typeof(self) weakSelf = self;
     NSString *className = NSStringFromClass([self class]);
-    [[session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *urlResponse, NSError *error) {
+    [network sendRequest:request dataResponseBlock:^(NSData *data, NSURLResponse *urlResponse, NSError *error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         SFSDKOAuthTokenEndpointResponse *endpointResponse = nil;
         [SFNetwork removeSharedInstanceForIdentifier:instanceIdentifier];
@@ -329,7 +329,7 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
                 }
             });
         }
-    }] resume];
+    }];
 }
 
 - (void)openIDTokenForRefresh:(SFSDKOAuthTokenEndpointRequest *)endpointReq completion:(void (^)(NSString *))completionBlock {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFNetworkTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFNetworkTests.m
@@ -27,6 +27,7 @@
 #import "SalesforceSDKCore/SFNetwork.h"
 #import "SalesforceSDKCore/SFRestAPI+Blocks.h"
 #import "SalesforceSDKCore/SalesforceSDKCore-Swift.h"
+#import "SalesforceSDKCore/SalesforceSDKManager.h"
 
 @interface SFNetwork (Testing)
 
@@ -140,6 +141,16 @@
     };
     
     [self waitForExpectations:@[getExpectation, metricsExpectation] timeout:30];
+}
+
+- (void)testRequestUserAgent {
+    SFNetwork *network = [SFNetwork sharedEphemeralInstance];
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"https://www.salesforce.com"]];
+    [network sendRequest:request dataResponseBlock:nil];
+    
+    NSString *userAgent = request.allHTTPHeaderFields[@"User-Agent"];
+    NSString *expectedUserAgent = [SalesforceSDKManager sharedManager].userAgentString(@"");
+    XCTAssertEqualObjects(userAgent, expectedUserAgent, @"User-Agent header should match SDK manager's user agent");
 }
 
 @end


### PR DESCRIPTION
Confirmed with Charles that Android includes the MSDK user agent on the equivalent requests for `accessTokenForApprovalCode` and `accessTokenForRefresh`, updating iOS to match