### PR TITLE
Update SQLCipher to 4.16.0

### DIFF
--- a/.claude/skills/update-sqlcipher/SKILL.md
+++ b/.claude/skills/update-sqlcipher/SKILL.md
@@ -27,7 +27,7 @@ Use this skill when you need to:
 SQLCipher is an open-source extension to SQLite that provides transparent 256-bit AES encryption of database files. The SDK uses it in the SmartStore library for secure local data storage.
 
 ## Parameters
-- `NEW_VERSION`: The new SQLCipher version (e.g., "4.6.1", "4.6.2")
+- `NEW_VERSION`: The new SQLCipher version (e.g., "4.6.1", "4.6.2", "4.16.0")
 - `OLD_VERSION`: The current SQLCipher version (default: check podspecs)
 - `NEW_PROVIDER_VERSION`: The cipher provider version bundled with the new SQLCipher (check SQLCipher release notes)
 

--- a/SmartStore.podspec
+++ b/SmartStore.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
       smartstore.dependency 'SalesforceSDKCore', "~>#{s.version}"
       smartstore.dependency 'FMDB/SQLCipher', '~> 2.7.12'
-      smartstore.dependency 'SQLCipher', '~> 4.15.0'
+      smartstore.dependency 'SQLCipher', '~> 4.16.0'
       smartstore.source_files = 'libs/SmartStore/SmartStore/Classes/**/*.{h,m,swift}', 'libs/SmartStore/SmartStore/SmartStore.h'
       smartstore.public_header_files = 'libs/SmartStore/SmartStore/Classes/SFAlterSoupLongOperation.h', 'libs/SmartStore/SmartStore/Classes/SFQuerySpec.h', 'libs/SmartStore/SmartStore/Classes/SFSDKSmartStoreLogger.h', 'libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.h', 'libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStore.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreInspectorViewController.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreUtils.h', 'libs/SmartStore/SmartStore/Classes/SFSoupIndex.h', 'libs/SmartStore/SmartStore/Classes/SFStoreCursor.h', 'libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.h', 'libs/SmartStore/SmartStore/SmartStore.h'
       smartstore.prefix_header_contents = '#import "SFSDKSmartStoreLogger.h"', '#import <SalesforceSDKCore/SalesforceSDKConstants.h>'

--- a/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
+++ b/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
@@ -1364,7 +1364,7 @@
 			repositoryURL = "https://github.com/sqlcipher/SQLCipher.swift";
 			requirement = {
 				kind = exactVersion;
-				version = 4.15.0;
+				version = 4.16.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -104,13 +104,13 @@
 - (void) testSqliteVersion
 {
     NSString* version = [NSString stringWithUTF8String:sqlite3_libversion()];
-    XCTAssertEqualObjects(version, @"3.53.0");
+    XCTAssertEqualObjects(version, @"3.53.1");
 }
 
 - (void) testSqlCipherVersion
 {
     NSString* version = [self.store getSQLCipherVersion];
-    XCTAssertEqualObjects(version, @"4.15.0 community");
+    XCTAssertEqualObjects(version, @"4.16.0 community");
 }
 
 - (void) testCipherProviderVersion

--- a/mobilesdk_pods.rb
+++ b/mobilesdk_pods.rb
@@ -25,7 +25,7 @@ def use_mobile_sdk!(options={})
 
   source 'https://www.github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs'
 
-  pod 'SQLCipher', '4.15.0'
+  pod 'SQLCipher', '4.16.0'
   pod 'SalesforceSDKCommon', :path => path
   pod 'SalesforceAnalytics', :path => path
   pod 'SalesforceSDKCore', :path => path

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
@@ -1178,7 +1178,7 @@
 			repositoryURL = "https://github.com/sqlcipher/SQLCipher.swift";
 			requirement = {
 				kind = exactVersion;
-				version = 4.15.0;
+				version = 4.16.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
## Summary
Updates SQLCipher from 4.15.0 to 4.16.0 in the iOS SDK.

## Changes
- Updated `SmartStore.podspec`: SQLCipher dependency from ~> 4.15.0 to ~> 4.16.0
- Updated `mobilesdk_pods.rb`: SQLCipher version reference to 4.16.0
- Updated `SmartStore.xcodeproj/project.pbxproj`: XCRemoteSwiftPackageReference to 4.16.0
- Updated `MobileSyncExplorer.xcodeproj/project.pbxproj`: Sample app SQLCipher reference to 4.16.0
- Updated `SFSmartStoreTests.m`: 
  - `testSqlCipherVersion`: Expects "4.16.0 community"
  - `testSqliteVersion`: Expects "3.53.1"
- Updated update-sqlcipher skill documentation

## SQLCipher 4.16.0 Details
- **SQLite Version**: 3.53.1 (updated from 3.53.0)
- **Cipher Provider**: LibTomCrypt (version unchanged)
- **Changes**: Bug fixes for allocation issues and reduced mlock warnings
- **API Changes**: None
- **Release Notes**: https://github.com/sqlcipher/sqlcipher/releases/tag/v4.16.0

## Testing
- Build: ✅ BUILD SUCCEEDED
- Tests: ✅ All SmartStore tests PASSED (177 tests)
- All version tests verified correct values
- No regressions detected

## Related PRs
- Android: https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/2883
- iOS-Hybrid: (creating next)
- iOS-Specs: (creating next)

## Prerequisite
Requires SQLCipher 4.16.0 podspec in iOS-Specs repo (see related PR).