### PR TITLE
Add DPoP proof JWTs to iOS token exchanges

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		00209E9DDE281C6B1FB7B75A /* WelcomeDiscoveryLoginHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2A70B3207E0F66D9367BCAB /* WelcomeDiscoveryLoginHostTests.swift */; };
 		009D77521CA4A92200D5183A /* SFPushNotificationManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 009D77511CA4A92200D5183A /* SFPushNotificationManagerTests.m */; };
 		010A9B551CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 010A9B511CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h */; };
 		010A9B591CC1A147002AF4D3 /* SFCryptoStreamTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 010A9B521CC1A131002AF4D3 /* SFCryptoStreamTestUtils.m */; };
@@ -49,7 +50,6 @@
 		23D626992DF9DF2D00B898D0 /* URLSessionWebSocketTask+WebSocketClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D626982DF9DF1E00B898D0 /* URLSessionWebSocketTask+WebSocketClient.swift */; };
 		23D96B6F2E145AC20004B06A /* DomainDiscoveryCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D96B6E2E145AC20004B06A /* DomainDiscoveryCoordinator.swift */; };
 		23D96B762E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D96B752E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift */; };
-		00209E9DDE281C6B1FB7B75A /* WelcomeDiscoveryLoginHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2A70B3207E0F66D9367BCAB /* WelcomeDiscoveryLoginHostTests.swift */; };
 		23EDDEFE2DE0F7620024AD39 /* URLRequest+RestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDDEF82DE0F7480024AD39 /* URLRequest+RestRequest.swift */; };
 		23EDDF022DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EDDF012DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift */; };
 		23EED88A2E2ACD3300646B10 /* SFOAuthCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EED8892E2ACD3300646B10 /* SFOAuthCoordinatorTests.swift */; };
@@ -119,6 +119,11 @@
 		4FE0070F2EBED6C000CFD66F /* SFSDKLoginHost.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FE006CB2EBEBBF300CFD66F /* SFSDKLoginHost.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FE5332A1BFFE70600814D2A /* Main_iPad.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB4981BFFCEF600768720 /* Main_iPad.storyboard */; };
 		4FE5332B1BFFE70600814D2A /* Main_iPhone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F7EB49A1BFFCEF600768720 /* Main_iPhone.storyboard */; };
+		68FE80562FD0DE4E00947FFF /* SFSDKDPoPNonceCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FE80522FD0DE4E00947FFF /* SFSDKDPoPNonceCache.swift */; };
+		68FE80572FD0DE4E00947FFF /* SFSDKDPoPRequestDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FE80542FD0DE4E00947FFF /* SFSDKDPoPRequestDecorator.swift */; };
+		68FE80582FD0DE4E00947FFF /* SFSDKDPoPProofBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FE80532FD0DE4E00947FFF /* SFSDKDPoPProofBuilder.swift */; };
+		68FE80592FD0DE4E00947FFF /* SFSDKDPoPKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FE80512FD0DE4E00947FFF /* SFSDKDPoPKeyStore.swift */; };
+		68FE80602FD0E35D00947FFF /* SFSDKDPoPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FE805F2FD0E35D00947FFF /* SFSDKDPoPTests.swift */; };
 		6900B62C24B64DD800500923 /* NSURLResponse+SFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6900B62A24B64DD800500923 /* NSURLResponse+SFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6900B62D24B64DD800500923 /* NSURLResponse+SFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6900B62B24B64DD800500923 /* NSURLResponse+SFAdditions.m */; };
 		6900D804243D521C00888336 /* SFRestAPI+Notifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 6900D802243D521C00888336 /* SFRestAPI+Notifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -568,7 +573,6 @@
 		23D626982DF9DF1E00B898D0 /* URLSessionWebSocketTask+WebSocketClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionWebSocketTask+WebSocketClient.swift"; sourceTree = "<group>"; };
 		23D96B6E2E145AC20004B06A /* DomainDiscoveryCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainDiscoveryCoordinator.swift; sourceTree = "<group>"; };
 		23D96B752E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DomainDiscoveryCoordinatorTests.swift; path = SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift; sourceTree = SOURCE_ROOT; };
-		A2A70B3207E0F66D9367BCAB /* WelcomeDiscoveryLoginHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WelcomeDiscoveryLoginHostTests.swift; path = SalesforceSDKCoreTests/WelcomeDiscoveryLoginHostTests.swift; sourceTree = SOURCE_ROOT; };
 		23EDDEF82DE0F7480024AD39 /* URLRequest+RestRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+RestRequest.swift"; sourceTree = "<group>"; };
 		23EDDF012DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "URLRequest+RestRequestTests.swift"; path = "SalesforceSDKCoreTests/URLRequest+RestRequestTests.swift"; sourceTree = SOURCE_ROOT; };
 		23EED8892E2ACD3300646B10 /* SFOAuthCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SFOAuthCoordinatorTests.swift; path = SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift; sourceTree = SOURCE_ROOT; };
@@ -729,6 +733,11 @@
 		4FF946221BFFF663005368C5 /* NSURL+SFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+SFAdditions.m"; sourceTree = "<group>"; };
 		4FF946251BFFF7AD005368C5 /* SFIdentityData+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SFIdentityData+Internal.h"; sourceTree = "<group>"; };
 		4FFE4A001BFE522F00F15E01 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		68FE80512FD0DE4E00947FFF /* SFSDKDPoPKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSDKDPoPKeyStore.swift; sourceTree = "<group>"; };
+		68FE80522FD0DE4E00947FFF /* SFSDKDPoPNonceCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSDKDPoPNonceCache.swift; sourceTree = "<group>"; };
+		68FE80532FD0DE4E00947FFF /* SFSDKDPoPProofBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSDKDPoPProofBuilder.swift; sourceTree = "<group>"; };
+		68FE80542FD0DE4E00947FFF /* SFSDKDPoPRequestDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSDKDPoPRequestDecorator.swift; sourceTree = "<group>"; };
+		68FE805F2FD0E35D00947FFF /* SFSDKDPoPTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSDKDPoPTests.swift; sourceTree = "<group>"; };
 		6900B62A24B64DD800500923 /* NSURLResponse+SFAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLResponse+SFAdditions.h"; sourceTree = "<group>"; };
 		6900B62B24B64DD800500923 /* NSURLResponse+SFAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURLResponse+SFAdditions.m"; sourceTree = "<group>"; };
 		6900D802243D521C00888336 /* SFRestAPI+Notifications.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SFRestAPI+Notifications.h"; sourceTree = "<group>"; };
@@ -804,6 +813,7 @@
 		82C5E3ED1C1B62AF00376C00 /* SalesforceSDKResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = SalesforceSDKResources.bundle; path = ../../shared/resources/SalesforceSDKResources.bundle; sourceTree = "<group>"; };
 		82D0AB191C497F410081F833 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		82D4642419C7C8170006BDFE /* SalesforceSDKCoreTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SalesforceSDKCoreTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A2A70B3207E0F66D9367BCAB /* WelcomeDiscoveryLoginHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WelcomeDiscoveryLoginHostTests.swift; path = SalesforceSDKCoreTests/WelcomeDiscoveryLoginHostTests.swift; sourceTree = SOURCE_ROOT; };
 		A315F83A26EAAC8400B94428 /* ScreenLockManagerInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenLockManagerInternal.swift; sourceTree = "<group>"; };
 		A315F84226EAAFF800B94428 /* ScreenLockUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenLockUIView.swift; sourceTree = "<group>"; };
 		A32C854925268005000FFA42 /* KeyValueEncryptedFileStoreInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueEncryptedFileStoreInspector.swift; sourceTree = "<group>"; };
@@ -1040,6 +1050,7 @@
 		4F7EB3F61BFFC84700768720 /* SalesforceSDKCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				68FE805F2FD0E35D00947FFF /* SFSDKDPoPTests.swift */,
 				AA9154472F59E3C900A0A41C /* SFRestAPIDataTaskRaceTests.m */,
 				23F200AB2E551C890091C5F5 /* ActionTypeTests.swift */,
 				4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */,
@@ -1196,6 +1207,7 @@
 		4F96FCC41BFD32130022F021 /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
+				68FE80552FD0DE4E00947FFF /* DPoP */,
 				4F5A494F2E98711600C89DDD /* ScopeParser.swift */,
 				23D96B6E2E145AC20004B06A /* DomainDiscoveryCoordinator.swift */,
 				4F8A3B002CEC202F00ECDC76 /* JwtAccessToken.swift */,
@@ -1335,6 +1347,17 @@
 				4FE006B02EBEB65900CFD66F /* AuthFlowTypesView.swift */,
 			);
 			path = DevConfig;
