### PR TITLE
Fix: Choose Connection Screen Crash on Swipe Dismissal 

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -356,6 +356,7 @@
 - (SFSDKLoginHostListViewController *)createLoginHostListViewController {
     SFSDKLoginHostListViewController *loginHostListViewController = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
     loginHostListViewController.config = self.config;
+    loginHostListViewController.delegate = self;
     return loginHostListViewController;
 }
 
@@ -400,7 +401,6 @@
 - (SFSDKLoginHostListViewController *)loginHostListViewController {
     if (!_loginHostListViewController) {
         _loginHostListViewController = [self createLoginHostListViewController];
-        _loginHostListViewController.delegate = self;
     }
     return _loginHostListViewController;
 }
@@ -453,7 +453,6 @@
 - (void)showHostListView {
     // Create a FRESH instance each time instead of reusing the cached one
     SFSDKLoginHostListViewController *hostListVC = [self createLoginHostListViewController];
-    hostListVC.delegate = self;
 
     SFSDKNavigationController *navController = [[SFSDKNavigationController alloc] initWithRootViewController:hostListVC];
     navController.modalPresentationStyle = UIModalPresentationPageSheet;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -451,9 +451,13 @@
 #pragma mark - Login Host
 
 - (void)showHostListView {
-    SFSDKNavigationController *navController = [[SFSDKNavigationController alloc] initWithRootViewController:self.loginHostListViewController];
+    // Create a FRESH instance each time instead of reusing the cached one
+    SFSDKLoginHostListViewController *hostListVC = [self createLoginHostListViewController];
+    hostListVC.delegate = self;
+
+    SFSDKNavigationController *navController = [[SFSDKNavigationController alloc] initWithRootViewController:hostListVC];
     navController.modalPresentationStyle = UIModalPresentationPageSheet;
-    
+
     [self presentViewController:navController animated:YES completion:nil];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLoginHostTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLoginHostTests.m
@@ -173,10 +173,14 @@
     XCTAssertNotEqual(instance2, instance3, "Second and third instances should be different objects");
     XCTAssertNotEqual(instance1, instance3, "First and third instances should be different objects");
 
-    // Verify each instance is properly configured
+    // Verify each instance is properly configured with config and delegate
     XCTAssertNotNil(instance1.config, "First instance should have config");
     XCTAssertNotNil(instance2.config, "Second instance should have config");
     XCTAssertNotNil(instance3.config, "Third instance should have config");
+
+    XCTAssertEqual(instance1.delegate, loginViewController, "First instance delegate should be set to loginViewController");
+    XCTAssertEqual(instance2.delegate, loginViewController, "Second instance delegate should be set to loginViewController");
+    XCTAssertEqual(instance3.delegate, loginViewController, "Third instance delegate should be set to loginViewController");
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLoginHostTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLoginHostTests.m
@@ -32,6 +32,11 @@
 #import "SFSDKLoginHostStorage.h"
 #import "SFSDKLoginHost.h"
 
+// Expose private method for testing
+@interface SFLoginViewController (Testing)
+- (SFSDKLoginHostListViewController *)createLoginHostListViewController;
+@end
+
 @interface SFSDKLoginHostTests : XCTestCase
 
 @property (nonatomic, strong) NSString *productionUrl;
@@ -144,6 +149,34 @@
     XCTAssertEqual(4, [loginHostStorage numberOfLoginHosts], "Number of login hosts should be equal to 4");
     XCTAssertEqualObjects(self.customName2, loginHost.name, @"%@ Should be equal to %@", self.customName2, loginHost.name);
     XCTAssertEqualObjects(self.customUrl2, loginHost.host, @"%@ Should be equal to %@", self.customUrl2, loginHost.host);
+}
+
+- (void) testLoginHostListViewControllerCreatesUniqueInstances {
+    // This test verifies the fix for the swipe dismissal race condition crash.
+    // Each call to createLoginHostListViewController should return a fresh instance,
+    // preventing the "nested navigation controllers" error when rapidly opening/closing
+    // the connection screen with swipe gestures.
+
+    SFLoginViewController *loginViewController = [[SFLoginViewController alloc] init];
+
+    // Create multiple instances
+    SFSDKLoginHostListViewController *instance1 = [loginViewController createLoginHostListViewController];
+    SFSDKLoginHostListViewController *instance2 = [loginViewController createLoginHostListViewController];
+    SFSDKLoginHostListViewController *instance3 = [loginViewController createLoginHostListViewController];
+
+    // Verify each call creates a unique instance (different memory addresses)
+    XCTAssertNotNil(instance1, "First instance should not be nil");
+    XCTAssertNotNil(instance2, "Second instance should not be nil");
+    XCTAssertNotNil(instance3, "Third instance should not be nil");
+
+    XCTAssertNotEqual(instance1, instance2, "First and second instances should be different objects");
+    XCTAssertNotEqual(instance2, instance3, "Second and third instances should be different objects");
+    XCTAssertNotEqual(instance1, instance3, "First and third instances should be different objects");
+
+    // Verify each instance is properly configured
+    XCTAssertNotNil(instance1.config, "First instance should have config");
+    XCTAssertNotNil(instance2.config, "Second instance should have config");
+    XCTAssertNotNil(instance3.config, "Third instance should have config");
 }
 
 @end


### PR DESCRIPTION
**What Changed**

**Before**: The code reused the same cached loginHostListViewController instance via the lazy property getter, causing a race condition when the view controller was still attached to a previous navigation controller during swipe dismissal.

**After**: Each time the "Choose Connection" screen is opened, a fresh SFSDKLoginHostListViewController instance is created, eliminating the possibility of the view controller being embedded in multiple navigation controllers simultaneously.

**Why This Fixes the Crash**

- No more reuse: Each presentation gets a brand new VC instance
- Clean state: No leftover navigation controller relationships
- Race-safe: Even rapid swipe gestures won't trigger the "nested navigation controllers" error
- Simple: No complex state management needed