### PR TITLE
@W-23007797: [iOS] Stabilize flaky RestClientPublisherTests

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientPublisherTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/RestClientPublisherTests.swift
@@ -27,7 +27,7 @@ import Combine
 @testable import SalesforceSDKCore
 
 class RestClientPublisherTests: XCTestCase {
-    
+
     var currentUser: UserAccount?
     
     override class func setUp() {
@@ -36,29 +36,30 @@ class RestClientPublisherTests: XCTestCase {
         TestSetupUtils.populateAuthCredentialsFromConfigFile(for: SFSDKAuthUtilTests.self)
         TestSetupUtils.synchronousAuthRefresh()
     }
-    
+
     override func setUp() {
+        super.setUp()
         currentUser = UserAccountManager.shared.currentUserAccount
     }
-    
+
     func testQueryPublisher() {
         let request = RestClient.shared.request(forQuery: "select name from CONTACT", apiVersion: nil)
         let publisher = RestClient.shared.publisher(for: request)
-        
+
         let validTest = evaluateResults(publisher: publisher)
-        wait(for: validTest.expectations, timeout: 5)
+        wait(for: validTest.expectations, timeout: 60)
         validTest.cancellable?.cancel()
     }
-    
+
     func testRecordsPublisher() {
         let request = RestClient.shared.request(forQuery: "select name from CONTACT", apiVersion: nil)
         let publisher: AnyPublisher<RestClient.QueryResponse<TestContact>, Never> = RestClient.shared.records(forRequest: request)
-        
+
         let validTest = evaluateResults(publisher: publisher)
-        wait(for: validTest.expectations, timeout: 5)
+        wait(for: validTest.expectations, timeout: 60)
         validTest.cancellable?.cancel()
     }
-  
+
     func testCompositePublisher() {
         let accountName = self.generateRecordName()
         let contactName = self.generateRecordName()
@@ -68,12 +69,12 @@ class RestClientPublisherTests: XCTestCase {
             .add(RestClient.shared.requestForCreate(withObjectType: "Contact", fields: ["LastName": contactName,"AccountId": "@{refAccount.id}"], apiVersion: apiVersion), referenceId: "refContact")
             .add(RestClient.shared.request(forQuery: "select Id, AccountId from Contact where LastName =  '\(contactName)'", apiVersion: apiVersion), referenceId: "refQuery")
             .setAllOrNone(true)
-        
+
         let compositeRequest = requestBuilder.buildCompositeRequest(apiVersion)
         let publisher = RestClient.shared.publisher(for: compositeRequest)
-        
+
         let validTest = evaluateResults(publisher: publisher)
-        wait(for: validTest.expectations, timeout: 10)
+        wait(for: validTest.expectations, timeout: 60)
         validTest.cancellable?.cancel()
     }
 
@@ -81,51 +82,52 @@ class RestClientPublisherTests: XCTestCase {
         let accountName = self.generateRecordName()
         let contactName = self.generateRecordName()
         let apiVersion = RestClient.shared.apiVersion
-        
+
         let requestBuilder = BatchRequestBuilder()
             .add(RestClient.shared.requestForCreate(withObjectType: "Account", fields: ["Name": accountName], apiVersion: apiVersion))
             .add(RestClient.shared.requestForCreate(withObjectType: "Contact", fields: ["LastName": contactName], apiVersion: apiVersion))
             .add(RestClient.shared.request(forQuery: "select Id from Account where Name ", apiVersion:  apiVersion)) // bad query
             .add(RestClient.shared.request(forQuery: "select Id from Contact where Name = '\(contactName)'", apiVersion: apiVersion))
             .setHaltOnError(false)
-        
+
         let batchRequest = requestBuilder.buildBatchRequest(apiVersion)
         let publisher = RestClient.shared.publisher(for: batchRequest)
-        
+
         let validTest = evaluateResults(publisher: publisher)
-        wait(for: validTest.expectations, timeout: 10)
+        wait(for: validTest.expectations, timeout: 60)
         validTest.cancellable?.cancel()
     }
-    
+
     private func evaluateResults<T: Publisher>(publisher: T?, evaluateValidResult: Bool = true) ->  (expectations:[XCTestExpectation], cancellable: AnyCancellable?)  {
         let finished = expectation(description: "finished")
         let received = expectation(description: "received")
         let failed = expectation(description: "failed")
-        
+
         if evaluateValidResult {
             failed.isInverted = true
         } else {
             received.isInverted = true
         }
-        
-        let cancellable = publisher?.sink (receiveCompletion: { (completion) in
-            switch completion {
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                failed.fulfill()
-            case .finished:
-                finished.fulfill()
-            }
-        }, receiveValue: { response in
-            XCTAssertNotNil(response)
-            received.fulfill()
-        })
+
+        let cancellable = publisher?
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    XCTAssertNotNil(error)
+                    failed.fulfill()
+                case .finished:
+                    finished.fulfill()
+                }
+            }, receiveValue: { response in
+                XCTAssertNotNil(response)
+                received.fulfill()
+            })
         return (expectations: [finished, received, failed], cancellable: cancellable)
     }
     
     private func generateRecordName() -> String {
-        let timecode = Date.timeIntervalSinceReferenceDate
-        return "SwiftPublishersTestsiOS\(timecode)"
+        return "SwiftPublishersTestsiOS\(Date.timeIntervalSinceReferenceDate)"
     }
-    
+
 }


### PR DESCRIPTION
## Summary
Stabilizes 4 flaky Combine publisher tests that failed intermittently — on iOS 18 in isolation and on both platforms under full-suite CI load.

## Root Causes
1. **Thread delivery race**: `RestClient.publisher(for:)` resolves its `Future` on the cooperative thread pool. XCTestExpectation fulfillment from a background thread races with `wait(for:timeout:)`.
2. **Timeout too short under load**: 5-10s timeouts insufficient when ~200 concurrent API calls hit the same org during full-suite execution.

## Fix
- Added `.receive(on: DispatchQueue.main)` before `.sink` in the shared `evaluateResults()` helper — ensures expectation fulfillment on the main thread where the waiter is synchronized
- Increased timeouts from 5/10s to 60s — accommodates CI load where the org responds slowly (safety net only; expectations fulfill immediately on response)
- Added missing `super.setUp()` call in instance setUp

## Tests Fixed
- `testQueryPublisher`
- `testRecordsPublisher`
- `testCompositePublisher`
- `testBatchPublisher`

## Verification
- [x] All 4 tests pass locally (3 consecutive runs)
- [x] 6 CI runs with no target test failures
- [x] Validated under full-suite load (combined branch)

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*