### PR TITLE
Hide navigation bar on native login view presentation

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -2293,6 +2293,10 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             UIViewController *multiWindowNativeLoginVC = [[SalesforceSDKManager sharedManager].nativeLoginViewControllers objectForKey:viewHandler.scene.session.persistentIdentifier];
             UIViewController *nativeLogin = multiWindowNativeLoginVC ? multiWindowNativeLoginVC : [[[SalesforceSDKManager sharedManager] nativeLoginViewControllers] objectForKey:kSFDefaultNativeLoginViewControllerKey];
             UIViewController *controllerToPresent = [[SFSDKNavigationController alloc] initWithRootViewController:nativeLogin];
+            // Hide the nav bar for custom native login views. SFLoginViewController hides it
+            // internally, but custom VCs don't — without this, a Salesforce-blue nav bar appears
+            // on top of the native login view on re-presentation (e.g. after fallback to web auth).
+            [(UINavigationController *)controllerToPresent setNavigationBarHidden:YES animated:NO];
             controllerToPresent.modalPresentationStyle = UIModalPresentationFullScreen;
             [[[SFSDKWindowManager sharedManager] authWindow:viewHandler.scene].viewController presentViewController:controllerToPresent animated:NO completion:^{ }];
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/NativeLoginManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/NativeLoginManagerTests.swift
@@ -178,3 +178,14 @@ final class NativeLoginManagerTests: XCTestCase {
         return user
     }
 }
+
+// MARK: - Test Helpers
+
+private class MockPresenterViewController: UIViewController {
+    var onPresent: ((UIViewController) -> Void)?
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        onPresent?(viewControllerToPresent)
+        completion?()
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/NativeLoginManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/NativeLoginManagerTests.swift
@@ -125,6 +125,47 @@ final class NativeLoginManagerTests: XCTestCase {
         bioAuthManager.locked = false
     }
     
+    func testNativeLoginPresentationHidesNavigationBar() {
+        // Verify that when native login is enabled and the auth view is presented,
+        // the wrapping SFSDKNavigationController has its navigation bar hidden.
+        // This prevents an unwanted Salesforce-blue nav bar from appearing on top
+        // of custom native login views (especially on re-presentation after
+        // fallback-to-web-auth → back).
+        let accountManager = UserAccountManager.shared
+
+        // Native login is already configured via `nativeLoginManager` property.
+        XCTAssertTrue(accountManager.nativeLoginEnabled, "Native login should be enabled.")
+        accountManager.shouldFallbackToWebAuthentication = false
+
+        let expectation = self.expectation(description: "Auth view presented")
+        var presentedController: UIViewController?
+
+        // Set up auth window with a mock VC that captures presentViewController: calls.
+        // This lets the real presentLoginView: execute end-to-end.
+        let mockPresenter = MockPresenterViewController()
+        mockPresenter.onPresent = { controller in
+            presentedController = controller
+            expectation.fulfill()
+        }
+        SFSDKWindowManager.shared().authWindow(nil).viewController = mockPresenter
+
+        // Directly invoke the default authViewHandler's display block with an
+        // AuthViewHolder configured for the native login path (no loginController,
+        // not advanced auth). This triggers presentLoginView: in production code.
+        let viewHolder = AuthViewHolder()
+        viewHolder.isAdvancedAuthFlow = false
+        accountManager.authViewHandler.authViewDisplayBlock(viewHolder)
+
+        waitForExpectations(timeout: 5)
+
+        // Verify the navigation bar is hidden on the presented SFSDKNavigationController
+        if let navController = presentedController as? UINavigationController {
+            XCTAssertTrue(navController.isNavigationBarHidden, "Navigation bar should be hidden for native login presentation.")
+        } else {
+            XCTFail("Expected a UINavigationController to be presented for native login.")
+        }
+    }
+
     private func createUser() -> UserAccount {
         let credentials = OAuthCredentials(identifier: "identifier-0", clientId: "fakeClientIdForTesting", encrypted: true)!
         let user = UserAccount(credentials: credentials)


### PR DESCRIPTION
## Summary
- Hide the `SFSDKNavigationController` navigation bar when presenting custom native login view controllers in `presentLoginView:`
- Previously, the wrapping nav controller's bar (styled with Salesforce blue) was visible by default. `SFLoginViewController` hides it internally, but custom native login VCs had no such handling — resulting in an unwanted nav bar appearing on top of the app's login UI, especially on re-presentation after fallback-to-web-auth → back
- Add unit test verifying the navigation bar is hidden when a native login VC is presented

## Test plan
- [x] New unit test `testNativeLoginPresentationHidesNavigationBar` passes
- [x] Test correctly fails when the fix is reverted
- [x] All existing `NativeLoginManagerTests` pass
- [x] Manual verification: use an app with custom native login, trigger fallback to web auth, press back — confirm no blue nav bar appears