### PR TITLE
Add ES256 signing + P-256 JWK to Encryptor; expose KeyGenerator EC API

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/Encryptor.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/Encryptor.swift
@@ -36,6 +36,9 @@ public class Encryptor: NSObject {
         case encryptionFailed(underlyingError: Error?)
         case decryptionFailed(underlyingError: Error?)
         case noEncryptionKey
+        case signingFailed(underlyingError: Error?)
+        case publicKeyExportFailed(underlyingError: Error?)
+        case unsupportedPublicKeyFormat
     }
 
     // MARK: Symmetric Encrypt/Decrypt
@@ -137,6 +140,50 @@ public class Encryptor: NSObject {
         }
         return decryptedData as Data
     }
+
+    // MARK: ES256 / JWK (P-256)
+
+    /// Signs `data` with a P-256 private key using JWS `ES256`. Returns a 64-byte raw `R‖S`
+    /// signature suitable for the JWS compact signature segment per RFC 7515 §3.4. The
+    /// underlying `SecKeyCreateSignature` returns ASN.1 DER; this method strips the DER
+    /// envelope and pads `R` and `S` to 32 bytes each.
+    public static func signES256(_ data: Data, with privateKey: SecKey) throws -> Data {
+        var error: Unmanaged<CFError>?
+        guard let der = SecKeyCreateSignature(privateKey,
+                                              .ecdsaSignatureMessageX962SHA256,
+                                              data as CFData,
+                                              &error) else {
+            throw EncryptorError.signingFailed(underlyingError: error?.takeRetainedValue())
+        }
+        do {
+            let signature = try P256.Signing.ECDSASignature(derRepresentation: der as Data)
+            return signature.rawRepresentation
+        } catch {
+            throw EncryptorError.signingFailed(underlyingError: error)
+        }
+    }
+
+    /// Exports a P-256 public key as a JWK dictionary per RFC 7517 / RFC 7518 §6.2:
+    /// `{kty: "EC", crv: "P-256", x: <base64url>, y: <base64url>}`. `x` and `y` are the
+    /// 32-byte big-endian affine coordinates from the uncompressed point representation.
+    public static func jwkP256(from publicKey: SecKey) throws -> [String: String] {
+        var error: Unmanaged<CFError>?
+        guard let raw = SecKeyCopyExternalRepresentation(publicKey, &error) as Data? else {
+            throw EncryptorError.publicKeyExportFailed(underlyingError: error?.takeRetainedValue())
+        }
+        // Uncompressed P-256: 0x04 || X(32) || Y(32) = 65 bytes.
+        guard raw.count == 65, raw[0] == 0x04 else {
+            throw EncryptorError.unsupportedPublicKeyFormat
+        }
+        let x = raw.subdata(in: 1..<33)
+        let y = raw.subdata(in: 33..<65)
+        return [
+            "kty": "EC",
+            "crv": "P-256",
+            "x": (x as NSData).sfsdk_base64UrlString(),
+            "y": (y as NSData).sfsdk_base64UrlString()
+        ]
+    }
 }
 
 @objc(SFSDKKeyGenerator)
@@ -156,9 +203,9 @@ public class KeyGenerator: NSObject {
         case invalidQueryResult
     }
     
-    struct KeyPair {
-        let publicKey: SecKey
-        let privateKey: SecKey
+    public struct KeyPair {
+        public let publicKey: SecKey
+        public let privateKey: SecKey
     }
     
     /// Returns an encryption key for the given label. If the key doesn't already exist, it
@@ -220,7 +267,10 @@ public class KeyGenerator: NSObject {
         }
     }
     
