### PR TITLE
@W-22954921: [iOS] Stabilize flaky test testMissingLoginHint

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
@@ -1,12 +1,8 @@
 import XCTest
 @testable import SalesforceSDKCore
 
-/// Tests for DomainDiscoveryCoordinator. We call `handle(callbackURL:)` directly with a URL
-/// instead of building a MockNavigationAction, because subclassing WKNavigationAction and
-/// calling super.init() can trigger an abort in WebKit on CI (signal abrt).
-///
-/// These tests exercise only synchronous URL-parsing logic, so they avoid @MainActor and async
-/// to prevent main-actor contention with WebKit-using tests running in the same bundle.
+/// Tests for DomainDiscoveryCoordinator. These exercise synchronous URL-parsing logic
+/// via `handle(callbackURL:)` directly.
 final class DomainDiscoveryCoordinatorTests: XCTestCase {
 
     func testCallbackSuccess() throws {
@@ -44,7 +40,7 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
     }
 
     func testMissingLoginHint() throws {
-        // Given
+        // Given: callback URL with my_domain but no login_hint
         let coordinator = DomainDiscoveryCoordinator()
         var components = URLComponents()
         components.scheme = "sfdc"
@@ -74,7 +70,7 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
     }
 
     func testNonCallbackURL() throws {
-        // Given
+        // Given: URL that is not a domain discovery callback
         let coordinator = DomainDiscoveryCoordinator()
         var components = URLComponents()
         components.scheme = "https"

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
@@ -41,6 +41,7 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         XCTAssertNil(results)
     }
 
+    // Flaky test stabilization - W-22954921
     func testMissingLoginHint() async throws {
         // Given: callback URL with my_domain only (no login_hint). Build via URLComponents so parsing is deterministic on all platforms.
         let coordinator = DomainDiscoveryCoordinator()

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DomainDiscoveryCoordinatorTests.swift
@@ -4,10 +4,12 @@ import XCTest
 /// Tests for DomainDiscoveryCoordinator. We call `handle(callbackURL:)` directly with a URL
 /// instead of building a MockNavigationAction, because subclassing WKNavigationAction and
 /// calling super.init() can trigger an abort in WebKit on CI (signal abrt).
-@MainActor
+///
+/// These tests exercise only synchronous URL-parsing logic, so they avoid @MainActor and async
+/// to prevent main-actor contention with WebKit-using tests running in the same bundle.
 final class DomainDiscoveryCoordinatorTests: XCTestCase {
 
-    func testCallbackSuccess() async throws {
+    func testCallbackSuccess() throws {
         // Given
         let coordinator = DomainDiscoveryCoordinator()
         let expectedDomain = "foo.my.salesforce.com"
@@ -26,7 +28,7 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         XCTAssertEqual(results?.loginHint, expectedLoginHint)
     }
 
-    func testMissingMyDomain() async throws {
+    func testMissingMyDomain() throws {
         // Given
         let coordinator = DomainDiscoveryCoordinator()
         let expectedLoginHint = "testuser@example.com"
@@ -41,9 +43,8 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         XCTAssertNil(results)
     }
 
-    // Flaky test stabilization - W-22954921
-    func testMissingLoginHint() async throws {
-        // Given: callback URL with my_domain only (no login_hint). Build via URLComponents so parsing is deterministic on all platforms.
+    func testMissingLoginHint() throws {
+        // Given
         let coordinator = DomainDiscoveryCoordinator()
         var components = URLComponents()
         components.scheme = "sfdc"
@@ -58,7 +59,7 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         XCTAssertNil(results)
     }
 
-    func testMalformedCallbackURL() async throws {
+    func testMalformedCallbackURL() throws {
         // Given
         let coordinator = DomainDiscoveryCoordinator()
         let callbackURLString = "sfdc://discocallback?my_domain=&login_hint="
@@ -72,8 +73,8 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         XCTAssertEqual(results?.loginHint, "")
     }
 
-    func testNonCallbackURL() async throws {
-        // Given: URL that is not a domain discovery callback. Build via URLComponents so parsing is deterministic on all platforms.
+    func testNonCallbackURL() throws {
+        // Given
         let coordinator = DomainDiscoveryCoordinator()
         var components = URLComponents()
         components.scheme = "https"
@@ -87,7 +88,7 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         XCTAssertNil(results)
     }
 
-    func testSpecialCharactersInLoginHint() async throws {
+    func testSpecialCharactersInLoginHint() throws {
         // Given
         let coordinator = DomainDiscoveryCoordinator()
         let expectedDomain = "foo.my.salesforce.com"
@@ -106,7 +107,7 @@ final class DomainDiscoveryCoordinatorTests: XCTestCase {
         XCTAssertEqual(results?.loginHint, expectedLoginHint)
     }
 
-    func testExtraQueryParameters() async throws {
+    func testExtraQueryParameters() throws {
         // Given
         let coordinator = DomainDiscoveryCoordinator()
         let expectedDomain = "foo.my.salesforce.com"


### PR DESCRIPTION
## Summary

Stabilizes the flaky `DomainDiscoveryCoordinatorTests` test class by removing unnecessary `@MainActor` and `async` annotations from synchronous tests.

## Root Cause

The test class was annotated with `@MainActor` and all test methods were marked `async throws`, despite every test body being purely synchronous URL-parsing logic with no async work. Under CI load, these annotations caused intermittent failures across multiple tests in the class (`testMissingLoginHint`, `testCallbackSuccess`, `testSpecialCharactersInLoginHint`, `testMissingMyDomain`, `testNonCallbackURL`) due to main-actor scheduling contention with WebKit-using tests running in the same bundle.

## Fix

- Removed `@MainActor` from the class declaration
- Changed all 7 test methods from `async throws` to `throws`

## Verification

**Before fix**: Over 3 CI runs on the unmodified code, different tests in this class failed on each run — `testCallbackSuccess`, `testSpecialCharactersInLoginHint`, `testMissingMyDomain`, and `testNonCallbackURL` all appeared in failure reports, confirming class-wide flakiness.

**After fix**: Over 6 CI runs post-fix, no test in `DomainDiscoveryCoordinatorTests` has appeared in any failure report. The sibling test failures that were occurring every run have stopped entirely.

## Test plan

- [x] All 7 tests pass locally (0.000-0.001s each — truly synchronous)
- [x] Full test class passes in isolation
- [x] `testMissingLoginHint` not observed failing in 6 CI runs post-fix
- [x] No `DomainDiscoveryCoordinatorTests` sibling tests observed failing post-fix (they were failing pre-fix)

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*