### PR TITLE
Fix Native Login.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/NativeLogin/NativeLoginManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/NativeLogin/NativeLoginManagerInternal.swift
@@ -219,7 +219,8 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
     private func generateChallenge(codeVerifier: String) -> String? {
         guard let data = codeVerifier.data(using: .utf8) else { return nil }
         let hash = SHA256.hash(data: data)
-        return urlSafeBase64Encode(data: hash.dataRepresentation)
+        let hashData = Data(hash)  // Explicitly copy bytes into a new Data on the heap
+        return urlSafeBase64Encode(data: hashData)
     }
     
     // MARK: Salesforce Identity API Headless Registration Flow


### PR DESCRIPTION
This change appears entirely pointless but is a critical bugfix.

### The issue: 

Under certain compiler conditions Native Login would consistently fail PKCE (and therefore login).  The exact same source code running on the same device would yield a successful login when run from Xcode but fail if the build was produced with CI. 

Testing against a local server uncovered strange client side behavior when generating code challenge.  Repeated attempts generated similar looking challenges that didn't even appear to be hashed properly, such as:
`LAAAAAAAAACQqzNrAQAAACAAAAAAAAAAAAAAAAAAAAA`
`LAAAAAAAAACQKØVrAQAAACAAAAAAAAAAAAAAAAAAAAA`
...

I was eventually able to reproduce the issue by simply building the release scheme of our template in Xcode.

### Explanation of Fix: 

Looking at the pre-fix code:
```
   private func generateChallenge(codeVerifier: String) -> String? {
        guard let data = codeVerifier.data(using: .utf8) else { return nil }
        let hash = SHA256.hash(data: data)
        return urlSafeBase64Encode(data: hash.dataRepresentation)
   }
```

`SHA256.hash(data:)` returns a `SHA256Digest` struct that stores the 32 hash bytes inline **on the stack**. The `.dataRepresentation` computed property creates a `Data` from those stack bytes.  Depending on optimization, the compiler may reuse the stack slot occupied by hash before `base64EncodedString()` actually reads the bytes from the `Data`.  As a result the `Data` points to stack memory that's been partially overwritten.

### Why web login is unaffected:

From `SFOAuthCoordinator.m` 
```
  NSMutableData *sha256Data = [NSMutableData dataWithLength:CC_SHA256_DIGEST_LENGTH];
  CC_SHA256(self.bytes, (CC_LONG)self.length, sha256Data.mutableBytes);
```

`CommonCrypto` `CC_SHA256` writes directly into a **heap-allocated** `NSMutableData` buffer.  The Objective-C code does not use `CryptoKit` or `SHA256Digest.dataRepresentation`.  