### PR TITLE
@W-22954922: [iOS] Stabilize flaky test testCAOpaque_DefaultScopes_WebServerFlow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -183,8 +183,8 @@ jobs:
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
       pr_test: "AuthFlowTesterUITests/LegacyLoginTests/testCAOpaque_DefaultScopes_WebServerFlow"
-      short_timeout: "2"
-      long_timeout: "7"
+      short_timeout: "3"
+      long_timeout: "15"
     secrets:
       UI_TEST_CONFIG: ${{ secrets.UI_TEST_CONFIG }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ui-test-nightly.yaml
+++ b/.github/workflows/ui-test-nightly.yaml
@@ -26,8 +26,8 @@ jobs:
     with:
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
-      short_timeout: "2"
-      long_timeout: "7"
+      short_timeout: "3"
+      long_timeout: "15"
     secrets:
       UI_TEST_CONFIG: ${{ secrets.UI_TEST_CONFIG }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTesterMainPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTesterMainPageObject.swift
@@ -221,7 +221,7 @@ class AuthFlowTesterMainPageObject {
     }
     
     func isShowing() -> Bool {
-        return navigationTitle().waitForExistence(timeout: UITestTimeouts.long)
+        return navigationTitle().waitForExistence(timeout: UITestTimeouts.network)
     }
     
     func performLogout() {
@@ -461,13 +461,14 @@ class AuthFlowTesterMainPageObject {
 
     // MARK: - Actions
     
-    private func tap(_ element: XCUIElement) {
-        _ = element.waitForExistence(timeout: UITestTimeouts.long)
+    private func tap(_ element: XCUIElement, timeout: TimeInterval = UITestTimeouts.long, file: StaticString = #file, line: UInt = #line) {
+        let exists = element.waitForExistence(timeout: timeout)
+        XCTAssertTrue(exists, "Element \(element.debugDescription) did not appear within \(timeout)s", file: file, line: line)
         element.tap()
     }
-    
-    private func tapIfPresent(_ element: XCUIElement) {
-        if (element.waitForExistence(timeout: UITestTimeouts.long)) {
+
+    private func tapIfPresent(_ element: XCUIElement, timeout: TimeInterval = UITestTimeouts.long) {
+        if element.waitForExistence(timeout: timeout) {
             element.tap()
         }
     }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTypesPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTypesPageObject.swift
@@ -88,8 +88,9 @@ class AuthFlowTypesPageObject {
 
     // MARK: - Actions
 
-    private func tap(_ element: XCUIElement) {
-        _ = element.waitForExistence(timeout: UITestTimeouts.long)
+    private func tap(_ element: XCUIElement, timeout: TimeInterval = UITestTimeouts.long, file: StaticString = #file, line: UInt = #line) {
+        let exists = element.waitForExistence(timeout: timeout)
+        XCTAssertTrue(exists, "Element \(element.debugDescription) did not appear within \(timeout)s", file: file, line: line)
         element.tap()
     }
 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginOptionsPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginOptionsPageObject.swift
@@ -148,8 +148,9 @@ class LoginOptionsPageObject {
 
     // MARK: - Actions
 
-    private func tap(_ element: XCUIElement) {
-        _ = element.waitForExistence(timeout: UITestTimeouts.long)
+    private func tap(_ element: XCUIElement, timeout: TimeInterval = UITestTimeouts.long, file: StaticString = #file, line: UInt = #line) {
+        let exists = element.waitForExistence(timeout: timeout)
+        XCTAssertTrue(exists, "Element \(element.debugDescription) did not appear within \(timeout)s", file: file, line: line)
         element.tap()
     }
 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -39,7 +39,7 @@ class LoginPageObject {
     }
     
     func isShowing() -> Bool {
-        return loginNavigationBar().waitForExistence(timeout: UITestTimeouts.long)
+        return loginNavigationBar().waitForExistence(timeout: UITestTimeouts.network)
     }
     
     func hasFilledUsernameField(username: String) -> Bool {
@@ -84,16 +84,16 @@ class LoginPageObject {
             usernameField().typeText(XCUIKeyboardKey.return.rawValue)
         } else {
             dismissKeyboardAfterTyping()
-            tap(loginButton())
+            tap(loginButton(), timeout: UITestTimeouts.network)
         }
         setTextField(passwordField(), value: password)
         if advancedAuth {
             passwordField().typeText(XCUIKeyboardKey.return.rawValue)
         } else {
             dismissKeyboardAfterTyping()
-            tap(loginButton())
+            tap(loginButton(), timeout: UITestTimeouts.network)
         }
-        tapIfPresent(allowButton())
+        tapIfPresent(allowButton(), timeout: UITestTimeouts.network)
     }
 
     /// Performs login via the "Login for Admin" flow.
@@ -111,15 +111,15 @@ class LoginPageObject {
     }
 
     func performWelcomeLogin(password: String, advancedAuth: Bool = false) {
-        tap(loginButton())
+        tap(loginButton(), timeout: UITestTimeouts.network)
         setTextField(passwordField(), value: password)
         if advancedAuth {
             passwordField().typeText(XCUIKeyboardKey.return.rawValue)
         } else {
             dismissKeyboardAfterTyping()
-            tap(loginButton())
+            tap(loginButton(), timeout: UITestTimeouts.network)
         }
-        tapIfPresent(allowButton())
+        tapIfPresent(allowButton(), timeout: UITestTimeouts.network)
     }
     
     func configureLoginOptions(
@@ -257,14 +257,15 @@ class LoginPageObject {
     
     // MARK: - Actions
     
-    private func tap(_ element: XCUIElement) {
-        _ = element.waitForExistence(timeout: UITestTimeouts.long)
+    private func tap(_ element: XCUIElement, timeout: TimeInterval = UITestTimeouts.long, file: StaticString = #file, line: UInt = #line) {
+        let exists = element.waitForExistence(timeout: timeout)
+        XCTAssertTrue(exists, "Element \(element.debugDescription) did not appear within \(timeout)s", file: file, line: line)
         element.tap()
     }
-    
+
     @discardableResult
-    private func tapIfPresent(_ element: XCUIElement) -> Bool {
-        if element.waitForExistence(timeout: UITestTimeouts.long) {
+    private func tapIfPresent(_ element: XCUIElement, timeout: TimeInterval = UITestTimeouts.long) -> Bool {
+        if element.waitForExistence(timeout: timeout) {
             element.tap()
             return true
         }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestTimeouts.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestTimeouts.swift
@@ -28,13 +28,16 @@
 import Foundation
 
 /// Provides timeout values for UI test element waits.
-/// Values come from the environment (`UI_TEST_SHORT_TIMEOUT`, `UI_TEST_LONG_TIMEOUT`) when set,
-/// otherwise from defaults. CI workflows can pass larger timeouts via these env vars.
+/// Values come from the environment (`UI_TEST_SHORT_TIMEOUT`, `UI_TEST_LONG_TIMEOUT`,
+/// `UI_TEST_NETWORK_TIMEOUT`) when set, otherwise from defaults.
+/// CI workflows can pass larger timeouts via these env vars.
 enum UITestTimeouts {
     /// Default short timeout in seconds (e.g. for quick UI state checks).
-    private static let defaultShort: TimeInterval = 1
+    private static let defaultShort: TimeInterval = 2
     /// Default long timeout in seconds (e.g. for page load or alert appearance).
-    private static let defaultLong: TimeInterval = 3
+    private static let defaultLong: TimeInterval = 10
+    /// Default network timeout in seconds (e.g. for operations that hit real OAuth servers).
+    private static let defaultNetwork: TimeInterval = 30
 
     private static func parseEnv(_ key: String) -> TimeInterval? {
         guard let raw = ProcessInfo.processInfo.environment[key],
@@ -52,5 +55,11 @@ enum UITestTimeouts {
     /// Long timeout (seconds). Use for page visibility, alerts, and general element waits.
     static var long: TimeInterval {
         parseEnv("UI_TEST_LONG_TIMEOUT") ?? defaultLong
+    }
+
+    /// Network timeout (seconds). Use for operations involving real server round-trips
+    /// (e.g. OAuth login, WKWebView page loads hitting Salesforce endpoints).
+    static var network: TimeInterval {
+        parseEnv("UI_TEST_NETWORK_TIMEOUT") ?? defaultNetwork
     }
 }


### PR DESCRIPTION
## Summary

Stabilizes the flaky `testCAOpaque_DefaultScopes_WebServerFlow` UI test by increasing timeouts for network-dependent operations and asserting wait results before element interaction.

## Root Cause

The test exercises a full OAuth web server login flow against live Salesforce infrastructure. CI xcresult logs show the failure is "Failed to get matching snapshots: Timed out while evaluating UI query" in `AuthFlowTypesPageObject` during login configuration. The CI timeout values (`short: 2s`, `long: 7s`) are insufficient for element appearance under loaded CI runners. Additionally, `tap()` helpers discarded `waitForExistence` results and proceeded unconditionally, causing cryptic downstream failures when elements weren't ready.

## Fix

- **Increased default timeouts**: `defaultShort` 1→2s, `defaultLong` 3→10s, added `network` timeout (30s) for server-bound operations
- **CI workflow timeouts**: Bumped from 2/7 to 3/15 in both `pr.yaml` and `ui-test-nightly.yaml`
- **Assert wait results in `tap()` helpers**: All four page objects now assert `waitForExistence` succeeded before tapping, with `file:`/`line:` for precise failure reporting
- **Network timeout for OAuth operations**: `isShowing()`, `loginButton()`, and `allowButton()` use the new 30s network timeout for WKWebView/OAuth-dependent waits

## Verification

**Before fix**: `testCAOpaque_DefaultScopes_WebServerFlow` failed on 3 consecutive attempts (344s, 77s, 184s) in the pre-fix CI run on iOS 18.

**After fix**: Over 6 CI runs post-fix, `testCAOpaque_DefaultScopes_WebServerFlow` has not appeared in any failure report. Cannot verify locally — requires OAuth credentials only available in CI.

## Test plan

- [x] Build compiles locally
- [x] `testCAOpaque_DefaultScopes_WebServerFlow` not observed failing in 6 CI runs post-fix
- [x] No regressions in other AuthFlowTester UI tests (no UI test failures in any post-fix run)

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*