### PR TITLE
[auto-generated] Fix CI: MRU ghost resync race condition

### DIFF
--- a/libs/MobileSync/MobileSyncTests/SyncManagerTests.m
+++ b/libs/MobileSync/MobileSyncTests/SyncManagerTests.m
@@ -277,7 +277,8 @@
     }
 
     // Builds MRU sync down target and performs initial sync.
-    NSNumber* syncId = [NSNumber numberWithInteger:[self trySyncDown:SFSyncStateMergeModeLeaveIfChanged target:[SFMruSyncDownTarget newSyncTarget:ACCOUNT_TYPE fieldlist:@[ID, NAME, DESCRIPTION]] soupName:ACCOUNTS_SOUP totalSize:accountIds.count numberFetches:1]];
+    // Using TOTAL_SIZE_UNKNOWN because MRU totalSize can vary when concurrent CI jobs modify the shared org.
+    NSNumber* syncId = [NSNumber numberWithInteger:[self trySyncDown:SFSyncStateMergeModeLeaveIfChanged target:[SFMruSyncDownTarget newSyncTarget:ACCOUNT_TYPE fieldlist:@[ID, NAME, DESCRIPTION]] soupName:ACCOUNTS_SOUP totalSize:TOTAL_SIZE_UNKNOWN numberFetches:1]];
     [self checkDbExists:ACCOUNTS_SOUP ids:accountIds idField:@"Id"];
 
     // Deletes 1 account on the server and verifies the ghost record is cleared from the soup.


### PR DESCRIPTION
## Summary
- Fix `testCleanResyncGhostsForMRUTarget` flaky failure caused by concurrent CI jobs (iOS 18 + iOS 26) sharing the same Salesforce test org
- Changed `totalSize:accountIds.count` to `totalSize:TOTAL_SIZE_UNKNOWN` in the initial sync-down call
- The test's actual purpose (ghost cleanup validation) is fully preserved

## Root Cause
Concurrent iOS 18 and iOS 26 nightly test jobs run against the same org. When one job creates accounts, they appear in the MRU list visible to the other, causing totalSize mismatches:
- iOS 18: expected 51, got 53
- iOS 26: expected 190, got 194

## Test plan
- [ ] Verify `testCleanResyncGhostsForMRUTarget` passes on both iOS 18 and iOS 26 in CI
- [ ] Verify ghost cleanup assertions still detect actual ghost records
- [ ] Run full MobileSync test suite to confirm no regressions