+			sourceTree = "<group>";
+		};
+		68FE80552FD0DE4E00947FFF /* DPoP */ = {
+			isa = PBXGroup;
+			children = (
+				68FE80512FD0DE4E00947FFF /* SFSDKDPoPKeyStore.swift */,
+				68FE80522FD0DE4E00947FFF /* SFSDKDPoPNonceCache.swift */,
+				68FE80532FD0DE4E00947FFF /* SFSDKDPoPProofBuilder.swift */,
+				68FE80542FD0DE4E00947FFF /* SFSDKDPoPRequestDecorator.swift */,
+			);
+			path = DPoP;
 			sourceTree = "<group>";
 		};
 		6935FB9823FDE919002BEFCC /* UserAccount */ = {
@@ -2221,6 +2244,7 @@
 				4F06AF941C49A18E00F70798 /* SFTestSDKManagerFlow.m in Sources */,
 				23CAB0F92DCBE51F00B8929B /* MockRestClient.swift in Sources */,
 				B7E66AE923763278005A652E /* RestClientPublisherTests.swift in Sources */,
+				68FE80602FD0E35D00947FFF /* SFSDKDPoPTests.swift in Sources */,
 				697F5C4F267BE29A00F382A9 /* EncryptionTests.swift in Sources */,
 				23D96B762E145B400004B06A /* DomainDiscoveryCoordinatorTests.swift in Sources */,
 				00209E9DDE281C6B1FB7B75A /* WelcomeDiscoveryLoginHostTests.swift in Sources */,
@@ -2313,6 +2337,10 @@
 				B72171572353BFF20022510F /* SFSDKAuthRequest.m in Sources */,
 				B78A238D21014FCA00B19AB3 /* SFSDKAuthHelper.m in Sources */,
 				A3C7475F29F7087B00D72B7F /* BiometricAuthenticationManager.swift in Sources */,
+				68FE80562FD0DE4E00947FFF /* SFSDKDPoPNonceCache.swift in Sources */,
+				68FE80572FD0DE4E00947FFF /* SFSDKDPoPRequestDecorator.swift in Sources */,
+				68FE80582FD0DE4E00947FFF /* SFSDKDPoPProofBuilder.swift in Sources */,
+				68FE80592FD0DE4E00947FFF /* SFSDKDPoPKeyStore.swift in Sources */,
 				4FE006B12EBEB65900CFD66F /* AuthFlowTypesView.swift in Sources */,
 				4FE006B22EBEB65900CFD66F /* BootConfigEditor.swift in Sources */,
 				4FE006B32EBEB65900CFD66F /* LoginOptionsViewController.swift in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -258,6 +258,14 @@ NS_SWIFT_NAME(SalesforceManager)
  */
 @property (nonatomic, assign) BOOL useHybridAuthentication;
 
+/** Whether DPoP (RFC 9449) proof JWTs should be attached to token-endpoint requests.
+ *  Defaults to NO. Enable only when the Salesforce External Client App / Connected App
+ *  is configured with `dpop_bound_access_tokens=true`. When enabled, the SDK lazily
+ *  generates a per-user P-256 keypair (Secure Enclave when available) and signs a
+ *  proof JWT for every request to `/services/oauth2/token`.
+ */
+@property (nonatomic, assign) BOOL useDPoP NS_SWIFT_NAME(usesDPoP);
+
 /** Detect use of "Use Custom Domain" input from login web view using the given regex.
  *  Example for a specific org:
  *    "^https:\\/\\/mobilesdk\\.my\\.salesforce\\.com/\\?startURL=%2Fsetup%2Fsecur%2FRemoteAccessAuthorizationPage\\.apexp"

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -316,6 +316,7 @@ SFNativeLoginManagerInternal *nativeLogin;
         self.useWebServerAuthentication = YES;
         self.blockSalesforceIntegrationUser = NO;
         self.useHybridAuthentication = YES;
+        self.useDPoP = NO;
         [self setupServiceConfiguration];
         _snapshotViewControllers = [SFSDKSafeMutableDictionary new];
         _nativeLoginViewControllers = [SFSDKSafeMutableDictionary new];
@@ -553,6 +554,7 @@ SFNativeLoginManagerInternal *nativeLogin;
     [devInfos addObjectsFromArray:@[
             @"Use Web Server Authentication", [self useWebServerAuthentication]  ? @"YES" : @"NO",
             @"Use Hybrid Authentication", [self useHybridAuthentication]  ? @"YES" : @"NO",
+            @"Use DPoP", [self useDPoP] ? @"YES" : @"NO",
             @"Browser Login Enabled", [SFUserAccountManager sharedInstance].useBrowserAuth? @"YES" : @"NO",
             @"IDP Enabled", [self idpEnabled] ? @"YES" : @"NO",
             @"Identity Provider", [self isIdentityProvider] ? @"YES" : @"NO"

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPKeyStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPKeyStore.swift
@@ -1,0 +1,145 @@
+//
+//  SFSDKDPoPKeyStore.swift
+//  SalesforceSDKCore
+//
+//  Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+//
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import Security
+
+@objc(SFSDKDPoPKeyPair)
+public final class SFSDKDPoPKeyPair: NSObject {
+    @objc public let publicKey: SecKey
+    @objc public let privateKey: SecKey
+
+    init(publicKey: SecKey, privateKey: SecKey) {
+        self.publicKey = publicKey
+        self.privateKey = privateKey
+    }
+}
+
+@objc(SFSDKDPoPKeyStoreError)
+public enum SFSDKDPoPKeyStoreError: Int, Error {
+    case missingScopeIdentifier = 1
+    case keyGenerationFailed = 2
+    case keyLookupFailed = 3
+}
+
+/// Per-credentials DPoP keypair lifecycle, scoped on `SFOAuthCredentials.identifier`
+/// (stable from before the first token-endpoint call, since the auth-code exchange
+/// happens before an `SFUserAccount` exists). Persisted in the iOS Keychain and
+/// uses the Secure Enclave when available; otherwise falls back to software-backed
+/// keychain storage.
+@objc(SFSDKDPoPKeyStore)
+public final class SFSDKDPoPKeyStore: NSObject {
+
+    @objc public static let shared = SFSDKDPoPKeyStore()
+
+    private let queue = DispatchQueue(label: "com.salesforce.dpop.keystore", attributes: .concurrent)
+
+    private override init() { super.init() }
+
+    /// Returns the keypair bound to the given scope identifier, generating it on first call.
+    @objc(keyPairForScope:error:)
+    public func keyPair(forScope scope: String) throws -> SFSDKDPoPKeyPair {
+        guard !scope.isEmpty else {
+            throw SFSDKDPoPKeyStoreError.missingScopeIdentifier
+        }
+        let name = Self.keyName(for: scope)
+        return try queue.sync(flags: .barrier) {
+            try self.fetchOrCreate(name: name)
+        }
+    }
+
+    /// Convenience: scope on `credentials.identifier`.
+    @objc(keyPairForCredentials:error:)
+    public func keyPair(forCredentials credentials: SFOAuthCredentials) throws -> SFSDKDPoPKeyPair {
+        return try keyPair(forScope: credentials.identifier)
+    }
+
+    /// Removes any existing keypair for the scope. Idempotent.
+    @objc(deleteForScope:)
+    public func delete(forScope scope: String) {
+        guard !scope.isEmpty else { return }
+        let name = Self.keyName(for: scope)
+        queue.sync(flags: .barrier) {
+            _ = SFSDKCryptoUtils.deleteECKeyPair(withName: name)
+        }
+    }
+
+    @objc(deleteForCredentials:)
+    public func delete(forCredentials credentials: SFOAuthCredentials) {
+        delete(forScope: credentials.identifier)
+    }
+
+    // MARK: - Internal helpers
+
+    static func keyName(for scope: String) -> String {
+        return "dpop_" + scope
+    }
+
+    private func fetchOrCreate(name: String) throws -> SFSDKDPoPKeyPair {
+        if let pair = lookup(name: name) {
+            return pair
+        }
+        let useSecureEnclave = SFSDKCryptoUtils.isSecureEnclaveAvailable()
+        if !useSecureEnclave {
+            SFSDKCoreLogger.i(Self.self, message: "DPoP keypair using software-backed storage; Secure Enclave unavailable")
+        }
+        let created = SFSDKCryptoUtils.createECKeyPair(withName: name,
+                                                      accessibleAttribute: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+                                                      useSecureEnclave: useSecureEnclave)
+        if !created {
+            // Secure Enclave generation can fail on policy-locked devices. Try software-backed
+            // as a one-time recovery before surfacing the failure.
+            if useSecureEnclave {
+                let retry = SFSDKCryptoUtils.createECKeyPair(withName: name,
+                                                             accessibleAttribute: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+                                                             useSecureEnclave: false)
+                if !retry {
+                    throw SFSDKDPoPKeyStoreError.keyGenerationFailed
+                }
+            } else {
+                throw SFSDKDPoPKeyStoreError.keyGenerationFailed
+            }
+        }
+        guard let pair = lookup(name: name) else {
+            throw SFSDKDPoPKeyStoreError.keyLookupFailed
+        }
+        return pair
+    }
+
+    private func lookup(name: String) -> SFSDKDPoPKeyPair? {
+        guard let priv = SFSDKCryptoUtils.getECPrivateKeyRef(withName: name)?.takeRetainedValue() else {
+            return nil
+        }
+        if let pub = SFSDKCryptoUtils.getECPublicKeyRef(withName: name)?.takeRetainedValue() {
+            return SFSDKDPoPKeyPair(publicKey: pub, privateKey: priv)
+        }
+        // Public key entry can be missing on Secure-Enclave-backed pairs; derive from private.
+        if let derived = SecKeyCopyPublicKey(priv) {
+            return SFSDKDPoPKeyPair(publicKey: derived, privateKey: priv)
+        }
+        return nil
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPKeyStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPKeyStore.swift
@@ -28,7 +28,7 @@ import Foundation
 import Security
 
 @objc(SFSDKDPoPKeyPair)
-public final class SFSDKDPoPKeyPair: NSObject {
+public final class DPoPKeyPair: NSObject {
     @objc public let publicKey: SecKey
     @objc public let privateKey: SecKey
 
@@ -39,7 +39,7 @@ public final class SFSDKDPoPKeyPair: NSObject {
 }
 
 @objc(SFSDKDPoPKeyStoreError)
-public enum SFSDKDPoPKeyStoreError: Int, Error {
+public enum DPoPKeyStoreError: Int, Error {
     case missingScopeIdentifier = 1
     case keyGenerationFailed = 2
     case keyLookupFailed = 3
@@ -51,9 +51,9 @@ public enum SFSDKDPoPKeyStoreError: Int, Error {
 /// uses the Secure Enclave when available; otherwise falls back to software-backed
 /// keychain storage.
 @objc(SFSDKDPoPKeyStore)
-public final class SFSDKDPoPKeyStore: NSObject {
+public final class DPoPKeyStore: NSObject {
 
-    @objc public static let shared = SFSDKDPoPKeyStore()
+    @objc public static let shared = DPoPKeyStore()
 
     private let queue = DispatchQueue(label: "com.salesforce.dpop.keystore", attributes: .concurrent)
 
@@ -61,9 +61,9 @@ public final class SFSDKDPoPKeyStore: NSObject {
 
     /// Returns the keypair bound to the given scope identifier, generating it on first call.
     @objc(keyPairForScope:error:)
-    public func keyPair(forScope scope: String) throws -> SFSDKDPoPKeyPair {
+    public func keyPair(forScope scope: String) throws -> DPoPKeyPair {
         guard !scope.isEmpty else {
-            throw SFSDKDPoPKeyStoreError.missingScopeIdentifier
+            throw DPoPKeyStoreError.missingScopeIdentifier
         }
         let name = Self.keyName(for: scope)
         return try queue.sync(flags: .barrier) {
@@ -73,7 +73,7 @@ public final class SFSDKDPoPKeyStore: NSObject {
 
     /// Convenience: scope on `credentials.identifier`.
     @objc(keyPairForCredentials:error:)
-    public func keyPair(forCredentials credentials: SFOAuthCredentials) throws -> SFSDKDPoPKeyPair {
+    public func keyPair(forCredentials credentials: OAuthCredentials) throws -> DPoPKeyPair {
         return try keyPair(forScope: credentials.identifier)
     }
 
@@ -88,7 +88,7 @@ public final class SFSDKDPoPKeyStore: NSObject {
     }
 
     @objc(deleteForCredentials:)
-    public func delete(forCredentials credentials: SFOAuthCredentials) {
+    public func delete(forCredentials credentials: OAuthCredentials) {
         delete(forScope: credentials.identifier)
     }
 
@@ -98,7 +98,7 @@ public final class SFSDKDPoPKeyStore: NSObject {
         return "dpop_" + scope
     }
 
-    private func fetchOrCreate(name: String) throws -> SFSDKDPoPKeyPair {
+    private func fetchOrCreate(name: String) throws -> DPoPKeyPair {
         if let pair = lookup(name: name) {
             return pair
         }
@@ -117,28 +117,28 @@ public final class SFSDKDPoPKeyStore: NSObject {
                                                              accessibleAttribute: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
                                                              useSecureEnclave: false)
                 if !retry {
-                    throw SFSDKDPoPKeyStoreError.keyGenerationFailed
+                    throw DPoPKeyStoreError.keyGenerationFailed
                 }
             } else {
-                throw SFSDKDPoPKeyStoreError.keyGenerationFailed
+                throw DPoPKeyStoreError.keyGenerationFailed
             }
         }
         guard let pair = lookup(name: name) else {
-            throw SFSDKDPoPKeyStoreError.keyLookupFailed
+            throw DPoPKeyStoreError.keyLookupFailed
         }
         return pair
     }
 
-    private func lookup(name: String) -> SFSDKDPoPKeyPair? {
+    private func lookup(name: String) -> DPoPKeyPair? {
         guard let priv = SFSDKCryptoUtils.getECPrivateKeyRef(withName: name)?.takeRetainedValue() else {
             return nil
         }
         if let pub = SFSDKCryptoUtils.getECPublicKeyRef(withName: name)?.takeRetainedValue() {
-            return SFSDKDPoPKeyPair(publicKey: pub, privateKey: priv)
+            return DPoPKeyPair(publicKey: pub, privateKey: priv)
         }
         // Public key entry can be missing on Secure-Enclave-backed pairs; derive from private.
         if let derived = SecKeyCopyPublicKey(priv) {
-            return SFSDKDPoPKeyPair(publicKey: derived, privateKey: priv)
+            return DPoPKeyPair(publicKey: derived, privateKey: priv)
         }
         return nil
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPNonceCache.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPNonceCache.swift
@@ -1,0 +1,87 @@
+//
+//  SFSDKDPoPNonceCache.swift
+//  SalesforceSDKCore
+//
+//  Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+//
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+
+/// Process-lifetime cache of `DPoP-Nonce` values, keyed by `(htu, scope)`.
+/// `scope` is typically `SFOAuthCredentials.identifier`. Fed by:
+///  - reactive 400 / 401 challenges (RFC 9449 §8)
+///  - proactive `DPoP-Nonce` response headers on 200 OK (Salesforce backend rotation).
+@objc(SFSDKDPoPNonceCache)
+public final class SFSDKDPoPNonceCache: NSObject {
+
+    @objc public static let shared = SFSDKDPoPNonceCache()
+
+    private let queue = DispatchQueue(label: "com.salesforce.dpop.nonceCache", attributes: .concurrent)
+    private var storage: [String: String] = [:]
+
+    private override init() { super.init() }
+
+    @objc(nonceForHtu:scope:)
+    public func nonce(htu: URL, scope: String?) -> String? {
+        let key = Self.cacheKey(htu: htu, scope: scope)
+        return queue.sync { storage[key] }
+    }
+
+    @objc(setNonce:htu:scope:)
+    public func setNonce(_ nonce: String, htu: URL, scope: String?) {
+        let key = Self.cacheKey(htu: htu, scope: scope)
+        queue.async(flags: .barrier) { [weak self] in
+            self?.storage[key] = nonce
+        }
+    }
+
+    @objc(clearForScope:)
+    public func clear(forScope scope: String) {
+        guard !scope.isEmpty else { return }
+        let suffix = "|" + scope
+        queue.async(flags: .barrier) { [weak self] in
+            guard let self = self else { return }
+            self.storage = self.storage.filter { !$0.key.hasSuffix(suffix) }
+        }
+    }
+
+    @objc public func clearAll() {
+        queue.async(flags: .barrier) { [weak self] in
+            self?.storage.removeAll()
+        }
+    }
+
+    // MARK: - Internal
+
+    private static func cacheKey(htu: URL, scope: String?) -> String {
+        let canonical = canonicalize(htu)
+        let scopeKey = (scope?.isEmpty == false) ? scope! : "anonymous"
+        return "\(canonical)|\(scopeKey)"
+    }
+
+    private static func canonicalize(_ url: URL) -> String {
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.query = nil
+        components?.fragment = nil
+        return components?.url?.absoluteString ?? url.absoluteString
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPNonceCache.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPNonceCache.swift
@@ -31,9 +31,9 @@ import Foundation
 ///  - reactive 400 / 401 challenges (RFC 9449 §8)
 ///  - proactive `DPoP-Nonce` response headers on 200 OK (Salesforce backend rotation).
 @objc(SFSDKDPoPNonceCache)
-public final class SFSDKDPoPNonceCache: NSObject {
+public final class DPoPNonceCache: NSObject {
 
-    @objc public static let shared = SFSDKDPoPNonceCache()
+    @objc public static let shared = DPoPNonceCache()
 
     private let queue = DispatchQueue(label: "com.salesforce.dpop.nonceCache", attributes: .concurrent)
     private var storage: [String: String] = [:]

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPProofBuilder.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPProofBuilder.swift
@@ -1,0 +1,107 @@
+//
+//  SFSDKDPoPProofBuilder.swift
+//  SalesforceSDKCore
+//
+//  Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+//
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import Security
+
+@objc(SFSDKDPoPProofBuilderError)
+public enum SFSDKDPoPProofBuilderError: Int, Error {
+    case jwkExportFailed = 1
+    case serializationFailed = 2
+    case signingFailed = 3
+}
+
+/// Builds an RFC 9449 §4 DPoP proof JWS for a single token-endpoint request.
+@objc(SFSDKDPoPProofBuilder)
+public final class SFSDKDPoPProofBuilder: NSObject {
+
+    /// Build a compact-serialized JWS suitable for the `DPoP` HTTP header.
+    /// - Parameters:
+    ///   - httpMethod: HTTP verb (`"POST"` for token endpoint).
+    ///   - htu: Full request URL with no query and no fragment, per RFC 9449 §4.2.
+    ///   - nonce: Optional `nonce` claim from a prior `DPoP-Nonce` server hint.
+    ///   - keyPair: Public key is embedded in the JWS header `jwk`; private key signs.
+    ///   - now: Injected clock for deterministic tests; defaults to `Date()`.
+    @objc public static func buildProof(httpMethod: String,
+                                        htu: URL,
+                                        nonce: String?,
+                                        keyPair: SFSDKDPoPKeyPair,
+                                        now: Date = Date()) throws -> String {
+        guard let jwk = SFSDKCryptoUtils.jwkExport(fromPublicKeyRef: keyPair.publicKey) else {
+            throw SFSDKDPoPProofBuilderError.jwkExportFailed
+        }
+        let header: [String: Any] = [
+            "typ": "dpop+jwt",
+            "alg": "ES256",
+            "jwk": jwk
+        ]
+        var payload: [String: Any] = [
+            "htm": httpMethod.uppercased(),
+            "htu": canonicalize(htu),
+            "iat": Int(now.timeIntervalSince1970),
+            "jti": newJti()
+        ]
+        if let nonce = nonce, !nonce.isEmpty {
+            payload["nonce"] = nonce
+        }
+        guard let headerSegment = encode(json: header),
+              let payloadSegment = encode(json: payload) else {
+            throw SFSDKDPoPProofBuilderError.serializationFailed
+        }
+        let signingInput = "\(headerSegment).\(payloadSegment)"
+        guard let signingData = signingInput.data(using: .utf8),
+              let signature = SFSDKCryptoUtils.signDataES256(signingData, withKeyRef: keyPair.privateKey) else {
+            throw SFSDKDPoPProofBuilderError.signingFailed
+        }
+        let signatureSegment = (signature as NSData).sfsdk_base64UrlString()
+        return "\(signingInput).\(signatureSegment)"
+    }
+
+    // MARK: - Helpers
+
+    /// `htu` MUST be the request URL without query or fragment (RFC 9449 §4.2).
+    private static func canonicalize(_ url: URL) -> String {
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.query = nil
+        components?.fragment = nil
+        return components?.url?.absoluteString ?? url.absoluteString
+    }
+
+    /// 96 bits (12 bytes) of random entropy, per backend design doc.
+    private static func newJti() -> String {
+        let raw = SFSDKCryptoUtils.randomByteData(withLength: 12)
+        return (raw as NSData).sfsdk_base64UrlString()
+    }
+
+    private static func encode(json: [String: Any]) -> String? {
+        // .sortedKeys keeps output stable so unit tests can snapshot byte-for-byte.
+        guard let data = try? JSONSerialization.data(withJSONObject: json,
+                                                     options: [.sortedKeys, .withoutEscapingSlashes]) else {
+            return nil
+        }
+        return (data as NSData).sfsdk_base64UrlString()
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPProofBuilder.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPProofBuilder.swift
@@ -28,7 +28,7 @@ import Foundation
 import Security
 
 @objc(SFSDKDPoPProofBuilderError)
-public enum SFSDKDPoPProofBuilderError: Int, Error {
+public enum DPoPProofBuilderError: Int, Error {
     case jwkExportFailed = 1
     case serializationFailed = 2
     case signingFailed = 3
@@ -36,7 +36,7 @@ public enum SFSDKDPoPProofBuilderError: Int, Error {
 
 /// Builds an RFC 9449 §4 DPoP proof JWS for a single token-endpoint request.
 @objc(SFSDKDPoPProofBuilder)
-public final class SFSDKDPoPProofBuilder: NSObject {
+public final class DPoPProofBuilder: NSObject {
 
     /// Build a compact-serialized JWS suitable for the `DPoP` HTTP header.
     /// - Parameters:
@@ -48,10 +48,10 @@ public final class SFSDKDPoPProofBuilder: NSObject {
     @objc public static func buildProof(httpMethod: String,
                                         htu: URL,
                                         nonce: String?,
-                                        keyPair: SFSDKDPoPKeyPair,
+                                        keyPair: DPoPKeyPair,
                                         now: Date = Date()) throws -> String {
         guard let jwk = SFSDKCryptoUtils.jwkExport(fromPublicKeyRef: keyPair.publicKey) else {
-            throw SFSDKDPoPProofBuilderError.jwkExportFailed
+            throw DPoPProofBuilderError.jwkExportFailed
         }
         let header: [String: Any] = [
             "typ": "dpop+jwt",
@@ -69,12 +69,12 @@ public final class SFSDKDPoPProofBuilder: NSObject {
         }
         guard let headerSegment = encode(json: header),
               let payloadSegment = encode(json: payload) else {
-            throw SFSDKDPoPProofBuilderError.serializationFailed
+            throw DPoPProofBuilderError.serializationFailed
         }
         let signingInput = "\(headerSegment).\(payloadSegment)"
         guard let signingData = signingInput.data(using: .utf8),
               let signature = SFSDKCryptoUtils.signDataES256(signingData, withKeyRef: keyPair.privateKey) else {
-            throw SFSDKDPoPProofBuilderError.signingFailed
+            throw DPoPProofBuilderError.signingFailed
         }
         let signatureSegment = (signature as NSData).sfsdk_base64UrlString()
         return "\(signingInput).\(signatureSegment)"

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPRequestDecorator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPRequestDecorator.swift
@@ -1,0 +1,94 @@
+//
+//  SFSDKDPoPRequestDecorator.swift
+//  SalesforceSDKCore
+//
+//  Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+//
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+
+@objc(SFSDKDPoPRequestDecorator)
+public final class SFSDKDPoPRequestDecorator: NSObject {
+
+    @objc public static let dpopHeaderName = "DPoP"
+    @objc public static let dpopNonceHeaderName = "DPoP-Nonce"
+    @objc public static let nonceErrorCode = "use_dpop_nonce"
+
+    /// No-op when `SalesforceSDKManager.shared.useDPoP == NO`. Otherwise builds a fresh
+    /// proof JWT (with cached nonce if any) and sets it on the `DPoP` header.
+    /// `scope` is typically `SFOAuthCredentials.identifier` so the keypair and nonce cache
+    /// are isolated per-account, even before an `SFUserAccount` exists.
+    @objc(decorateRequest:scope:error:)
+    public static func decorate(_ request: NSMutableURLRequest, scope: String) throws {
+        guard SalesforceSDKManager.shared().useDPoP else { return }
+        guard !scope.isEmpty else {
+            SFSDKCoreLogger.i(self, message: "DPoP decorator skipped: empty scope identifier")
+            return
+        }
+        guard let url = request.url else { return }
+        let method = request.httpMethod
+
+        let keyPair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: scope)
+        let nonce = SFSDKDPoPNonceCache.shared.nonce(htu: url, scope: scope)
+        let proof = try SFSDKDPoPProofBuilder.buildProof(httpMethod: method,
+                                                         htu: url,
+                                                         nonce: nonce,
+                                                         keyPair: keyPair)
+        request.setValue(proof, forHTTPHeaderField: dpopHeaderName)
+    }
+
+    /// Reads `DPoP-Nonce` from a response and stores it in the cache for the next outbound
+    /// request to the same `htu`. Per backend design doc, harvest from both 200 OK responses
+    /// (proactive rotation) and 400/401 challenges (reactive).
+    @objc(harvestNonceFromResponse:requestURL:scope:)
+    public static func harvestNonce(from response: URLResponse?,
+                                    requestURL: URL?,
+                                    scope: String?) {
+        guard let http = response as? HTTPURLResponse,
+              let url = requestURL,
+              let nonce = http.value(forHTTPHeaderField: dpopNonceHeaderName),
+              !nonce.isEmpty else {
+            return
+        }
+        SFSDKDPoPNonceCache.shared.setNonce(nonce, htu: url, scope: scope)
+    }
+
+    /// Returns true if the response is a DPoP nonce challenge per RFC 9449 §8 — either a 401
+    /// with a `DPoP-Nonce` header, or a 400 whose body contains `error=use_dpop_nonce`.
+    @objc(isNonceChallengeWithStatusCode:body:response:)
+    public static func isNonceChallenge(statusCode: Int,
+                                        body: Data?,
+                                        response: URLResponse?) -> Bool {
+        guard statusCode == 400 || statusCode == 401 else { return false }
+        if statusCode == 401 {
+            if let http = response as? HTTPURLResponse,
+               let nonce = http.value(forHTTPHeaderField: dpopNonceHeaderName),
+               !nonce.isEmpty {
+                return true
+            }
+        }
+        if let body = body, let str = String(data: body, encoding: .utf8) {
+            return str.contains(nonceErrorCode)
+        }
+        return false
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPRequestDecorator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/SFSDKDPoPRequestDecorator.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 @objc(SFSDKDPoPRequestDecorator)
-public final class SFSDKDPoPRequestDecorator: NSObject {
+public final class DPoPRequestDecorator: NSObject {
 
     @objc public static let dpopHeaderName = "DPoP"
     @objc public static let dpopNonceHeaderName = "DPoP-Nonce"
@@ -39,7 +39,7 @@ public final class SFSDKDPoPRequestDecorator: NSObject {
     /// are isolated per-account, even before an `SFUserAccount` exists.
     @objc(decorateRequest:scope:error:)
     public static func decorate(_ request: NSMutableURLRequest, scope: String) throws {
-        guard SalesforceSDKManager.shared().useDPoP else { return }
+        guard SalesforceManager.shared.usesDPoP else { return }
         guard !scope.isEmpty else {
             SFSDKCoreLogger.i(self, message: "DPoP decorator skipped: empty scope identifier")
             return
@@ -47,9 +47,9 @@ public final class SFSDKDPoPRequestDecorator: NSObject {
         guard let url = request.url else { return }
         let method = request.httpMethod
 
-        let keyPair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: scope)
-        let nonce = SFSDKDPoPNonceCache.shared.nonce(htu: url, scope: scope)
-        let proof = try SFSDKDPoPProofBuilder.buildProof(httpMethod: method,
+        let keyPair = try DPoPKeyStore.shared.keyPair(forScope: scope)
+        let nonce = DPoPNonceCache.shared.nonce(htu: url, scope: scope)
+        let proof = try DPoPProofBuilder.buildProof(httpMethod: method,
                                                          htu: url,
                                                          nonce: nonce,
                                                          keyPair: keyPair)
@@ -69,7 +69,7 @@ public final class SFSDKDPoPRequestDecorator: NSObject {
               !nonce.isEmpty else {
             return
         }
-        SFSDKDPoPNonceCache.shared.setNonce(nonce, htu: url, scope: scope)
+        DPoPNonceCache.shared.setNonce(nonce, htu: url, scope: scope)
     }
 
     /// Returns true if the response is a DPoP nonce challenge per RFC 9449 §8 — either a 401

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -518,8 +518,39 @@
     [request setHTTPBody:body];
     [request setHTTPMethod:kHttpMethodPost];
     [request setValue:kHttpPostContentType forHTTPHeaderField:kHttpHeaderContentType];
-    
-    [[self.session dataTaskWithRequest:request completionHandler:completionHandler] resume];
+    [self attachDPoPHeaderIfNeeded:request];
+
+    __weak typeof(self) weakSelf = self;
+    [[self.session dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (error == nil && strongSelf.credentials.identifier.length > 0) {
+            [SFSDKDPoPRequestDecorator harvestNonceFromResponse:response
+                                                     requestURL:request.URL
+                                                          scope:strongSelf.credentials.identifier];
+            NSInteger statusCode = 0;
+            if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+                statusCode = ((NSHTTPURLResponse *)response).statusCode;
+            }
+            if ([SFSDKDPoPRequestDecorator isNonceChallengeWithStatusCode:statusCode body:data response:response]) {
+                [SFSDKCoreLogger i:[strongSelf class] format:@"DPoP nonce challenge received on JWT swap; retrying once."];
+                [request setValue:nil forHTTPHeaderField:@"DPoP"];
+                [strongSelf attachDPoPHeaderIfNeeded:request];
+                [[strongSelf.session dataTaskWithRequest:request completionHandler:completionHandler] resume];
+                return;
+            }
+        }
+        completionHandler(data, response, error);
+    }] resume];
+}
+
+- (void)attachDPoPHeaderIfNeeded:(NSMutableURLRequest *)request {
+    NSString *scope = self.credentials.identifier;
+    if (scope.length == 0) return;
+    NSError *err = nil;
+    [SFSDKDPoPRequestDecorator decorateRequest:request scope:scope error:&err];
+    if (err) {
+        [SFSDKCoreLogger e:[self class] format:@"DPoP attach failed on JWT swap (code=%ld); proceeding without DPoP header.", (long)err.code];
+    }
 }
 
 // Refresh token migration
@@ -620,7 +651,8 @@
     request.refreshToken = self.credentials.refreshToken;
     request.redirectURI = self.credentials.redirectUri;
     request.serverURL = [self.credentials overrideDomainIfNeeded];
-    
+    request.credentialsIdentifier = self.credentials.identifier;
+
     __weak typeof (self) weakSelf = self;
     if (self.approvalCode) {
         [SFSDKCoreLogger i:[self class] format:@"%@: Initiating authorization code flow.", NSStringFromSelector(_cmd)];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -83,6 +83,7 @@
     request.refreshToken = self.credentials.refreshToken;
     request.redirectURI = self.credentials.redirectUri;
     request.serverURL = [self.credentials overrideDomainIfNeeded];
+    request.credentialsIdentifier = self.credentials.identifier;
     __weak typeof(self) weakSelf = self;
     id<SFSDKOAuthProtocol> authClient = [SFUserAccountManager sharedInstance].authClient();
     [authClient accessTokenForRefresh:request completion:^(SFSDKOAuthTokenEndpointResponse * response) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.h
@@ -203,6 +203,26 @@ extern NSUInteger const kSFPBKDFDefaultSaltByteLength;
  */
 + (nullable NSData*)decryptUsingECforData:(NSData * )data withKeyRef:(SecKeyRef)keyRef;
 
+/**
+ * Sign data with a P-256 private key and return a 64-byte fixed-length R||S signature
+ * suitable for the JWS ES256 alg per RFC 7515 §3.4. The underlying iOS API
+ * `SecKeyCreateSignature` returns ASN.1 DER; this method strips the DER envelope
+ * and pads R and S to 32 bytes each.
+ * @param data Data to sign.
+ * @param privateKeyRef P-256 private key handle.
+ * @return 64-byte R||S signature, or `nil` on failure.
+ */
++ (nullable NSData *)signDataES256:(NSData *)data withKeyRef:(SecKeyRef)privateKeyRef;
+
+/**
+ * Export a P-256 public key as a JWK dictionary per RFC 7518 §6.2.
+ * Keys returned: `kty=EC`, `crv=P-256`, `x` and `y` as base64url-encoded
+ * 32-byte big-endian coordinates.
+ * @param publicKeyRef P-256 public key handle.
+ * @return JWK dictionary, or `nil` on failure.
+ */
++ (nullable NSDictionary<NSString *, NSString *> *)jwkExportFromPublicKeyRef:(SecKeyRef)publicKeyRef;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/SFSDKCryptoUtils.m
@@ -25,6 +25,7 @@
 #import "SFSDKCryptoUtils.h"
 #import <CommonCrypto/CommonCrypto.h>
 #import "NSData+SFAdditions.h"
+#import "NSData+SFSDKUtils.h"
 #import <Security/Security.h>
 #import "TargetConditionals.h"
 #import <LocalAuthentication/LocalAuthentication.h>
@@ -317,11 +318,140 @@ static NSString * const kSFECPrivateKeyTagPrefix = @"com.salesforce.eckey.privat
         // Handle the error. . .
         [SFSDKCoreLogger e:[self class] format:@"Error decrypting data with EC key. Error code: %@", err.localizedDescription];
     }
