### PR TITLE
Handle test_login_domain with or without https:// prefix

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestCredentialsData.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestCredentialsData.m
@@ -80,7 +80,10 @@
 
 - (NSString *)loginHost
 {
-    return _credentialsDict[@"test_login_domain"];
+    NSString *value = _credentialsDict[@"test_login_domain"];
+    if ([value hasPrefix:@"https://"]) return [value substringFromIndex:8];
+    if ([value hasPrefix:@"http://"]) return [value substringFromIndex:7];
+    return value;
 }
 
 - (NSString *)communityUrl


### PR DESCRIPTION
## Summary

`SFSDKTestCredentialsData.loginHost` now strips `https://` or `http://` prefix if present, returning just the hostname. This allows the same `test_credentials.json` to work on both iOS and Android without platform-specific formatting.

iOS strips the scheme if present. Android (companion PR) adds it if missing.

## Test plan

- [x] Existing tests pass with current `test_credentials.json` format (bare hostname)
- [x] Tests also pass with full URL format (`https://login.salesforce.com`)