### PR TITLE
@W-19688946: Updating MobileSyncExplorer to use UIScene lifecycle

### DIFF
--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		696A8B6A2AD0F7B300A85A1D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 696A8B692AD0F7B300A85A1D /* PrivacyInfo.xcprivacy */; };
 		820C8B0E19E6054E00E9BE5C /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 820C8B0D19E6054E00E9BE5C /* AppDelegate.m */; };
 		820C8B1119E6059400E9BE5C /* InitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 820C8B1019E6059400E9BE5C /* InitialViewController.m */; };
+		SD00000119E6054E00D37B27 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = SD00000019E6054E00D37B27 /* SceneDelegate.m */; };
 		820C8B1F19E6081C00E9BE5C /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 820C8B1E19E6081C00E9BE5C /* ImageIO.framework */; };
 		820C8B2319E6088400E9BE5C /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 820C8B2219E6088400E9BE5C /* MessageUI.framework */; };
 		820C8B2719E6091100E9BE5C /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 820C8B2619E6091100E9BE5C /* SystemConfiguration.framework */; };
@@ -272,6 +273,8 @@
 		696A8B692AD0F7B300A85A1D /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		820C8B0C19E6054E00E9BE5C /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		820C8B0D19E6054E00E9BE5C /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		SD00000219E6054E00D37B27 /* SceneDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
+		SD00000019E6054E00D37B27 /* SceneDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
 		820C8B0F19E6059400E9BE5C /* InitialViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InitialViewController.h; sourceTree = "<group>"; };
 		820C8B1019E6059400E9BE5C /* InitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InitialViewController.m; sourceTree = "<group>"; };
 		820C8B1E19E6081C00E9BE5C /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
@@ -363,6 +366,8 @@
 				4FEAC2431B97C65C00B08512 /* ActionsPopupController.h */,
 				820C8B0C19E6054E00E9BE5C /* AppDelegate.h */,
 				820C8B0D19E6054E00E9BE5C /* AppDelegate.m */,
+				SD00000219E6054E00D37B27 /* SceneDelegate.h */,
+				SD00000019E6054E00D37B27 /* SceneDelegate.m */,
 				820C8B0F19E6059400E9BE5C /* InitialViewController.h */,
 				820C8B1019E6059400E9BE5C /* InitialViewController.m */,
 				8284055419EA09E40079AB60 /* ContactDetailViewController.h */,
@@ -809,6 +814,7 @@
 			files = (
 				820C8B1119E6059400E9BE5C /* InitialViewController.m in Sources */,
 				820C8B0E19E6054E00E9BE5C /* AppDelegate.m in Sources */,
+				SD00000119E6054E00D37B27 /* SceneDelegate.m in Sources */,
 				4FEAC2451B97C65C00B08512 /* ActionsPopupController.m in Sources */,
 				8284055619EA09E40079AB60 /* ContactDetailViewController.m in Sources */,
 				820C8B3219E60BDE00E9BE5C /* ContactListViewController.m in Sources */,

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/AppDelegate.m
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/AppDelegate.m
@@ -23,8 +23,6 @@
  */
 
 #import "AppDelegate.h"
-#import "InitialViewController.h"
-#import "ContactListViewController.h"
 #import <MobileSyncExplorerCommon/MobileSyncExplorerConfig.h>
 #import <UserNotifications/UserNotifications.h>
 
@@ -33,17 +31,6 @@
 @import MobileSync;
 
 @interface AppDelegate ()
-
-/**
- * Convenience method for setting up the main UIViewController and setting self.window's rootViewController
- * property accordingly.
- */
-- (void)setupRootViewController;
-
-/**
- * (Re-)sets the view state when the app first loads (or post-logout).
- */
-- (void)initializeAppViewState;
 
 @end
 
@@ -60,20 +47,11 @@
         [SFSDKDatasharingHelper sharedInstance].appGroupEnabled = config.appGroupsEnabled;
 
         [MobileSyncSDKManager initializeSDK];
-        
-        //App Setup for any changes to the current authenticated user
-        __weak typeof (self) weakSelf = self;
-        [SFSDKAuthHelper registerBlockForCurrentUserChangeNotifications:^{
-            __strong typeof (weakSelf) strongSelf = weakSelf;
-            [strongSelf resetUserloginStatus];
-            [strongSelf resetViewState:^{
-                [strongSelf setupRootViewController];
-            }];
-        }];
+
         //Uncomment following lines to enable IDP Login flow. Set scheme of idpAppp & display name (optional)
         //[MobileSyncSDKManager sharedManager].idpAppURIScheme = @"sampleidpapp";
         //[MobileSyncSDKManager sharedManager].appDisplayName = @"SampleAppOne";
-        
+
     }
     return self;
 }
