### PR TITLE
 Add UI tests for refresh token rotation

### DIFF
--- a/native/SampleApps/AuthFlowTester/AuthFlowTester/ViewControllers/SessionDetailViewController.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester/ViewControllers/SessionDetailViewController.swift
@@ -31,6 +31,7 @@ import SalesforceSDKCore
 struct SessionDetailView: View {
     @State private var refreshTrigger = UUID()
     @State private var showMigrateRefreshToken = false
+    @State private var showAuthFlowTypes = false
     @State private var showLogoutConfirmation = false
     @State private var isUserCredentialsExpanded = false
     @State private var isJwtDetailsExpanded = false
@@ -89,17 +90,26 @@ struct SessionDetailView: View {
                 }) {
                     Label("Change Key", systemImage: "key.horizontal.fill")
                 }
-                
+
                 Spacer()
-                
+
+                Button(action: {
+                    showAuthFlowTypes = true
+                }) {
+                    Label("Auth Flow", systemImage: "arrow.triangle.2.circlepath")
+                }
+                .accessibilityIdentifier("authFlowTypesButton")
+
+                Spacer()
+
                 Button(action: {
                     onSwitchUser()
                 }) {
                     Label("Switch User", systemImage: "person.2.fill")
                 }
-                
+
                 Spacer()
-                
+
                 Button(action: {
                     showLogoutConfirmation = true
                 }) {
@@ -146,6 +156,21 @@ struct SessionDetailView: View {
                         }
                     }
                 }
