### PR TITLE
@W-23004495: [iOS] Stabilize flaky test testLoginViewControllerCustomizations

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -473,7 +473,10 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     SFSDKAuthSession *session = [[SFSDKAuthSession alloc] initWith:request credentials:nil];
     SFOAuthCoordinator *coordinator = [[SFOAuthCoordinator alloc] initWithAuthSession:session];
     coordinator.delegate = [SFUserAccountManager sharedInstance];
-    [coordinator beginWebViewFlow];
+
+    // Invoke the delegate directly — no WKWebView needed since this test only verifies
+    // that loginViewControllerConfig propagates correctly to the presented controller.
+    [[SFUserAccountManager sharedInstance] oauthCoordinator:coordinator didBeginAuthenticationWithView:coordinator.view];
 
     [self waitForExpectations:@[expectation] timeout:20];
     XCTAssertTrue(success, @"SFSDKLoginViewController config should have changed" );


### PR DESCRIPTION
## Summary
Stabilizes `testLoginViewControllerCustomizations` in `SFUserAccountManagerTests` which failed intermittently on iOS 26.

## Root Cause
The test called `[coordinator beginWebViewFlow]` to trigger the auth view display block. This relied on WKWebView firing `didStartProvisionalNavigation:` — unreliable for WKWebView instances not attached to a window hierarchy on iOS 26.

## Fix
Replaced the indirect WKWebView trigger with direct delegate invocation:
```objc
[[SFUserAccountManager sharedInstance] oauthCoordinator:coordinator
    didBeginAuthenticationWithView:coordinator.view];
```
`oauthCoordinator:didBeginAuthenticationWithView:` is the delegate callback that `beginWebViewFlow` invokes after navigation completes — so calling it directly exercises the same production code path (config propagation to the login controller) without depending on WKWebView navigation lifecycle.

## Verification
- [x] Target test passes locally (3 consecutive runs)
- [x] 6 CI runs with no target test failures
- [x] No regressions in SFUserAccountManagerTests

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*