### PR TITLE
Re-working CI workflows for UI tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -141,8 +141,5 @@ jobs:
     uses: ./.github/workflows/reusable-ui-test-workflow.yaml
     with:
       is_pr: true
-      pr_tests: |
-        [
-          "AuthFlowTesterUITests/ECALoginTests/testECAOpaque_DefaultScopes"
-        ]
+      test-plan-configuration: "Smoke"
     secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -141,5 +141,5 @@ jobs:
     uses: ./.github/workflows/reusable-ui-test-workflow.yaml
     with:
       is_pr: true
-      test-plan-configuration: "Smoke"
+      pr_test: "AuthFlowTesterUITests/LegacyLoginTests/testCAOpaque_DefaultScopes_WebServerFlow"
     secrets: inherit

--- a/.github/workflows/reusable-ui-test-workflow.yaml
+++ b/.github/workflows/reusable-ui-test-workflow.yaml
@@ -16,9 +16,9 @@ on:
         default: macos-latest
         required: false
         type: string
-      test-plan-configuration:
-        description: "Test plan configuration to run (e.g. 'Smoke' or 'All Tests'). Passed to xcodebuild -testPlanConfiguration."
-        default: "All Tests"
+      pr_test:
+        description: "Test identifier to run for PR (e.g. 'AuthFlowTesterUITests/LegacyLoginTests/testMethod'). Empty = run all tests."
+        default: ""
         required: false
         type: string
       destination:
@@ -82,11 +82,15 @@ jobs:
         id: xcodebuild
         run: |
           DESTINATION="${{ steps.resolve_destination.outputs.destination }}"
+          ONLY_TESTING_ARGS=()
+          if [ -n "${{ inputs.pr_test }}" ]; then
+            ONLY_TESTING_ARGS+=(-only-testing "${{ inputs.pr_test }}")
+          fi
           xcodebuild test \
             -workspace SalesforceMobileSDK.xcworkspace \
             -scheme AuthFlowTester \
             -testPlan AuthFlowTester \
-            -only-test-configuration "${{ inputs.test-plan-configuration }}" \
+            "${ONLY_TESTING_ARGS[@]}" \
             -destination "$DESTINATION" \
             -resultBundlePath test \
             -enableCodeCoverage YES \
@@ -99,7 +103,7 @@ jobs:
         with:
           path: test.xcresult
           show-passed-tests: true
-          title: AuthFlowTester UI Test Results (${{ inputs.test-plan-configuration }})
+          title: AuthFlowTester UI Test Results
       - uses: codecov/codecov-action@v4
         if: success() || failure()
         with:
@@ -110,6 +114,6 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: xcresult-authflowtester-ui-${{ inputs.test-plan-configuration }}-ios${{ inputs.ios }}
+          name: xcresult-authflowtester-ui-ios${{ inputs.ios }}
           path: test.xcresult/
           retention-days: 30

--- a/.github/workflows/reusable-ui-test-workflow.yaml
+++ b/.github/workflows/reusable-ui-test-workflow.yaml
@@ -16,19 +16,9 @@ on:
         default: macos-latest
         required: false
         type: string
-      test-retry-iterations:
-        description: "Max retries per test on failure (1 = no retry)."
-        default: 2
-        required: false
-        type: number
-      test_suite:
-        description: "Test class to run only (e.g. ECALoginTests). Empty = run all. Ignored when is_pr (PR uses pr_tests instead)."
-        default: ""
-        required: false
-        type: string
-      pr_tests:
-        description: "JSON array of test identifiers to run (e.g. ['AuthFlowTesterUITests/ECALoginTests/testECA...']). Used when is_pr is true; empty = use default PR smoke test."
-        default: "[]"
+      test-plan-configuration:
+        description: "Test plan configuration to run (e.g. 'Smoke' or 'All Tests'). Passed to xcodebuild -testPlanConfiguration."
+        default: "All Tests"
         required: false
         type: string
       destination:
@@ -36,11 +26,6 @@ on:
         default: ""
         required: false
         type: string
-      parallel-testing-worker-count:
-        description: "xcodebuild -parallel-testing-worker-count (0 = do not set; parallel testing uses xcodebuild default)."
-        default: 0
-        required: false
-        type: number
 
 jobs:
   test-ui:
