### PR TITLE
Remove redundant biometric auto-present from SFLoginViewController.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -92,10 +92,6 @@
         [self.view addSubview:self.biometricButton];
     }
     
-    if (bioAuthManager.locked && bioAuthManager.hasBiometricOptedIn) {
-        [bioAuthManager presentBiometricWithScene:self.view.window.windowScene];
-    }
-    
     [self registerForTraitChanges:@[UITraitDisplayScale.class] withAction:@selector(setupNavigationBar)];
 }
 


### PR DESCRIPTION
## Summary
- Removes redundant biometric auto-presentation code from `SFLoginViewController.viewDidLoad` (lines 95-97)
- `BiometricAuthenticationManagerInternal.lock()` now serves as the single source of truth for auto-presenting biometric unlock
- The removed code did not respect the `automaticPresentation` flag introduced in PR #4041

## Context
PR #4041 added `automaticPresentation` to `lock()` which auto-presents biometric on all connected scenes. `SFLoginViewController` had its own independent auto-present logic that predated this and didn't check `automaticPresentation`. With `automaticPresentation` defaulting to `true`, both paths produced the same behavior — consolidating into `lock()` ensures the flag is always respected.

## Test plan
- [x] All 15 `BiometricAuthenticationManagerTests` pass
- [x] Manual: webview login app with biometric policy + user opted in → biometric prompt still auto-presents on lock
- [x] Manual: set `automaticPresentation = false` → biometric prompt does NOT auto-present (user must tap button)
- [x] Manual: biometric button on login screen still works when tapped manually