@@ -81,24 +59,11 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    // The Mobile SDK uses multiple UIWindow's inorder to present views. Having
-    // Multiple windows with different controllers varying rotational behaviors
-    // lead to weird UIWindow behaviors. To avoid such rotation and other issues
-    // between visible and hidden windows use the SFSDKUIWindow instead of  
-    // UIWindow.
-    self.window = [[SFSDKUIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-    [self initializeAppViewState];
-    
     // If you wish to register for push notifications, uncomment the line below.  Note that,
     // if you want to receive push notifications from Salesforce, you will also need to
     // implement the application:didRegisterForRemoteNotificationsWithDeviceToken: method (below).
 //    [self registerForRemotePushNotifications];
-    
-    __weak typeof (self) weakSelf = self;
-    [SFSDKAuthHelper loginIfRequired:^{
-        [weakSelf resetUserloginStatus];
-        [weakSelf setupRootViewController];
-    }];
+
     return YES;
 }
 
@@ -143,39 +108,6 @@
     // return [[SFUserAccountManager sharedInstance] handleIDPAuthenticationResponse:url options:options];
     return NO;
 
-}
-
-#pragma mark - Private methods
-- (void)resetUserloginStatus {
-    BOOL loggedIn = [SFUserAccountManager.sharedInstance currentUser] != nil;
-    [[NSUserDefaults msdkUserDefaults] setBool:loggedIn forKey:@"userLoggedIn"];
-    [[NSUserDefaults msdkUserDefaults] synchronize];
-    [SFSDKMobileSyncLogger log:[self class] level:SFLogLevelDebug format:@"%d userLoggedIn", [[NSUserDefaults msdkUserDefaults] boolForKey:@"userLoggedIn"] ];
-}
-
-- (void)initializeAppViewState
-{
-    self.window.rootViewController = [[InitialViewController alloc] initWithNibName:nil bundle:nil];
-    [self.window makeKeyAndVisible];
-}
-
-- (void)setupRootViewController
-{
-    ContactListViewController *rootVC = [[ContactListViewController alloc] initWithStyle:UITableViewStylePlain];
-    SFSDKNavigationController *navVC = [[SFSDKNavigationController alloc] initWithRootViewController:rootVC];
-    self.window.rootViewController = navVC;
-    [self.window makeKeyAndVisible];
-}
-
-- (void)resetViewState:(void (^)(void))postResetBlock
-{
-    if ([self.window.rootViewController presentedViewController]) {
-        [self.window.rootViewController dismissViewControllerAnimated:NO completion:^{
-            postResetBlock();
-        }];
-    } else {
-        postResetBlock();
-    }
 }
 
 @end

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/SceneDelegate.h
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/SceneDelegate.h
@@ -1,0 +1,31 @@
+/*
+ Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+@end

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/SceneDelegate.m
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/Classes/SceneDelegate.m
@@ -1,0 +1,161 @@
+/*
+ Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SceneDelegate.h"
+#import "InitialViewController.h"
+#import "ContactListViewController.h"
+
+@import SalesforceSDKCommon;
+@import SalesforceSDKCore;
+@import MobileSync;
+
+@interface SceneDelegate ()
+
+/**
+ * Convenience method for setting up the main UIViewController and setting self.window's rootViewController
+ * property accordingly.
+ */
+- (void)setupRootViewController;
+
+/**
+ * (Re-)sets the view state when the app first loads (or post-logout).
+ */
+- (void)initializeAppViewState;
+
+/**
+ * Resets the view state with a completion block.
+ */
+- (void)resetViewState:(void (^)(void))postResetBlock;
+
+/**
+ * Updates the user login status in user defaults.
+ */
+- (void)resetUserloginStatus;
+
+@end
+
+@implementation SceneDelegate
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions {
+    if (![scene isKindOfClass:[UIWindowScene class]]) {
+        return;
+    }
+
+    UIWindowScene *windowScene = (UIWindowScene *)scene;
+    self.window = [[SFSDKUIWindow alloc] initWithWindowScene:windowScene];
+
+    // App Setup for any changes to the current authenticated user
+    __weak typeof(self) weakSelf = self;
+    [SFSDKAuthHelper registerBlockForCurrentUserChangeNotifications:scene completion:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf resetUserloginStatus];
+        [strongSelf resetViewState:^{
+            [strongSelf setupRootViewController];
+        }];
+    }];
+
+    [self initializeAppViewState];
+
+    [SFSDKAuthHelper loginIfRequired:scene completion:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf resetUserloginStatus];
+        [strongSelf setupRootViewController];
+    }];
+}
+
+- (void)sceneDidDisconnect:(UIScene *)scene {
+    // Called as the scene is being released by the system.
+    // This occurs shortly after the scene enters the background, or when its session is discarded.
+    // Release any resources associated with this scene that can be re-created the next time the scene connects.
+    // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene {
+    // Called when the scene has moved from an inactive state to an active state.
+    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene {
+    // Called when the scene will move from an active state to an inactive state.
+    // This may occur due to temporary interruptions (ex. an incoming phone call).
+}
+
+- (void)sceneWillEnterForeground:(UIScene *)scene {
+    // Called as the scene transitions from the background to the foreground.
+    // Use this method to undo the changes made on entering the background.
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene {
+    // Called as the scene transitions from the foreground to the background.
+    // Use this method to save data, release shared resources, and store enough scene-specific state information
+    // to restore the scene back to its current state.
+}
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts {
+    // Uncomment following block to enable IDP Login flow
+    // UIOpenURLContext *urlContext = URLContexts.anyObject;
+    // if (urlContext) {
+    //     [[SFUserAccountManager sharedInstance] handleIdentityProviderResponse:urlContext.URL
+    //         withOptions:@{kSFUserAccountManagerSceneKey: scene.session.persistentIdentifier}];
+    // }
+}
+
+#pragma mark - Private methods
+
+- (void)resetUserloginStatus {
+    BOOL loggedIn = [SFUserAccountManager.sharedInstance currentUser] != nil;
+    [[NSUserDefaults msdkUserDefaults] setBool:loggedIn forKey:@"userLoggedIn"];
+    [[NSUserDefaults msdkUserDefaults] synchronize];
+    [SFSDKMobileSyncLogger log:[self class] level:SFLogLevelDebug format:@"%d userLoggedIn", [[NSUserDefaults msdkUserDefaults] boolForKey:@"userLoggedIn"]];
+}
+
+- (void)initializeAppViewState {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self initializeAppViewState];
+        });
+        return;
+    }
+
+    self.window.rootViewController = [[InitialViewController alloc] initWithNibName:nil bundle:nil];
+    [self.window makeKeyAndVisible];
+}
+
+- (void)setupRootViewController {
+    ContactListViewController *rootVC = [[ContactListViewController alloc] initWithStyle:UITableViewStylePlain];
+    SFSDKNavigationController *navVC = [[SFSDKNavigationController alloc] initWithRootViewController:rootVC];
+    self.window.rootViewController = navVC;
+}
+
+- (void)resetViewState:(void (^)(void))postResetBlock {
+    if ([self.window.rootViewController presentedViewController]) {
+        [self.window.rootViewController dismissViewControllerAnimated:NO completion:^{
+            postResetBlock();
+        }];
+    } else {
+        postResetBlock();
+    }
+}
+
+@end

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/MobileSyncExplorer-Info.plist
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer/MobileSyncExplorer-Info.plist
@@ -26,6 +26,23 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
  1. Created SceneDelegate files:
    - SceneDelegate.h - Header file declaring the scene delegate
    - SceneDelegate.m - Implementation with scene lifecycle methods
  2. Updated AppDelegate.m:
    - Removed window management (now in SceneDelegate)
    - Removed user change notification registration (now scene-aware)
    - Removed loginIfRequired call (now in SceneDelegate)
    - Kept SDK initialization and push notification handling
  3. Updated Info.plist:
    - Added UIApplicationSceneManifest configuration
    - Set UISceneDelegateClassName to SceneDelegate
  4. Updated Xcode project:
    - Added SceneDelegate.h and SceneDelegate.m to build targets