@@ -97,75 +82,34 @@ jobs:
         id: xcodebuild
         run: |
           DESTINATION="${{ steps.resolve_destination.outputs.destination }}"
-          RETRY_ARGS=()
-          if [ "${{ inputs.test-retry-iterations }}" -gt 1 ]; then
-            RETRY_ARGS=(-retry-tests-on-failure -test-iterations "${{ inputs.test-retry-iterations }}")
-          fi
-          ONLY_TESTING_ARGS=()
-          if [ "$IS_PR" = "true" ]; then
-            PR_TESTS='${{ inputs.pr_tests }}'
-            if [ -n "$PR_TESTS" ] && [ "$PR_TESTS" != "[]" ]; then
-              while IFS= read -r t; do
-                ONLY_TESTING_ARGS+=(-only-testing "$t")
-              done < <(echo "$PR_TESTS" | python3 -c "import sys, json; [print(t) for t in json.load(sys.stdin)]")
-            else
-              ONLY_TESTING_ARGS=(-only-testing 'AuthFlowTesterUITests/ECALoginTests/testECAJwt_DefaultScopes')
-            fi
-          elif [ -n "${{ inputs.test_suite }}" ]; then
-            ONLY_TESTING_ARGS=(-only-testing "AuthFlowTesterUITests/${{ inputs.test_suite }}")
-          fi
-          PARALLEL_ARGS=()
-          if [ "${{ inputs.parallel-testing-worker-count }}" -gt 0 ]; then
-            PARALLEL_ARGS=(-parallel-testing-enabled YES -parallel-testing-worker-count "${{ inputs.parallel-testing-worker-count }}")
-          fi
           xcodebuild test \
             -workspace SalesforceMobileSDK.xcworkspace \
             -scheme AuthFlowTester \
             -testPlan AuthFlowTester \
+            -only-test-configuration "${{ inputs.test-plan-configuration }}" \
             -destination "$DESTINATION" \
-            "${PARALLEL_ARGS[@]}" \
-            "${ONLY_TESTING_ARGS[@]}" \
-            "${RETRY_ARGS[@]}" \
             -resultBundlePath test \
             -enableCodeCoverage YES \
             | xcbeautify
         env:
           CODE_COVERAGE: YES
-          IS_PR: ${{ inputs.is_pr }}
-      - name: Parse test results
-        if: success() || failure()
-        run: |
-          brew install xcresultparser
-          mkdir -p firebase_results
-          SUITE="${{ inputs.test_suite }}"
-          [ -z "$SUITE" ] && SUITE=all
-          [ "$IS_PR" = "true" ] && SUITE=pr
-          xcresultparser -o junit test.xcresult > firebase_results/authflowtester-ui-${SUITE}-test_result.xml
-      - name: Test Report
-        uses: mikepenz/action-junit-report@v5
+      - name: Publish test results
+        uses: kishikawakatsumi/xcresulttool@v1
         if: success() || failure()
         with:
-          check_name: AuthFlowTester UI Test Results ${{ inputs.test_suite && format('({0})', inputs.test_suite) || '' }}
-          job_name: AuthFlowTester UI Test Results ${{ inputs.test_suite && format('({0})', inputs.test_suite) || '' }}
-          require_tests: true
-          check_retries: true
-          flaky_summary: true
-          fail_on_failure: true
-          group_reports: false
-          include_passed: true
-          include_empty_in_summary: false
-          simplified_summary: true
-          job_summary: ${{ steps.xcodebuild.outcome == 'failure' }}
-          report_paths: 'firebase_results/**.xml'
+          path: test.xcresult
+          show-passed-tests: true
+          title: AuthFlowTester UI Test Results (${{ inputs.test-plan-configuration }})
       - uses: codecov/codecov-action@v4
         if: success() || failure()
         with:
           flags: AuthFlowTesterUI
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - name: Upload test results artifact
+      - name: Upload xcresult bundle
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-authflowtester-ui-${{ inputs.test_suite || 'all' }}-ios${{ inputs.ios }}
-          path: firebase_results/
+          name: xcresult-authflowtester-ui-${{ inputs.test-plan-configuration }}-ios${{ inputs.ios }}
+          path: test.xcresult/
+          retention-days: 30

