### PR TITLE
Fix iOS 18 advanced auth UI tests and add iOS 18 to CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -138,9 +138,20 @@ jobs:
 
   ui-tests-pr:
     needs: [test-orchestrator]
+    strategy:
+      fail-fast: false
+      matrix:
+        ios: [^26, ^18]
+        include:
+          - ios: ^26
+            xcode: ^26
+          - ios: ^18
+            xcode: ^16
     uses: ./.github/workflows/reusable-ui-test-workflow.yaml
     with:
       is_pr: true
+      ios: ${{ matrix.ios }}
+      xcode: ${{ matrix.xcode }}
       pr_test: "AuthFlowTesterUITests/LegacyLoginTests/testCAOpaque_DefaultScopes_WebServerFlow"
       short_timeout: "2"
       long_timeout: "7"

--- a/.github/workflows/ui-test-nightly.yaml
+++ b/.github/workflows/ui-test-nightly.yaml
@@ -7,10 +7,19 @@ on:
 
 jobs:
   ios-ui-test-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        ios: [^26, ^18]
+        include:
+          - ios: ^26
+            xcode: ^26
+          - ios: ^18
+            xcode: ^16
     uses: ./.github/workflows/reusable-ui-test-workflow.yaml
     with:
-      ios: "^26"
-      xcode: "^26"
+      ios: ${{ matrix.ios }}
+      xcode: ${{ matrix.xcode }}
       short_timeout: "2"
       long_timeout: "7"
     secrets: inherit

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -226,7 +226,7 @@ class LoginPageObject {
         if closeButton.exists {
             return closeButton
         }
-        // Earlier iOS versions use "Close", iOS 18+ uses "Cancel"
+        // Earlier iOS versions use "Cancel"
         return topBar.buttons["Cancel"]
     }
     

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -221,7 +221,13 @@ class LoginPageObject {
     }
 
     private func advancedAuthCloseButton() -> XCUIElement {
-        return app.otherElements["TopBrowserBar"].buttons["Close"]
+        let topBar = app.otherElements["TopBrowserBar"]
+        let closeButton = topBar.buttons["Close"]
+        if closeButton.exists {
+            return closeButton
+        }
+        // Earlier iOS versions use "Close", iOS 18+ uses "Cancel"
+        return topBar.buttons["Cancel"]
     }
     
     // MARK: - Actions


### PR DESCRIPTION
- Update LoginPageObject to handle iOS 18 button to exit ASWebAuthenticationSession (it's cancel on iOS 18 and close (X) on iOS 26)
- Add iOS 18 (Xcode 16) to UI test matrix in pr.yaml workflow
- Add iOS 18 (Xcode 16) to UI test matrix in ui-test-nightly.yaml workflow
