### PR TITLE
Ability to simulate welcome discovery flow (for testing)

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -100,7 +100,8 @@
 		4FDEVINFO001234567890ABCD /* DevInfoViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDEVINFO112345678901ABCD /* DevInfoViewControllerTests.swift */; };
 		4FE006B12EBEB65900CFD66F /* AuthFlowTypesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE006B02EBEB65900CFD66F /* AuthFlowTypesView.swift */; };
 		4FE006B22EBEB65900CFD66F /* BootConfigEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE006AE2EBEB65900CFD66F /* BootConfigEditor.swift */; };
-		4FE006B32EBEB65900CFD66F /* BootConfigPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE006AF2EBEB65900CFD66F /* BootConfigPickerViewController.swift */; };
+		4FE006B32EBEB65900CFD66F /* LoginOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE006AF2EBEB65900CFD66F /* LoginOptionsViewController.swift */; };
+		4FE006B52EBEB65900CFD66F /* DiscoveryResultEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE006B42EBEB65900CFD66F /* DiscoveryResultEditor.swift */; };
 		4FE006D42EBEBBF300CFD66F /* SFSDKLoginHostListViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FE006CE2EBEBBF300CFD66F /* SFSDKLoginHostListViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FE006D52EBEBBF300CFD66F /* SFSDKTextFieldTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FE006D22EBEBBF300CFD66F /* SFSDKTextFieldTableViewCell.h */; };
 		4FE006D62EBEBBF300CFD66F /* SFSDKLoginHostStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FE006D02EBEBBF300CFD66F /* SFSDKLoginHostStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -708,7 +709,8 @@
 		4FBOOTCP112345678901ABCD /* BootConfigPickerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BootConfigPickerViewControllerTests.swift; path = SalesforceSDKCoreTests/BootConfigPickerViewControllerTests.swift; sourceTree = SOURCE_ROOT; };
 		4FDEVINFO112345678901ABCD /* DevInfoViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DevInfoViewControllerTests.swift; path = SalesforceSDKCoreTests/DevInfoViewControllerTests.swift; sourceTree = SOURCE_ROOT; };
 		4FE006AE2EBEB65900CFD66F /* BootConfigEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BootConfigEditor.swift; path = SalesforceSDKCore/Classes/Login/DevConfig/BootConfigEditor.swift; sourceTree = SOURCE_ROOT; };
-		4FE006AF2EBEB65900CFD66F /* BootConfigPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BootConfigPickerViewController.swift; path = SalesforceSDKCore/Classes/Login/DevConfig/BootConfigPickerViewController.swift; sourceTree = SOURCE_ROOT; };
+		4FE006AF2EBEB65900CFD66F /* LoginOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LoginOptionsViewController.swift; path = SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift; sourceTree = SOURCE_ROOT; };
+		4FE006B42EBEB65900CFD66F /* DiscoveryResultEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DiscoveryResultEditor.swift; path = SalesforceSDKCore/Classes/Login/DevConfig/DiscoveryResultEditor.swift; sourceTree = SOURCE_ROOT; };
 		4FE006B02EBEB65900CFD66F /* AuthFlowTypesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AuthFlowTypesView.swift; path = SalesforceSDKCore/Classes/Login/DevConfig/AuthFlowTypesView.swift; sourceTree = SOURCE_ROOT; };
 		4FE006CA2EBEBBF300CFD66F /* NewLoginHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewLoginHostView.swift; sourceTree = "<group>"; };
 		4FE006CB2EBEBBF300CFD66F /* SFSDKLoginHost.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKLoginHost.h; sourceTree = "<group>"; };
@@ -1357,7 +1359,8 @@
 			isa = PBXGroup;
 			children = (
 				4FE006AE2EBEB65900CFD66F /* BootConfigEditor.swift */,
-				4FE006AF2EBEB65900CFD66F /* BootConfigPickerViewController.swift */,
+				4FE006B42EBEB65900CFD66F /* DiscoveryResultEditor.swift */,
+				4FE006AF2EBEB65900CFD66F /* LoginOptionsViewController.swift */,
 				4FE006B02EBEB65900CFD66F /* AuthFlowTypesView.swift */,
 			);
 			path = DevConfig;
@@ -2344,7 +2347,8 @@
 				CE4CE33F1C0E524B009F6029 /* SFInstrumentation.m in Sources */,
 				4FE006B12EBEB65900CFD66F /* AuthFlowTypesView.swift in Sources */,
 				4FE006B22EBEB65900CFD66F /* BootConfigEditor.swift in Sources */,
-				4FE006B32EBEB65900CFD66F /* BootConfigPickerViewController.swift in Sources */,
+				4FE006B32EBEB65900CFD66F /* LoginOptionsViewController.swift in Sources */,
+				4FE006B52EBEB65900CFD66F /* DiscoveryResultEditor.swift in Sources */,
 				697A91A12363C3D800D2836F /* SFSDKPushNotificationDecryption.m in Sources */,
 				CE675A341E0B2CC6002DBF5A /* SFSDKSoqlBuilder.m in Sources */,
 				69E2FD9F22FB937F008E0AF0 /* SFSDKEncryptedURLCache.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -96,7 +96,8 @@
 		4F9E05322DD6A08000548985 /* SFSDKOAuthTokenEndpointResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */; };
 		4F9E05342DD7BE1500548985 /* SFOAuthCredentialsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9E05332DD7BE0A00548985 /* SFOAuthCredentialsTests.m */; };
 		4FAUTHFLOW001234567890ABC /* AuthFlowTypesViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */; };
-		4FBOOTCP001234567890ABCD /* BootConfigPickerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FBOOTCP112345678901ABCD /* BootConfigPickerViewControllerTests.swift */; };
+		4FBOOTCP001234567890ABCD /* LoginOptionsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FBOOTCP112345678901ABCD /* LoginOptionsViewControllerTests.swift */; };
+		4FDISCOV001234567890ABCD /* DiscoveryResultEditorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDISCOV112345678901ABCD /* DiscoveryResultEditorTests.swift */; };
 		4FDEVINFO001234567890ABCD /* DevInfoViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDEVINFO112345678901ABCD /* DevInfoViewControllerTests.swift */; };
 		4FE006B12EBEB65900CFD66F /* AuthFlowTypesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE006B02EBEB65900CFD66F /* AuthFlowTypesView.swift */; };
 		4FE006B22EBEB65900CFD66F /* BootConfigEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE006AE2EBEB65900CFD66F /* BootConfigEditor.swift */; };
@@ -706,7 +707,8 @@
 		4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKOAuthTokenEndpointResponseTests.m; path = ../SalesforceSDKCoreTests/SFSDKOAuthTokenEndpointResponseTests.m; sourceTree = "<group>"; };
 		4F9E05332DD7BE0A00548985 /* SFOAuthCredentialsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFOAuthCredentialsTests.m; path = ../SalesforceSDKCoreTests/SFOAuthCredentialsTests.m; sourceTree = "<group>"; };
 		4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AuthFlowTypesViewTests.swift; path = SalesforceSDKCoreTests/AuthFlowTypesViewTests.swift; sourceTree = SOURCE_ROOT; };
-		4FBOOTCP112345678901ABCD /* BootConfigPickerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BootConfigPickerViewControllerTests.swift; path = SalesforceSDKCoreTests/BootConfigPickerViewControllerTests.swift; sourceTree = SOURCE_ROOT; };
+		4FBOOTCP112345678901ABCD /* LoginOptionsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LoginOptionsViewControllerTests.swift; path = SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift; sourceTree = SOURCE_ROOT; };
+		4FDISCOV112345678901ABCD /* DiscoveryResultEditorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DiscoveryResultEditorTests.swift; path = SalesforceSDKCoreTests/DiscoveryResultEditorTests.swift; sourceTree = SOURCE_ROOT; };
 		4FDEVINFO112345678901ABCD /* DevInfoViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DevInfoViewControllerTests.swift; path = SalesforceSDKCoreTests/DevInfoViewControllerTests.swift; sourceTree = SOURCE_ROOT; };
 		4FE006AE2EBEB65900CFD66F /* BootConfigEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BootConfigEditor.swift; path = SalesforceSDKCore/Classes/Login/DevConfig/BootConfigEditor.swift; sourceTree = SOURCE_ROOT; };
 		4FE006AF2EBEB65900CFD66F /* LoginOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LoginOptionsViewController.swift; path = SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift; sourceTree = SOURCE_ROOT; };
@@ -1057,8 +1059,9 @@
 				23F200AB2E551C890091C5F5 /* ActionTypeTests.swift */,
 				4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */,
 				696E91452AD0A14A00205884 /* BiometricAuthenticationManagerTests.swift */,
-				4FBOOTCP112345678901ABCD /* BootConfigPickerViewControllerTests.swift */,
+				4FBOOTCP112345678901ABCD /* LoginOptionsViewControllerTests.swift */,
 				23F200AD2E551C890091C5F5 /* BootconfigTests.swift */,
+				4FDISCOV112345678901ABCD /* DiscoveryResultEditorTests.swift */,
 				69DFE0682B969C1D000906E4 /* CryptoUtilsTests.swift */,
 				237C18722E450B710008015C /* DecryptStreamTests.swift */,
 				4FDEVINFO112345678901ABCD /* DevInfoViewControllerTests.swift */,
@@ -2265,7 +2268,8 @@
 				23F200AC2E551C890091C5F5 /* ActionTypeTests.swift in Sources */,
 				4FAUTHFLOW001234567890ABC /* AuthFlowTypesViewTests.swift in Sources */,
 				23F200AE2E551C890091C5F5 /* BootconfigTests.swift in Sources */,
-				4FBOOTCP001234567890ABCD /* BootConfigPickerViewControllerTests.swift in Sources */,
+				4FBOOTCP001234567890ABCD /* LoginOptionsViewControllerTests.swift in Sources */,
+				4FDISCOV001234567890ABCD /* DiscoveryResultEditorTests.swift in Sources */,
 				4F7EB4171BFFC8D700768720 /* SFEncryptionKeyTests.m in Sources */,
 				69848CBD2364063E00893E57 /* SFSDKPushNotificationDataProvider.m in Sources */,
 				23A4C7492D0CAFCF00DF55EB /* NativeLoginManagerTests.swift in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -26,7 +26,7 @@
 #import <UIKit/UIKit.h>
 #import <SalesforceSDKCore/SalesforceSDKCoreDefines.h>
 #import <SalesforceSDKCore/SalesforceSDKConstants.h>
-@class SFUserAccount, SFSDKAppConfig, SFScreenLockManager, SFBiometricAuthenticationManager;
+@class SFUserAccount, SFSDKAppConfig, SFScreenLockManager, SFBiometricAuthenticationManager, SFDomainDiscoveryResult;
 @protocol SFScreenLockManager, SFBiometricAuthenticationManager, SFNativeLoginManager;
 
 /**
@@ -237,6 +237,10 @@ NS_SWIFT_NAME(SalesforceManager)
 /** Use this flag to indicate if the login webview should be inspectable
  */
 @property (nonatomic, assign) BOOL isLoginWebviewInspectable;
+
+/** When set (DEBUG builds only; setter is a no-op in Release), a callback URL is built from this result to trigger the domain discovery callback handler when welcome.salesforce.com is the login server. Used by tests to simulate domain discovery.
+ */
+@property (nonatomic, strong, nullable) SFDomainDiscoveryResult *simulatedDomainDiscoveryResult;
 
 /** The type of cache used for the shared URL cache, defaults to kSFURLCacheTypeEncrypted.
 */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -131,6 +131,12 @@ SFNativeLoginManagerInternal *nativeLogin;
 
 @synthesize webViewUserAgent = _webViewUserAgent;
 
+- (void)setSimulatedDomainDiscoveryResult:(SFDomainDiscoveryResult *)simulatedDomainDiscoveryResult {
+#ifdef DEBUG
+    _simulatedDomainDiscoveryResult = simulatedDomainDiscoveryResult;
+#endif
+}
+
 + (void)setInstanceClass:(Class)className {
     InstanceClass = className;
 }
