### PR TITLE
[auto-generated] Fix CI: signal semaphore in SFSDKTestRequestListener setter

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
@@ -56,7 +56,14 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
 - (void)dealloc {
     self.dataResponse = nil;
     self.lastError = nil;
-    self.returnStatus = nil;
+    _returnStatus = nil;
+}
+
+- (void)setReturnStatus:(NSString *)returnStatus {
+    _returnStatus = returnStatus;
+    if (![returnStatus isEqualToString:kTestRequestStatusWaiting]) {
+        dispatch_semaphore_signal(_completionSemaphore);
+    }
 }
 
 - (NSString *)waitForCompletion {
@@ -79,7 +86,6 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
 {
     [SFSDKCoreLogger i:[self class] format:@"%@", NSStringFromSelector(_cmd)];
     self.returnStatus = kTestRequestStatusDidLoad;
-    dispatch_semaphore_signal(_completionSemaphore);
 }
 
 - (void)identityCoordinator:(SFIdentityCoordinator *)coordinator didFailWithError:(NSError *)error
@@ -87,7 +93,6 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
     [SFSDKCoreLogger i:[self class] format:@"%@ with error: %@", NSStringFromSelector(_cmd), error];
     self.lastError = error;
     self.returnStatus = kTestRequestStatusDidFail;
-    dispatch_semaphore_signal(_completionSemaphore);
 }
 
 #pragma mark - SFOAuthCoordinatorDelegate
@@ -129,7 +134,6 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
 {
     [SFSDKCoreLogger i:[self class] format:@"%@ with authInfo: %@", NSStringFromSelector(_cmd), info];
     self.returnStatus = kTestRequestStatusDidLoad;
-    dispatch_semaphore_signal(_completionSemaphore);
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didFailWithError:(NSError *)error authInfo:(SFOAuthInfo *)info
@@ -137,7 +141,6 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
     [SFSDKCoreLogger i:[self class] format:@"%@ with authInfo: %@, error: %@", NSStringFromSelector(_cmd), info, error];
     self.lastError = error;
     self.returnStatus = kTestRequestStatusDidFail;
-    dispatch_semaphore_signal(_completionSemaphore);
 }
 
 @end


### PR DESCRIPTION
## Summary
- Adds custom `setReturnStatus:` setter in `SFSDKTestRequestListener.m` that signals the completion semaphore when status transitions away from `kTestRequestStatusWaiting`
- Removes redundant explicit `dispatch_semaphore_signal` calls from 4 delegate methods (the setter handles it)
- Fixes MobileSync test timeouts (BriefcaseSyncDownTests, SyncManagerTests, BatchSyncUpTargetTests) caused by commit 7118b559c

## Root Cause
Commit 7118b559c replaced run-loop polling in `waitForCompletion` with `dispatch_semaphore_wait`, but only signaled the semaphore from OAuth/Identity delegate callback methods. External code that sets `returnStatus` directly via block-based callbacks (`TestSetupUtils.synchronousAuthRefresh`, `SyncManagerTestCase.sendSyncRequest`) never signaled the semaphore, causing every REST API call to timeout at 30 seconds instead of completing in 1-2 seconds.

## Test plan
- [ ] Verify MobileSync Nightly Tests pass on both iOS 18 and iOS 26
- [ ] Verify BriefcaseSyncDownTests, SyncManagerTests, BatchSyncUpTargetTests pass
- [ ] Verify SalesforceSDKCore tests still pass (no double-signal issues)
- [ ] Confirm this is test-infrastructure only — no production code changes