-    static func ecKeyPair(name: String) throws -> KeyPair {
+    /// Returns a P-256 EC keypair stored in the keychain under `name`. If a keypair already
+    /// exists for the given name it is returned; otherwise a new one is generated (using
+    /// the Secure Enclave when available). The keypair is `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`.
+    public static func ecKeyPair(name: String) throws -> KeyPair {
         let privateTag = try keyTag(name: name, prefix: ecPrivateKeyTagPrefix)
         let publicTag = try keyTag(name: name, prefix: ecPublicKeyTagPrefix)
 
@@ -228,9 +278,19 @@ public class KeyGenerator: NSObject {
            let publicKey = try? ecKey(tag: publicTag) {
             return KeyPair(publicKey: publicKey, privateKey: privateKey)
         }
-    
+
         removeECKeyPair(privateTag: privateTag, publicTag: publicTag)
         return try createECKeyPair(privateTag: privateTag, publicTag: publicTag)
+    }
+
+    /// Removes the EC keypair stored under `name`. Idempotent — returns `true` even if no
+    /// keypair existed. Returns `false` only when a keychain delete fails for a reason
+    /// other than `errSecItemNotFound`.
+    @discardableResult
+    public static func removeECKeyPair(name: String) throws -> Bool {
+        let privateTag = try keyTag(name: name, prefix: ecPrivateKeyTagPrefix)
+        let publicTag = try keyTag(name: name, prefix: ecPublicKeyTagPrefix)
+        return removeECKeyPair(privateTag: privateTag, publicTag: publicTag)
     }
     
     static func keyTag(name: String, prefix: String) throws -> Data {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/EncryptorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/EncryptorTests.swift
@@ -1,0 +1,182 @@
+//
+//  EncryptorTests.swift
+//  SalesforceSDKCore
+//
+//  Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+//
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import Security
+import XCTest
+@testable import SalesforceSDKCore
+
+class EncryptorTests: XCTestCase {
+
+    private let keyName = "encryptor-tests-\(UUID().uuidString)"
+
+    override func tearDownWithError() throws {
+        _ = try? KeyGenerator.removeECKeyPair(name: keyName)
+        try super.tearDownWithError()
+    }
+
+    // MARK: - signES256
+
+    func test_givenP256KeyPair_whenSignES256_thenReturns64ByteRawSignatureThatVerifies() throws {
+        let pair = try KeyGenerator.ecKeyPair(name: keyName)
+        let payload = Data("hello dpop".utf8)
+
+        let signature = try Encryptor.signES256(payload, with: pair.privateKey)
+        XCTAssertEqual(signature.count, 64, "ES256 raw R||S signature must be 64 bytes")
+
+        // Verify by converting raw R||S back to DER and asking SecKeyVerifySignature.
+        let derSignature = try derEncode(rawSignature: signature)
+        var error: Unmanaged<CFError>?
+        let verified = SecKeyVerifySignature(pair.publicKey,
+                                             .ecdsaSignatureMessageX962SHA256,
+                                             payload as CFData,
+                                             derSignature as CFData,
+                                             &error)
+        XCTAssertTrue(verified,
+                      "Signature should verify against public key. error=\(String(describing: error))")
+    }
+
+    func test_givenSamePayloadAndKey_whenSignTwice_thenSignaturesDifferButBothVerify() throws {
+        let pair = try KeyGenerator.ecKeyPair(name: keyName)
+        let payload = Data("hello dpop".utf8)
+
+        let s1 = try Encryptor.signES256(payload, with: pair.privateKey)
+        let s2 = try Encryptor.signES256(payload, with: pair.privateKey)
+
+        XCTAssertEqual(s1.count, 64)
+        XCTAssertEqual(s2.count, 64)
+        XCTAssertNotEqual(s1, s2, "ECDSA must use a fresh nonce per signature")
+
+        for sig in [s1, s2] {
+            let der = try derEncode(rawSignature: sig)
+            var error: Unmanaged<CFError>?
+            let ok = SecKeyVerifySignature(pair.publicKey,
+                                           .ecdsaSignatureMessageX962SHA256,
+                                           payload as CFData,
+                                           der as CFData,
+                                           &error)
+            XCTAssertTrue(ok)
+        }
+    }
+
+    // MARK: - jwkP256
+
+    func test_givenP256PublicKey_whenJwkP256_thenReturnsRfc7518FieldsWith32ByteCoordinates() throws {
+        let pair = try KeyGenerator.ecKeyPair(name: keyName)
+
+        let jwk = try Encryptor.jwkP256(from: pair.publicKey)
+
+        XCTAssertEqual(jwk["kty"], "EC")
+        XCTAssertEqual(jwk["crv"], "P-256")
+
+        let x = try XCTUnwrap(jwk["x"])
+        let y = try XCTUnwrap(jwk["y"])
+        XCTAssertFalse(x.contains("="), "base64url must not include padding")
+        XCTAssertFalse(y.contains("="), "base64url must not include padding")
+        XCTAssertFalse(x.contains("+") || x.contains("/"), "x must use base64url charset")
+        XCTAssertFalse(y.contains("+") || y.contains("/"), "y must use base64url charset")
+
+        let xBytes = try base64UrlDecode(x)
+        let yBytes = try base64UrlDecode(y)
+        XCTAssertEqual(xBytes.count, 32)
+        XCTAssertEqual(yBytes.count, 32)
+    }
+
+    // MARK: - removeECKeyPair(name:)
+
+    func test_givenExistingKeyPair_whenRemoveByName_thenSubsequentLookupGeneratesFreshKey() throws {
+        let pair1 = try KeyGenerator.ecKeyPair(name: keyName)
+        let payload = Data("rotate me".utf8)
+        let sig1 = try Encryptor.signES256(payload, with: pair1.privateKey)
+
+        let removed = try KeyGenerator.removeECKeyPair(name: keyName)
+        XCTAssertTrue(removed)
+
+        let pair2 = try KeyGenerator.ecKeyPair(name: keyName)
+
+        // Fresh keypair must not verify a signature produced by the rotated-out key.
+        let der = try derEncode(rawSignature: sig1)
+        var error: Unmanaged<CFError>?
+        let verified = SecKeyVerifySignature(pair2.publicKey,
+                                             .ecdsaSignatureMessageX962SHA256,
+                                             payload as CFData,
+                                             der as CFData,
+                                             &error)
+        XCTAssertFalse(verified)
+    }
+
+    func test_givenNoKeyPair_whenRemoveByName_thenReturnsTrue() throws {
+        XCTAssertTrue(try KeyGenerator.removeECKeyPair(name: "never-created-\(UUID().uuidString)"))
+    }
+
+    // MARK: - Helpers
+
+    /// Convert a 64-byte raw R||S ES256 signature to ASN.1 DER (`SEQUENCE { INTEGER r, INTEGER s }`)
+    /// for `SecKeyVerifySignature`, which expects DER for `.ecdsaSignatureMessageX962SHA256`.
+    private func derEncode(rawSignature raw: Data) throws -> Data {
+        guard raw.count == 64 else {
+            throw NSError(domain: "EncryptorTests", code: -1,
+                          userInfo: [NSLocalizedDescriptionKey: "raw signature must be 64 bytes"])
+        }
+        let r = derInteger(raw.prefix(32))
+        let s = derInteger(raw.suffix(32))
+        let inner = r + s
+        var out = Data([0x30])
+        out.append(contentsOf: derLength(inner.count))
+        out.append(inner)
+        return out
+    }
+
+    private func derInteger(_ bytes: Data) -> Data {
+        var b = Array(bytes)
+        while b.count > 1 && b[0] == 0x00 && (b[1] & 0x80) == 0 { b.removeFirst() }
+        if (b[0] & 0x80) != 0 { b.insert(0x00, at: 0) }
+        var out = Data([0x02])
+        out.append(contentsOf: derLength(b.count))
+        out.append(contentsOf: b)
+        return out
+    }
+
+    private func derLength(_ n: Int) -> [UInt8] {
+        if n < 0x80 { return [UInt8(n)] }
+        var bytes: [UInt8] = []
+        var v = n
+        while v > 0 { bytes.insert(UInt8(v & 0xff), at: 0); v >>= 8 }
+        return [UInt8(0x80 | bytes.count)] + bytes
+    }
+
+    private func base64UrlDecode(_ s: String) throws -> Data {
+        var b64 = s.replacingOccurrences(of: "-", with: "+")
+                   .replacingOccurrences(of: "_", with: "/")
+        let pad = (4 - b64.count % 4) % 4
+        b64 += String(repeating: "=", count: pad)
+        guard let d = Data(base64Encoded: b64) else {
+            throw NSError(domain: "EncryptorTests", code: -2,
+                          userInfo: [NSLocalizedDescriptionKey: "bad base64url"])
+        }
+        return d
+    }
+}


### PR DESCRIPTION
 ## Summary
Pure-Swift crypto prerequisites for upcoming DPoP work. **No behavior changes; no DPoP code lands here.**

This PR is a direct response to PR-review feedback on the DPoP work ([review thread](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/4051#discussion_r3346039293)) noting that the codebase is migrating off `SFSDKCryptoUtils` toward Swift. By landing the signing + JWK primitives in `Encryptor.swift` and reusing `KeyGenerator` for keypair lifecycle, this follow-up DPoP PR introduces zero new Objective-C and stays consistent with the codebase's Swift direction.

- `Encryptor.signES256(_:with:)` — signs `Data` with a P-256 private key and returns a 64-byte raw R‖S signature suitable for the JWS compact signature segment per RFC 7515 §3.4. Uses `SecKeyCreateSignature(.ecdsaSignatureMessageX962SHA256)` and `CryptoKit.P256.Signing.ECDSASignature` to strip the DER envelope.
- `Encryptor.jwkP256(from:)` — exports a P-256 public key as the RFC 7517 /RFC 7518 §6.2 JWK fields (`kty`, `crv`, `x`, `y`), with `x` and `y` as base64url-encoded 32-byte affine coordinates.
- Widens `KeyGenerator.KeyPair`, `KeyGenerator.ecKeyPair(name:)`, and a new name-based `KeyGenerator.removeECKeyPair(name:)` to `public` so external callers (and the upcoming DPoP keystore) can consume the existing keypair lifecycle without re-implementing the keychain dance.
- Three new `EncryptorError` cases for the new methods: `signingFailed`, `publicKeyExportFailed`, `unsupportedPublicKeyFormat`.

> ⚠️  **Public API addition — please review carefully.** Per `CLAUDE.md`,
> changes to public API surface require human review. The new symbols are:
> `Encryptor.signES256(_:with:)`, `Encryptor.jwkP256(from:)`,
> `KeyGenerator.KeyPair` (struct + properties), `KeyGenerator.ecKeyPair(name:)`,
> `KeyGenerator.removeECKeyPair(name:)`. Once these ship in a release, any
> signature change requires a deprecation cycle.

  ## Test plan
- [x] `xcodebuild test -workspace SalesforceMobileSDK.xcworkspace -scheme SalesforceSDKCore -sdk iphonesimulator-only-testing:SalesforceSDKCoreTests/EncryptorTests` passes
- [x] Full `SalesforceSDKCore` test suite passes (no regression in existing `EncryptionTests` that consume
  `KeyGenerator` internals)
- [x] `SalesforceSDKCoreTests/EncryptorTests.swift` is added to the `SalesforceSDKCoreTests` target in
  `SalesforceSDKCore.xcodeproj`