### PR TITLE
Fix thread-safety race in SFUserAccount encodeWithCoder

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.m
@@ -95,12 +95,14 @@ NSString * const kUserAccountPhotoEncryptionKeyLabel = @"com.salesforce.userAcco
 }
 
 - (void)encodeWithCoder:(NSCoder*)encoder {
-    [encoder encodeObject:_accessScopes forKey:kUser_ACCESS_SCOPES];
-    [encoder encodeObject:_credentials forKey:kUser_CREDENTIALS];
-    [encoder encodeObject:_idData forKey:kUser_ID_DATA];
-    [encoder encodeObject:_customData forKey:kUser_CUSTOM_DATA];
-    [encoder encodeInteger:_accessRestrictions forKey:kUser_ACCESS_RESTRICTIONS];
-    [encoder encodeObject:_notificationTypes forKey:kUser_NOTIFICATION_TYPES];
+    dispatch_sync(_syncQueue, ^{
+        [encoder encodeObject:self->_accessScopes forKey:kUser_ACCESS_SCOPES];
+        [encoder encodeObject:self->_credentials forKey:kUser_CREDENTIALS];
+        [encoder encodeObject:self->_idData forKey:kUser_ID_DATA];
+        [encoder encodeObject:self->_customData forKey:kUser_CUSTOM_DATA];
+        [encoder encodeInteger:self->_accessRestrictions forKey:kUser_ACCESS_RESTRICTIONS];
+        [encoder encodeObject:self->_notificationTypes forKey:kUser_NOTIFICATION_TYPES];
+    });
 }
 
 - (id)initWithCoder:(NSCoder*)decoder {


### PR DESCRIPTION
## Summary
- `encodeWithCoder:` accessed ivars (`_accessScopes`, `_idData`, `_customData`) directly without synchronizing on the concurrent queue, while their setters use `dispatch_barrier_async`. This caused a race where encoding immediately after setting these properties could capture stale (nil/empty) values.
- Wraps the encoder calls in `dispatch_sync` on `_syncQueue` so pending barrier writes complete before the ivars are read.

## Test plan
- [ ] Verify `testUserAccountEncoding` passes on iOS 26 (Xcode 26) nightly CI
- [ ] Verify no deadlocks when archiving `SFUserAccount` from different threads
- [ ] Run full SalesforceSDKCore test suite