### PR TITLE
Add nil key guards to SFSDKSafeMutableDictionary

### DIFF
--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Util/SFSDKSafeMutableDictionary.m
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Util/SFSDKSafeMutableDictionary.m
@@ -23,6 +23,7 @@
  */
 
 #import "SFSDKSafeMutableDictionary.h"
+#import "SFLogger.h"
 
 @interface SFSDKSafeMutableDictionary()
 
@@ -89,6 +90,10 @@
 #pragma Mark - Mutating Methods
 
 - (void)setObject:(id)object forKey:(id<NSCopying>)aKey {
+    if (aKey == nil) {
+        [SFLogger w:[self class] format:@"Attempted to set object with nil key in safe dictionary"];
+        return;
+    }
     dispatch_barrier_async(self.queue, ^{
         self.backingDictionary[aKey] = object;
     });
@@ -99,6 +104,10 @@
 }
 
 - (void)removeObject:(id<NSCopying>)aKey {
+    if (aKey == nil) {
+        [SFLogger w:[self class] format:@"Attempted to remove nil key from safe dictionary"];
+        return;
+    }
     dispatch_barrier_async(self.queue, ^{
         [self.backingDictionary removeObjectForKey:aKey];
     });


### PR DESCRIPTION
## Summary
- Fixes crash when `removeObject:` or `setObject:forKey:` are called with nil keys
- Adds nil guards that log warnings and return early instead of crashing
- Prevents `NSInvalidArgumentException` in auth session cleanup when `sceneId` is nil

## Root Cause
When identity retrieval fails with missing parameters (error 770), cleanup code in `SFUserAccountManager` attempts to remove auth sessions from the dictionary. If `authSession.sceneId` is nil, the dictionary crashes with:
```
*** -[__NSDictionaryM removeObjectForKey:]: key cannot be nil
```

## Solution
Added nil checks in:
- `setObject:forKey:` - logs warning and returns early if key is nil
- `removeObject:` - logs warning and returns early if key is nil

This makes `SFSDKSafeMutableDictionary` truly "safe" as the class name implies.