### PR TITLE
Lower AuthFlowTester deployment target to iOS 17.0 and add iOS 17 to UI nightly tests

### DIFF
--- a/.github/workflows/ui-test-nightly.yaml
+++ b/.github/workflows/ui-test-nightly.yaml
@@ -7,10 +7,21 @@ on:
 
 jobs:
   ios-ui-test-nightly:
+    strategy:
+      fail-fast: false
+      matrix:
+        ios: [^26, ^18, ^17]
+        include:
+          - ios: ^26
+            xcode: ^26
+          - ios: ^18
+            xcode: ^16
+          - ios: ^17
+            xcode: ^16
     uses: ./.github/workflows/reusable-ui-test-workflow.yaml
     with:
-      ios: "^26"
-      xcode: "^26"
+      ios: ${{ matrix.ios }}
+      xcode: ${{ matrix.xcode }}
       short_timeout: "2"
       long_timeout: "7"
     secrets: inherit

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester.xcodeproj/project.pbxproj
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester.xcodeproj/project.pbxproj
@@ -359,7 +359,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.salesforce.mobilesdk.AuthFlowTesterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -379,7 +379,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.salesforce.mobilesdk.AuthFlowTesterUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -530,7 +530,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -560,7 +560,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
- Changed IPHONEOS_DEPLOYMENT_TARGET from 17.6 to 17.0 in AuthFlowTester and AuthFlowTesterUITests to match SalesforceSDKCore's minimum target
- Added iOS 17 (with Xcode 16) to ui-test-nightly.yaml workflow matrix to ensure AuthFlowTester UI tests run on iOS 17.5 in CI