+            }
+        }
+        .sheet(isPresented: $showAuthFlowTypes) {
+            NavigationView {
+                AuthFlowTypesView()
+                    .padding()
+                    .navigationTitle("Auth Flow Types")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("Done") {
+                                showAuthFlowTypes = false
+                            }
+                        }
+                    }
             }
         }
         .alert("Migration Error", isPresented: $showMigrationError) {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTesterMainPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTesterMainPageObject.swift
@@ -268,6 +268,15 @@ class AuthFlowTesterMainPageObject {
         tap(swithToUserButton())
     }
     
+    func setAuthFlowTypes(useWebServerFlow: Bool, useHybridFlow: Bool) {
+        tap(bottomBarAuthFlowTypesButton())
+        authFlowTypesPageObject.setAuthFlowTypes(
+            useWebServerFlow: useWebServerFlow,
+            useHybridFlow: useHybridFlow
+        )
+        tap(authFlowTypesDoneButton())
+    }
+
     func changeAppConfig(appConfig: AppConfig, scopesToRequest: String = "", useWebServerFlow: Bool, useHybridFlow: Bool) -> Bool {
         // Tap Change Key button to open the sheet
         tap(bottomBarChangeKeyButton())
@@ -343,6 +352,14 @@ class AuthFlowTesterMainPageObject {
         return app.buttons["Change Key"]
     }
     
+    private func bottomBarAuthFlowTypesButton() -> XCUIElement {
+        return app.buttons["authFlowTypesButton"]
+    }
+
+    private func authFlowTypesDoneButton() -> XCUIElement {
+        return app.buttons["Done"]
+    }
+
     private func bottomBarSwitchUserButton() -> XCUIElement {
         return app.buttons["Switch User"]
     }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -78,21 +78,21 @@ class LoginPageObject {
         }
     }
     
-    func performLogin(username: String, password: String) {
+    func performLogin(username: String, password: String, advancedAuth: Bool = false) {
         setTextField(usernameField(), value: username)
-        dismissKeyboardAfterTyping()
-        tap(loginButton())
+        if advancedAuth {
+            usernameField().typeText(XCUIKeyboardKey.return.rawValue)
+        } else {
+            dismissKeyboardAfterTyping()
+            tap(loginButton())
+        }
         setTextField(passwordField(), value: password)
-        dismissKeyboardAfterTyping()
-        tap(loginButton())
-        tapIfPresent(allowButton())
-    }
-
-    func performAdvancedLogin(username: String, password: String) {
-        setTextField(usernameField(), value: username)
-        usernameField().typeText(XCUIKeyboardKey.return.rawValue)
-        setTextField(passwordField(), value: password)
-        passwordField().typeText(XCUIKeyboardKey.return.rawValue)
+        if advancedAuth {
+            passwordField().typeText(XCUIKeyboardKey.return.rawValue)
+        } else {
+            dismissKeyboardAfterTyping()
+            tap(loginButton())
+        }
         tapIfPresent(allowButton())
     }
 
@@ -100,7 +100,6 @@ class LoginPageObject {
     /// Taps Settings → "Login for Admin" which triggers ASWebAuthenticationSession (native browser),
     /// then completes authentication in the browser.
     func performLoginForAdmin(username: String, password: String) {
-        // Tap Settings gear icon → "Login for Admin" menu item
         tap(settingsButton())
         tap(loginForAdminButton())
 
@@ -108,19 +107,18 @@ class LoginPageObject {
         let topBar = app.otherElements["TopBrowserBar"]
         _ = topBar.waitForExistence(timeout: UITestTimeouts.long)
 
-        // Complete login in the browser (same interaction as advanced auth)
-        setTextField(usernameField(), value: username)
-        usernameField().typeText(XCUIKeyboardKey.return.rawValue)
-        setTextField(passwordField(), value: password)
-        passwordField().typeText(XCUIKeyboardKey.return.rawValue)
-        tapIfPresent(allowButton())
+        performLogin(username: username, password: password, advancedAuth: true)
     }
-    
-    func performWelcomeLogin(password: String) {
+
+    func performWelcomeLogin(password: String, advancedAuth: Bool = false) {
         tap(loginButton())
         setTextField(passwordField(), value: password)
-        dismissKeyboardAfterTyping()
-        tap(loginButton())
+        if advancedAuth {
+            passwordField().typeText(XCUIKeyboardKey.return.rawValue)
+        } else {
+            dismissKeyboardAfterTyping()
+            tap(loginButton())
+        }
         tapIfPresent(allowButton())
     }
     

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
@@ -48,6 +48,7 @@ class RTRLoginTests: BaseAuthFlowTester {
     func testECAJwtRtr_Hybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr)
         restartAndValidateUser(userAppConfigName: .ecaJwtRtr)
+        assertRevokeAndRefreshWorks(isRtr: true)
     }
 
     /// Login with ECA JWT RTR without hybrid flow.
@@ -59,6 +60,7 @@ class RTRLoginTests: BaseAuthFlowTester {
     func testECAJwtRtr_NoHybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr, useHybridFlow: false)
         restartAndValidateUser(userAppConfigName: .ecaJwtRtr, useHybridFlow: false)
+        assertRevokeAndRefreshWorks(isRtr: true)
     }
 
     // MARK: - ECA Opaque RTR Tests
@@ -72,6 +74,7 @@ class RTRLoginTests: BaseAuthFlowTester {
     func testECAOpaqueRtr_Hybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr)
         restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr)
+        assertRevokeAndRefreshWorks(isRtr: true)
     }
 
     /// Login with ECA Opaque RTR without hybrid flow.
@@ -83,5 +86,6 @@ class RTRLoginTests: BaseAuthFlowTester {
     func testECAOpaqueRtr_NoHybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
         restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
+        assertRevokeAndRefreshWorks(isRtr: true)
     }
 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
@@ -36,11 +36,15 @@ class RTRLoginTests: BaseAuthFlowTester {
     // MARK: - ECA JWT RTR Tests
 
     /// Login with ECA JWT RTR using hybrid flow.
+    /// - Note: Expected to fail until W-22512846 (Enable Named JWTs for Hybrid Flows) is resolved.
+    ///   The server currently returns invalid_grant when RTR is used with JWT tokens in hybrid flow.
     func testECAJwtRtr_Hybrid() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr)
     }
 
     /// Login with ECA JWT RTR using hybrid flow, restart app, and verify session persists.