--- a/.github/workflows/ui-test-nightly.yaml
+++ b/.github/workflows/ui-test-nightly.yaml
@@ -11,5 +11,4 @@ jobs:
     with:
       ios: "^26"
       xcode: "^26"
-      test-plan-configuration: "All Tests"
     secrets: inherit

--- a/.github/workflows/ui-test-nightly.yaml
+++ b/.github/workflows/ui-test-nightly.yaml
@@ -7,22 +7,9 @@ on:
 
 jobs:
   ios-ui-test-nightly:
-    strategy:
-      fail-fast: false
-      matrix:
-        test_suite:
-          - AdvancedAuthBeaconLoginTests
-          - BeaconLoginTests
-          - ECALoginTests
-          - LegacyLoginTests
-          - LoginWithRestartTests
-          - MultiUserLoginTests
-          - RefreshTokenMigrationTests
-          - RefreshTokenMigrationWithRestartTests
-          - WelcomeLoginTests
     uses: ./.github/workflows/reusable-ui-test-workflow.yaml
     with:
       ios: "^26"
       xcode: "^26"
-      test_suite: ${{ matrix.test_suite }}
+      test-plan-configuration: "All Tests"
     secrets: inherit

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester.xctestplan
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester.xctestplan
@@ -2,7 +2,7 @@
   "configurations" : [
     {
       "id" : "12345678-1234-1234-1234-123456789012",
-      "name" : "AuthFlowTester UI Tests",
+      "name" : "All Tests",
       "options" : {
         "appPrivacyConfiguration" : {
           "allowedPrivacyPermissions" : [
@@ -32,6 +32,52 @@
         "testTimeoutsEnabled" : true,
         "uiTestingScreenshotsLifetime" : "deleteOnSuccess"
       }
+    },
+    {
+      "id" : "87654321-4321-4321-4321-210987654321",
+      "name" : "Smoke",
+      "options" : {
+        "appPrivacyConfiguration" : {
+          "allowedPrivacyPermissions" : [
+            "all"
+          ]
+        },
+        "environmentVariableEntries" : [
+          {
+            "key" : "AutomaticTextCompletionEnabled",
+            "value" : "0"
+          }
+        ],
+        "language" : "en",
+        "locationScenario" : {
+          "identifier" : "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+        },
+        "maximumTestExecutionTimeAllowance" : 360,
+        "region" : "US",
+        "targetForVariableExpansion" : {
+          "containerPath" : "container:AuthFlowTester.xcodeproj",
+          "identifier" : "PRODUCT_BUNDLE_IDENTIFIER",
+          "name" : "AuthFlowTester"
+        },
+        "testExecutionOrdering" : "random",
+        "testRepetitionMode" : "retryOnFailure",
+        "maximumTestRepetitions" : 3,
+        "testTimeoutsEnabled" : true,
+        "uiTestingScreenshotsLifetime" : "deleteOnSuccess"
+      },
+      "testTargets" : [
+        {
+          "parallelizable" : true,
+          "selectedTests" : [
+            "AuthFlowTesterUITests/LegacyLoginTests/testCAOpaque_DefaultScopes_WebServerFlow"
+          ],
+          "target" : {
+            "containerPath" : "container:AuthFlowTester.xcodeproj",
+            "identifier" : "4F8E4AF02ED13CE800DA7B7A",
+            "name" : "AuthFlowTesterUITests"
+          }
+        }
+      ]
     }
   ],
   "defaultOptions" : {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester.xctestplan
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester.xctestplan
@@ -20,6 +20,7 @@
           "identifier" : "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
         },
         "maximumTestExecutionTimeAllowance" : 360,
+        "maximumTestRepetitions" : 3,
         "region" : "US",
         "targetForVariableExpansion" : {
           "containerPath" : "container:AuthFlowTester.xcodeproj",
@@ -28,56 +29,9 @@
         },
         "testExecutionOrdering" : "random",
         "testRepetitionMode" : "retryOnFailure",
-        "maximumTestRepetitions" : 3,
         "testTimeoutsEnabled" : true,
         "uiTestingScreenshotsLifetime" : "deleteOnSuccess"
       }
-    },
-    {
-      "id" : "87654321-4321-4321-4321-210987654321",
-      "name" : "Smoke",
-      "options" : {
-        "appPrivacyConfiguration" : {
-          "allowedPrivacyPermissions" : [
-            "all"
-          ]
-        },
-        "environmentVariableEntries" : [
-          {
-            "key" : "AutomaticTextCompletionEnabled",
-            "value" : "0"
-          }
-        ],
-        "language" : "en",
-        "locationScenario" : {
-          "identifier" : "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
-        },
-        "maximumTestExecutionTimeAllowance" : 360,
-        "region" : "US",
-        "targetForVariableExpansion" : {
-          "containerPath" : "container:AuthFlowTester.xcodeproj",
-          "identifier" : "PRODUCT_BUNDLE_IDENTIFIER",
-          "name" : "AuthFlowTester"
-        },
-        "testExecutionOrdering" : "random",
-        "testRepetitionMode" : "retryOnFailure",
-        "maximumTestRepetitions" : 3,
-        "testTimeoutsEnabled" : true,
-        "uiTestingScreenshotsLifetime" : "deleteOnSuccess"
-      },
-      "testTargets" : [
-        {
-          "parallelizable" : true,
-          "selectedTests" : [
-            "AuthFlowTesterUITests/LegacyLoginTests/testCAOpaque_DefaultScopes_WebServerFlow"
-          ],
-          "target" : {
-            "containerPath" : "container:AuthFlowTester.xcodeproj",
-            "identifier" : "4F8E4AF02ED13CE800DA7B7A",
-            "name" : "AuthFlowTesterUITests"
-          }
-        }
-      ]
     }
   ],
   "defaultOptions" : {
@@ -97,6 +51,7 @@
       "identifier" : "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
     },
     "maximumTestExecutionTimeAllowance" : 360,
