### PR TITLE
W-22917328: Rename beacon_child_consumer_{key,secret} to auto_installed_app_org_consumer_{key,secret}

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -469,11 +469,16 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     if (params[kSFOAuthTokenFormat]) {
         self.tokenFormat = params[kSFOAuthTokenFormat];
     }
+    // TODO: Remove kSFOAuthLegacyBeaconChildConsumer* fallback once server version 264 has rolled out everywhere.
     if (params[kSFOAuthBeaconChildConsumerKey]) {
         self.beaconChildConsumerKey = params[kSFOAuthBeaconChildConsumerKey];
+    } else if (params[kSFOAuthLegacyBeaconChildConsumerKey]) {
+        self.beaconChildConsumerKey = params[kSFOAuthLegacyBeaconChildConsumerKey];
     }
     if (params[kSFOAuthBeaconChildConsumerSecret]) {
         self.beaconChildConsumerSecret = params[kSFOAuthBeaconChildConsumerSecret];
+    } else if (params[kSFOAuthLegacyBeaconChildConsumerSecret]) {
+        self.beaconChildConsumerSecret = params[kSFOAuthLegacyBeaconChildConsumerSecret];
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -78,8 +78,8 @@ static NSString * const kSFOAuthCookieSidClient                 = @"cookie-sid_C
 static NSString * const kSFOAuthSidCookieName                   = @"sidCookieName";
 static NSString * const kSFOAuthParentSid                       = @"parent_sid";
 static NSString * const kSFOAuthTokenFormat                     = @"token_format";
-static NSString * const kSFOAuthBeaconChildConsumerKey          = @"beacon_child_consumer_key";
-static NSString * const kSFOAuthBeaconChildConsumerSecret       = @"beacon_child_consumer_secret";
+static NSString * const kSFOAuthBeaconChildConsumerKey          = @"auto_installed_app_org_consumer_key";
+static NSString * const kSFOAuthBeaconChildConsumerSecret       = @"auto_installed_app_org_consumer_secret";
 
 
 // Used for the IP bypass flow, Advanced auth flow

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -80,6 +80,9 @@ static NSString * const kSFOAuthParentSid                       = @"parent_sid";
 static NSString * const kSFOAuthTokenFormat                     = @"token_format";
 static NSString * const kSFOAuthBeaconChildConsumerKey          = @"auto_installed_app_org_consumer_key";
 static NSString * const kSFOAuthBeaconChildConsumerSecret       = @"auto_installed_app_org_consumer_secret";
+// TODO: Remove legacy fallback constants once server version 264 has rolled out everywhere.
+static NSString * const kSFOAuthLegacyBeaconChildConsumerKey    = @"beacon_child_consumer_key";
+static NSString * const kSFOAuthLegacyBeaconChildConsumerSecret = @"beacon_child_consumer_secret";
 
 
 // Used for the IP bypass flow, Advanced auth flow

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCredentialsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCredentialsTests.m
@@ -77,8 +77,8 @@
     [params setObject:@"test-sid-cookie-name" forKey:@"sidCookieName"];
     [params setObject:@"test-parent-sid" forKey:@"parent_sid"];
     [params setObject:@"test-token-format" forKey:@"token_format"];
-    [params setObject:@"test-beacon-child-consumer-key" forKey:@"beacon_child_consumer_key"];
-    [params setObject:@"test-beacon-child-consumer-secret" forKey:@"beacon_child_consumer_secret"];
+    [params setObject:@"test-beacon-child-consumer-key" forKey:@"auto_installed_app_org_consumer_key"];
+    [params setObject:@"test-beacon-child-consumer-secret" forKey:@"auto_installed_app_org_consumer_secret"];
     [creds updateCredentials:params];
     
     // Check updated SFOAuthCredentials

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKOAuthTokenEndpointResponseTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKOAuthTokenEndpointResponseTests.m
@@ -63,8 +63,8 @@
     [params setObject:@"test-sid-cookie-name" forKey:@"sidCookieName"];
     [params setObject:@"test-parent-sid" forKey:@"parent_sid"];
     [params setObject:@"test-token-format" forKey:@"token_format"];
-    [params setObject:@"test-beacon-child-consumer-key" forKey:@"beacon_child_consumer_key"];
-    [params setObject:@"test-beacon-child-consumer-secret" forKey:@"beacon_child_consumer_secret"];
+    [params setObject:@"test-beacon-child-consumer-key" forKey:@"auto_installed_app_org_consumer_key"];
+    [params setObject:@"test-beacon-child-consumer-secret" forKey:@"auto_installed_app_org_consumer_secret"];
 
     // Additional fields
     NSArray<NSString *>* additionalFields = @[ @"additional-1", @"additional-2" ];


### PR DESCRIPTION
## Summary

Updates the token endpoint wire-format keys and adds a legacy fallback for servers that haven't yet rolled out version 264.

When parsing the token response, the SDK now:
1. Checks for `auto_installed_app_org_consumer_{key,secret}` (new field name)
2. Falls back to `beacon_child_consumer_{key,secret}` if the new field is absent

A `TODO` comment marks both fallback constants and the fallback logic for removal once server version 264 has rolled out everywhere.

All code symbol names (`kSFOAuthBeaconChildConsumerKey`, `beaconChildConsumerKey` property, etc.) are **unchanged**.

## Files changed
- `SFSDKOAuthConstants.h` — new constant values + legacy fallback constants added
- `SFOAuthCredentials.m` — parsing updated with new-then-old fallback
- `SFSDKOAuthTokenEndpointResponseTests.m` — test key strings updated
- `SFOAuthCredentialsTests.m` — test key strings updated

## Test plan
- [x] `SalesforceSDKCore` unit test suite passes (iPhone 16 / iOS 18.6)
- [ ] AuthFlowTester UI tests pass (running externally)

## Related
- Android counterpart: forcedotcom/SalesforceMobileSDK-Android#2923
- GUS: W-22917328