### PR TITLE
@W-22954918: [iOS] Stabilize flaky test testBootConfigPickerViewRendered

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift
@@ -104,8 +104,10 @@ class LoginOptionsViewControllerTests: XCTestCase {
         hostingController.beginAppearanceTransition(true, animated: false)
         hostingController.endAppearanceTransition()
 
-        // Verify view rendered with BootConfig
-        XCTAssertNotNil(hostingController.view)
+        // Verify view rendered with non-zero layout
+        hostingController.view.layoutIfNeeded()
+        XCTAssertGreaterThan(hostingController.view.subviews.count, 0)
+        XCTAssertGreaterThan(hostingController.view.frame.height, 0)
 
         // Clean up
         window.rootViewController = nil

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift
@@ -79,10 +79,7 @@ class LoginOptionsViewControllerTests: XCTestCase {
         #endif
     }
     
-    // Flaky test stabilization - W-22954918
     func testBootConfigPickerViewRendered() {
-        let expectation = XCTestExpectation(description: "View works with existing BootConfig")
-        
         // Create a test BootConfig
         let testConfig: [String: Any] = [
             "remoteAccessConsumerKey": "test_boot_config_key",
@@ -91,34 +88,28 @@ class LoginOptionsViewControllerTests: XCTestCase {
             "shouldAuthenticate": true
         ]
         SalesforceManager.shared.bootConfig = BootConfig(testConfig)
-        
+
         let view = LoginOptionsView {
             // No-op callback
         }
-        
+
         let hostingController = UIHostingController(rootView: view)
-        
+
         // Create a window and add the view controller
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
         window.rootViewController = hostingController
         window.makeKeyAndVisible()
-        
-        // Trigger view lifecycle (use appearance transition APIs to avoid callback misuse warning)
+
+        // Trigger view lifecycle
         hostingController.beginAppearanceTransition(true, animated: false)
         hostingController.endAppearanceTransition()
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            // Verify view rendered with BootConfig
-            XCTAssertNotNil(hostingController.view)
-            
-            // Clean up
-            window.rootViewController = nil
-            window.isHidden = true
-            
-            expectation.fulfill()
-        }
-        
-        wait(for: [expectation], timeout: 2.0)
+
+        // Verify view rendered with BootConfig
+        XCTAssertNotNil(hostingController.view)
+
+        // Clean up
+        window.rootViewController = nil
+        window.isHidden = true
     }
     
     func testStaticConfigButtonAction() {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift
@@ -100,13 +100,13 @@ class LoginOptionsViewControllerTests: XCTestCase {
         window.rootViewController = hostingController
         window.makeKeyAndVisible()
 
-        // Trigger view lifecycle
+        // Trigger view lifecycle (use appearance transition APIs to avoid callback misuse warning)
         hostingController.beginAppearanceTransition(true, animated: false)
         hostingController.endAppearanceTransition()
 
-        // Verify view rendered with non-zero layout
+        // Verify view rendered with non-zero layout (frame.height relies only on UIKit layout,
+        // avoiding SwiftUI internals like subview count which could vary across OS versions)
         hostingController.view.layoutIfNeeded()
-        XCTAssertGreaterThan(hostingController.view.subviews.count, 0)
         XCTAssertGreaterThan(hostingController.view.frame.height, 0)
 
         // Clean up

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift
@@ -79,6 +79,7 @@ class LoginOptionsViewControllerTests: XCTestCase {
         #endif
     }
     
+    // Flaky test stabilization - W-22954918
     func testBootConfigPickerViewRendered() {
         let expectation = XCTestExpectation(description: "View works with existing BootConfig")
         


### PR DESCRIPTION
## Summary

Stabilizes the flaky `testBootConfigPickerViewRendered` test by removing a non-deterministic timing pattern and replacing with a synchronous layout assertion.

## Root Cause

The test used a hardcoded 200ms `DispatchQueue.main.asyncAfter` delay with a 2-second `XCTestExpectation` timeout to wait for a SwiftUI view hierarchy to render. Under CI load, the main run loop can be starved long enough that the `asyncAfter` block doesn't fire within the timeout window, causing intermittent failures.

## Fix

- Removed the `asyncAfter` delay, `XCTestExpectation`, and `wait(for:timeout:)`
- Added `layoutIfNeeded()` to force synchronous layout
- Replaced the trivially-true `XCTAssertNotNil(hostingController.view)` with `XCTAssertGreaterThan(hostingController.view.frame.height, 0)` to verify the view actually laid out in the window

## Verification

**Before fix**: `testBootConfigPickerViewRendered` appeared in CI failure reports on the first run (iOS 18).

**After fix**: Over 6 CI runs post-fix, `testBootConfigPickerViewRendered` has not appeared in any failure report. Test executes in ~0.13s deterministically.

## Test plan

- [x] Test passes locally in isolation
- [x] `testBootConfigPickerViewRendered` not observed failing in 6 CI runs post-fix
- [x] No regressions in `LoginOptionsViewControllerTests` class (all 6 tests pass)
- [x] Negative test: assertion fails when window frame is zeroed (confirms assertion is meaningful, not trivially true)

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*