+    "maximumTestRepetitions" : 3,
     "region" : "US",
     "targetForVariableExpansion" : {
       "containerPath" : "container:AuthFlowTester.xcodeproj",
@@ -105,7 +60,6 @@
     },
     "testExecutionOrdering" : "random",
     "testRepetitionMode" : "retryOnFailure",
-    "maximumTestRepetitions" : 3,
     "testTimeoutsEnabled" : true,
     "uiTestingScreenshotsLifetime" : "deleteOnSuccess"
   },

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -73,9 +73,18 @@ class LoginPageObject {
     
     func performLogin(username: String, password: String) {
         setTextField(usernameField(), value: username)
-        tap(passwordFieldLabel()) // click on label to hide keyboard
+        tap(toolbarDoneButton())
         setTextField(passwordField(), value: password)
-        tap(passwordFieldLabel()) // click on label to hide keyboard
+        tap(toolbarDoneButton())
+        tap(loginButton())
+        tapIfPresent(allowButton())
+    }
+
+    func performAdvancedLogin(username: String, password: String) {
+        setTextField(usernameField(), value: username)
+        tap(passwordFieldLabel())
+        setTextField(passwordField(), value: password)
+        tap(usernameFieldLabel())
         tap(loginButton())
         tapIfPresent(allowButton())
     }
@@ -152,6 +161,10 @@ class LoginPageObject {
     
     private func hostRow(host: String) -> XCUIElement {
         return app.staticTexts[host].firstMatch
+    }
+    
+    private func toolbarDoneButton() -> XCUIElement {
+        return app.toolbars["Toolbar"].buttons["Done"]
     }
 
     private func usernameFieldLabel() -> XCUIElement {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -129,7 +129,11 @@ class BaseAuthFlowTester: XCTestCase {
             XCTAssertTrue(loginPage.hasFilledUsernameField(username: userConfig.username), "Login page should have pre-filled username")
             loginPage.performWelcomeLogin(password: userConfig.password)
         } else {
-            loginPage.performLogin(username: userConfig.username, password: userConfig.password)
+            if (loginHost == .regularAuth) {
+                loginPage.performLogin(username: userConfig.username, password: userConfig.password)
+            } else {
+                loginPage.performAdvancedLogin(username: userConfig.username, password: userConfig.password)
+            }
         }
     }
     


### PR DESCRIPTION
- saving the test.xcresult
- using kishikawakatsumi/xcresulttool to present results (better integration with Xcode tests metadata)