-    
+
     return (__bridge_transfer NSData*) decryptedData;
 }
 
++ (nullable NSData *)signDataES256:(NSData *)data withKeyRef:(SecKeyRef)privateKeyRef
+{
+    if (data == nil || privateKeyRef == NULL) {
+        return nil;
+    }
+    CFErrorRef error = NULL;
+    CFDataRef derSignature = SecKeyCreateSignature(privateKeyRef,
+                                                   kSecKeyAlgorithmECDSASignatureMessageX962SHA256,
+                                                   (__bridge CFDataRef)data,
+                                                   &error);
+    if (derSignature == NULL) {
+        NSError *err = CFBridgingRelease(error);
+        [SFSDKCoreLogger e:[self class] format:@"ES256 signing failed: %@", err.localizedDescription];
+        return nil;
+    }
+    NSData *der = (__bridge_transfer NSData *)derSignature;
+    return [self jwsRawSignatureFromDER:der componentLength:32];
+}
+
++ (nullable NSDictionary<NSString *, NSString *> *)jwkExportFromPublicKeyRef:(SecKeyRef)publicKeyRef
+{
+    if (publicKeyRef == NULL) {
+        return nil;
+    }
+    CFErrorRef error = NULL;
+    CFDataRef external = SecKeyCopyExternalRepresentation(publicKeyRef, &error);
+    if (external == NULL) {
+        NSError *err = CFBridgingRelease(error);
+        [SFSDKCoreLogger e:[self class] format:@"JWK export failed: %@", err.localizedDescription];
+        return nil;
+    }
+    NSData *raw = (__bridge_transfer NSData *)external;
+    // Uncompressed P-256: 0x04 || X(32) || Y(32) = 65 bytes.
+    if (raw.length != 65) {
+        return nil;
+    }
+    const uint8_t *bytes = raw.bytes;
+    if (bytes[0] != 0x04) {
+        return nil;
+    }
+    NSData *x = [raw subdataWithRange:NSMakeRange(1, 32)];
+    NSData *y = [raw subdataWithRange:NSMakeRange(33, 32)];
+    return @{ @"kty": @"EC",
+              @"crv": @"P-256",
+              @"x": [x sfsdk_base64UrlString],
+              @"y": [y sfsdk_base64UrlString] };
+}
+
 #pragma mark - Private methods
