### PR TITLE
Fixing instant login

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -196,20 +196,22 @@ SFNativeLoginManagerInternal *nativeLogin;
 
 + (void)initializeSDK {
     [self initializeSDKWithClass:InstanceClass];
+}
+
++ (void)initializeSDKWithClass:(Class)className {
+    [self setInstanceClass:className];
+
 #ifdef DEBUG
     // For debug app builds only, use test instant log in if applicable.
     NSArray<NSString *> *arguments = [[NSProcessInfo processInfo] arguments];
     if ([arguments containsObject:@"-creds"]) {
         NSString *creds = arguments[[arguments indexOfObject:@"-creds"] + 1];
-        
+
         [TestSetupUtils populateAuthCredentialsFromString:creds initializeSdk:NO];
         [TestSetupUtils synchronousAuthRefreshWithUserDidLoginNotification:YES];
     }
 #endif
-}
 
-+ (void)initializeSDKWithClass:(Class)className {
-    [self setInstanceClass:className];
     [SalesforceSDKManager sharedManager];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
@@ -30,7 +30,9 @@ NSString* const kTestRequestStatusWaiting = @"waiting";
 NSString* const kTestRequestStatusDidLoad = @"didLoad";
 NSString* const kTestRequestStatusDidFail = @"didFail";
 
-@interface SFSDKTestRequestListener ()
+@interface SFSDKTestRequestListener () {
+    dispatch_semaphore_t _completionSemaphore;
+}
 @end
 
 @implementation SFSDKTestRequestListener
@@ -46,6 +48,7 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
     if (nil != self) {
         self.maxWaitTime = 30.0;
         self.returnStatus = kTestRequestStatusWaiting;
+        _completionSemaphore = dispatch_semaphore_create(0);
     }
     return self;
 }
@@ -57,15 +60,16 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
 }
 
 - (NSString *)waitForCompletion {
-    NSDate *startTime = [NSDate date] ;
-    while ([self.returnStatus isEqualToString:kTestRequestStatusWaiting]) {
-        NSTimeInterval elapsed = [[NSDate date] timeIntervalSinceDate:startTime];
-        if (elapsed > self.maxWaitTime) {
-            [SFSDKCoreLogger d:[self class] format:@"Request took too long (> %f secs) to complete.", elapsed];
-            return kTestRequestStatusDidFail;
-        }
-        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+    // Wait for completion signal with timeout
+    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.maxWaitTime * NSEC_PER_SEC));
+    long result = dispatch_semaphore_wait(_completionSemaphore, timeout);
+
+    if (result != 0) {
+        // Timeout occurred
+        [SFSDKCoreLogger d:[self class] format:@"Request took too long (> %f secs) to complete.", self.maxWaitTime];
+        return kTestRequestStatusDidFail;
     }
+
     return self.returnStatus;
 }
 
@@ -75,6 +79,7 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
 {
     [SFSDKCoreLogger i:[self class] format:@"%@", NSStringFromSelector(_cmd)];
     self.returnStatus = kTestRequestStatusDidLoad;
+    dispatch_semaphore_signal(_completionSemaphore);
 }
 
 - (void)identityCoordinator:(SFIdentityCoordinator *)coordinator didFailWithError:(NSError *)error
@@ -82,6 +87,7 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
     [SFSDKCoreLogger i:[self class] format:@"%@ with error: %@", NSStringFromSelector(_cmd), error];
     self.lastError = error;
     self.returnStatus = kTestRequestStatusDidFail;
+    dispatch_semaphore_signal(_completionSemaphore);
 }
 
 #pragma mark - SFOAuthCoordinatorDelegate
@@ -123,6 +129,7 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
 {
     [SFSDKCoreLogger i:[self class] format:@"%@ with authInfo: %@", NSStringFromSelector(_cmd), info];
     self.returnStatus = kTestRequestStatusDidLoad;
+    dispatch_semaphore_signal(_completionSemaphore);
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFailWithError:(NSError *)error authInfo:(SFOAuthInfo *)info
@@ -130,6 +137,7 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
     [SFSDKCoreLogger i:[self class] format:@"%@ with authInfo: %@, error: %@", NSStringFromSelector(_cmd), info, error];
     self.lastError = error;
     self.returnStatus = kTestRequestStatusDidFail;
+    dispatch_semaphore_signal(_completionSemaphore);
 }
 
 @end


### PR DESCRIPTION
## Summary

Fixes instant login to work correctly with SDK manager subclasses and during early app lifecycle.

## Changes

### 1. Move instant login to `initializeSDKWithClass:`

**File**: `SalesforceSDKManager.m`

Move instant login code from `initializeSDK` to `initializeSDKWithClass:` so that it executes when SDK manager subclasses (like `SalesforceReactSDKManager`) override `initializeSDK` and call `[super initializeSDKWithClass:self.class]`.

### 2. Use semaphore instead of run loop in `SFSDKTestRequestListener`

**File**: `SFSDKTestRequestListener.m`

Replace run loop pumping with dispatch semaphore to allow synchronous auth requests without processing UI events. This enables instant login to work during SDK initialization before the scene system is activated.

**Why this is needed**: The previous implementation used `[[NSRunLoop currentRunLoop] runUntilDate:]` which processes pending UI events including scene updates. When called during SDK initialization, this triggered "Invalid system behavior" errors about scene updates before application activation.

The semaphore-based approach blocks the thread without pumping the run loop, allowing instant login to complete safely during early app lifecycle.

## Testing

Verified instant login works in React Native test app with UI tests using `-creds` launch argument.