### PR TITLE
@W-23011893: [iOS] Stabilize flaky UI test testCAOpaque_DefaultScopes_WebServerFlow

### DIFF
--- a/native/SampleApps/AuthFlowTester/AuthFlowTester/Classes/SceneDelegate.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester/Classes/SceneDelegate.swift
@@ -45,8 +45,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
         }
         self.initializeAppViewState()
-        AuthHelper.loginIfRequired(scene) {
-            self.setupRootViewController()
+
+        // Defer login to the next run loop iteration so the scene finishes setup first.
+        // On iOS 26, XCTest requires the app to reach foreground-ready state quickly;
+        // starting the WKWebView-based login synchronously can exceed the background
+        // assertion timeout (~60 s on CI) and fail the launch.
+        DispatchQueue.main.async {
+            AuthHelper.loginIfRequired(scene) {
+                self.setupRootViewController()
+            }
         }
     }
 

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -79,6 +79,7 @@ class LoginPageObject {
     }
     
     func performLogin(username: String, password: String, advancedAuth: Bool = false) {
+        waitForLoginFormReady()
         setTextField(usernameField(), value: username)
         if advancedAuth {
             usernameField().typeText(XCUIKeyboardKey.return.rawValue)
@@ -147,8 +148,29 @@ class LoginPageObject {
         )
     }
 
+    // MARK: - Login Form Readiness
+
+    /// Pre-warms the WKWebView process pool by waiting for the initial login page to render.
+    /// Called once after app launch to absorb the cold-start cost of WKWebView process creation.
+    /// Uses a longer timeout than normal because the first WebView load includes process pool
+    /// initialization, TLS session setup, and initial page compilation.
+    func waitForWebViewReady() {
+        let webView = app.webViews.firstMatch
+        _ = webView.waitForExistence(timeout: UITestTimeouts.network * 2)
+    }
+
+    /// Waits for the WKWebView login form to be fully loaded and interactive.
+    /// After a login host change, the WebView navigates to a new URL and the form elements
+    /// are not immediately available. This method waits for the username text field inside
+    /// the WebView to become available, which signals the login form has fully rendered.
+    private func waitForLoginFormReady() {
+        let webViewTextField = app.webViews.webViews.webViews.textFields.firstMatch
+        let formReady = webViewTextField.waitForExistence(timeout: UITestTimeouts.network)
+        XCTAssertTrue(formReady, "Login form did not load within \(UITestTimeouts.network)s — WebView may not have finished loading the login page")
+    }
+
     // MARK: - UI Element Accessors
-    
+
     private func loginNavigationBar() -> XCUIElement {
         return app.navigationBars["Log In"]
     }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -42,6 +42,19 @@ class BaseAuthFlowTester: XCTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
+
+        addUIInterruptionMonitor(withDescription: "System Alert") { alert in
+            let dominated = ["Allow", "OK", "Continue", "Allow While Using App",
+                             "Don\u{2019}t Allow", "Allow Paste"]
+            for label in dominated {
+                let button = alert.buttons[label]
+                if button.exists {
+                    button.tap()
+                    return true
+                }
+            }
+            return false
+        }
     }
     
     override func tearDown() {
@@ -67,6 +80,11 @@ class BaseAuthFlowTester: XCTestCase {
         mainPage = AuthFlowTesterMainPageObject(testApp: app)
         app.launch()
 
+        // Tap the app to trigger any pending system alert interruption handlers.
+        // On CI, system alerts (tracking permission, paste confirmation) can block
+        // the UI if not dismissed before interacting with app elements.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+
         // Start logged out
         if (mainPage.isShowing()) {
             logout()
@@ -76,8 +94,14 @@ class BaseAuthFlowTester: XCTestCase {
         if (loginPage.isShowingAdvancedAuth()) {
             loginPage.closeAdvancedAuth()
         }
+
+        // Pre-warm the WKWebView process pool by waiting for the initial login page
+        // to fully load. On the first test in a class, the WebView process hasn't
+        // been created yet — this absorbs the cold-start cost so subsequent
+        // host-change navigations don't time out.
+        loginPage.waitForWebViewReady()
     }
-    
+
     /// Performs login with the specified configuration.
     ///
     /// Configures the login options and performs authentication for the specified user.


### PR DESCRIPTION
## Summary
Stabilizes the flaky UI test `testCAOpaque_DefaultScopes_WebServerFlow` which failed on iOS 18 (WebView timeout) and iOS 26 (background assertion timeout during app launch).

## Root Causes
1. **iOS 18 — WebView cold start**: First test in the class bears the cost of WKWebView process creation. The login form isn't ready when `performLogin()` tries to interact.
2. **iOS 26 — Background assertion timeout**: `AuthHelper.loginIfRequired(scene)` called synchronously in `scene(_:willConnectTo:)` triggers WKWebView creation during scene setup. iOS 26's stricter timeout kills the app when it can't reach foreground-ready state.
3. **System alerts**: CI simulators present system dialogs that block UI interaction.

## Fix
- **SceneDelegate.swift** (sample app): Wrapped `AuthHelper.loginIfRequired` in `DispatchQueue.main.async` so the scene finishes setup before login begins. No user-visible change — login still starts immediately, one run loop iteration later.
- **LoginPageObject.swift**: Added `waitForLoginFormReady()` — waits for WebView text field with network timeout before form interaction. Added `waitForWebViewReady()` — pre-warms WKWebView process pool on first test.
- **BaseAuthFlowTester.swift**: Added `addUIInterruptionMonitor` to dismiss system alerts. Added coordinate tap after launch to trigger pending handlers. Calls `waitForWebViewReady()` after launch to absorb cold-start cost.

## Tests Fixed
- `testCAOpaque_DefaultScopes_WebServerFlow`

## Verification
- [x] Target test passes locally on both iOS 18 and iOS 26
- [x] 6 CI runs with target test not in failure reports
- [x] No regressions in AuthFlowTesterUITests

## Note
All changes are in the **sample app** (AuthFlowTester) and its UI test infrastructure — no SDK framework code is modified.

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*