+    /// - Note: Expected to fail until W-22512846 (Enable Named JWTs for Hybrid Flows) is resolved.
+    ///   The server currently returns invalid_grant when RTR is used with JWT tokens in hybrid flow.
     func testECAJwtRtr_Hybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr)
         restartAndValidateUser(userAppConfigName: .ecaJwtRtr)

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
@@ -1,0 +1,83 @@
+/*
+ RTRLoginTests.swift
+ AuthFlowTesterUITests
+
+ Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+
+/// Tests for login flows using External Client App (ECA) configurations with Refresh Token Rotation (RTR).
+///
+/// NB: Tests use the first user from ui_test_config.json
+///
+class RTRLoginTests: BaseAuthFlowTester {
+
+    // MARK: - ECA JWT RTR Tests
+
+    /// Login with ECA JWT RTR using hybrid flow.
+    func testECAJwtRtr_Hybrid() throws {
+        launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr)
+    }
+
+    /// Login with ECA JWT RTR using hybrid flow, restart app, and verify session persists.
+    func testECAJwtRtr_Hybrid_WithRestart() throws {
+        launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr)
+        restartAndValidateUser(userAppConfigName: .ecaJwtRtr)
+    }
+
+    /// Login with ECA JWT RTR without hybrid flow.
+    func testECAJwtRtr_NoHybrid() throws {
+        launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr, useHybridFlow: false)
+    }
+
+    /// Login with ECA JWT RTR without hybrid flow, restart app, and verify session persists.
+    func testECAJwtRtr_NoHybrid_WithRestart() throws {
+        launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr, useHybridFlow: false)
+        restartAndValidateUser(userAppConfigName: .ecaJwtRtr, useHybridFlow: false)
+    }
+
+    // MARK: - ECA Opaque RTR Tests
+
+    /// Login with ECA Opaque RTR using hybrid flow.
+    func testECAOpaqueRtr_Hybrid() throws {
+        launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr)
+    }
+
+    /// Login with ECA Opaque RTR using hybrid flow, restart app, and verify session persists.
+    func testECAOpaqueRtr_Hybrid_WithRestart() throws {
+        launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr)
+        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr)
+    }
+
+    /// Login with ECA Opaque RTR without hybrid flow.
+    func testECAOpaqueRtr_NoHybrid() throws {
+        launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
+    }
+
+    /// Login with ECA Opaque RTR without hybrid flow, restart app, and verify session persists.
+    func testECAOpaqueRtr_NoHybrid_WithRestart() throws {
+        launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
+        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
+    }
+}

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -619,7 +619,8 @@ class BaseAuthFlowTester: XCTestCase {
         )
         
         // Revoke and refresh cycle
-        assertRevokeAndRefreshWorks(previousCredentials: userCredentials)
+        let userAppConfig = getAppConfig(named: userAppConfigName)
+        assertRevokeAndRefreshWorks(previousCredentials: userCredentials, isRtr: userAppConfig.isRtr)
 
         // Check the oauth configuration
         _ = checkOauthConfiguration(
@@ -747,21 +748,36 @@ class BaseAuthFlowTester: XCTestCase {
         }
     }
     
-    private func assertRevokeAndRefreshWorks(previousCredentials: UserCredentialsData) {
+    private func assertRevokeAndRefreshWorks(previousCredentials: UserCredentialsData, isRtr: Bool) {
         // Revoke access token
         XCTAssert(mainPage.revokeAccessToken(), "Failed to revoke access token")
 
         // Make REST request (which should trigger token refresh)
         XCTAssert(mainPage.makeRestRequest(), "Failed to make REST request")
-        
+
         let credentialsAfterRefresh = getUserCredentials()
-        
+
         // Assert access token changed
         XCTAssertNotEqual(
             previousCredentials.accessToken,
             credentialsAfterRefresh.accessToken,
             "Access token should have been refreshed"
         )
+
+        // Assert refresh token rotated (RTR) or stayed the same (non-RTR)
+        if isRtr {
+            XCTAssertNotEqual(
+                previousCredentials.refreshToken,
+                credentialsAfterRefresh.refreshToken,
+                "Refresh token should have rotated (RTR app)"
+            )
+        } else {
+            XCTAssertEqual(
+                previousCredentials.refreshToken,
+                credentialsAfterRefresh.refreshToken,
+                "Refresh token should not have changed (non-RTR app)"
+            )
+        }
     }
     
     private func sortedScopes(_ value: String) -> String {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -145,15 +145,11 @@ class BaseAuthFlowTester: XCTestCase {
         // Welcome login
         else if (useWelcomeDiscovery) {
             XCTAssertTrue(loginPage.hasFilledUsernameField(username: userConfig.username), "Login page should have pre-filled username")
-            loginPage.performWelcomeLogin(password: userConfig.password)
+            loginPage.performWelcomeLogin(password: userConfig.password, advancedAuth: loginHost == .advancedAuth)
         }
-        // Regular auth
-        else if (loginHost == .regularAuth) {
-            loginPage.performLogin(username: userConfig.username, password: userConfig.password)
-        }
-        // Advanced auth
-        else if (loginHost == .advancedAuth) {
-            loginPage.performAdvancedLogin(username: userConfig.username, password: userConfig.password)
+        // Regular or advanced auth
+        else {
+            loginPage.performLogin(username: userConfig.username, password: userConfig.password, advancedAuth: loginHost == .advancedAuth)
         }
         
         // Invalid scope

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -430,7 +430,10 @@ class BaseAuthFlowTester: XCTestCase {
         // Restart
         app.terminate()
         app.launch()
-        
+
+        // Restore auth flow settings lost on restart
+        mainPage.setAuthFlowTypes(useWebServerFlow: useWebServerFlow, useHybridFlow: useHybridFlow)
+
         // Validate user
         // Not checking static app config since it will depend on the bootconfig of the target app
         validateUser(

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -748,6 +748,11 @@ class BaseAuthFlowTester: XCTestCase {
         }
     }
     
+    /// Captures current credentials then performs a revoke/refresh cycle and validates the result.
+    func assertRevokeAndRefreshWorks(isRtr: Bool) {
+        assertRevokeAndRefreshWorks(previousCredentials: getUserCredentials(), isRtr: isRtr)
+    }
+
     private func assertRevokeAndRefreshWorks(previousCredentials: UserCredentialsData, isRtr: Bool) {
         // Revoke access token
         XCTAssert(mainPage.revokeAccessToken(), "Failed to revoke access token")

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestConfigUtils.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestConfigUtils.swift
@@ -94,6 +94,8 @@ enum KnownLoginHostConfig: String {
 enum KnownAppConfig: String {
     case ecaOpaque = "eca_opaque"
     case ecaJwt = "eca_jwt"
+    case ecaOpaqueRtr = "eca_opaque_rtr"
+    case ecaJwtRtr = "eca_jwt_rtr"
     case beaconOpaque = "beacon_opaque"
     case beaconJwt = "beacon_jwt"
     case caOpaque = "ca_opaque"
@@ -127,6 +129,11 @@ struct AppConfig: Codable {
     /// Returns true if the app issues JWT tokens (name contains "_jwt")
     var issuesJwt: Bool {
         return name.contains("_jwt")
+    }
+
+    /// Returns true if the app uses Refresh Token Rotation (name contains "_rtr")
+    var isRtr: Bool {
+        return name.contains("_rtr")
     }
     
     /// Returns scopes as an array

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/overview.md
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/overview.md
@@ -12,6 +12,7 @@ This document provides an overview of all UI tests in the AuthFlowTester test su
 | `BeaconLoginTests` | Tests for Beacon app login flows (using regular_auth login host) |
 | `AdvancedAuthBeaconLoginTests` | Tests for Beacon app login flows (using advanced_auth login host) |
 | `WelcomeLoginTests` | Tests for welcome (domain discovery) login flows using simulated domain discovery |
+| `RTRLoginTests` | Tests for ECA login flows with Refresh Token Rotation (RTR), with and without hybrid flow, with and without app restart |
 | `LoginWithRestartTests` | Tests for verifying that user sessions persist across app restarts |
 | `RefreshTokenMigrationTests` | Tests for refresh token migration between app configurations without re-authentication |
 | `RefreshTokenMigrationWithRestartTests` | Tests for verifying that migrated refresh tokens persist across app restarts |
@@ -61,6 +62,21 @@ Tests for External Client App (ECA) configurations using web server flow with hy
 | `testECAJwt_AllScopes` | ECA JWT | All | Standard login with all scopes |
 | `testDynamicConfigurationWithInvalidClientId` | Invalid (dynamic) | Default | Negative test: invalid client ID in dynamic config |
 | `testDynamicConfigurationWithInvalidScope` | ECA JWT (dynamic) | Invalid | Negative test: invalid scope in dynamic config |
+
+### RTRLoginTests (8 tests)
+
+Tests for ECA configurations with Refresh Token Rotation (RTR) enabled. Verifies that the refresh token rotates on each token refresh (RTR apps) and that sessions survive app restarts. The `assertRevokeAndRefreshWorks` check asserts the refresh token **changes** after a revoke/refresh cycle for RTR apps, and **stays the same** for non-RTR apps.
+
+| Test Name | App Config | Hybrid | Restart |
+|-----------|------------|--------|---------|
+| `testECAJwtRtr_Hybrid` | ECA JWT RTR | Yes | No |
+| `testECAJwtRtr_Hybrid_WithRestart` | ECA JWT RTR | Yes | Yes |
+| `testECAJwtRtr_NoHybrid` | ECA JWT RTR | No | No |
+| `testECAJwtRtr_NoHybrid_WithRestart` | ECA JWT RTR | No | Yes |
+| `testECAOpaqueRtr_Hybrid` | ECA Opaque RTR | Yes | No |
+| `testECAOpaqueRtr_Hybrid_WithRestart` | ECA Opaque RTR | Yes | Yes |
+| `testECAOpaqueRtr_NoHybrid` | ECA Opaque RTR | No | No |
+| `testECAOpaqueRtr_NoHybrid_WithRestart` | ECA Opaque RTR | No | Yes |
 
 ### BeaconLoginTests (6 tests)
 
@@ -187,6 +203,7 @@ Tests for login scenarios with two users using various configurations, including
 |----------|--------------|-------------|
 | **CA** | Opaque/JWT | Connected App |
 | **ECA** | Opaque/JWT | External Client App |
+| **ECA RTR** | Opaque/JWT | External Client App with Refresh Token Rotation enabled |
 | **Beacon** | Opaque/JWT | Beacon App |
 
 ### Configuration Modes
@@ -202,6 +219,8 @@ Tests for login scenarios with two users using various configurations, including
 |-------------|----------|-------|--------|
 | `ecaOpaque` | ECA | Opaque | `api content id lightning refresh_token sfap_api visualforce web` |
 | `ecaJwt` | ECA | JWT | `api content id lightning refresh_token sfap_api visualforce web` |
+| `ecaOpaqueRtr` | ECA RTR | Opaque | `api content id lightning refresh_token sfap_api web` |
+| `ecaJwtRtr` | ECA RTR | JWT | `api content id lightning refresh_token sfap_api web` |
 | `beaconOpaque` | Beacon | Opaque | `api content id lightning refresh_token sfap_api web` |
 | `beaconJwt` | Beacon | JWT | `api content id lightning refresh_token sfap_api web` |
 | `caOpaque` | CA | Opaque | `api content id lightning refresh_token sfap_api visualforce web` |

--- a/shared/test/ui_test_config.json.sample
+++ b/shared/test/ui_test_config.json.sample
@@ -89,6 +89,18 @@
             "consumerKey": "your_consumer_key_here",
             "redirectUri": "beaconadvancedjwt://success/done",
             "scopes": "api content id lightning refresh_token sfap_api web"
+        },
+        {
+            "name": "eca_jwt_rtr",
+            "consumerKey": "your_consumer_key_here",
+            "redirectUri": "ecajwtrtr://success/done",
+            "scopes": "api content id lightning refresh_token sfap_api web"
+        },
+        {
+            "name": "eca_opaque_rtr",
+            "consumerKey": "your_consumer_key_here",
+            "redirectUri": "ecaopaquertr://success/done",
+            "scopes": "api content id lightning refresh_token sfap_api web"
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Adds `RTRLoginTests` — 8 UI tests covering ECA apps with Refresh Token Rotation (RTR) enabled, across hybrid/non-hybrid flows and with/without app restart
- `assertRevokeAndRefreshWorks` now asserts the refresh token **rotates** after a revoke/refresh cycle for RTR apps, and **stays stable** for non-RTR apps
- Adds `ecaOpaqueRtr` and `ecaJwtRtr` to `KnownAppConfig` and `AppConfig.isRtr` computed property in `UITestConfigUtils`
- Updates `ui_test_config.json.sample` with the two new RTR app entries
- Updates `overview.md` to document the new test class and app configs

## Known failures — W-22512846

`testECAJwtRtr_Hybrid` and `testECAJwtRtr_Hybrid_WithRestart` are **expected to fail** until [W-22512846](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002a74cTYAQ/view) (_Enable Named JWTs for Hybrid Flows_) is resolved on the server side.

The server currently returns `invalid_grant` when RTR is used with JWT-based access tokens in hybrid flow. The four non-hybrid and opaque RTR tests are expected to pass.