+
+// Convert ASN.1 DER ECDSA signature (SEQUENCE of two INTEGERs) into the
+// fixed-length R||S concatenation that JWS ES256 (RFC 7515 §3.4) expects.
+// componentLength is 32 for P-256.
++ (nullable NSData *)jwsRawSignatureFromDER:(NSData *)der componentLength:(NSUInteger)componentLength
+{
+    const uint8_t *p = der.bytes;
+    NSUInteger len = der.length;
+    if (len < 8 || p[0] != 0x30) {
+        return nil;
+    }
+    NSUInteger idx = 1;
+    NSUInteger seqLen;
+    if ((p[idx] & 0x80) == 0) {
+        seqLen = p[idx];
+        idx += 1;
+    } else {
+        NSUInteger lenBytes = p[idx] & 0x7F;
+        idx += 1;
+        if (lenBytes == 0 || lenBytes > 2 || idx + lenBytes > len) {
+            return nil;
+        }
+        seqLen = 0;
+        for (NSUInteger i = 0; i < lenBytes; i++) {
+            seqLen = (seqLen << 8) | p[idx + i];
+        }
+        idx += lenBytes;
+    }
+    if (idx + seqLen > len) {
+        return nil;
+    }
+    NSData *r = [self readASN1IntegerAt:p length:len cursor:&idx];
+    if (r == nil) return nil;
+    NSData *s = [self readASN1IntegerAt:p length:len cursor:&idx];
+    if (s == nil) return nil;
+    if (r.length > componentLength || s.length > componentLength) {
+        return nil;
+    }
+    NSMutableData *raw = [NSMutableData dataWithLength:componentLength * 2];
+    uint8_t *out = raw.mutableBytes;
+    memcpy(out + (componentLength - r.length), r.bytes, r.length);
+    memcpy(out + componentLength + (componentLength - s.length), s.bytes, s.length);
+    return raw;
+}
+
+// Reads one ASN.1 INTEGER, advancing *cursor. Strips leading 0x00 sign byte.
++ (nullable NSData *)readASN1IntegerAt:(const uint8_t *)buf length:(NSUInteger)len cursor:(NSUInteger *)cursor
+{
+    NSUInteger idx = *cursor;
+    if (idx + 2 > len || buf[idx] != 0x02) {
+        return nil;
+    }
+    idx += 1;
+    NSUInteger intLen;
+    if ((buf[idx] & 0x80) == 0) {
+        intLen = buf[idx];
+        idx += 1;
+    } else {
+        NSUInteger lenBytes = buf[idx] & 0x7F;
+        idx += 1;
+        if (lenBytes == 0 || lenBytes > 2 || idx + lenBytes > len) {
+            return nil;
+        }
+        intLen = 0;
+        for (NSUInteger i = 0; i < lenBytes; i++) {
+            intLen = (intLen << 8) | buf[idx + i];
+        }
+        idx += lenBytes;
+    }
+    if (idx + intLen > len || intLen == 0) {
+        return nil;
+    }
+    NSUInteger start = idx;
+    if (buf[start] == 0x00 && intLen > 1) {
+        start += 1;
+        intLen -= 1;
+    }
+    NSData *value = [NSData dataWithBytes:buf + start length:intLen];
+    *cursor = idx + (start - idx) + intLen;
+    return value;
+}
 
 + (BOOL)executeCrypt:(NSData *)inData cryptor:(CCCryptorRef)cryptor resultData:(NSData **)resultData
 {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -438,7 +438,8 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     request.refreshToken = credentials.refreshToken;
     request.redirectURI = credentials.redirectUri;
     request.serverURL = [credentials overrideDomainIfNeeded];
-    
+    request.credentialsIdentifier = credentials.identifier;
+
     __weak typeof(self) weakSelf = self;
     id<SFSDKOAuthProtocol> authClient = self.authClient();
     [authClient accessTokenForRefresh:request completion:^(SFSDKOAuthTokenEndpointResponse * response) {
@@ -735,6 +736,10 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
                                                        userInfo:userInfo];
 
     [self deleteAccountForUser:user error:nil];
+    if (user.credentials.identifier.length > 0) {
+        [SFSDKDPoPKeyStore.shared deleteForCredentials:user.credentials];
+        [SFSDKDPoPNonceCache.shared clearForScope:user.credentials.identifier];
+    }
     id<SFSDKOAuthProtocol> authClient = self.authClient();
     [authClient revokeRefreshToken:user.credentials reason:reason];
     BOOL isCurrentUser = [user isEqual:self.currentUser];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -101,6 +101,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSURL *serverURL;
 @property (nonatomic, strong, nullable) NSDictionary * additionalTokenRefreshParams;
 @property (nonatomic, strong, nullable) NSArray<NSString *> *additionalOAuthParameterKeys;
+/// `SFOAuthCredentials.identifier` for the in-flight account. Used by the DPoP layer to
+/// scope the per-account keypair and nonce cache. Optional; when nil, DPoP is skipped.
+@property (nonatomic, copy, nullable) NSString *credentialsIdentifier;
 @end
 
 @interface SFSDKOAuthTokenEndpointResponse : NSObject

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -34,6 +34,7 @@
 #import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
 #import <SalesforceSDKCommon/SFJsonUtils.h>
 #import "NSData+SFAdditions.h"
+#import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 
 NSString * const  kSFOAuthErrorDomain  = @"com.salesforce.OAuth.ErrorDomain";
 const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
@@ -234,12 +235,12 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     [params appendFormat:@"&%@=%@&%@=%@", kSFOAuthGrantType, grantType, kSFOAuthApprovalCode, endpointReq.approvalCode];
     NSData *encodedBody = [params dataUsingEncoding:NSUTF8StringEncoding];
     [request setHTTPBody:encodedBody];
-    
-    __block NSString *networkIdentifier = [SFNetwork uniqueInstanceIdentifier];
-    SFNetwork *network = [SFNetwork sharedEphemeralInstanceWithIdentifier:networkIdentifier];
+
     __weak typeof(self) weakSelf = self;
-    [network sendRequest:request dataResponseBlock:^(NSData * data, NSURLResponse *urlResponse, NSError *error) {
-        [SFNetwork removeSharedInstanceForIdentifier:networkIdentifier];
+    [self sendTokenEndpointRequest:request
+                forEndpointRequest:endpointReq
+             retryOnNonceChallenge:YES
+                 dataResponseBlock:^(NSData *data, NSURLResponse *urlResponse, NSError *error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         SFSDKOAuthTokenEndpointResponse *endpointResponse = nil;
         if (error) {
@@ -289,15 +290,15 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     }
     NSData *encodedBody = [params dataUsingEncoding:NSUTF8StringEncoding];
     [request setHTTPBody:encodedBody];
-    __block NSString *instanceIdentifier = [SFNetwork uniqueInstanceIdentifier];
-    SFNetwork *network = [SFNetwork sharedEphemeralInstanceWithIdentifier:instanceIdentifier];
 
     __weak typeof(self) weakSelf = self;
     NSString *className = NSStringFromClass([self class]);
-    [network sendRequest:request dataResponseBlock:^(NSData *data, NSURLResponse *urlResponse, NSError *error) {
+    [self sendTokenEndpointRequest:request
+                forEndpointRequest:endpointReq
+             retryOnNonceChallenge:YES
+                 dataResponseBlock:^(NSData *data, NSURLResponse *urlResponse, NSError *error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         SFSDKOAuthTokenEndpointResponse *endpointResponse = nil;
-        [SFNetwork removeSharedInstanceForIdentifier:instanceIdentifier];
         if (error) {
             NSURL *requestUrl = [request URL];
             NSString *errorUrlString = [NSString stringWithFormat:@"%@://%@%@", [requestUrl scheme], [requestUrl host], [requestUrl relativePath]];
@@ -360,7 +361,54 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     [request setHTTPMethod:kHttpMethodPost];
     [request setValue:kHttpPostContentType forHTTPHeaderField:kHttpHeaderContentType];
     [request setHTTPShouldHandleCookies:NO];
+    [self attachDPoPHeaderIfNeeded:request scope:endpointReq.credentialsIdentifier];
     return request;
+}
+
+- (void)attachDPoPHeaderIfNeeded:(NSMutableURLRequest *)request scope:(NSString *)scope {
+    if (scope.length == 0) return;
+    NSError *err = nil;
+    [SFSDKDPoPRequestDecorator decorateRequest:request scope:scope error:&err];
+    if (err) {
+        [SFSDKCoreLogger e:[self class] format:@"DPoP attach failed (code=%ld); proceeding without DPoP header.", (long)err.code];
+    }
+}
+
+// Sends a token-endpoint request, harvesting DPoP-Nonce headers from the response and
+// retrying exactly once if the server returns a use_dpop_nonce / 401-with-DPoP-Nonce
+// challenge (RFC 9449 §8). When DPoP is disabled this is a thin pass-through.
+- (void)sendTokenEndpointRequest:(NSMutableURLRequest *)request
+              forEndpointRequest:(SFSDKOAuthTokenEndpointRequest *)endpointReq
+           retryOnNonceChallenge:(BOOL)retryOnNonceChallenge
+               dataResponseBlock:(void (^)(NSData *, NSURLResponse *, NSError *))block {
+    __block NSString *networkIdentifier = [SFNetwork uniqueInstanceIdentifier];
+    SFNetwork *network = [SFNetwork sharedEphemeralInstanceWithIdentifier:networkIdentifier];
+    __weak typeof(self) weakSelf = self;
+    [network sendRequest:request dataResponseBlock:^(NSData *data, NSURLResponse *urlResponse, NSError *error) {
+        [SFNetwork removeSharedInstanceForIdentifier:networkIdentifier];
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (error == nil && endpointReq.credentialsIdentifier.length > 0) {
+            [SFSDKDPoPRequestDecorator harvestNonceFromResponse:urlResponse
+                                                     requestURL:request.URL
+                                                          scope:endpointReq.credentialsIdentifier];
+            NSInteger statusCode = 0;
+            if ([urlResponse isKindOfClass:[NSHTTPURLResponse class]]) {
+                statusCode = ((NSHTTPURLResponse *)urlResponse).statusCode;
+            }
+            if (retryOnNonceChallenge &&
+                [SFSDKDPoPRequestDecorator isNonceChallengeWithStatusCode:statusCode body:data response:urlResponse]) {
+                [SFSDKCoreLogger i:[strongSelf class] format:@"DPoP nonce challenge received; retrying token-endpoint request once."];
+                [request setValue:nil forHTTPHeaderField:@"DPoP"];
+                [strongSelf attachDPoPHeaderIfNeeded:request scope:endpointReq.credentialsIdentifier];
+                [strongSelf sendTokenEndpointRequest:request
+                                  forEndpointRequest:endpointReq
+                               retryOnNonceChallenge:NO
+                                   dataResponseBlock:block];
+                return;
+            }
+        }
+        block(data, urlResponse, error);
+    }];
 }
 
 - (void)handleTokenEndpointResponse:(void (^)(SFSDKOAuthTokenEndpointResponse *))completionBlock request:(SFSDKOAuthTokenEndpointRequest *)endpointReq data:(NSData *)data urlResponse:(NSURLResponse *)response {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
@@ -36,21 +36,21 @@ class SFSDKDPoPTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        SFSDKDPoPKeyStore.shared.delete(forScope: testScope)
-        SFSDKDPoPNonceCache.shared.clear(forScope: testScope)
+        DPoPKeyStore.shared.delete(forScope: testScope)
+        DPoPNonceCache.shared.clear(forScope: testScope)
     }
 
     override func tearDownWithError() throws {
-        SFSDKDPoPKeyStore.shared.delete(forScope: testScope)
-        SFSDKDPoPNonceCache.shared.clear(forScope: testScope)
+        DPoPKeyStore.shared.delete(forScope: testScope)
+        DPoPNonceCache.shared.clear(forScope: testScope)
         try super.tearDownWithError()
     }
 
     // MARK: - Proof builder
 
     func test_givenValidKeyPair_whenBuildProof_thenJwsHasThreeSegmentsAndValidHeader() throws {
-        let pair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
-        let proof = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST",
+        let pair = try DPoPKeyStore.shared.keyPair(forScope: testScope)
+        let proof = try DPoPProofBuilder.buildProof(httpMethod: "POST",
                                                          htu: tokenURL,
                                                          nonce: nil,
                                                          keyPair: pair,
@@ -68,8 +68,8 @@ class SFSDKDPoPTests: XCTestCase {
     }
 
     func test_givenNonceProvided_whenBuildProof_thenPayloadIncludesNonce() throws {
-        let pair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
-        let proof = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST",
+        let pair = try DPoPKeyStore.shared.keyPair(forScope: testScope)
+        let proof = try DPoPProofBuilder.buildProof(httpMethod: "POST",
                                                          htu: tokenURL,
                                                          nonce: "abc123",
                                                          keyPair: pair)
@@ -83,9 +83,9 @@ class SFSDKDPoPTests: XCTestCase {
     }
 
     func test_givenURLWithQueryAndFragment_whenBuildProof_thenHtuIsCanonicalized() throws {
-        let pair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        let pair = try DPoPKeyStore.shared.keyPair(forScope: testScope)
         let messy = URL(string: "https://login.salesforce.com/services/oauth2/token?foo=bar#frag")!
-        let proof = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST",
+        let proof = try DPoPProofBuilder.buildProof(httpMethod: "POST",
                                                          htu: messy,
                                                          nonce: nil,
                                                          keyPair: pair)
@@ -95,9 +95,9 @@ class SFSDKDPoPTests: XCTestCase {
     }
 
     func test_givenSamePair_whenBuildProofTwice_thenJtisDiffer() throws {
-        let pair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
-        let p1 = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST", htu: tokenURL, nonce: nil, keyPair: pair)
-        let p2 = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST", htu: tokenURL, nonce: nil, keyPair: pair)
+        let pair = try DPoPKeyStore.shared.keyPair(forScope: testScope)
+        let p1 = try DPoPProofBuilder.buildProof(httpMethod: "POST", htu: tokenURL, nonce: nil, keyPair: pair)
+        let p2 = try DPoPProofBuilder.buildProof(httpMethod: "POST", htu: tokenURL, nonce: nil, keyPair: pair)
         let jti1 = try decodeBase64UrlJSON(String(p1.split(separator: ".")[1]))["jti"] as? String
         let jti2 = try decodeBase64UrlJSON(String(p2.split(separator: ".")[1]))["jti"] as? String
         XCTAssertNotNil(jti1)
@@ -106,8 +106,8 @@ class SFSDKDPoPTests: XCTestCase {
     }
 
     func test_givenProof_whenSignatureIsVerified_thenItValidatesAgainstPublicKey() throws {
-        let pair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
-        let proof = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST", htu: tokenURL, nonce: nil, keyPair: pair)
+        let pair = try DPoPKeyStore.shared.keyPair(forScope: testScope)
+        let proof = try DPoPProofBuilder.buildProof(httpMethod: "POST", htu: tokenURL, nonce: nil, keyPair: pair)
         let segments = proof.split(separator: ".")
         let signingInput = "\(segments[0]).\(segments[1])"
         let inputData = signingInput.data(using: .utf8)!
@@ -126,8 +126,8 @@ class SFSDKDPoPTests: XCTestCase {
     // MARK: - Key store
 
     func test_givenSameScope_whenKeyPairCalledTwice_thenSameKeyIsReturned() throws {
-        let p1 = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
-        let p2 = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        let p1 = try DPoPKeyStore.shared.keyPair(forScope: testScope)
+        let p2 = try DPoPKeyStore.shared.keyPair(forScope: testScope)
         // The SecKey backing the same keychain entry should sign identically; sign+compare.
         let payload = "hello".data(using: .utf8)!
         let s1 = try XCTUnwrap(SFSDKCryptoUtils.signDataES256(payload, withKeyRef: p1.privateKey))
@@ -144,19 +144,19 @@ class SFSDKDPoPTests: XCTestCase {
     }
 
     func test_givenEmptyScope_whenKeyPairRequested_thenThrowsMissingScopeIdentifier() {
-        XCTAssertThrowsError(try SFSDKDPoPKeyStore.shared.keyPair(forScope: "")) { error in
-            XCTAssertEqual(error as? SFSDKDPoPKeyStoreError, .missingScopeIdentifier)
+        XCTAssertThrowsError(try DPoPKeyStore.shared.keyPair(forScope: "")) { error in
+            XCTAssertEqual(error as? DPoPKeyStoreError, .missingScopeIdentifier)
         }
     }
 
     func test_givenScopedKey_whenDeleted_thenSubsequentLookupGeneratesFreshKey() throws {
-        let pair1 = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        let pair1 = try DPoPKeyStore.shared.keyPair(forScope: testScope)
         let payload = "hello".data(using: .utf8)!
         let sig1 = try XCTUnwrap(SFSDKCryptoUtils.signDataES256(payload, withKeyRef: pair1.privateKey))
 
-        SFSDKDPoPKeyStore.shared.delete(forScope: testScope)
+        DPoPKeyStore.shared.delete(forScope: testScope)
 
-        let pair2 = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        let pair2 = try DPoPKeyStore.shared.keyPair(forScope: testScope)
         // pair2's public key should NOT verify signatures from pair1.
         let der = try derEncodeRawECSignature(sig1)
         var error: Unmanaged<CFError>?
@@ -171,47 +171,47 @@ class SFSDKDPoPTests: XCTestCase {
     // MARK: - Nonce cache
 
     func test_givenScopedNonce_whenSameUrlSameScope_thenReturnsCachedValue() {
-        SFSDKDPoPNonceCache.shared.setNonce("nonceA", htu: tokenURL, scope: testScope)
-        XCTAssertEqual(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope), "nonceA")
+        DPoPNonceCache.shared.setNonce("nonceA", htu: tokenURL, scope: testScope)
+        XCTAssertEqual(DPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope), "nonceA")
     }
 
     func test_givenScopedNonce_whenDifferentScope_thenReturnsNil() {
-        SFSDKDPoPNonceCache.shared.setNonce("nonceA", htu: tokenURL, scope: testScope)
-        XCTAssertNil(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: "other-scope"))
+        DPoPNonceCache.shared.setNonce("nonceA", htu: tokenURL, scope: testScope)
+        XCTAssertNil(DPoPNonceCache.shared.nonce(htu: tokenURL, scope: "other-scope"))
     }
 
     func test_givenNonceForUrlWithQuery_whenLookedUpByCleanUrl_thenMatches() {
         let messy = URL(string: tokenURL.absoluteString + "?foo=bar")!
-        SFSDKDPoPNonceCache.shared.setNonce("nonceB", htu: messy, scope: testScope)
-        XCTAssertEqual(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope), "nonceB")
+        DPoPNonceCache.shared.setNonce("nonceB", htu: messy, scope: testScope)
+        XCTAssertEqual(DPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope), "nonceB")
     }
 
     func test_givenNoncesAcrossScopes_whenClearForScope_thenOnlyMatchingScopeIsRemoved() {
-        SFSDKDPoPNonceCache.shared.setNonce("nA", htu: tokenURL, scope: testScope)
-        SFSDKDPoPNonceCache.shared.setNonce("nB", htu: tokenURL, scope: "other-scope")
-        SFSDKDPoPNonceCache.shared.clear(forScope: testScope)
-        XCTAssertNil(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope))
-        XCTAssertEqual(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: "other-scope"), "nB")
-        SFSDKDPoPNonceCache.shared.clear(forScope: "other-scope")
+        DPoPNonceCache.shared.setNonce("nA", htu: tokenURL, scope: testScope)
+        DPoPNonceCache.shared.setNonce("nB", htu: tokenURL, scope: "other-scope")
+        DPoPNonceCache.shared.clear(forScope: testScope)
+        XCTAssertNil(DPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope))
+        XCTAssertEqual(DPoPNonceCache.shared.nonce(htu: tokenURL, scope: "other-scope"), "nB")
+        DPoPNonceCache.shared.clear(forScope: "other-scope")
     }
 
     // MARK: - Decorator gating + nonce challenge detection
 
     func test_givenUseDPoPDisabled_whenDecorate_thenNoHeaderAttached() throws {
-        SalesforceSDKManager.shared().useDPoP = false
+        SalesforceManager.shared.usesDPoP = false
         let req = NSMutableURLRequest(url: tokenURL)
         req.httpMethod = "POST"
-        try SFSDKDPoPRequestDecorator.decorate(req, scope: testScope)
+        try DPoPRequestDecorator.decorate(req, scope: testScope)
         XCTAssertNil(req.value(forHTTPHeaderField: "DPoP"))
     }
 
     func test_givenUseDPoPEnabled_whenDecorate_thenDPoPHeaderAttached() throws {
-        let prior = SalesforceSDKManager.shared().useDPoP
-        SalesforceSDKManager.shared().useDPoP = true
-        defer { SalesforceSDKManager.shared().useDPoP = prior }
+        let prior = SalesforceManager.shared.usesDPoP
+        SalesforceManager.shared.usesDPoP = true
+        defer { SalesforceManager.shared.usesDPoP = prior }
         let req = NSMutableURLRequest(url: tokenURL)
         req.httpMethod = "POST"
-        try SFSDKDPoPRequestDecorator.decorate(req, scope: testScope)
+        try DPoPRequestDecorator.decorate(req, scope: testScope)
         let header = try XCTUnwrap(req.value(forHTTPHeaderField: "DPoP"))
         XCTAssertEqual(header.split(separator: ".").count, 3)
     }
@@ -221,18 +221,18 @@ class SFSDKDPoPTests: XCTestCase {
                                    statusCode: 401,
                                    httpVersion: nil,
                                    headerFields: ["DPoP-Nonce": "fresh-nonce"])
-        XCTAssertTrue(SFSDKDPoPRequestDecorator.isNonceChallenge(statusCode: 401, body: nil, response: resp))
+        XCTAssertTrue(DPoPRequestDecorator.isNonceChallenge(statusCode: 401, body: nil, response: resp))
     }
 
     func test_given400WithUseDPoPNonceErrorBody_whenIsNonceChallenge_thenTrue() {
         let body = "{\"error\":\"use_dpop_nonce\"}".data(using: .utf8)
         let resp = HTTPURLResponse(url: tokenURL, statusCode: 400, httpVersion: nil, headerFields: nil)
-        XCTAssertTrue(SFSDKDPoPRequestDecorator.isNonceChallenge(statusCode: 400, body: body, response: resp))
+        XCTAssertTrue(DPoPRequestDecorator.isNonceChallenge(statusCode: 400, body: body, response: resp))
     }
 
     func test_given200OK_whenIsNonceChallenge_thenFalse() {
         let resp = HTTPURLResponse(url: tokenURL, statusCode: 200, httpVersion: nil, headerFields: nil)
-        XCTAssertFalse(SFSDKDPoPRequestDecorator.isNonceChallenge(statusCode: 200, body: nil, response: resp))
+        XCTAssertFalse(DPoPRequestDecorator.isNonceChallenge(statusCode: 200, body: nil, response: resp))
     }
 
     func test_givenResponseWithDPoPNonce_whenHarvest_thenCacheUpdated() {
@@ -240,8 +240,8 @@ class SFSDKDPoPTests: XCTestCase {
                                    statusCode: 200,
                                    httpVersion: nil,
                                    headerFields: ["DPoP-Nonce": "harvested-nonce"])
-        SFSDKDPoPRequestDecorator.harvestNonce(from: resp, requestURL: tokenURL, scope: testScope)
-        XCTAssertEqual(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope), "harvested-nonce")
+        DPoPRequestDecorator.harvestNonce(from: resp, requestURL: tokenURL, scope: testScope)
+        XCTAssertEqual(DPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope), "harvested-nonce")
     }
 
     // MARK: - Helpers

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
@@ -1,0 +1,302 @@
+//
+//  SFSDKDPoPTests.swift
+//  SalesforceSDKCore
+//
+//  Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+//
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import Security
+import XCTest
+@testable import SalesforceSDKCore
+
+class SFSDKDPoPTests: XCTestCase {
+
+    private let testScope = "test-credentials-id-\(UUID().uuidString)"
+    private let tokenURL = URL(string: "https://login.salesforce.com/services/oauth2/token")!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        SFSDKDPoPKeyStore.shared.delete(forScope: testScope)
+        SFSDKDPoPNonceCache.shared.clear(forScope: testScope)
+    }
+
+    override func tearDownWithError() throws {
+        SFSDKDPoPKeyStore.shared.delete(forScope: testScope)
+        SFSDKDPoPNonceCache.shared.clear(forScope: testScope)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Proof builder
+
+    func test_givenValidKeyPair_whenBuildProof_thenJwsHasThreeSegmentsAndValidHeader() throws {
+        let pair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        let proof = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST",
+                                                         htu: tokenURL,
+                                                         nonce: nil,
+                                                         keyPair: pair,
+                                                         now: Date(timeIntervalSince1970: 1_700_000_000))
+        let segments = proof.split(separator: ".")
+        XCTAssertEqual(segments.count, 3)
+        let header = try decodeBase64UrlJSON(String(segments[0]))
+        XCTAssertEqual(header["typ"] as? String, "dpop+jwt")
+        XCTAssertEqual(header["alg"] as? String, "ES256")
+        let jwk = try XCTUnwrap(header["jwk"] as? [String: Any])
+        XCTAssertEqual(jwk["kty"] as? String, "EC")
+        XCTAssertEqual(jwk["crv"] as? String, "P-256")
+        XCTAssertNotNil(jwk["x"] as? String)
+        XCTAssertNotNil(jwk["y"] as? String)
+    }
+
+    func test_givenNonceProvided_whenBuildProof_thenPayloadIncludesNonce() throws {
+        let pair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        let proof = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST",
+                                                         htu: tokenURL,
+                                                         nonce: "abc123",
+                                                         keyPair: pair)
+        let segments = proof.split(separator: ".")
+        let payload = try decodeBase64UrlJSON(String(segments[1]))
+        XCTAssertEqual(payload["nonce"] as? String, "abc123")
+        XCTAssertEqual(payload["htm"] as? String, "POST")
+        XCTAssertEqual(payload["htu"] as? String, tokenURL.absoluteString)
+        XCTAssertNotNil(payload["jti"] as? String)
+        XCTAssertNotNil(payload["iat"] as? Int)
+    }
+
+    func test_givenURLWithQueryAndFragment_whenBuildProof_thenHtuIsCanonicalized() throws {
+        let pair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        let messy = URL(string: "https://login.salesforce.com/services/oauth2/token?foo=bar#frag")!
+        let proof = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST",
+                                                         htu: messy,
+                                                         nonce: nil,
+                                                         keyPair: pair)
+        let segments = proof.split(separator: ".")
+        let payload = try decodeBase64UrlJSON(String(segments[1]))
+        XCTAssertEqual(payload["htu"] as? String, "https://login.salesforce.com/services/oauth2/token")
+    }
+
+    func test_givenSamePair_whenBuildProofTwice_thenJtisDiffer() throws {
+        let pair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        let p1 = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST", htu: tokenURL, nonce: nil, keyPair: pair)
+        let p2 = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST", htu: tokenURL, nonce: nil, keyPair: pair)
+        let jti1 = try decodeBase64UrlJSON(String(p1.split(separator: ".")[1]))["jti"] as? String
+        let jti2 = try decodeBase64UrlJSON(String(p2.split(separator: ".")[1]))["jti"] as? String
+        XCTAssertNotNil(jti1)
+        XCTAssertNotNil(jti2)
+        XCTAssertNotEqual(jti1, jti2)
+    }
+
+    func test_givenProof_whenSignatureIsVerified_thenItValidatesAgainstPublicKey() throws {
+        let pair = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        let proof = try SFSDKDPoPProofBuilder.buildProof(httpMethod: "POST", htu: tokenURL, nonce: nil, keyPair: pair)
+        let segments = proof.split(separator: ".")
+        let signingInput = "\(segments[0]).\(segments[1])"
+        let inputData = signingInput.data(using: .utf8)!
+        let rawSig = try base64UrlDecode(String(segments[2]))
+        XCTAssertEqual(rawSig.count, 64)
+        let derSig = try derEncodeRawECSignature(rawSig)
+        var error: Unmanaged<CFError>?
+        let ok = SecKeyVerifySignature(pair.publicKey,
+                                       .ecdsaSignatureMessageX962SHA256,
+                                       inputData as CFData,
+                                       derSig as CFData,
+                                       &error)
+        XCTAssertTrue(ok, "Signature should verify against public key. error=\(String(describing: error))")
+    }
+
+    // MARK: - Key store
+
+    func test_givenSameScope_whenKeyPairCalledTwice_thenSameKeyIsReturned() throws {
+        let p1 = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        let p2 = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        // The SecKey backing the same keychain entry should sign identically; sign+compare.
+        let payload = "hello".data(using: .utf8)!
+        let s1 = try XCTUnwrap(SFSDKCryptoUtils.signDataES256(payload, withKeyRef: p1.privateKey))
+        XCTAssertEqual(s1.count, 64)
+        // verify with p2's public key (must be the same pair)
+        let der = try derEncodeRawECSignature(s1)
+        var error: Unmanaged<CFError>?
+        let ok = SecKeyVerifySignature(p2.publicKey,
+                                       .ecdsaSignatureMessageX962SHA256,
+                                       payload as CFData,
+                                       der as CFData,
+                                       &error)
+        XCTAssertTrue(ok)
+    }
+
+    func test_givenEmptyScope_whenKeyPairRequested_thenThrowsMissingScopeIdentifier() {
+        XCTAssertThrowsError(try SFSDKDPoPKeyStore.shared.keyPair(forScope: "")) { error in
+            XCTAssertEqual(error as? SFSDKDPoPKeyStoreError, .missingScopeIdentifier)
+        }
+    }
+
+    func test_givenScopedKey_whenDeleted_thenSubsequentLookupGeneratesFreshKey() throws {
+        let pair1 = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        let payload = "hello".data(using: .utf8)!
+        let sig1 = try XCTUnwrap(SFSDKCryptoUtils.signDataES256(payload, withKeyRef: pair1.privateKey))
+
+        SFSDKDPoPKeyStore.shared.delete(forScope: testScope)
+
+        let pair2 = try SFSDKDPoPKeyStore.shared.keyPair(forScope: testScope)
+        // pair2's public key should NOT verify signatures from pair1.
+        let der = try derEncodeRawECSignature(sig1)
+        var error: Unmanaged<CFError>?
+        let ok = SecKeyVerifySignature(pair2.publicKey,
+                                       .ecdsaSignatureMessageX962SHA256,
+                                       payload as CFData,
+                                       der as CFData,
+                                       &error)
+        XCTAssertFalse(ok, "Fresh keypair should not verify signatures from rotated-out key.")
+    }
+
+    // MARK: - Nonce cache
+
+    func test_givenScopedNonce_whenSameUrlSameScope_thenReturnsCachedValue() {
+        SFSDKDPoPNonceCache.shared.setNonce("nonceA", htu: tokenURL, scope: testScope)
+        XCTAssertEqual(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope), "nonceA")
+    }
+
+    func test_givenScopedNonce_whenDifferentScope_thenReturnsNil() {
+        SFSDKDPoPNonceCache.shared.setNonce("nonceA", htu: tokenURL, scope: testScope)
+        XCTAssertNil(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: "other-scope"))
+    }
+
+    func test_givenNonceForUrlWithQuery_whenLookedUpByCleanUrl_thenMatches() {
+        let messy = URL(string: tokenURL.absoluteString + "?foo=bar")!
+        SFSDKDPoPNonceCache.shared.setNonce("nonceB", htu: messy, scope: testScope)
+        XCTAssertEqual(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope), "nonceB")
+    }
+
+    func test_givenNoncesAcrossScopes_whenClearForScope_thenOnlyMatchingScopeIsRemoved() {
+        SFSDKDPoPNonceCache.shared.setNonce("nA", htu: tokenURL, scope: testScope)
+        SFSDKDPoPNonceCache.shared.setNonce("nB", htu: tokenURL, scope: "other-scope")
+        SFSDKDPoPNonceCache.shared.clear(forScope: testScope)
+        XCTAssertNil(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope))
+        XCTAssertEqual(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: "other-scope"), "nB")
+        SFSDKDPoPNonceCache.shared.clear(forScope: "other-scope")
+    }
+
+    // MARK: - Decorator gating + nonce challenge detection
+
+    func test_givenUseDPoPDisabled_whenDecorate_thenNoHeaderAttached() throws {
+        SalesforceSDKManager.shared().useDPoP = false
+        let req = NSMutableURLRequest(url: tokenURL)
+        req.httpMethod = "POST"
+        try SFSDKDPoPRequestDecorator.decorate(req, scope: testScope)
+        XCTAssertNil(req.value(forHTTPHeaderField: "DPoP"))
+    }
+
+    func test_givenUseDPoPEnabled_whenDecorate_thenDPoPHeaderAttached() throws {
+        let prior = SalesforceSDKManager.shared().useDPoP
+        SalesforceSDKManager.shared().useDPoP = true
+        defer { SalesforceSDKManager.shared().useDPoP = prior }
+        let req = NSMutableURLRequest(url: tokenURL)
+        req.httpMethod = "POST"
+        try SFSDKDPoPRequestDecorator.decorate(req, scope: testScope)
+        let header = try XCTUnwrap(req.value(forHTTPHeaderField: "DPoP"))
+        XCTAssertEqual(header.split(separator: ".").count, 3)
+    }
+
+    func test_given401WithDPoPNonceHeader_whenIsNonceChallenge_thenTrue() {
+        let resp = HTTPURLResponse(url: tokenURL,
+                                   statusCode: 401,
+                                   httpVersion: nil,
+                                   headerFields: ["DPoP-Nonce": "fresh-nonce"])
+        XCTAssertTrue(SFSDKDPoPRequestDecorator.isNonceChallenge(statusCode: 401, body: nil, response: resp))
+    }
+
+    func test_given400WithUseDPoPNonceErrorBody_whenIsNonceChallenge_thenTrue() {
+        let body = "{\"error\":\"use_dpop_nonce\"}".data(using: .utf8)
+        let resp = HTTPURLResponse(url: tokenURL, statusCode: 400, httpVersion: nil, headerFields: nil)
+        XCTAssertTrue(SFSDKDPoPRequestDecorator.isNonceChallenge(statusCode: 400, body: body, response: resp))
+    }
+
+    func test_given200OK_whenIsNonceChallenge_thenFalse() {
+        let resp = HTTPURLResponse(url: tokenURL, statusCode: 200, httpVersion: nil, headerFields: nil)
+        XCTAssertFalse(SFSDKDPoPRequestDecorator.isNonceChallenge(statusCode: 200, body: nil, response: resp))
+    }
+
+    func test_givenResponseWithDPoPNonce_whenHarvest_thenCacheUpdated() {
+        let resp = HTTPURLResponse(url: tokenURL,
+                                   statusCode: 200,
+                                   httpVersion: nil,
+                                   headerFields: ["DPoP-Nonce": "harvested-nonce"])
+        SFSDKDPoPRequestDecorator.harvestNonce(from: resp, requestURL: tokenURL, scope: testScope)
+        XCTAssertEqual(SFSDKDPoPNonceCache.shared.nonce(htu: tokenURL, scope: testScope), "harvested-nonce")
+    }
+
+    // MARK: - Helpers
+
+    private func decodeBase64UrlJSON(_ segment: String) throws -> [String: Any] {
+        let data = try base64UrlDecode(segment)
+        let obj = try JSONSerialization.jsonObject(with: data, options: [])
+        return try XCTUnwrap(obj as? [String: Any])
+    }
+
+    private func base64UrlDecode(_ s: String) throws -> Data {
+        var b64 = s.replacingOccurrences(of: "-", with: "+")
+                   .replacingOccurrences(of: "_", with: "/")
+        let pad = (4 - b64.count % 4) % 4
+        b64 += String(repeating: "=", count: pad)
+        guard let d = Data(base64Encoded: b64) else {
+            throw NSError(domain: "DPoPTest", code: -1, userInfo: [NSLocalizedDescriptionKey: "bad base64url"])
+        }
+        return d
+    }
+
+    /// Convert a 64-byte raw R||S signature back into ASN.1 DER for `SecKeyVerifySignature`,
+    /// which expects `ecdsaSignatureMessageX962SHA256` to receive DER.
+    private func derEncodeRawECSignature(_ raw: Data) throws -> Data {
+        guard raw.count == 64 else {
+            throw NSError(domain: "DPoPTest", code: -2, userInfo: [NSLocalizedDescriptionKey: "raw signature must be 64 bytes"])
+        }
+        let r = raw.prefix(32)
+        let s = raw.suffix(32)
+        let rDER = derInteger(r)
+        let sDER = derInteger(s)
+        var seq = Data()
+        seq.append(0x30)
+        let inner = rDER + sDER
+        seq.append(contentsOf: derLength(inner.count))
+        seq.append(inner)
+        return seq
+    }
+
+    private func derInteger(_ bytes: Data) -> Data {
+        var b = Array(bytes)
+        while b.count > 1 && b[0] == 0x00 && (b[1] & 0x80) == 0 { b.removeFirst() }
+        if (b[0] & 0x80) != 0 { b.insert(0x00, at: 0) }
+        var out = Data()
+        out.append(0x02)
+        out.append(contentsOf: derLength(b.count))
+        out.append(contentsOf: b)
+        return out
+    }
+
+    private func derLength(_ n: Int) -> [UInt8] {
+        if n < 0x80 { return [UInt8(n)] }
+        var bytes: [UInt8] = []
+        var v = n
+        while v > 0 { bytes.insert(UInt8(v & 0xff), at: 0); v >>= 8 }
+        return [UInt8(0x80 | bytes.count)] + bytes
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKOAuthTokenEndpointResponseTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKOAuthTokenEndpointResponseTests.m
@@ -27,11 +27,17 @@
 
 #import <XCTest/XCTest.h>
 #import "SFSDKOAuth2.h"
+#import "SalesforceSDKManager.h"
 
 @interface SFSDKOAuthTokenEndpointResponse ()
 
 - (instancetype)initWithDictionary:(NSDictionary *)nvPairs parseAdditionalFields:(NSArray<NSString *> *)additionalOAuthParameterKeys;
 
+@end
+
+// Expose private helper for byte-stability regression tests (SC-4).
+@interface SFSDKOAuth2 (TestingPrivate)
+- (NSMutableURLRequest *)prepareBasicRequest:(SFSDKOAuthTokenEndpointRequest *)endpointReq;
 @end
 
 @interface SFSDKOAuthTokenEndpointResponseTests : XCTestCase
@@ -106,6 +112,30 @@
         XCTAssertEqualObjects(response.additionalOAuthFields[field], value);
     }
 
+}
+
+// SC-4: with useDPoP == NO, the prepared token-endpoint request must be byte-identical
+// to the pre-DPoP baseline — no DPoP header, same URL/method/headers, even when a
+// credentialsIdentifier is set on the endpoint request.
+- (void)test_givenUseDPoPDisabled_whenPrepareBasicRequest_thenNoDPoPHeaderAndCanonicalShape {
+    BOOL prior = [[SalesforceSDKManager sharedManager] useDPoP];
+    [[SalesforceSDKManager sharedManager] setUseDPoP:NO];
+
+    SFSDKOAuthTokenEndpointRequest *endpointReq = [[SFSDKOAuthTokenEndpointRequest alloc] init];
+    endpointReq.serverURL = [NSURL URLWithString:@"https://login.salesforce.com"];
+    endpointReq.timeout = 60.0;
+    endpointReq.credentialsIdentifier = @"some-credentials-id";
+
+    SFSDKOAuth2 *oauth = [[SFSDKOAuth2 alloc] init];
+    NSMutableURLRequest *request = [oauth prepareBasicRequest:endpointReq];
+
+    XCTAssertEqualObjects(request.HTTPMethod, @"POST");
+    XCTAssertEqualObjects(request.URL.absoluteString, @"https://login.salesforce.com/services/oauth2/token");
+    XCTAssertEqualObjects([request valueForHTTPHeaderField:@"Content-Type"], @"application/x-www-form-urlencoded");
+    XCTAssertNil([request valueForHTTPHeaderField:@"DPoP"]);
+    XCTAssertFalse(request.HTTPShouldHandleCookies);
+
+    [[SalesforceSDKManager sharedManager] setUseDPoP:prior];
 }
 
 @end


### PR DESCRIPTION
Adds opt-in DPoP sender-constrained proof JWTs to all Phase 1 OAuth token-endpoint requests on iOS: auth-code exchange, refresh-token, and the hybrid JWT-bearer swap. Behind a new `SalesforceSDKManager.useDPoP` flag (defaults to `NO`), so existing integrators are byte-for-byteunaffected.

When enabled, every outbound request to `/services/oauth2/token` carries a fresh `DPoP` header — an ES256-signed JWS whose payload binds the request to the URL, method, time, a unique JTI, and (when known) the server-issued
`DPoP-Nonce`. The signing key is a per-account P-256 keypair generated on first use, stored in the iOS Keychain, and
backed by the Secure Enclave when available.

- **What's added (iOS only — Android out of scope per spec A-12):**
  - `SFSDKDPoPKeyStore` — per-account P-256 keypair lifecycle (Secure Enclave with software-backed fallback).
  - `SFSDKDPoPProofBuilder` — JWS construction (ES256, JWK header, canonical `htu`,
`iat`/`jti`/optional `nonce`).
  - `SFSDKDPoPNonceCache` — process-lifetime `(htu, scope)`-keyed nonce cache fed by both reactive 400/401 challenges and proactive 200 OK rotations.
  - `SFSDKDPoPRequestDecorator` — gates on `useDPoP`, attaches `DPoP` header, harvests responses, and detects nonce challenges.
  - `SFSDKCryptoUtils` — two new helpers: `signDataES256:withKeyRef:`and `jwkExportFromPublicKeyRef:`.

- **Wiring:**
  - `SFSDKOAuth2.prepareBasicRequest:` attaches the proof for both auth-code and refresh paths.
  - A new `sendTokenEndpointRequest:` helper centralizes one-shot retry on the `use_dpop_nonce` /
401-with-`DPoP-Nonce` challenge.
  - `SFOAuthCoordinator.swapJWTWithCompletionHandler:` gets the same attach + retry inline (this path bypasses
`SFSDKOAuth2`/`SFNetwork`).
  - `SFUserAccountManager.postPushUnregistration:logoutReason:` clears the keystore + nonce cache for the logged-out account.

- **Public API surface:** Just one new property — `SalesforceSDKManager.useDPoP` (Swift: `usesDPoP`). All other types
are `@objc`-exposed for ObjC interop but used internally by the SDK.

 ## Design Notes

- **Per-account scope:** The keystore and nonce cache are scoped on `SFOAuthCredentials.identifier` rather than
`<orgId>_<userId>`. The auth-code exchange runs *before* an `SFUserAccount` exists, so org/user IDs aren't available at first proof. `credentials.identifier` is stable from credential construction and is what the SDK already uses to namespace per-account keychain entries.
- **Backward compatibility:** With `useDPoP=NO` (the default), `prepareBasicRequest:` produces a byte-identical
 request to before — no `DPoP` header, same URL, method, content-type, and cookie policy. Asserted by a regression test.
- **Secure Enclave:** Used when available; falls back to software-backed keychain storage on policy-locked devices, with one retry before surfacing failure.