@@ -483,7 +489,7 @@ SFNativeLoginManagerInternal *nativeLogin;
     // Login Options - only show on login screen
     if (isShowingLogin) {
         [actions addObject:[[SFSDKDevAction alloc]initWith:@"Login Options" handler:^{
-            UIViewController *configPicker = [BootConfigPickerViewController makeViewControllerOnConfigurationCompleted:^{
+            UIViewController *configPicker = [LoginOptionsViewController makeViewControllerOnConfigurationCompleted:^{
                 [presentedViewController dismissViewControllerAnimated:YES completion:^{
                     // Restart authentication with the updated configuration
                     if ([presentedViewController isKindOfClass:[SFLoginViewController class]]) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/AuthFlowTypesView.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/AuthFlowTypesView.swift
@@ -38,13 +38,13 @@ public struct AuthFlowTypesView: View {
     
     public var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Authentication Flow Types")
+            Text(SFSDKResourceUtils.localizedString("LOGIN_OPTIONS_AUTH_FLOW_TYPES_TITLE"))
                 .font(.headline)
                 .padding(.horizontal)
             
             VStack(alignment: .leading, spacing: 8) {
                 Toggle(isOn: $useWebServerFlow) {
-                    Text("Use Web Server Flow")
+                    Text(SFSDKResourceUtils.localizedString("LOGIN_OPTIONS_USE_WEB_SERVER_FLOW"))
                         .font(.body)
                 }
                 .onChange(of: useWebServerFlow) { _, newValue in
@@ -53,7 +53,7 @@ public struct AuthFlowTypesView: View {
                 .padding(.horizontal)
                 
                 Toggle(isOn: $useHybridFlow) {
-                    Text("Use Hybrid Flow")
+                    Text(SFSDKResourceUtils.localizedString("LOGIN_OPTIONS_USE_HYBRID_FLOW"))
                         .font(.body)
                 }
                 .onChange(of: useHybridFlow) { _, newValue in

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/BootConfigEditor.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/BootConfigEditor.swift
@@ -101,30 +101,30 @@ public struct BootConfigEditor: View {
             
             if isExpanded {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Consumer Key:")
+                    Text(SFSDKResourceUtils.localizedString("BOOTCONFIG_CONSUMER_KEY_LABEL"))
                         .font(.caption)
                         .foregroundColor(.secondary)
-                    TextField("Consumer Key", text: $consumerKey)
+                    TextField(SFSDKResourceUtils.localizedString("BOOTCONFIG_CONSUMER_KEY_PLACEHOLDER"), text: $consumerKey)
                         .font(.system(.caption, design: .monospaced))
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
                         .accessibilityIdentifier("consumerKeyTextField")
                     
-                    Text("Callback URL:")
+                    Text(SFSDKResourceUtils.localizedString("BOOTCONFIG_CALLBACK_URL_LABEL"))
                         .font(.caption)
                         .foregroundColor(.secondary)
-                    TextField("Callback URL", text: $callbackUrl)
+                    TextField(SFSDKResourceUtils.localizedString("BOOTCONFIG_CALLBACK_URL_PLACEHOLDER"), text: $callbackUrl)
                         .font(.system(.caption, design: .monospaced))
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
                         .accessibilityIdentifier("callbackUrlTextField")
                     
-                    Text("Scopes (space-separated):")
+                    Text(SFSDKResourceUtils.localizedString("BOOTCONFIG_SCOPES_LABEL"))
                         .font(.caption)
                         .foregroundColor(.secondary)
-                    TextField("e.g. id api refresh_token", text: $scopes)
+                    TextField(SFSDKResourceUtils.localizedString("BOOTCONFIG_SCOPES_PLACEHOLDER"), text: $scopes)
                         .font(.system(.caption, design: .monospaced))
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                         .autocapitalization(.none)
@@ -150,14 +150,14 @@ public struct BootConfigEditor: View {
         .onAppear {
             isExpanded = initiallyExpanded
         }
-        .alert("Import Configuration", isPresented: $showImportAlert) {
-            TextField("Paste JSON here", text: $importJSONText)
-            Button("Import") {
+        .alert(SFSDKResourceUtils.localizedString("BOOTCONFIG_IMPORT_ALERT_TITLE"), isPresented: $showImportAlert) {
+            TextField(SFSDKResourceUtils.localizedString("BOOTCONFIG_IMPORT_PLACEHOLDER"), text: $importJSONText)
+            Button(SFSDKResourceUtils.localizedString("BOOTCONFIG_IMPORT_BUTTON")) {
                 importConfigFromJSON()
             }
-            Button("Cancel", role: .cancel) { }
+            Button(SFSDKResourceUtils.localizedString("BOOTCONFIG_IMPORT_CANCEL"), role: .cancel) { }
         } message: {
-            Text("Paste JSON with remoteAccessConsumerKey, oauthRedirectURI, and scopes")
+            Text(SFSDKResourceUtils.localizedString("BOOTCONFIG_IMPORT_MESSAGE"))
         }
     }
     

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/DiscoveryResultEditor.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/DiscoveryResultEditor.swift
@@ -111,7 +111,7 @@ public struct DiscoveryResultEditor: View {
             }
 
             Button(action: applySimulatedResult) {
-                Text("Use for domain discovery simulation")
+                Text("Save simulated result")
                     .font(.headline)
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
@@ -119,7 +119,7 @@ public struct DiscoveryResultEditor: View {
                     .background(Color.orange)
                     .cornerRadius(8)
             }
-            .accessibilityIdentifier("useForDomainDiscoverySimulationButton")
+            .accessibilityIdentifier("saveSimulatedResultButton")
             .padding(.horizontal)
         }
         .padding(.vertical)

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/DiscoveryResultEditor.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/DiscoveryResultEditor.swift
@@ -1,0 +1,159 @@
+/*
+ DiscoveryResultEditor.swift
+ SalesforceSDKCore
+
+ Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import SwiftUI
+
+/// JSON keys for importing a discovery result.
+public enum DiscoveryResultJSONKeys {
+    public static let loginHint = "login_hint"
+    public static let myDomain = "my_domain"
+}
+
+/// Editor for simulating a domain discovery result (login host and username). Used in debug to bypass the real discovery flow.
+public struct DiscoveryResultEditor: View {
+    @Binding var loginHost: String
+    @Binding var userName: String
+    let onUseForSimulation: (DomainDiscoveryResult) -> Void
+    @State private var isExpanded: Bool = false
+    @State private var showImportAlert: Bool = false
+    @State private var importJSONText: String = ""
+    let initiallyExpanded: Bool
+
+    public init(
+        loginHost: Binding<String>,
+        userName: Binding<String>,
+        onUseForSimulation: @escaping (DomainDiscoveryResult) -> Void,
+        initiallyExpanded: Bool = false
+    ) {
+        self._loginHost = loginHost
+        self._userName = userName
+        self.onUseForSimulation = onUseForSimulation
+        self.initiallyExpanded = initiallyExpanded
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Button(action: {
+                    withAnimation {
+                        isExpanded.toggle()
+                    }
+                }) {
+                    HStack {
+                        Text("Simulate Domain Discovery")
+                            .font(.headline)
+                            .foregroundColor(.primary)
+                        Spacer()
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .foregroundColor(.secondary)
+                    }
+                }
+                Button(action: {
+                    importJSONText = ""
+                    showImportAlert = true
+                }) {
+                    Image(systemName: "square.and.arrow.down")
+                        .font(.subheadline)
+                        .foregroundColor(.blue)
+                }
+                .accessibilityIdentifier("importDiscoveryResultButton")
+            }
+            .padding(.horizontal)
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Login host (My Domain):")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    TextField("e.g. mycompany.my.salesforce.com", text: $loginHost)
+                        .font(.system(.caption, design: .monospaced))
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                        .accessibilityIdentifier("discoveryLoginHostTextField")
+
+                    Text("User name (login hint):")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    TextField("e.g. user@company.com", text: $userName)
+                        .font(.system(.caption, design: .monospaced))
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                        .keyboardType(.emailAddress)
+                        .accessibilityIdentifier("discoveryUserNameTextField")
+                }
+                .padding(.horizontal)
+            }
+
+            Button(action: applySimulatedResult) {
+                Text("Use for domain discovery simulation")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 44)
+                    .background(Color.orange)
+                    .cornerRadius(8)
+            }
+            .padding(.horizontal)
+        }
+        .padding(.vertical)
+        .onAppear {
+            isExpanded = initiallyExpanded
+        }
+        .alert("Import Discovery Result", isPresented: $showImportAlert) {
+            TextField("Paste JSON here", text: $importJSONText)
+            Button("Import") {
+                importDiscoveryResultFromJSON()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Paste JSON with login_hint and my_domain")
+        }
+    }
+
+    private func importDiscoveryResultFromJSON() {
+        guard let jsonData = importJSONText.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any] else {
+            return
+        }
+        if let hint = json[DiscoveryResultJSONKeys.loginHint] as? String {
+            userName = hint
+        }
+        if let domain = json[DiscoveryResultJSONKeys.myDomain] as? String {
+            loginHost = domain
+        }
+    }
+
+    private func applySimulatedResult() {
+        let trimmedHost = loginHost.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedUser = userName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedHost.isEmpty, !trimmedUser.isEmpty else { return }
+        let result = DomainDiscoveryResult(loginHint: trimmedUser, myDomain: trimmedHost)
+        onUseForSimulation(result)
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/DiscoveryResultEditor.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/DiscoveryResultEditor.swift
@@ -64,7 +64,7 @@ public struct DiscoveryResultEditor: View {
                     }
                 }) {
                     HStack {
-                        Text("Simulate Domain Discovery")
+                        Text(SFSDKResourceUtils.localizedString("DISCOVERY_SIMULATE_TITLE"))
                             .font(.headline)
                             .foregroundColor(.primary)
                         Spacer()
@@ -86,20 +86,20 @@ public struct DiscoveryResultEditor: View {
 
             if isExpanded {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Login host (My Domain):")
+                    Text(SFSDKResourceUtils.localizedString("DISCOVERY_LOGIN_HOST_LABEL"))
                         .font(.caption)
                         .foregroundColor(.secondary)
-                    TextField("e.g. mycompany.my.salesforce.com", text: $loginHost)
+                    TextField(SFSDKResourceUtils.localizedString("DISCOVERY_LOGIN_HOST_PLACEHOLDER"), text: $loginHost)
                         .font(.system(.caption, design: .monospaced))
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                         .autocapitalization(.none)
                         .disableAutocorrection(true)
                         .accessibilityIdentifier("discoveryLoginHostTextField")
 
-                    Text("User name (login hint):")
+                    Text(SFSDKResourceUtils.localizedString("DISCOVERY_USER_NAME_LABEL"))
                         .font(.caption)
                         .foregroundColor(.secondary)
-                    TextField("e.g. user@company.com", text: $userName)
+                    TextField(SFSDKResourceUtils.localizedString("DISCOVERY_USER_NAME_PLACEHOLDER"), text: $userName)
                         .font(.system(.caption, design: .monospaced))
                         .textFieldStyle(RoundedBorderTextFieldStyle())
                         .autocapitalization(.none)
@@ -111,7 +111,7 @@ public struct DiscoveryResultEditor: View {
             }
 
             Button(action: applySimulatedResult) {
-                Text("Save simulated result")
+                Text(SFSDKResourceUtils.localizedString("DISCOVERY_SAVE_SIMULATED_RESULT"))
                     .font(.headline)
                     .foregroundColor(.white)
                     .frame(maxWidth: .infinity)
@@ -126,14 +126,14 @@ public struct DiscoveryResultEditor: View {
         .onAppear {
             isExpanded = initiallyExpanded
         }
-        .alert("Import Discovery Result", isPresented: $showImportAlert) {
-            TextField("Paste JSON here", text: $importJSONText)
-            Button("Import") {
+        .alert(SFSDKResourceUtils.localizedString("DISCOVERY_IMPORT_ALERT_TITLE"), isPresented: $showImportAlert) {
+            TextField(SFSDKResourceUtils.localizedString("DISCOVERY_IMPORT_PLACEHOLDER"), text: $importJSONText)
+            Button(SFSDKResourceUtils.localizedString("DISCOVERY_IMPORT_BUTTON")) {
                 importDiscoveryResultFromJSON()
             }
-            Button("Cancel", role: .cancel) { }
+            Button(SFSDKResourceUtils.localizedString("DISCOVERY_IMPORT_CANCEL"), role: .cancel) { }
         } message: {
-            Text("Paste JSON with login_hint and my_domain")
+            Text(SFSDKResourceUtils.localizedString("DISCOVERY_IMPORT_MESSAGE"))
         }
     }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/DiscoveryResultEditor.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/DiscoveryResultEditor.swift
@@ -150,7 +150,8 @@ public struct DiscoveryResultEditor: View {
         }
     }
 
-    private func applySimulatedResult() {
+    /// Applies current field values and invokes the callback. Internal for unit testing.
+    internal func applySimulatedResult() {
         let trimmedHost = loginHost.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedUser = userName.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmedHost.isEmpty {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/DiscoveryResultEditor.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/DiscoveryResultEditor.swift
@@ -37,7 +37,7 @@ public enum DiscoveryResultJSONKeys {
 public struct DiscoveryResultEditor: View {
     @Binding var loginHost: String
     @Binding var userName: String
-    let onUseForSimulation: (DomainDiscoveryResult) -> Void
+    let onUseForSimulation: (DomainDiscoveryResult?) -> Void
     @State private var isExpanded: Bool = false
     @State private var showImportAlert: Bool = false
     @State private var importJSONText: String = ""
@@ -46,7 +46,7 @@ public struct DiscoveryResultEditor: View {
     public init(
         loginHost: Binding<String>,
         userName: Binding<String>,
-        onUseForSimulation: @escaping (DomainDiscoveryResult) -> Void,
+        onUseForSimulation: @escaping (DomainDiscoveryResult?) -> Void,
         initiallyExpanded: Bool = false
     ) {
         self._loginHost = loginHost
@@ -119,6 +119,7 @@ public struct DiscoveryResultEditor: View {
                     .background(Color.orange)
                     .cornerRadius(8)
             }
+            .accessibilityIdentifier("useForDomainDiscoverySimulationButton")
             .padding(.horizontal)
         }
         .padding(.vertical)
@@ -152,7 +153,10 @@ public struct DiscoveryResultEditor: View {
     private func applySimulatedResult() {
         let trimmedHost = loginHost.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedUser = userName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedHost.isEmpty, !trimmedUser.isEmpty else { return }
+        if trimmedHost.isEmpty {
+            onUseForSimulation(nil)
+            return
+        }
         let result = DomainDiscoveryResult(loginHint: trimmedUser, myDomain: trimmedHost)
         onUseForSimulation(result)
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift
@@ -72,7 +72,7 @@ public struct LoginOptionsView: View {
         VStack(spacing: 0) {
             // Custom title bar with close button
             TitleBarView(title: "Login Options", onDismiss: {
-                dismiss()
+                onConfigurationCompleted()
             })
 
             // Content
@@ -87,7 +87,7 @@ public struct LoginOptionsView: View {
                         // Static config section
                         BootConfigEditor(
                             title: "Static Configuration",
-                            buttonLabel: "Use static config",
+                            buttonLabel: "Save static config",
                             buttonColor: .blue,
                             consumerKey: $staticConsumerKey,
                             callbackUrl: $staticCallbackUrl,
@@ -102,7 +102,7 @@ public struct LoginOptionsView: View {
                         // Dynamic config section
                         BootConfigEditor(
                             title: "Dynamic Configuration",
-                            buttonLabel: "Use dynamic config",
+                            buttonLabel: "Save dynamic config",
                             buttonColor: .green,
                             consumerKey: $dynamicConsumerKey,
                             callbackUrl: $dynamicCallbackUrl,
@@ -184,9 +184,6 @@ public struct LoginOptionsView: View {
         UserAccountManager.shared.oauthClientID = staticConsumerKey
         UserAccountManager.shared.oauthCompletionURL = staticCallbackUrl
         UserAccountManager.shared.scopes = scopesArray.isEmpty ? [] : Set(scopesArray)
-
-        // Proceed with login
-        onConfigurationCompleted()
     }
 
     internal func handleDynamicBootconfig() {
@@ -211,16 +208,10 @@ public struct LoginOptionsView: View {
 
             callback(BootConfig(configDict))
         }
-
-        // Proceed with login
-        onConfigurationCompleted()
     }
 
     internal func handleSimulatedDomainDiscovery(result: DomainDiscoveryResult?) {
         SalesforceManager.shared.simulatedDomainDiscoveryResult = result
-        
-        // Proceed with login
-        onConfigurationCompleted()
     }
 }
 
@@ -253,6 +244,7 @@ struct TitleBarView: View {
                         .foregroundColor(.white)
                         .padding(12)
                 }
+                .accessibilityIdentifier("loginOptionsCloseButton")
             }
         }
         .frame(height: 44)

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift
@@ -71,7 +71,7 @@ public struct LoginOptionsView: View {
     public var body: some View {
         VStack(spacing: 0) {
             // Custom title bar with close button – trigger handler then dismiss so presenter can run its callback
-            TitleBarView(title: "Login Options", onDismiss: closeSheet)
+            TitleBarView(title: SFSDKResourceUtils.localizedString("LOGIN_OPTIONS"), onDismiss: closeSheet)
 
             // Content
             ScrollView {
@@ -84,8 +84,8 @@ public struct LoginOptionsView: View {
 
                         // Static config section
                         BootConfigEditor(
-                            title: "Static Configuration",
-                            buttonLabel: "Save static config",
+                            title: SFSDKResourceUtils.localizedString("LOGIN_OPTIONS_STATIC_CONFIG_TITLE"),
+                            buttonLabel: SFSDKResourceUtils.localizedString("LOGIN_OPTIONS_SAVE_STATIC_CONFIG"),
                             buttonColor: .blue,
                             consumerKey: $staticConsumerKey,
                             callbackUrl: $staticCallbackUrl,
@@ -99,8 +99,8 @@ public struct LoginOptionsView: View {
 
                         // Dynamic config section
                         BootConfigEditor(
-                            title: "Dynamic Configuration",
-                            buttonLabel: "Save dynamic config",
+                            title: SFSDKResourceUtils.localizedString("LOGIN_OPTIONS_DYNAMIC_CONFIG_TITLE"),
+                            buttonLabel: SFSDKResourceUtils.localizedString("LOGIN_OPTIONS_SAVE_DYNAMIC_CONFIG"),
                             buttonColor: .green,
                             consumerKey: $dynamicConsumerKey,
                             callbackUrl: $dynamicCallbackUrl,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift
@@ -1,9 +1,9 @@
 /*
- BootConfigPickerViewController.swift
+ LoginOptionsViewController.swift
  SalesforceSDKCore
 
  Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
- 
+
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright notice, this list of conditions
@@ -14,7 +14,7 @@
  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
  endorse or promote products derived from this software without specific prior written
  permission of salesforce.com, inc.
- 
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
@@ -28,21 +28,23 @@
 import SwiftUI
 import UIKit
 
-public struct BootConfigPickerView: View {
+public struct LoginOptionsView: View {
     @State internal var staticConsumerKey = ""
     @State internal var staticCallbackUrl = ""
     @State internal var staticScopes = ""
     @State internal var dynamicConsumerKey = ""
     @State internal var dynamicCallbackUrl = ""
     @State internal var dynamicScopes = ""
+    @State internal var discoveryLoginHost = ""
+    @State internal var discoveryUserName = ""
     @Environment(\.dismiss) private var dismiss
-    
+
     let onConfigurationCompleted: () -> Void
-    
+
     public init(onConfigurationCompleted: @escaping () -> Void) {
         self.onConfigurationCompleted = onConfigurationCompleted
     }
-    
+
     // Internal initializer for testing with pre-set state values
     internal init(
         onConfigurationCompleted: @escaping () -> Void,
@@ -51,7 +53,9 @@ public struct BootConfigPickerView: View {
         staticScopes: String = "",
         dynamicConsumerKey: String = "",
         dynamicCallbackUrl: String = "",
-        dynamicScopes: String = ""
+        dynamicScopes: String = "",
+        discoveryLoginHost: String = "",
+        discoveryUserName: String = ""
     ) {
         self.onConfigurationCompleted = onConfigurationCompleted
         self._staticConsumerKey = State(initialValue: staticConsumerKey)
@@ -60,24 +64,26 @@ public struct BootConfigPickerView: View {
         self._dynamicConsumerKey = State(initialValue: dynamicConsumerKey)
         self._dynamicCallbackUrl = State(initialValue: dynamicCallbackUrl)
         self._dynamicScopes = State(initialValue: dynamicScopes)
+        self._discoveryLoginHost = State(initialValue: discoveryLoginHost)
+        self._discoveryUserName = State(initialValue: discoveryUserName)
     }
-    
+
     public var body: some View {
         VStack(spacing: 0) {
             // Custom title bar with close button
             TitleBarView(title: "Login Options", onDismiss: {
                 dismiss()
             })
-            
+
             // Content
             ScrollView {
                     VStack(spacing: 30) {
                         // Flow types section
                         AuthFlowTypesView()
                             .padding(.top, 20)
-                        
+
                         Divider()
-                        
+
                         // Static config section
                         BootConfigEditor(
                             title: "Static Configuration",
@@ -90,9 +96,9 @@ public struct BootConfigPickerView: View {
                             onUseConfig: handleStaticConfig,
                             initiallyExpanded: false
                         )
-                        
+
                         Divider()
-                        
+
                         // Dynamic config section
                         BootConfigEditor(
                             title: "Dynamic Configuration",
@@ -105,68 +111,84 @@ public struct BootConfigPickerView: View {
                             onUseConfig: handleDynamicBootconfig,
                             initiallyExpanded: false
                         )
+
+                        Divider()
+
+                        // Simulate domain discovery – sets simulatedDomainDiscoveryResult so the next discovery navigation uses this result
+                        DiscoveryResultEditor(
+                            loginHost: $discoveryLoginHost,
+                            userName: $discoveryUserName,
+                            onUseForSimulation: handleSimulatedDomainDiscovery,
+                            initiallyExpanded: false
+                        )
                     }
                     .padding(.bottom, 40)
                 }
                 .background(Color(.systemBackground))
             }
         .onAppear {
-            loadConfigDefaults()
+            logDefaults()
         }
     }
-    
+
     // MARK: - Helper Methods
-    
-    private func loadConfigDefaults() {
+
+    private func logDefaults() {
         // Load static config from bootconfig.plist (via SalesforceManager)
         if let config = SalesforceManager.shared.bootConfig {
             staticConsumerKey = config.remoteAccessConsumerKey
             staticCallbackUrl = config.oauthRedirectURI
             staticScopes = config.oauthScopes.sorted().joined(separator: " ")
         }
-        
+
         // Load dynamic config defaults from bootconfig2.plist
         if let config = BootConfig("/bootconfig2.plist") {
             dynamicConsumerKey = config.remoteAccessConsumerKey
             dynamicCallbackUrl = config.oauthRedirectURI
             dynamicScopes = config.oauthScopes.sorted().joined(separator: " ")
         }
+
+        // Load discovery simulation defaults from simulatedDomainDiscoveryResult
+        if let simulated = SalesforceManager.shared.simulatedDomainDiscoveryResult {
+            discoveryLoginHost = simulated.myDomain
+            discoveryUserName = simulated.loginHint
+        }
     }
-    
+
     // MARK: - Button Actions
-    
+
     internal func handleStaticConfig() {
         // Parse scopes from space-separated string
         let scopesArray = staticScopes
             .split(separator: " ")
             .map { String($0) }
             .filter { !$0.isEmpty }
-        
+
         // Create BootConfig with values from the editor
         var configDict: [String: Any] = [
             "remoteAccessConsumerKey": staticConsumerKey,
             "oauthRedirectURI": staticCallbackUrl,
             "shouldAuthenticate": true
         ]
-        
+
         // Only add scopes if not empty
         if !scopesArray.isEmpty {
             configDict["oauthScopes"] = scopesArray
         }
-        
+
         // Set as the bootConfig
         SalesforceManager.shared.bootConfig = BootConfig(configDict)
         SalesforceManager.shared.bootConfigRuntimeSelector = nil
-        
+
         // Update UserAccountManager properties
         UserAccountManager.shared.oauthClientID = staticConsumerKey
         UserAccountManager.shared.oauthCompletionURL = staticCallbackUrl
         UserAccountManager.shared.scopes = scopesArray.isEmpty ? [] : Set(scopesArray)
-        
+
         // Proceed with login
         onConfigurationCompleted()
     }
-    
+
     internal func handleDynamicBootconfig() {
         SalesforceManager.shared.bootConfigRuntimeSelector = { _, callback in
             // Create dynamic BootConfig from user-entered values
@@ -175,22 +197,27 @@ public struct BootConfigPickerView: View {
                 .split(separator: " ")
                 .map { String($0) }
                 .filter { !$0.isEmpty }
-            
+
             var configDict: [String: Any] = [
                 "remoteAccessConsumerKey": self.dynamicConsumerKey,
                 "oauthRedirectURI": self.dynamicCallbackUrl,
                 "shouldAuthenticate": true
             ]
-            
+
             // Only add scopes if not empty
             if !scopesArray.isEmpty {
                 configDict["oauthScopes"] = scopesArray
             }
-            
+
             callback(BootConfig(configDict))
         }
-        
+
         // Proceed with login
+        onConfigurationCompleted()
+    }
+
+    internal func handleSimulatedDomainDiscovery(result: DomainDiscoveryResult) {
+        SalesforceManager.shared.simulatedDomainDiscoveryResult = result
         onConfigurationCompleted()
     }
 }
@@ -200,24 +227,24 @@ public struct BootConfigPickerView: View {
 struct TitleBarView: View {
     let title: String
     let onDismiss: () -> Void
-    
+
     var body: some View {
         ZStack {
             Color(UIColor.salesforceBlue)
-            
+
             HStack {
                 Spacer()
-                
+
                 Text(title)
                     .font(.system(size: 18, weight: .regular))
                     .foregroundColor(.white)
-                
+
                 Spacer()
             }
-            
+
             HStack {
                 Spacer()
-                
+
                 Button(action: onDismiss) {
                     Image(systemName: "xmark")
                         .font(.system(size: 16, weight: .medium))
@@ -233,12 +260,13 @@ struct TitleBarView: View {
 
 // MARK: - Objective-C Bridge
 
-@objc public class BootConfigPickerViewController: NSObject {
-    
-    @objc public static func makeViewController(onConfigurationCompleted: @escaping () -> Void) -> UIViewController {
-        let view = BootConfigPickerView(onConfigurationCompleted: onConfigurationCompleted)
+@objc public class LoginOptionsViewController: NSObject {
+
+    @objc(makeViewControllerOnConfigurationCompleted:)
+    public static func makeViewController(onConfigurationCompleted: @escaping () -> Void) -> UIViewController {
+        let view = LoginOptionsView(onConfigurationCompleted: onConfigurationCompleted)
         let hostingController = UIHostingController(rootView: view)
-        
+
         // Use pageSheet for slide-up presentation
         #if !os(visionOS)
         if let sheet = hostingController.sheetPresentationController {
@@ -247,8 +275,7 @@ struct TitleBarView: View {
             sheet.preferredCornerRadius = 16
         }
         #endif
-        
+
         return hostingController
     }
 }
-

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift
@@ -216,8 +216,10 @@ public struct LoginOptionsView: View {
         onConfigurationCompleted()
     }
 
-    internal func handleSimulatedDomainDiscovery(result: DomainDiscoveryResult) {
+    internal func handleSimulatedDomainDiscovery(result: DomainDiscoveryResult?) {
         SalesforceManager.shared.simulatedDomainDiscoveryResult = result
+        
+        // Proceed with login
         onConfigurationCompleted()
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/LoginOptionsViewController.swift
@@ -70,10 +70,8 @@ public struct LoginOptionsView: View {
 
     public var body: some View {
         VStack(spacing: 0) {
-            // Custom title bar with close button
-            TitleBarView(title: "Login Options", onDismiss: {
-                onConfigurationCompleted()
-            })
+            // Custom title bar with close button – trigger handler then dismiss so presenter can run its callback
+            TitleBarView(title: "Login Options", onDismiss: closeSheet)
 
             // Content
             ScrollView {
@@ -155,7 +153,13 @@ public struct LoginOptionsView: View {
         }
     }
 
-    // MARK: - Button Actions
+    // MARK: - Close / Button Actions
+
+    /// Invoked when the title bar close button is tapped. Call from tests to verify completion handler is run.
+    internal func closeSheet() {
+        onConfigurationCompleted()
+        dismiss()
+    }
 
     internal func handleStaticConfig() {
         // Parse scopes from space-separated string

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -315,7 +315,7 @@
                                                    image:nil
                                               identifier:nil
                                                  handler:^(__kindof UIAction* _Nonnull action) {
-            UIViewController *configPicker = [BootConfigPickerViewController makeViewControllerOnConfigurationCompleted:^{
+            UIViewController *configPicker = [LoginOptionsViewController makeViewControllerOnConfigurationCompleted:^{
                 [self dismissViewControllerAnimated:YES completion:^{
                     if ([self.delegate respondsToSelector:@selector(loginViewControllerDidChangeLoginOptions:)]) {
                         [self.delegate loginViewControllerDidChangeLoginOptions:self];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DomainDiscoveryCoordinator.swift
@@ -67,7 +67,18 @@ public class DomainDiscoveryCoordinator: NSObject {
     /// Call this from your WKNavigationDelegate when a navigation action occurs to detect and extract the result from the domain discovery callback URL.
     @objc(handleWithWebAction:)
     public func handle(action: WKNavigationAction) -> DomainDiscoveryResult? {
-        guard let url = action.request.url else {
+        let url: URL?
+        // When simulatedDomainDiscoveryResult is set and the login server is welcome.salesforce.com,
+        // we build a callback URL to trigger the code that handles the domain discovery callback,
+        // simulating the user picking a specific domain/username.
+        let requestHost = action.request.url?.host?.lowercased()
+        if let simulated = SalesforceManager.shared.simulatedDomainDiscoveryResult,
+           requestHost == "welcome.salesforce.com" {
+            url = Self.buildSimulatedCallbackURL(loginHint: simulated.loginHint, myDomain: simulated.myDomain)
+        } else {
+            url = action.request.url
+        }
+        guard let url = url else {
             return nil
         }
         if isDomainDiscoveryCallbackURL(url) {
@@ -92,6 +103,17 @@ public class DomainDiscoveryCoordinator: NSObject {
 }
 
 extension DomainDiscoveryCoordinator {
+    private static func buildSimulatedCallbackURL(loginHint: String, myDomain: String) -> URL? {
+        var components = URLComponents()
+        components.scheme = "sfdc"
+        components.host = "discocallback"
+        components.queryItems = [
+            URLQueryItem(name: "login_hint", value: loginHint),
+            URLQueryItem(name: "my_domain", value: myDomain)
+        ]
+        return components.url
+    }
+
     private static func buildDiscoveryURL(clientId: String, clientVersion: String, domain: String, callbackURL: String = DomainDiscovery.callbackURL.rawValue) -> NSURL? {
         var components = URLComponents()
         components.scheme = DomainDiscovery.URLComponent.scheme.rawValue

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BootConfigPickerViewControllerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BootConfigPickerViewControllerTests.swift
@@ -33,6 +33,7 @@ class LoginOptionsViewControllerTests: XCTestCase {
     var originalOAuthClientID: String!
     var originalOAuthCompletionURL: String!
     var originalScopes: Set<String>!
+    var originalSimulatedDomainDiscoveryResult: DomainDiscoveryResult?
     
     override func setUp() {
         super.setUp()
@@ -43,6 +44,7 @@ class LoginOptionsViewControllerTests: XCTestCase {
         originalOAuthClientID = UserAccountManager.shared.oauthClientID
         originalOAuthCompletionURL = UserAccountManager.shared.oauthCompletionURL
         originalScopes = UserAccountManager.shared.scopes
+        originalSimulatedDomainDiscoveryResult = SalesforceManager.shared.simulatedDomainDiscoveryResult
     }
     
     override func tearDown() {
@@ -52,6 +54,7 @@ class LoginOptionsViewControllerTests: XCTestCase {
         UserAccountManager.shared.oauthClientID = originalOAuthClientID
         UserAccountManager.shared.oauthCompletionURL = originalOAuthCompletionURL
         UserAccountManager.shared.scopes = originalScopes
+        SalesforceManager.shared.simulatedDomainDiscoveryResult = originalSimulatedDomainDiscoveryResult
         
         super.tearDown()
     }
@@ -118,26 +121,16 @@ class LoginOptionsViewControllerTests: XCTestCase {
     }
     
     func testStaticConfigButtonAction() {
-        let expectation = XCTestExpectation(description: "Static config button triggers handler")
-        var completionCalled = false
-        
-        // Create view with test static config values
+        // Create view with test static config values (save buttons do not call onConfigurationCompleted)
         let view = LoginOptionsView(
-            onConfigurationCompleted: {
-                completionCalled = true
-                expectation.fulfill()
-            },
+            onConfigurationCompleted: {},
             staticConsumerKey: "test_static_key",
             staticCallbackUrl: "test://static/callback",
             staticScopes: "api refresh_token web"
         )
         
-        // Trigger the static config handler
+        // Trigger the static config handler (saves config only; does not dismiss)
         view.handleStaticConfig()
-        
-        // Verify the completion callback was called
-        wait(for: [expectation], timeout: 2.0)
-        XCTAssertTrue(completionCalled, "Completion callback should be called")
         
         // Verify SalesforceManager was updated
         XCTAssertNotNil(SalesforceManager.shared.bootConfig, "BootConfig should be set")
@@ -153,24 +146,16 @@ class LoginOptionsViewControllerTests: XCTestCase {
     }
     
     func testDynamicConfigButtonAction() {
-        let expectation = XCTestExpectation(description: "Dynamic config button triggers handler")
-        var completionCalled = false
-        
+        // Save dynamic config does not call onConfigurationCompleted
         let view = LoginOptionsView(
-            onConfigurationCompleted: {
-                completionCalled = true
-                expectation.fulfill()
-            },
+            onConfigurationCompleted: {},
             dynamicConsumerKey: "test_dynamic_key",
             dynamicCallbackUrl: "test://dynamic/callback",
             dynamicScopes: "api id"
         )
         
-        // Trigger the dynamic config handler
+        // Trigger the dynamic config handler (saves config only; does not dismiss)
         view.handleDynamicBootconfig()
-        
-        wait(for: [expectation], timeout: 2.0)
-        XCTAssertTrue(completionCalled, "Completion callback should be called")
         
         // Verify runtime selector was set
         XCTAssertNotNil(SalesforceManager.shared.bootConfigRuntimeSelector, "Runtime selector should be set for dynamic config")
@@ -186,6 +171,44 @@ class LoginOptionsViewControllerTests: XCTestCase {
         }
         
         wait(for: [selectorExpectation], timeout: 1.0)
+    }
+
+    func testSimulatedDomainDiscoveryButtonAction() {
+        // Save simulated result does not call onConfigurationCompleted
+        let view = LoginOptionsView(
+            onConfigurationCompleted: {},
+            discoveryLoginHost: "test.my.salesforce.com",
+            discoveryUserName: "user@example.com"
+        )
+        
+        // Trigger the simulated domain discovery handler (saves result only; does not dismiss)
+        let result = DomainDiscoveryResult(loginHint: "user@example.com", myDomain: "test.my.salesforce.com")
+        view.handleSimulatedDomainDiscovery(result: result)
+        
+        // Verify SalesforceManager was updated
+        XCTAssertNotNil(SalesforceManager.shared.simulatedDomainDiscoveryResult, "Simulated domain discovery result should be set")
+        XCTAssertEqual(SalesforceManager.shared.simulatedDomainDiscoveryResult?.loginHint, "user@example.com")
+        XCTAssertEqual(SalesforceManager.shared.simulatedDomainDiscoveryResult?.myDomain, "test.my.salesforce.com")
+        
+        // Clearing the simulated result (e.g. empty login host in editor)
+        view.handleSimulatedDomainDiscovery(result: nil)
+        XCTAssertNil(SalesforceManager.shared.simulatedDomainDiscoveryResult, "Simulated result should be cleared when passing nil")
+    }
+
+    func testCompletionHandlerCalledWhenClosingSheet() {
+        let expectation = XCTestExpectation(description: "Completion handler called when sheet is closed")
+        var completionCalled = false
+
+        let view = LoginOptionsView(onConfigurationCompleted: {
+            completionCalled = true
+            expectation.fulfill()
+        })
+
+        // Simulate user tapping the title bar close button (same code path)
+        view.closeSheet()
+
+        wait(for: [expectation], timeout: 2.0)
+        XCTAssertTrue(completionCalled, "Completion handler should be called when closing the sheet")
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BootConfigPickerViewControllerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BootConfigPickerViewControllerTests.swift
@@ -26,7 +26,7 @@ import XCTest
 import SwiftUI
 @testable import SalesforceSDKCore
 
-class BootConfigPickerViewControllerTests: XCTestCase {
+class LoginOptionsViewControllerTests: XCTestCase {
     
     var originalBootConfig: BootConfig?
     var originalRuntimeSelector: BootConfigRuntimeSelector?
@@ -57,7 +57,7 @@ class BootConfigPickerViewControllerTests: XCTestCase {
     }
     
     func testMakeViewControllerHasSheetPresentationConfiguration() {
-        let viewController = BootConfigPickerViewController.makeViewController {
+        let viewController = LoginOptionsViewController.makeViewController {
             // No-op callback
         }
         
@@ -88,7 +88,7 @@ class BootConfigPickerViewControllerTests: XCTestCase {
         ]
         SalesforceManager.shared.bootConfig = BootConfig(testConfig)
         
-        let view = BootConfigPickerView {
+        let view = LoginOptionsView {
             // No-op callback
         }
         
@@ -122,7 +122,7 @@ class BootConfigPickerViewControllerTests: XCTestCase {
         var completionCalled = false
         
         // Create view with test static config values
-        let view = BootConfigPickerView(
+        let view = LoginOptionsView(
             onConfigurationCompleted: {
                 completionCalled = true
                 expectation.fulfill()
@@ -156,7 +156,7 @@ class BootConfigPickerViewControllerTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Dynamic config button triggers handler")
         var completionCalled = false
         
-        let view = BootConfigPickerView(
+        let view = LoginOptionsView(
             onConfigurationCompleted: {
                 completionCalled = true
                 expectation.fulfill()

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DiscoveryResultEditorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DiscoveryResultEditorTests.swift
@@ -1,0 +1,83 @@
+/*
+ Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+import SwiftUI
+@testable import SalesforceSDKCore
+
+class DiscoveryResultEditorTests: XCTestCase {
+
+    func testApplySimulatedResultWithHostAndUserCallsCallbackWithResult() {
+        var loginHost = "mycompany.my.salesforce.com"
+        var userName = "user@company.com"
+        var receivedResult: DomainDiscoveryResult?
+
+        let view = DiscoveryResultEditor(
+            loginHost: Binding(get: { loginHost }, set: { loginHost = $0 }),
+            userName: Binding(get: { userName }, set: { userName = $0 }),
+            onUseForSimulation: { receivedResult = $0 }
+        )
+
+        view.applySimulatedResult()
+
+        XCTAssertNotNil(receivedResult, "Callback should receive a result when host and user are set")
+        XCTAssertEqual(receivedResult?.myDomain, "mycompany.my.salesforce.com")
+        XCTAssertEqual(receivedResult?.loginHint, "user@company.com")
+    }
+
+    func testApplySimulatedResultWithEmptyHostCallsCallbackWithNil() {
+        var loginHost = ""
+        var userName = "user@company.com"
+        var receivedResult: DomainDiscoveryResult?
+
+        let view = DiscoveryResultEditor(
+            loginHost: Binding(get: { loginHost }, set: { loginHost = $0 }),
+            userName: Binding(get: { userName }, set: { userName = $0 }),
+            onUseForSimulation: { receivedResult = $0 }
+        )
+
+        view.applySimulatedResult()
+
+        XCTAssertNil(receivedResult, "Callback should receive nil when login host is empty")
+    }
+
+    func testApplySimulatedResultWithHostOnlyAllowsEmptyLoginHint() {
+        var loginHost = "mycompany.my.salesforce.com"
+        var userName = ""
+        var receivedResult: DomainDiscoveryResult?
+
+        let view = DiscoveryResultEditor(
+            loginHost: Binding(get: { loginHost }, set: { loginHost = $0 }),
+            userName: Binding(get: { userName }, set: { userName = $0 }),
+            onUseForSimulation: { receivedResult = $0 }
+        )
+
+        view.applySimulatedResult()
+
+        XCTAssertNotNil(receivedResult, "Callback should receive a result when only host is set")
+        XCTAssertEqual(receivedResult?.myDomain, "mycompany.my.salesforce.com")
+        XCTAssertEqual(receivedResult?.loginHint, "")
+    }
+
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
@@ -2,31 +2,16 @@ import XCTest
 @testable import SalesforceSDKCore
 import WebKit
 
-// Mock WKWebView to simulate navigation and callback
-class MockWKWebView: WKWebView {
-    var simulatedCallbackURL: URL?
-    var mockAction: WKNavigationAction?
-    override func load(_ request: URLRequest) -> WKNavigation? {
-        if let callbackURL = simulatedCallbackURL {
-            mockAction = MockNavigationAction(url: callbackURL) as WKNavigationAction
-        }
-        
-        if let delegate = self.navigationDelegate, let action = mockAction {
-            delegate.webView?(self, decidePolicyFor: action, decisionHandler: { _ in })
-        }
-        return nil
-    }
-}
-
+/// Tests for DomainDiscoveryCoordinator. We avoid creating WKWebView and calling load(_:)
+/// in the parsing tests because WKWebView initialization in a unit test context can be
+/// fragile and cause intermittent crashes. Instead we build a MockNavigationAction
+/// and call coordinator.handle(action:) directly.
 @MainActor
 final class DomainDiscoveryCoordinatorTests: XCTestCase {
 
     func testCallbackSuccess() async throws {
         // Given
-        let mockWebView = MockWKWebView()
         let coordinator = DomainDiscoveryCoordinator()
-        let credentials = try XCTUnwrap(OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false))
-        
         let expectedDomain = "foo.my.salesforce.com"
         let mockDomain = "https://\(expectedDomain)"
         let expectedLoginHint = "testuser@example.com"
@@ -34,13 +19,11 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         let encodedHint = try XCTUnwrap(expectedLoginHint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed))
         let callbackURLString = "sfdc://discocallback?my_domain=\(encodedDomain)&login_hint=\(encodedHint)"
         let callbackURL = try XCTUnwrap(URL(string: callbackURLString))
-        mockWebView.simulatedCallbackURL = callbackURL
-        
+        let action = MockNavigationAction(url: callbackURL)
+
         // When
-        coordinator.runMyDomainsDiscovery(on: mockWebView, with: credentials)
-        let mockAction = try XCTUnwrap(mockWebView.mockAction)
-        let results = coordinator.handle(action: mockAction)
-        
+        let results = coordinator.handle(action: action)
+
         // Then
         XCTAssertEqual(results?.myDomain, expectedDomain)
         XCTAssertEqual(results?.loginHint, expectedLoginHint)
@@ -48,59 +31,47 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
 
     func testMissingMyDomain() async throws {
         // Given
-        let mockWebView = MockWKWebView()
         let coordinator = DomainDiscoveryCoordinator()
-        let credentials = try XCTUnwrap(OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false))
         let expectedLoginHint = "testuser@example.com"
         let encodedHint = try XCTUnwrap(expectedLoginHint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed))
         let callbackURLString = "sfdc://discocallback?login_hint=\(encodedHint)"
         let callbackURL = try XCTUnwrap(URL(string: callbackURLString))
-        mockWebView.simulatedCallbackURL = callbackURL
-        
+        let action = MockNavigationAction(url: callbackURL)
+
         // When
-        coordinator.runMyDomainsDiscovery(on: mockWebView, with: credentials)
-        let mockAction = try XCTUnwrap(mockWebView.mockAction)
-        let results = coordinator.handle(action: mockAction)
-        
+        let results = coordinator.handle(action: action)
+
         // Then
         XCTAssertNil(results)
     }
 
     func testMissingLoginHint() async throws {
         // Given
-        let mockWebView = MockWKWebView()
         let coordinator = DomainDiscoveryCoordinator()
-        let credentials = try XCTUnwrap(OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false))
         let expectedDomain = "foo.my.salesforce.com"
         let mockDomain = "https://\(expectedDomain)"
         let encodedDomain = try XCTUnwrap(mockDomain.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed))
         let callbackURLString = "sfdc://discocallback?my_domain=\(encodedDomain)"
         let callbackURL = try XCTUnwrap(URL(string: callbackURLString))
-        mockWebView.simulatedCallbackURL = callbackURL
+        let action = MockNavigationAction(url: callbackURL)
 
         // When
-        coordinator.runMyDomainsDiscovery(on: mockWebView, with: credentials)
-        let mockAction = try XCTUnwrap(mockWebView.mockAction)
-        let results = coordinator.handle(action: mockAction)
-        
+        let results = coordinator.handle(action: action)
+
         // Then
         XCTAssertNil(results)
     }
 
     func testMalformedCallbackURL() async throws {
         // Given
-        let mockWebView = MockWKWebView()
         let coordinator = DomainDiscoveryCoordinator()
-        let credentials = try XCTUnwrap(OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false))
         let callbackURLString = "sfdc://discocallback?my_domain=&login_hint="
         let callbackURL = try XCTUnwrap(URL(string: callbackURLString))
-        mockWebView.simulatedCallbackURL = callbackURL
+        let action = MockNavigationAction(url: callbackURL)
 
         // When
-        coordinator.runMyDomainsDiscovery(on: mockWebView, with: credentials)
-        let mockAction = try XCTUnwrap(mockWebView.mockAction)
-        let results = coordinator.handle(action: mockAction)
-        
+        let results = coordinator.handle(action: action)
+
         // Then
         XCTAssertEqual(results?.myDomain, "")
         XCTAssertEqual(results?.loginHint, "")
@@ -108,26 +79,20 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
 
     func testNonCallbackURL() async throws {
         // Given
-        let mockWebView = MockWKWebView()
         let coordinator = DomainDiscoveryCoordinator()
-        let credentials = try XCTUnwrap(OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false))
         let nonCallbackURL = try XCTUnwrap(URL(string: "https://example.com"))
-        mockWebView.simulatedCallbackURL = nonCallbackURL
+        let action = MockNavigationAction(url: nonCallbackURL)
 
         // When
-        coordinator.runMyDomainsDiscovery(on: mockWebView, with: credentials)
-        let mockAction = try XCTUnwrap(mockWebView.mockAction)
-        let results = coordinator.handle(action: mockAction)
-        
+        let results = coordinator.handle(action: action)
+
         // Then
         XCTAssertNil(results)
     }
 
     func testSpecialCharactersInLoginHint() async throws {
         // Given
-        let mockWebView = MockWKWebView()
         let coordinator = DomainDiscoveryCoordinator()
-        let credentials = try XCTUnwrap(OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false))
         let expectedDomain = "foo.my.salesforce.com"
         let mockDomain = "https://\(expectedDomain)"
         let expectedLoginHint = "user+test@example.com"
@@ -135,13 +100,11 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         let encodedHint = try XCTUnwrap(expectedLoginHint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed))
         let callbackURLString = "sfdc://discocallback?my_domain=\(encodedDomain)&login_hint=\(encodedHint)"
         let callbackURL = try XCTUnwrap(URL(string: callbackURLString))
-        mockWebView.simulatedCallbackURL = callbackURL
+        let action = MockNavigationAction(url: callbackURL)
 
         // When
-        coordinator.runMyDomainsDiscovery(on: mockWebView, with: credentials)
-        let mockAction = try XCTUnwrap(mockWebView.mockAction)
-        let results = coordinator.handle(action: mockAction)
-    
+        let results = coordinator.handle(action: action)
+
         // Then
         XCTAssertEqual(results?.myDomain, expectedDomain)
         XCTAssertEqual(results?.loginHint, expectedLoginHint)
@@ -149,9 +112,7 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
 
     func testExtraQueryParameters() async throws {
         // Given
-        let mockWebView = MockWKWebView()
         let coordinator = DomainDiscoveryCoordinator()
-        let credentials = try XCTUnwrap(OAuthCredentials(identifier: "test", clientId: "client123", encrypted: false))
         let expectedDomain = "foo.my.salesforce.com"
         let mockDomain = "https://\(expectedDomain)"
         let expectedLoginHint = "testuser@example.com"
@@ -159,16 +120,14 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         let encodedHint = try XCTUnwrap(expectedLoginHint.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed))
         let callbackURLString = "sfdc://discocallback?my_domain=\(encodedDomain)&login_hint=\(encodedHint)&extra=foo&another=bar"
         let callbackURL = try XCTUnwrap(URL(string: callbackURLString))
-        mockWebView.simulatedCallbackURL = callbackURL
+        let action = MockNavigationAction(url: callbackURL)
 
         // When
-        coordinator.runMyDomainsDiscovery(on: mockWebView, with: credentials)
-    
-        let populatedAction = try XCTUnwrap(mockWebView.mockAction)
-        let results = try XCTUnwrap(coordinator.handle(action: populatedAction))
-    
+        let results = try XCTUnwrap(coordinator.handle(action: action))
+
         // Then
         XCTAssertEqual(results.myDomain, expectedDomain)
         XCTAssertEqual(results.loginHint, expectedLoginHint)
     }
+
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift
@@ -211,4 +211,3 @@ class LoginOptionsViewControllerTests: XCTestCase {
         XCTAssertTrue(completionCalled, "Completion handler should be called when closing the sheet")
     }
 }
-

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginOptionsPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginOptionsPageObject.swift
@@ -1,0 +1,198 @@
+/*
+ LoginOptionsPageObject.swift
+ AuthFlowTesterUITests
+
+ Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Foundation
+import XCTest
+import SalesforceSDKCore
+
+/// Page object for interacting with the Login Options sheet (LoginOptionsViewController / LoginOptionsView) during UI tests.
+/// Use after navigating to Login Options from the login screen (e.g. via Settings → Login Options).
+class LoginOptionsPageObject {
+    let app: XCUIApplication
+    let timeout: double_t = 5
+
+    init(testApp: XCUIApplication) {
+        app = testApp
+    }
+
+    /// Configures login options: flow switches, static/dynamic app config, and discovery result.
+    /// Call when the Login Options sheet is already visible.
+    func configure(
+        staticAppConfig: AppConfig?,
+        staticScopes: String,
+        dynamicAppConfig: AppConfig?,
+        dynamicScopes: String,
+        useWebServerFlow: Bool,
+        useHybridFlow: Bool,
+        discoveryLoginHost: String,
+        discoveryUsername: String,
+    ) -> Void {
+        setSwitchField(useWebServerFlowSwitch(), value: useWebServerFlow)
+        setSwitchField(useHybridSwitch(), value: useHybridFlow)
+
+        if let staticAppConfig = staticAppConfig {
+            let configJSON = buildConfigJSON(consumerKey: staticAppConfig.consumerKey, redirectUri: staticAppConfig.redirectUri, scopes: staticScopes)
+            importConfig(configJSON, isStaticConfiguration: true)
+        }
+        tap(saveStaticConfigButton())
+
+        if let dynamicAppConfig = dynamicAppConfig {
+            let configJSON = buildConfigJSON(consumerKey: dynamicAppConfig.consumerKey, redirectUri: dynamicAppConfig.redirectUri, scopes: dynamicScopes)
+            importConfig(configJSON, isStaticConfiguration: false)
+            tap(saveDynamicConfigButton())
+        }
+
+        let discoveryResultJSON = buildDiscoveryResultJSON(loginHost: discoveryLoginHost, username: discoveryUsername)
+        importDiscoveryResult(discoveryResultJSON)
+        tap(saveSimulatedResultButton())
+
+        tap(loginOptionsCloseButton())
+    }
+
+    private func buildConfigJSON(consumerKey: String, redirectUri: String, scopes: String) -> String {
+        let config: [String: String] = [
+            BootConfigJSONKeys.consumerKey: consumerKey,
+            BootConfigJSONKeys.redirectUri: redirectUri,
+            BootConfigJSONKeys.scopes: scopes
+        ]
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: config, options: []),
+              let jsonString = String(data: jsonData, encoding: .utf8) else {
+            return "{}"
+        }
+        return jsonString
+    }
+
+    private func buildDiscoveryResultJSON(loginHost: String, username: String) -> String {
+        let config: [String: String] = [
+            "login_hint": username,
+            "my_domain": loginHost
+        ]
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: config, options: []),
+              let jsonString = String(data: jsonData, encoding: .utf8) else {
+            return "{}"
+        }
+        return jsonString
+    }
+
+    private func importConfig(_ jsonString: String, isStaticConfiguration: Bool = true) {
+        tap(importConfigButton(useStaticConfiguration: isStaticConfiguration))
+
+        // Wait for alert to appear
+        let alert = importConfigAlert()
+        _ = alert.waitForExistence(timeout: timeout)
+
+        // Type into the alert's text field
+        let textField = importConfigTextField()
+        textField.typeText(jsonString)
+
+        tap(importAlertButton())
+    }
+
+    private func importDiscoveryResult(_ jsonString: String) {
+        tap(importDiscoveryResultButton())
+        let alert = importDiscoveryResultAlert()
+        _ = alert.waitForExistence(timeout: timeout)
+        let textField = alert.textFields.firstMatch
+        textField.typeText(jsonString)
+        tap(importDiscoveryResultAlertImportButton())
+    }
+
+    // MARK: - UI Element Accessors (LoginOptionsView)
+
+    private func useWebServerFlowSwitch() -> XCUIElement {
+        return app.switches["Use Web Server Flow"]
+    }
+
+    private func useHybridSwitch() -> XCUIElement {
+        return app.switches["Use Hybrid Flow"]
+    }
+
+    private func saveStaticConfigButton() -> XCUIElement {
+        return app.buttons["Save static config"]
+    }
+
+    private func saveDynamicConfigButton() -> XCUIElement {
+        return app.buttons["Save dynamic config"]
+    }
+
+    /// Returns the import button for either the static or dynamic configuration section.
+    private func importConfigButton(useStaticConfiguration: Bool = true) -> XCUIElement {
+        let buttons = app.buttons.matching(identifier: "importConfigButton")
+        let index = useStaticConfiguration ? 0 : 1
+        return buttons.element(boundBy: index)
+    }
+
+    private func importConfigAlert() -> XCUIElement {
+        return app.alerts["Import Configuration"]
+    }
+
+    private func importConfigTextField() -> XCUIElement {
+        return importConfigAlert().textFields.firstMatch
+    }
+
+    private func importAlertButton() -> XCUIElement {
+        return importConfigAlert().buttons["Import"]
+    }
+
+    private func importDiscoveryResultButton() -> XCUIElement {
+        return app.buttons["importDiscoveryResultButton"]
+    }
+
+    private func importDiscoveryResultAlert() -> XCUIElement {
+        return app.alerts["Import Discovery Result"]
+    }
+
+    private func importDiscoveryResultAlertImportButton() -> XCUIElement {
+        return importDiscoveryResultAlert().buttons["Import"]
+    }
+
+    private func saveSimulatedResultButton() -> XCUIElement {
+        return app.buttons["saveSimulatedResultButton"]
+    }
+
+    private func loginOptionsCloseButton() -> XCUIElement {
+        return app.buttons["loginOptionsCloseButton"]
+    }
+
+    // MARK: - Actions
+
+    private func tap(_ element: XCUIElement) {
+        _ = element.waitForExistence(timeout: timeout)
+        element.tap()
+    }
+
+    private func setSwitchField(_ switchField: XCUIElement, value: Bool) {
+        _ = switchField.waitForExistence(timeout: timeout)
+
+        // Switch values are "0" (off) or "1" (on) in XCTest
+        let currentValue = (switchField.value as? String) == "1"
+
+        if currentValue != value {
+            tap(switchField)
+        }
+    }
+}

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -80,7 +80,7 @@ class LoginPageObject {
     
     func performWelcomeLogin(password: String) {
         setTextField(passwordField(), value: password)
-        tap(passwordFieldLabel()) // click on label to hide keyboard
+        tap(usernameFieldLabel()) // click on label to hide keyboard
         tap(loginButton())
         tapIfPresent(allowButton())
     }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -43,6 +43,10 @@ class LoginPageObject {
         return loginNavigationBar().waitForExistence(timeout: timeout)
     }
     
+    func hasFilledUsernameField(username: String) -> Bool {
+        return app.staticTexts[username].waitForExistence(timeout: timeout)
+    }
+    
     func switchToLSCIfShowingAdvancedAuthentication() -> Void {
         if (isShowingAdvancedAuth()) {
             tap(advancedAuthCloseButton())
@@ -74,6 +78,13 @@ class LoginPageObject {
         tapIfPresent(allowButton())
     }
     
+    func performWelcomeLogin(password: String) {
+        setTextField(passwordField(), value: password)
+        tap(passwordFieldLabel()) // click on label to hide keyboard
+        tap(loginButton())
+        tapIfPresent(allowButton())
+    }
+    
     func configureLoginOptions(
         staticAppConfig: AppConfig?,
         staticScopes: String,
@@ -81,6 +92,8 @@ class LoginPageObject {
         dynamicScopes: String,
         useWebServerFlow: Bool,
         useHybridFlow: Bool,
+        discoveryLoginHost: String,
+        discoveryUsername: String,
     ) -> Void {
         tap(settingsButton())
         tap(loginOptionsButton())
@@ -93,7 +106,7 @@ class LoginPageObject {
         }
         // In all cases - we want the static config to be set
         tap(useStaticConfigButton())
-
+        
         // Setting dynamic config when provided
         if let dynamicAppConfig = dynamicAppConfig {
             tap(settingsButton())
@@ -102,6 +115,13 @@ class LoginPageObject {
             importConfig(configJSON, isStaticConfiguration: false)
             tap(useDynamicConfigButton())
         }
+        
+        // Setting (or unsetting) simulated domain discovery
+        tap(settingsButton())
+        tap(loginOptionsButton())
+        let discoveryResultJSON = buildDiscoveryResultJSON(loginHost: discoveryLoginHost, username: discoveryUsername)
+        importDiscoveryResult(discoveryResultJSON)
+        tap(useForDomainDiscoverySimulationButton())
     }
     
     private func buildConfigJSON(consumerKey: String, redirectUri: String, scopes: String) -> String {
@@ -109,6 +129,18 @@ class LoginPageObject {
             BootConfigJSONKeys.consumerKey: consumerKey,
             BootConfigJSONKeys.redirectUri: redirectUri,
             BootConfigJSONKeys.scopes: scopes
+        ]
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: config, options: []),
+              let jsonString = String(data: jsonData, encoding: .utf8) else {
+            return "{}"
+        }
+        return jsonString
+    }
+
+    private func buildDiscoveryResultJSON(loginHost: String, username: String) -> String {
+        let config: [String: String] = [
+            "login_hint": username,
+            "my_domain": loginHost
         ]
         guard let jsonData = try? JSONSerialization.data(withJSONObject: config, options: []),
               let jsonString = String(data: jsonData, encoding: .utf8) else {
@@ -129,6 +161,15 @@ class LoginPageObject {
         textField.typeText(jsonString)
         
         tap(importAlertButton())
+    }
+
+    private func importDiscoveryResult(_ jsonString: String) {
+        tap(importDiscoveryResultButton())
+        let alert = importDiscoveryResultAlert()
+        _ = alert.waitForExistence(timeout: timeout)
+        let textField = alert.textFields.firstMatch
+        textField.typeText(jsonString)
+        tap(importDiscoveryResultAlertImportButton())
     }
     
     // MARK: - UI Element Accessors
@@ -255,6 +296,22 @@ class LoginPageObject {
     private func importAlertButton() -> XCUIElement {
         return importConfigAlert().buttons["Import"]
     }
+
+    private func importDiscoveryResultButton() -> XCUIElement {
+        return app.buttons["importDiscoveryResultButton"]
+    }
+
+    private func importDiscoveryResultAlert() -> XCUIElement {
+        return app.alerts["Import Discovery Result"]
+    }
+
+    private func importDiscoveryResultAlertImportButton() -> XCUIElement {
+        return importDiscoveryResultAlert().buttons["Import"]
+    }
+
+    private func useForDomainDiscoverySimulationButton() -> XCUIElement {
+        return app.buttons["useForDomainDiscoverySimulationButton"]
+    }
     
     private func advancedAuthCloseButton() -> XCUIElement {
         return app.otherElements["TopBrowserBar"].buttons["Close"]
@@ -308,7 +365,7 @@ class LoginPageObject {
     }
     
     // MARK: - Other
-
+    
     private func hasHost(host: String) -> Bool {
         let row = hostRow(host: host)
         return row.waitForExistence(timeout: timeout)

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -236,7 +236,7 @@ class LoginPageObject {
     }
     
     /// Returns the import button for either the static or dynamic configuration section.
-    /// The BootConfigPickerView has two BootConfigEditor sections - the first for static config, the second for dynamic config.
+    /// The LoginOptionsView has two BootConfigEditor sections - the first for static config, the second for dynamic config.
     private func importConfigButton(useStaticConfiguration: Bool = true) -> XCUIElement {
         let buttons = app.buttons.matching(identifier: "importConfigButton")
         let index = useStaticConfiguration ? 0 : 1

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -97,76 +97,19 @@ class LoginPageObject {
     ) -> Void {
         tap(settingsButton())
         tap(loginOptionsButton())
-        setSwitchField(useWebServerFlowSwitch(), value: useWebServerFlow)
-        setSwitchField(useHybridSwitch(), value: useHybridFlow)
-        
-        if let staticAppConfig = staticAppConfig {
-            let configJSON = buildConfigJSON(consumerKey: staticAppConfig.consumerKey, redirectUri: staticAppConfig.redirectUri, scopes: staticScopes)
-            importConfig(configJSON, isStaticConfiguration: true)
-        }
-        tap(saveStaticConfigButton())
-        
-        if let dynamicAppConfig = dynamicAppConfig {
-            let configJSON = buildConfigJSON(consumerKey: dynamicAppConfig.consumerKey, redirectUri: dynamicAppConfig.redirectUri, scopes: dynamicScopes)
-            importConfig(configJSON, isStaticConfiguration: false)
-            tap(saveDynamicConfigButton())
-        }
-        
-        let discoveryResultJSON = buildDiscoveryResultJSON(loginHost: discoveryLoginHost, username: discoveryUsername)
-        importDiscoveryResult(discoveryResultJSON)
-        tap(saveSimulatedResultButton())
-        
-        tap(loginOptionsCloseButton())
-    }
-    
-    private func buildConfigJSON(consumerKey: String, redirectUri: String, scopes: String) -> String {
-        let config: [String: String] = [
-            BootConfigJSONKeys.consumerKey: consumerKey,
-            BootConfigJSONKeys.redirectUri: redirectUri,
-            BootConfigJSONKeys.scopes: scopes
-        ]
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: config, options: []),
-              let jsonString = String(data: jsonData, encoding: .utf8) else {
-            return "{}"
-        }
-        return jsonString
+        let loginOptionsPage = LoginOptionsPageObject(testApp: app)
+        loginOptionsPage.configure(
+            staticAppConfig: staticAppConfig,
+            staticScopes: staticScopes,
+            dynamicAppConfig: dynamicAppConfig,
+            dynamicScopes: dynamicScopes,
+            useWebServerFlow: useWebServerFlow,
+            useHybridFlow: useHybridFlow,
+            discoveryLoginHost: discoveryLoginHost,
+            discoveryUsername: discoveryUsername
+        )
     }
 
-    private func buildDiscoveryResultJSON(loginHost: String, username: String) -> String {
-        let config: [String: String] = [
-            "login_hint": username,
-            "my_domain": loginHost
-        ]
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: config, options: []),
-              let jsonString = String(data: jsonData, encoding: .utf8) else {
-            return "{}"
-        }
-        return jsonString
-    }
-    
-    private func importConfig(_ jsonString: String, isStaticConfiguration: Bool = true) {
-        tap(importConfigButton(useStaticConfiguration: isStaticConfiguration))
-        
-        // Wait for alert to appear
-        let alert = importConfigAlert()
-        _ = alert.waitForExistence(timeout: timeout)
-        
-        // Type into the alert's text field
-        let textField = importConfigTextField()
-        textField.typeText(jsonString)
-        
-        tap(importAlertButton())
-    }
-
-    private func importDiscoveryResult(_ jsonString: String) {
-        tap(importDiscoveryResultButton())
-        let alert = importDiscoveryResultAlert()
-        _ = alert.waitForExistence(timeout: timeout)
-        let textField = alert.textFields.firstMatch
-        textField.typeText(jsonString)
-        tap(importDiscoveryResultAlertImportButton())
-    }
-    
     // MARK: - UI Element Accessors
     
     private func loginNavigationBar() -> XCUIElement {
@@ -238,80 +181,7 @@ class LoginPageObject {
     private func toolbarDoneButton() -> XCUIElement {
         return app.toolbars["Toolbar"].buttons["Done"]
     }
-    
-    private func useWebServerFlowSwitch() -> XCUIElement {
-        return app.switches["Use Web Server Flow"]
-    }
 
-    private func useHybridSwitch() -> XCUIElement {
-        return app.switches["Use Hybrid Flow"]
-    }
-
-    private func staticConfigurationSection() -> XCUIElement {
-        return app.buttons["Static Configuration"]
-    }
-    
-    private func consumerKeyField() -> XCUIElement {
-        return app.textFields["consumerKeyTextField"]
-    }
-    
-    private func callbackUrlField() -> XCUIElement {
-        return app.textFields["callbackUrlTextField"]
-    }
-    
-    private func scopesField() -> XCUIElement {
-        return app.textFields["scopesTextField"]
-    }
-    
-    private func saveStaticConfigButton() -> XCUIElement {
-        return app.buttons["Save static config"]
-    }
-
-    private func saveDynamicConfigButton() -> XCUIElement {
-        return app.buttons["Save dynamic config"]
-    }
-    
-    /// Returns the import button for either the static or dynamic configuration section.
-    /// The LoginOptionsView has two BootConfigEditor sections - the first for static config, the second for dynamic config.
-    private func importConfigButton(useStaticConfiguration: Bool = true) -> XCUIElement {
-        let buttons = app.buttons.matching(identifier: "importConfigButton")
-        let index = useStaticConfiguration ? 0 : 1
-        return buttons.element(boundBy: index)
-    }
-    
-    private func importConfigAlert() -> XCUIElement {
-        return app.alerts["Import Configuration"]
-    }
-    
-    private func importConfigTextField() -> XCUIElement {
-        // Access text field through the alert - SwiftUI alert TextFields are accessed this way
-        return importConfigAlert().textFields.firstMatch
-    }
-    
-    private func importAlertButton() -> XCUIElement {
-        return importConfigAlert().buttons["Import"]
-    }
-
-    private func importDiscoveryResultButton() -> XCUIElement {
-        return app.buttons["importDiscoveryResultButton"]
-    }
-
-    private func importDiscoveryResultAlert() -> XCUIElement {
-        return app.alerts["Import Discovery Result"]
-    }
-
-    private func importDiscoveryResultAlertImportButton() -> XCUIElement {
-        return importDiscoveryResultAlert().buttons["Import"]
-    }
-
-    private func saveSimulatedResultButton() -> XCUIElement {
-        return app.buttons["saveSimulatedResultButton"]
-    }
-
-    private func loginOptionsCloseButton() -> XCUIElement {
-        return app.buttons["loginOptionsCloseButton"]
-    }
-    
     private func advancedAuthCloseButton() -> XCUIElement {
         return app.otherElements["TopBrowserBar"].buttons["Close"]
     }
@@ -349,18 +219,6 @@ class LoginPageObject {
         
         textField.typeText(value)
         tapIfPresent(toolbarDoneButton())
-    }
-    
-    private func setSwitchField(_ switchField: XCUIElement, value: Bool) {
-        _ = switchField.waitForExistence(timeout: timeout)
-        
-        // Switch values are "0" (off) or "1" (on) in XCTest
-        let currentValue = (switchField.value as? String) == "1"
-        
-        // Only tap if the current state differs from desired state
-        if currentValue != value {
-            tap(switchField)
-        }
     }
     
     // MARK: - Other

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -104,24 +104,19 @@ class LoginPageObject {
             let configJSON = buildConfigJSON(consumerKey: staticAppConfig.consumerKey, redirectUri: staticAppConfig.redirectUri, scopes: staticScopes)
             importConfig(configJSON, isStaticConfiguration: true)
         }
-        // In all cases - we want the static config to be set
-        tap(useStaticConfigButton())
+        tap(saveStaticConfigButton())
         
-        // Setting dynamic config when provided
         if let dynamicAppConfig = dynamicAppConfig {
-            tap(settingsButton())
-            tap(loginOptionsButton())
             let configJSON = buildConfigJSON(consumerKey: dynamicAppConfig.consumerKey, redirectUri: dynamicAppConfig.redirectUri, scopes: dynamicScopes)
             importConfig(configJSON, isStaticConfiguration: false)
-            tap(useDynamicConfigButton())
+            tap(saveDynamicConfigButton())
         }
         
-        // Setting (or unsetting) simulated domain discovery
-        tap(settingsButton())
-        tap(loginOptionsButton())
         let discoveryResultJSON = buildDiscoveryResultJSON(loginHost: discoveryLoginHost, username: discoveryUsername)
         importDiscoveryResult(discoveryResultJSON)
-        tap(useForDomainDiscoverySimulationButton())
+        tap(saveSimulatedResultButton())
+        
+        tap(loginOptionsCloseButton())
     }
     
     private func buildConfigJSON(consumerKey: String, redirectUri: String, scopes: String) -> String {
@@ -268,12 +263,12 @@ class LoginPageObject {
         return app.textFields["scopesTextField"]
     }
     
-    private func useStaticConfigButton() -> XCUIElement {
-        return app.buttons["Use static config"]
+    private func saveStaticConfigButton() -> XCUIElement {
+        return app.buttons["Save static config"]
     }
 
-    private func useDynamicConfigButton() -> XCUIElement {
-        return app.buttons["Use dynamic config"]
+    private func saveDynamicConfigButton() -> XCUIElement {
+        return app.buttons["Save dynamic config"]
     }
     
     /// Returns the import button for either the static or dynamic configuration section.
@@ -309,8 +304,12 @@ class LoginPageObject {
         return importDiscoveryResultAlert().buttons["Import"]
     }
 
-    private func useForDomainDiscoverySimulationButton() -> XCUIElement {
-        return app.buttons["useForDomainDiscoverySimulationButton"]
+    private func saveSimulatedResultButton() -> XCUIElement {
+        return app.buttons["saveSimulatedResultButton"]
+    }
+
+    private func loginOptionsCloseButton() -> XCUIElement {
+        return app.buttons["loginOptionsCloseButton"]
     }
     
     private func advancedAuthCloseButton() -> XCUIElement {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/BeaconLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/BeaconLoginTests.swift
@@ -32,7 +32,7 @@ import XCTest
 ///
 /// NB: Tests use the first user from ui_test_config.json
 ///
-class BeaconLoginTests: BaseAuthFlowTesterTest {
+class BeaconLoginTests: BaseAuthFlowTester {
     
     // MARK: - Login Host Configuration
     
@@ -74,37 +74,5 @@ class BeaconLoginTests: BaseAuthFlowTesterTest {
     /// Login with Beacon advanced JWT using all scopes and web server flow.
     func testBeaconAdvancedJwt_AllScopes() throws {
         launchLoginAndValidate(loginHost: loginHostConfig(), staticAppConfigName: .beaconAdvancedJwt, staticScopeSelection: .all)
-    }
-    
-    // MARK: - Using dynamic config
-    
-    /// Login with Beacon advanced JWT using default scopes and web server flow provided as dynamic configuration.
-    /// Restart the application and validate it still works afterwards
-    func testBeaconAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart() throws {
-        launchLoginAndValidate(
-            loginHost: loginHostConfig(),
-            staticAppConfigName: .beaconAdvancedOpaque,
-            dynamicAppConfigName: .beaconAdvancedJwt
-        )
-        restartAndValidate(
-            loginHost: loginHostConfig(),
-            userAppConfigName: .beaconAdvancedJwt
-        )
-    }
-
-    /// Login with Beacon advanced JWT using subset of scopes and web server flow provided as dynamic configuration.
-    /// Restart the application and validate it still works afterwards
-    func testBeaconAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart() throws {
-        launchLoginAndValidate(
-            loginHost: loginHostConfig(),
-            staticAppConfigName: .beaconAdvancedOpaque,
-            dynamicAppConfigName: .beaconAdvancedJwt,
-            dynamicScopeSelection: .subset
-        )
-        restartAndValidate(
-            loginHost: loginHostConfig(),
-            userAppConfigName: .beaconAdvancedJwt,
-            userScopeSelection: .subset
-        )
     }
 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DefaultScopesLegacyLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DefaultScopesLegacyLoginTests.swift
@@ -1,0 +1,53 @@
+/*
+ DefaultScopesLegacyLoginTests.swift
+ AuthFlowTesterUITests
+
+ Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+
+/// Legacy login tests using default scopes (CA advanced opaque).
+/// NB: Tests use the first user from ui_test_config.json
+class DefaultScopesLegacyLoginTests: BaseAuthFlowTester {
+
+    /// Login with CA advanced opaque using default scopes and web server flow.
+    func testCAAdvancedOpaque_DefaultScopes_WebServerFlow() throws {
+        launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque)
+    }
+
+    /// Login with CA advanced opaque using default scopes and (non-hybrid) web server flow.
+    func testCAAdvancedOpaque_DefaultScopes_WebServerFlow_NotHybrid() throws {
+        launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque, useHybridFlow: false)
+    }
+
+    /// Login with CA advanced opaque using default scopes and user agent flow.
+    func testCAAdvancedOpaque_DefaultScopes_UserAgentFlow() throws {
+        launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque, useWebServerFlow: false)
+    }
+
+    /// Login with CA advanced opaque using default scopes and (non-hybrid) user agent flow.
+    func testCAAdvancedOpaque_DefaultScopes_UserAgentFlow_NotHybrid() throws {
+        launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque, useWebServerFlow: false, useHybridFlow: false)
+    }
+}

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DynamicConfigLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DynamicConfigLoginTests.swift
@@ -1,0 +1,113 @@
+/*
+ DynamicConfigLoginTests.swift
+ AuthFlowTesterUITests
+
+ Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+
+/// Tests for login flows using dynamic (runtime-selected) app configuration.
+/// Covers CA, ECA, and Beacon configs with dynamic config selection and restart validation.
+class DynamicConfigLoginTests: BaseAuthFlowTester {
+
+    // MARK: - CA Dynamic Configuration
+
+    /// Login with CA advanced JWT using default scopes and web server flow provided as dynamic configuration. Restart and validate.
+    func testCAAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart() throws {
+        launchLoginAndValidate(
+            staticAppConfigName: .caAdvancedOpaque,
+            dynamicAppConfigName: .caAdvancedJwt
+        )
+        restartAndValidate(
+            userAppConfigName: .caAdvancedJwt
+        )
+    }
+
+    /// Login with CA advanced JWT using subset of scopes and web server flow provided as dynamic configuration. Restart and validate.
+    func testCAAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart() throws {
+        launchLoginAndValidate(
+            staticAppConfigName: .caAdvancedOpaque,
+            dynamicAppConfigName: .caAdvancedJwt,
+            dynamicScopeSelection: .subset)
+        restartAndValidate(
+            userAppConfigName: .caAdvancedJwt,
+            userScopeSelection: .subset
+        )
+    }
+
+    // MARK: - ECA Dynamic Configuration
+
+    /// Login with ECA advanced JWT using default scopes and web server flow provided as dynamic configuration. Restart and validate.
+    func testECAAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart() throws {
+        launchLoginAndValidate(
+            staticAppConfigName: .ecaAdvancedOpaque,
+            dynamicAppConfigName: .ecaAdvancedJwt
+        )
+        restartAndValidate(
+            userAppConfigName: .ecaAdvancedJwt
+        )
+    }
+
+    /// Login with ECA advanced JWT using subset of scopes and web server flow provided as dynamic configuration. Restart and validate.
+    func testECAAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart() throws {
+        launchLoginAndValidate(
+            staticAppConfigName: .ecaAdvancedOpaque,
+            dynamicAppConfigName: .ecaAdvancedJwt,
+            dynamicScopeSelection: .subset)
+        restartAndValidate(
+            userAppConfigName: .ecaAdvancedJwt,
+            userScopeSelection: .subset
+        )
+    }
+
+    // MARK: - Beacon Dynamic Configuration
+
+    /// Login with Beacon advanced JWT using default scopes and web server flow provided as dynamic configuration. Restart and validate.
+    func testBeaconAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart() throws {
+        launchLoginAndValidate(
+            loginHost: .regularAuth,
+            staticAppConfigName: .beaconAdvancedOpaque,
+            dynamicAppConfigName: .beaconAdvancedJwt
+        )
+        restartAndValidate(
+            loginHost: .regularAuth,
+            userAppConfigName: .beaconAdvancedJwt
+        )
+    }
+
+    /// Login with Beacon advanced JWT using subset of scopes and web server flow provided as dynamic configuration. Restart and validate.
+    func testBeaconAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart() throws {
+        launchLoginAndValidate(
+            loginHost: .regularAuth,
+            staticAppConfigName: .beaconAdvancedOpaque,
+            dynamicAppConfigName: .beaconAdvancedJwt,
+            dynamicScopeSelection: .subset
+        )
+        restartAndValidate(
+            loginHost: .regularAuth,
+            userAppConfigName: .beaconAdvancedJwt,
+            userScopeSelection: .subset
+        )
+    }
+}

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ECALoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ECALoginTests.swift
@@ -32,7 +32,7 @@ import XCTest
 ///
 /// NB: Tests use the first user from ui_test_config.json
 ///
-class ECALoginTests: BaseAuthFlowTesterTest {
+class ECALoginTests: BaseAuthFlowTester {
     
     // MARK: - ECA Opaque Tests
     
@@ -66,32 +66,5 @@ class ECALoginTests: BaseAuthFlowTesterTest {
     /// Login with ECA advanced JWT using all scopes and web server flow.
     func testECAAdvancedJwt_AllScopes() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaAdvancedJwt, staticScopeSelection: .all)
-    }
-    
-    // MARK: - Using dynamic config
-    
-    /// Login with ECA advanced JWT using default scopes and web server flow provided as dynamic configuration.
-    /// Restart the application and validate it still works afterwards
-    func testECAAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart() throws {
-        launchLoginAndValidate(
-            staticAppConfigName: .ecaAdvancedOpaque,
-            dynamicAppConfigName: .ecaAdvancedJwt
-        )
-        restartAndValidate(
-            userAppConfigName: .ecaAdvancedJwt
-        )
-    }
-
-    /// Login with ECA advanced JWT using subset of scopes and web server flow provided as dynamic configuration.
-    /// Restart the application and validate it still works afterwards
-    func testECAAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart() throws {
-        launchLoginAndValidate(
-            staticAppConfigName: .ecaAdvancedOpaque,
-            dynamicAppConfigName: .ecaAdvancedJwt,
-            dynamicScopeSelection: .subset)
-        restartAndValidate(
-            userAppConfigName: .ecaAdvancedJwt,
-            userScopeSelection: .subset
-        )
     }
 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/LegacyLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/LegacyLoginTests.swift
@@ -34,15 +34,10 @@ import XCTest
 ///
 /// NB: Tests use the first user from ui_test_config.json
 ///
-class LegacyLoginTests: BaseAuthFlowTesterTest {
+class LegacyLoginTests: BaseAuthFlowTester {
 
     // MARK: - CA Web Server Flow Tests
-    
-    /// Login with CA advanced opaque using default scopes and web server flow.
-    func testCAAdvancedOpaque_DefaultScopes_WebServerFlow() throws {
-        launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque)
-    }
-    
+
     /// Login with CA advanced opaque using subset of scopes and web server flow.
     func testCAAdvancedOpaque_SubsetScopes_WebServerFlow() throws {
         launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque, staticScopeSelection: .subset, useHybridFlow: false)
@@ -55,11 +50,6 @@ class LegacyLoginTests: BaseAuthFlowTesterTest {
     
     // MARK: - CA Non-hybrid Web Server Flow Tests
 
-    /// Login with CA advanced opaque using default scopes and (non-hybrid) web server  flow.
-    func testCAAdvancedOpaque_DefaultScopes_WebServerFlow_NotHybrid() throws {
-        launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque, useHybridFlow: false)
-    }
-    
     /// Login with CA advanced opaque using subset of scopes and (non-hybrid) web server flow.
     func testCAAdvancedOpaque_SubsetScopes_WebServerFlow_NotHybrid() throws {
         launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque, staticScopeSelection: .subset, useHybridFlow: false)
@@ -71,12 +61,7 @@ class LegacyLoginTests: BaseAuthFlowTesterTest {
     }
     
     // MARK: - CA User Agent Flow Tests
-    
-    /// Login with CA advanced opaque using default scopes and user agent flow.
-    func testCAAdvancedOpaque_DefaultScopes_UserAgentFlow() throws {
-        launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque, useWebServerFlow: false)
-    }
-    
+
     /// Login with CA advanced opaque using subset of scopes and user agent flow.
     func testCAAdvancedOpaque_SubsetScopes_UserAgentFlow() throws {
         launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque, staticScopeSelection: .subset, useWebServerFlow: false)
@@ -88,13 +73,8 @@ class LegacyLoginTests: BaseAuthFlowTesterTest {
     }
     
     // MARK: - CA Non-hybrid User Agent Flow Tests
-    
-    /// Login with CA advanced opaque using default scopes and (non-hybrid) user agent  flow.
-    func testCAAdvancedOpaque_DefaultScopes_UserAgentFlow_NotHybrid() throws {
-        launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque, useWebServerFlow: false, useHybridFlow: false)
-    }
-    
-    /// Login with CA advanced opaque using subset of scopes and (non-hybrid) user agent  flow.
+
+    /// Login with CA advanced opaque using subset of scopes and (non-hybrid) user agent flow.
     func testCAAdvancedOpaque_SubsetScopes_UserAgentFlow_NotHybrid() throws {
         launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque, staticScopeSelection: .subset, useWebServerFlow: false, useHybridFlow: false)
     }
@@ -103,33 +83,5 @@ class LegacyLoginTests: BaseAuthFlowTesterTest {
     func testCAAdvancedOpaque_AllScopes_UserAgentFlow_NotHybrid() throws {
         launchLoginAndValidate(staticAppConfigName: .caAdvancedOpaque, staticScopeSelection: .all, useWebServerFlow: false, useHybridFlow: false)
     }
-    
-    // MARK: - Using dynamic config
-    
-    /// Login with CA advanced JWT using default scopes and web server flow provided as dynamic configuration.
-    /// Restart the application and validate it still works afterwards
-    func testCAAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart() throws {
-        launchLoginAndValidate(
-            staticAppConfigName: .caAdvancedOpaque,
-            dynamicAppConfigName: .caAdvancedJwt
-        )
-        restartAndValidate(
-            userAppConfigName: .caAdvancedJwt
-        )
-    }
-
-    /// Login with CA advanced JWT using subset of scopes and web server flow provided as dynamic configuration.
-    /// Restart the application and validate it still works afterwards
-    func testCAAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart() throws {
-        launchLoginAndValidate(
-            staticAppConfigName: .caAdvancedOpaque,
-            dynamicAppConfigName: .caAdvancedJwt,
-            dynamicScopeSelection: .subset)
-        restartAndValidate(
-            userAppConfigName: .caAdvancedJwt,
-            userScopeSelection: .subset
-        )
-    }
-
 }
 

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/MigrationTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/MigrationTests.swift
@@ -33,7 +33,7 @@ import XCTest
 ///
 /// NB: Tests use the second user from ui_test_config.json
 ///
-class MigrationTests: BaseAuthFlowTesterTest {
+class MigrationTests: BaseAuthFlowTester {
     
     // MARK: - Migration within same app (scope upgrade)
 

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/MultiUserLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/MultiUserLoginTests.swift
@@ -35,7 +35,7 @@ import XCTest
 ///
 /// NB: Tests use the fourth and fifth user from ui_test_config.json
 ///
-class MultiUserLoginTests: BaseAuthFlowTesterTest {
+class MultiUserLoginTests: BaseAuthFlowTester {
         
     // MARK: - Both Users Static Config
     

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/WelcomeLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/WelcomeLoginTests.swift
@@ -1,0 +1,71 @@
+/*
+ WelcomeLoginTests.swift
+ AuthFlowTesterUITests
+
+ Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+
+/// Tests for welcome discovery login flows.
+class WelcomeLoginTests: BaseAuthFlowTester {
+
+    /// Welcome discovery with regular auth host and static config.
+    func testWelcomeDiscoveryWithRegularAuthLoginHost() {
+        launchLoginAndValidate(
+            loginHost: .regularAuth,
+            staticAppConfigName: .ecaAdvancedOpaque,
+            useWelcomeDiscovery: true
+        )
+    }
+
+    /// Welcome discovery with advanced auth host and static config.
+    func testWelcomeDiscoveryWithAdvancedAuthLoginHost() {
+        launchLoginAndValidate(
+            loginHost: .advancedAuth,
+            staticAppConfigName: .ecaAdvancedOpaque,
+            useWelcomeDiscovery: true
+        )
+    }
+
+    /// Welcome discovery with regular auth host and dynamic config selection.
+    func testWelcomeDiscoveryWithRegularAuthLoginHostAndDynamicConfig() throws {
+        launchLoginAndValidate(
+            loginHost: .regularAuth,
+            staticAppConfigName: .ecaAdvancedOpaque,
+            dynamicAppConfigName: .ecaAdvancedJwt,
+            useWelcomeDiscovery: true
+        )
+    }
+
+    /// Welcome discovery with advanced auth host and dynamic config selection.
+    func testWelcomeDiscoveryWithAdvancedAuthLoginHostAndDynamicConfig() throws {
+        launchLoginAndValidate(
+            loginHost: .advancedAuth,
+            staticAppConfigName: .ecaAdvancedOpaque,
+            dynamicAppConfigName: .ecaAdvancedJwt,
+            useWelcomeDiscovery: true
+        )
+    }
+
+}

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/WelcomeLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/WelcomeLoginTests.swift
@@ -43,7 +43,7 @@ class WelcomeLoginTests: BaseAuthFlowTester {
     func testWelcomeDiscoveryWithAdvancedAuthLoginHost() {
         launchLoginAndValidate(
             loginHost: .advancedAuth,
-            staticAppConfigName: .ecaAdvancedOpaque,
+            staticAppConfigName: .beaconAdvancedOpaque,
             useWelcomeDiscovery: true
         )
     }
@@ -62,8 +62,8 @@ class WelcomeLoginTests: BaseAuthFlowTester {
     func testWelcomeDiscoveryWithAdvancedAuthLoginHostAndDynamicConfig() throws {
         launchLoginAndValidate(
             loginHost: .advancedAuth,
-            staticAppConfigName: .ecaAdvancedOpaque,
-            dynamicAppConfigName: .ecaAdvancedJwt,
+            staticAppConfigName: .beaconAdvancedOpaque,
+            dynamicAppConfigName: .beaconAdvancedJwt,
             useWelcomeDiscovery: true
         )
     }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -95,7 +95,7 @@ class BaseAuthFlowTester: XCTestCase {
         useWelcomeDiscovery: Bool = false,
     ) {
         let userConfig = getUser(loginHost: loginHost, user: user)
-        let hostConfig = try! testConfig.getLoginHost(loginHost)
+        let hostConfig = getLoginHost(loginHost: loginHost)
         let staticAppConfig = getAppConfig(named: staticAppConfigName)
         let dynamicAppConfig = dynamicAppConfigName == nil ? nil : getAppConfig(named: dynamicAppConfigName!)
         let staticScopes = testConfig.getScopesToRequest(for: staticAppConfig, staticScopeSelection)
@@ -601,6 +601,15 @@ class BaseAuthFlowTester: XCTestCase {
         } catch {
             XCTFail("Failed to get app config for \(name): \(error)")
             fatalError("Failed to get app config for \(name): \(error)")
+        }
+    }
+    
+    private func getLoginHost(loginHost: KnownLoginHostConfig) -> LoginHostConfig {
+        do {
+            return try testConfig.getLoginHost(loginHost)
+        } catch {
+            XCTFail("Failed to get login host \(loginHost): \(error)")
+            fatalError("Failed to get login host \(loginHost): \(error)")
         }
     }
     

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -119,7 +119,12 @@ class BaseAuthFlowTester: XCTestCase {
         let loginHostToUse = useWelcomeDiscovery ? "welcome.salesforce.com" : hostConfig.urlNoProtocol
         loginPage.configureLoginHost(host: loginHostToUse)
         
-        loginPage.performLogin(username: userConfig.username, password: userConfig.password)
+        if (useWelcomeDiscovery) {
+            XCTAssertTrue(loginPage.hasFilledUsernameField(username: userConfig.username), "Login page should have pre-filled username")
+            loginPage.performWelcomeLogin(password: userConfig.password)
+        } else {
+            loginPage.performLogin(username: userConfig.username, password: userConfig.password)
+        }
     }
     
     /// Logs out the current user by tapping the logout button and confirming.

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -1,9 +1,9 @@
 /*
- BaseAuthFlowTesterTest.swift
+ BaseAuthFlowTester.swift
  AuthFlowTesterUITests
- 
+
  Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
- 
+
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright notice, this list of conditions
@@ -14,7 +14,7 @@
  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
  endorse or promote products derived from this software without specific prior written
  permission of salesforce.com, inc.
- 
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
@@ -27,7 +27,7 @@
 
 import XCTest
 
-class BaseAuthFlowTesterTest: XCTestCase {
+class BaseAuthFlowTester: XCTestCase {
     // App object
     private var app: XCUIApplication!
 
@@ -82,6 +82,7 @@ class BaseAuthFlowTesterTest: XCTestCase {
     ///   - dynamicScopeSelection: The scope selection for dynamic configuration. Defaults to `.empty`.
     ///   - useWebServerFlow: Whether to use web server OAuth flow. Defaults to `true`.
     ///   - useHybridFlow: Whether to use hybrid authentication flow. Defaults to `true`.
+    ///   - useWelcomeDiscovery: When true, configures simulated domain discovery. Defaults to `false`.
     func login(
         loginHost: KnownLoginHostConfig,
         user: KnownUserConfig,
@@ -91,8 +92,10 @@ class BaseAuthFlowTesterTest: XCTestCase {
         dynamicScopeSelection: ScopeSelection = .empty,
         useWebServerFlow: Bool = true,
         useHybridFlow: Bool = true,
+        useWelcomeDiscovery: Bool = false,
     ) {
         let userConfig = getUser(loginHost: loginHost, user: user)
+        let hostConfig = try! testConfig.getLoginHost(loginHost)
         let staticAppConfig = getAppConfig(named: staticAppConfigName)
         let dynamicAppConfig = dynamicAppConfigName == nil ? nil : getAppConfig(named: dynamicAppConfigName!)
         let staticScopes = testConfig.getScopesToRequest(for: staticAppConfig, staticScopeSelection)
@@ -105,13 +108,16 @@ class BaseAuthFlowTesterTest: XCTestCase {
             dynamicScopes: dynamicScopes,
             useWebServerFlow: useWebServerFlow,
             useHybridFlow: useHybridFlow,
+            discoveryLoginHost: useWelcomeDiscovery ? hostConfig.urlNoProtocol : "",
+            discoveryUsername: useWelcomeDiscovery ? userConfig.username : "",
         )
         
         // Configuring login host last
         // When the configured login host requires advanced authentication
         // the login settings button is no longer available on the screen
-        let hostConfig = try! testConfig.getLoginHost(loginHost)
-        loginPage.configureLoginHost(host: hostConfig.urlNoProtocol)
+        // When useWelcomeDiscovery is true, use welcome.salesforce.com as the login server
+        let loginHostToUse = useWelcomeDiscovery ? "welcome.salesforce.com" : hostConfig.urlNoProtocol
+        loginPage.configureLoginHost(host: loginHostToUse)
         
         loginPage.performLogin(username: userConfig.username, password: userConfig.password)
     }
@@ -219,6 +225,7 @@ class BaseAuthFlowTesterTest: XCTestCase {
     ///   - dynamicScopeSelection: The scope selection for dynamic configuration. Defaults to `.empty`.
     ///   - useWebServerFlow: Whether to use web server OAuth flow. Defaults to `true`.
     ///   - useHybridFlow: Whether to use hybrid authentication flow. Defaults to `true`.
+    ///   - useWelcomeDiscovery: When true, configures simulated domain discovery. Defaults to `false`.
     func launchLoginAndValidate(
         loginHost: KnownLoginHostConfig = .regularAuth,
         user: KnownUserConfig = .first,
@@ -228,6 +235,7 @@ class BaseAuthFlowTesterTest: XCTestCase {
         dynamicScopeSelection: ScopeSelection = .empty,
         useWebServerFlow: Bool = true,
         useHybridFlow: Bool = true,
+        useWelcomeDiscovery: Bool = false,
     ) {
         let useStaticConfiguration = dynamicAppConfigName == nil
         let userAppConfigName = useStaticConfiguration ? staticAppConfigName : dynamicAppConfigName!
@@ -246,6 +254,7 @@ class BaseAuthFlowTesterTest: XCTestCase {
             dynamicScopeSelection: dynamicScopeSelection,
             useWebServerFlow: useWebServerFlow,
             useHybridFlow: useHybridFlow,
+            useWelcomeDiscovery: useWelcomeDiscovery
         )
         
         // Validate

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -115,8 +115,8 @@ class BaseAuthFlowTester: XCTestCase {
         // Configuring login host last
         // When the configured login host requires advanced authentication
         // the login settings button is no longer available on the screen
-        // When useWelcomeDiscovery is true, use welcome.salesforce.com as the login server
-        let loginHostToUse = useWelcomeDiscovery ? "welcome.salesforce.com" : hostConfig.urlNoProtocol
+        // When useWelcomeDiscovery is true, use welcome.salesforce.com/discovery as the login server
+        let loginHostToUse = useWelcomeDiscovery ? "welcome.salesforce.com/discovery" : hostConfig.urlNoProtocol
         loginPage.configureLoginHost(host: loginHostToUse)
         
         if (useWelcomeDiscovery) {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestConfigUtils.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestConfigUtils.swift
@@ -1,9 +1,9 @@
 /*
  UITestConfigUtils.swift
  AuthFlowTesterUITests
- 
+
  Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
- 
+
  Redistribution and use of this software in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
  * Redistributions of source code must retain the above copyright notice, this list of conditions
@@ -14,7 +14,7 @@
  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
  endorse or promote products derived from this software without specific prior written
  permission of salesforce.com, inc.
- 
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/overview.md
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/overview.md
@@ -6,10 +6,13 @@ This document provides an overview of all UI tests in the AuthFlowTester test su
 
 | Class | Description |
 |-------|-------------|
-| `LegacyLoginTests` | Tests for legacy login flows (connected apps, user agent flow, non-hybrid flow) |
+| `LegacyLoginTests` | Tests for legacy login flows with subset and all scopes (CA, user agent flow, non-hybrid flow) |
+| `DefaultScopesLegacyLoginTests` | Legacy login tests using default scopes (CA advanced opaque) |
 | `ECALoginTests` | Tests for External Client App (ECA) login flows |
 | `BeaconLoginTests` | Tests for Beacon app login flows (using regular_auth login host) |
 | `AdvancedAuthBeaconLoginTests` | Tests for Beacon app login flows (using advanced_auth login host) |
+| `DynamicConfigLoginTests` | Tests for login with dynamic (runtime-selected) app configuration; CA, ECA, and Beacon with restart validation |
+| `WelcomeLoginTests` | Tests for welcome (domain discovery) login flows using simulated domain discovery |
 | `MigrationTests` | Tests for refresh token migration between app configurations |
 | `MultiUserLoginTests` | Tests for multi-user login scenarios |
 
@@ -17,28 +20,33 @@ This document provides an overview of all UI tests in the AuthFlowTester test su
 
 ## Login Tests
 
-### LegacyLoginTests (14 tests)
+### LegacyLoginTests (8 tests)
 
-Tests for Connected App (CA) configurations including user agent flow and non-hybrid flow options.
+Tests for Connected App (CA) configurations with subset and all scopes, including user agent flow and non-hybrid flow options.
 
 | Test Name | App Config | Scopes | Flow | Hybrid | Dynamic Config |
 |-----------|------------|--------|------|--------|----------------|
-| `testCAAdvancedOpaque_DefaultScopes_WebServerFlow` | CA Advanced Opaque | Default | Web Server | Yes | No |
 | `testCAAdvancedOpaque_SubsetScopes_WebServerFlow` | CA Advanced Opaque | Subset | Web Server | No | No |
 | `testCAAdvancedOpaque_AllScopes_WebServerFlow` | CA Advanced Opaque | All | Web Server | Yes | No |
-| `testCAAdvancedOpaque_DefaultScopes_WebServerFlow_NotHybrid` | CA Advanced Opaque | Default | Web Server | No | No |
 | `testCAAdvancedOpaque_SubsetScopes_WebServerFlow_NotHybrid` | CA Advanced Opaque | Subset | Web Server | No | No |
 | `testCAAdvancedOpaque_AllScopes_WebServerFlow_NotHybrid` | CA Advanced Opaque | All | Web Server | No | No |
-| `testCAAdvancedOpaque_DefaultScopes_UserAgentFlow` | CA Advanced Opaque | Default | User Agent | Yes | No |
 | `testCAAdvancedOpaque_SubsetScopes_UserAgentFlow` | CA Advanced Opaque | Subset | User Agent | Yes | No |
 | `testCAAdvancedOpaque_AllScopes_UserAgentFlow` | CA Advanced Opaque | All | User Agent | Yes | No |
-| `testCAAdvancedOpaque_DefaultScopes_UserAgentFlow_NotHybrid` | CA Advanced Opaque | Default | User Agent | No | No |
 | `testCAAdvancedOpaque_SubsetScopes_UserAgentFlow_NotHybrid` | CA Advanced Opaque | Subset | User Agent | No | No |
 | `testCAAdvancedOpaque_AllScopes_UserAgentFlow_NotHybrid` | CA Advanced Opaque | All | User Agent | No | No |
-| `testCAAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart` | CA Advanced JWT | Default | Web Server | Yes | Yes |
-| `testCAAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart` | CA Advanced JWT | Subset | Web Server | Yes | Yes |
 
-### ECALoginTests (8 tests)
+### DefaultScopesLegacyLoginTests (4 tests)
+
+Legacy login tests using default scopes (CA advanced opaque).
+
+| Test Name | App Config | Scopes | Flow | Hybrid |
+|-----------|------------|--------|------|--------|
+| `testCAAdvancedOpaque_DefaultScopes_WebServerFlow` | CA Advanced Opaque | Default | Web Server | Yes |
+| `testCAAdvancedOpaque_DefaultScopes_WebServerFlow_NotHybrid` | CA Advanced Opaque | Default | Web Server | No |
+| `testCAAdvancedOpaque_DefaultScopes_UserAgentFlow` | CA Advanced Opaque | Default | User Agent | Yes |
+| `testCAAdvancedOpaque_DefaultScopes_UserAgentFlow_NotHybrid` | CA Advanced Opaque | Default | User Agent | No |
+
+### ECALoginTests (6 tests)
 
 Tests for External Client App (ECA) configurations using web server flow with hybrid auth.
 
@@ -50,10 +58,8 @@ Tests for External Client App (ECA) configurations using web server flow with hy
 | `testECAAdvancedJwt_DefaultScopes` | ECA Advanced JWT | Default | No |
 | `testECAAdvancedJwt_SubsetScopes_NotHybrid` | ECA Advanced JWT | Subset | No |
 | `testECAAdvancedJwt_AllScopes` | ECA Advanced JWT | All | No |
-| `testECAAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart` | ECA Advanced JWT | Default | Yes |
-| `testECAAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart` | ECA Advanced JWT | Subset | Yes |
 
-### BeaconLoginTests (8 tests)
+### BeaconLoginTests (6 tests)
 
 Tests for Beacon app configurations using web server flow with hybrid auth. Uses `regular_auth` login host.
 
@@ -65,23 +71,43 @@ Tests for Beacon app configurations using web server flow with hybrid auth. Uses
 | `testBeaconAdvancedJwt_DefaultScopes` | Beacon Advanced JWT | Default | No |
 | `testBeaconAdvancedJwt_SubsetScopes` | Beacon Advanced JWT | Subset | No |
 | `testBeaconAdvancedJwt_AllScopes` | Beacon Advanced JWT | All | No |
-| `testBeaconAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart` | Beacon Advanced JWT | Default | Yes |
-| `testBeaconAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart` | Beacon Advanced JWT | Subset | Yes |
 
-### AdvancedAuthBeaconLoginTests (8 tests)
+### AdvancedAuthBeaconLoginTests (6 tests)
 
 Tests for Beacon app configurations using web server flow with hybrid auth. Uses `advanced_auth` login host. Inherits all tests from `BeaconLoginTests` but runs them with advanced authentication.
 
-| Test Name | App Config | Scopes | Dynamic Config | Login Host |
-|-----------|------------|--------|----------------|------------|
-| `testBeaconAdvancedOpaque_DefaultScopes` | Beacon Advanced Opaque | Default | No | advanced_auth |
-| `testBeaconAdvancedOpaque_SubsetScopes` | Beacon Advanced Opaque | Subset | No | advanced_auth |
-| `testBeaconAdvancedOpaque_AllScopes` | Beacon Advanced Opaque | All | No | advanced_auth |
-| `testBeaconAdvancedJwt_DefaultScopes` | Beacon Advanced JWT | Default | No | advanced_auth |
-| `testBeaconAdvancedJwt_SubsetScopes` | Beacon Advanced JWT | Subset | No | advanced_auth |
-| `testBeaconAdvancedJwt_AllScopes` | Beacon Advanced JWT | All | No | advanced_auth |
-| `testBeaconAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart` | Beacon Advanced JWT | Default | Yes | advanced_auth |
-| `testBeaconAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart` | Beacon Advanced JWT | Subset | Yes | advanced_auth |
+| Test Name | App Config | Scopes | Login Host |
+|-----------|------------|--------|------------|
+| `testBeaconAdvancedOpaque_DefaultScopes` | Beacon Advanced Opaque | Default | advanced_auth |
+| `testBeaconAdvancedOpaque_SubsetScopes` | Beacon Advanced Opaque | Subset | advanced_auth |
+| `testBeaconAdvancedOpaque_AllScopes` | Beacon Advanced Opaque | All | advanced_auth |
+| `testBeaconAdvancedJwt_DefaultScopes` | Beacon Advanced JWT | Default | advanced_auth |
+| `testBeaconAdvancedJwt_SubsetScopes` | Beacon Advanced JWT | Subset | advanced_auth |
+| `testBeaconAdvancedJwt_AllScopes` | Beacon Advanced JWT | All | advanced_auth |
+
+### DynamicConfigLoginTests (6 tests)
+
+Tests for login using dynamic (runtime-selected) app configuration. Each test logs in with a dynamic config then restarts the app and validates the session.
+
+| Test Name | Static Config | Dynamic Config | Scopes |
+|-----------|---------------|----------------|--------|
+| `testCAAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart` | CA Advanced Opaque | CA Advanced JWT | Default |
+| `testCAAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart` | CA Advanced Opaque | CA Advanced JWT | Subset |
+| `testECAAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart` | ECA Advanced Opaque | ECA Advanced JWT | Default |
+| `testECAAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart` | ECA Advanced Opaque | ECA Advanced JWT | Subset |
+| `testBeaconAdvancedJwt_DefaultScopes_DynamicConfiguration_WithRestart` | Beacon Advanced Opaque | Beacon Advanced JWT | Default |
+| `testBeaconAdvancedJwt_SubsetScopes_DynamicConfiguration_WithRestart` | Beacon Advanced Opaque | Beacon Advanced JWT | Subset |
+
+### WelcomeLoginTests (4 tests)
+
+Tests for welcome (domain discovery) login flows. Uses simulated domain discovery with welcome.salesforce.com as the login server.
+
+| Test Name | Login Host | Dynamic Config |
+|-----------|------------|----------------|
+| `testWelcomeDiscoveryWithRegularAuthLoginHost` | regular_auth (simulated) | No |
+| `testWelcomeDiscoveryWithAdvancedAuthLoginHost` | advanced_auth (simulated) | No |
+| `testWelcomeDiscoveryWithRegularAuthLoginHostAndDynamicConfig` | regular_auth (simulated) | Yes |
+| `testWelcomeDiscoveryWithAdvancedAuthLoginHostAndDynamicConfig` | advanced_auth (simulated) | Yes |
 
 ---
 
@@ -184,5 +210,4 @@ The test suite supports testing against different Salesforce org configurations 
 | **regular_auth** | Org configured to use regular authentication | Authentication through web view |
 | **advanced_auth** | Org configured to use native browser for authentication | Chrome Custom Tab on Android and ASWebAuthenticationSession on iOS |
 
-Most tests use the `regular_auth` login host by default. The `AdvancedAuthBeaconLoginTests` class runs the same Beacon login tests but uses the `advanced_auth` login host to verify authentication flows work correctly with native browser authentication.
-
+Most tests use the `regular_auth` login host by default. The `AdvancedAuthBeaconLoginTests` class runs the same Beacon login tests but uses the `advanced_auth` login host to verify authentication flows work correctly with native browser authentication. The `WelcomeLoginTests` use simulated domain discovery with welcome.salesforce.com as the login server to test the welcome/domain discovery flow.

--- a/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
+++ b/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
@@ -72,6 +72,43 @@
 "LOGIN_CLEAR_CACHE" = "Clear Cache";
 "LOGIN_RELOAD" = "Reload";
 
+// Login Options (sheet title and sections)
+"LOGIN_OPTIONS_STATIC_CONFIG_TITLE" = "Static Configuration";
+"LOGIN_OPTIONS_SAVE_STATIC_CONFIG" = "Save static config";
+"LOGIN_OPTIONS_DYNAMIC_CONFIG_TITLE" = "Dynamic Configuration";
+"LOGIN_OPTIONS_SAVE_DYNAMIC_CONFIG" = "Save dynamic config";
+
+// Boot Config Editor (Login Options)
+"BOOTCONFIG_CONSUMER_KEY_LABEL" = "Consumer Key:";
+"BOOTCONFIG_CONSUMER_KEY_PLACEHOLDER" = "Consumer Key";
+"BOOTCONFIG_CALLBACK_URL_LABEL" = "Callback URL:";
+"BOOTCONFIG_CALLBACK_URL_PLACEHOLDER" = "Callback URL";
+"BOOTCONFIG_SCOPES_LABEL" = "Scopes (space-separated):";
+"BOOTCONFIG_SCOPES_PLACEHOLDER" = "e.g. id api refresh_token";
+"BOOTCONFIG_IMPORT_ALERT_TITLE" = "Import Configuration";
+"BOOTCONFIG_IMPORT_PLACEHOLDER" = "Paste JSON here";
+"BOOTCONFIG_IMPORT_BUTTON" = "Import";
+"BOOTCONFIG_IMPORT_CANCEL" = "Cancel";
+"BOOTCONFIG_IMPORT_MESSAGE" = "Paste JSON with remoteAccessConsumerKey, oauthRedirectURI, and scopes";
+
+// Discovery Result Editor (Login Options)
+"DISCOVERY_SIMULATE_TITLE" = "Simulate Domain Discovery";
+"DISCOVERY_LOGIN_HOST_LABEL" = "Login host (My Domain):";
+"DISCOVERY_LOGIN_HOST_PLACEHOLDER" = "e.g. mycompany.my.salesforce.com";
+"DISCOVERY_USER_NAME_LABEL" = "User name (login hint):";
+"DISCOVERY_USER_NAME_PLACEHOLDER" = "e.g. user@company.com";
+"DISCOVERY_SAVE_SIMULATED_RESULT" = "Save simulated result";
+"DISCOVERY_IMPORT_ALERT_TITLE" = "Import Discovery Result";
+"DISCOVERY_IMPORT_PLACEHOLDER" = "Paste JSON here";
+"DISCOVERY_IMPORT_BUTTON" = "Import";
+"DISCOVERY_IMPORT_CANCEL" = "Cancel";
+"DISCOVERY_IMPORT_MESSAGE" = "Paste JSON with login_hint and my_domain";
+
+// Auth Flow Types (Login Options)
+"LOGIN_OPTIONS_AUTH_FLOW_TYPES_TITLE" = "Authentication Flow Types";
+"LOGIN_OPTIONS_USE_WEB_SERVER_FLOW" = "Use Web Server Flow";
+"LOGIN_OPTIONS_USE_HYBRID_FLOW" = "Use Hybrid Flow";
+
 // Account Switcher
 "ACCOUNT_SWITCHER_TITLE" = "Manage Accounts";
 "LOG_OUT" = "Log Out";


### PR DESCRIPTION
Overview
- SalesforceSDKManager has a new field simulatedDomainDiscoveryResult. When set (DEBUG builds only; setter is a no-op in Release), a callback URL is built from simulatedDomainDiscoveryResult to trigger the domain discovery callback handler. 
- Login options screen provides a way to type in a login host and user name to be used as simulatedDomainDiscoveryResult.
- Added new test suite WelcomeLoginTests
- Also moved existing tests into more test suites (to keep them smaller and make parallel runs faster)

![WelcomeDiscoSimulation](https://github.com/user-attachments/assets/4dc6b337-93eb-4200-b7d7-9fa3ab3e614c)