### PR TITLE
@W-23003908: [iOS] Fix closure parameter mismatch introduced by #4066

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationManagerTests.swift
@@ -541,7 +541,7 @@ class PushNotificationManagerTests: XCTestCase {
 
         let unexpectedSend = XCTestExpectation(description: "send should not be called")
         unexpectedSend.isInverted = true
-        mockRestClient.onSend = {
+        mockRestClient.onSend = { _ in
             unexpectedSend.fulfill()
         }
 
@@ -565,7 +565,7 @@ class PushNotificationManagerTests: XCTestCase {
 
         let initialCallCount = mockRestClient.sendCallCount
         let expectation = XCTestExpectation(description: "Current user registration triggered")
-        mockRestClient.onSend = {
+        mockRestClient.onSend = { _ in
             expectation.fulfill()
         }
 


### PR DESCRIPTION
## Summary
Fast-follow fix for a build break introduced by PR #4066 during rebase conflict resolution.

## What Happened
PR #4066 was rebased onto dev (which already contained PR #4071's parameterized `onSend: ((RestRequest) -> Void)?`). The conflict resolution correctly updated 2 of 4 closure callsites from `{ }` to `{ _ in }`, but missed 2 others in commits applied during the rebase continuation. This caused a Swift compiler error: closures without parameters can't be assigned to `((RestRequest) -> Void)?`.

## Fix
Added `_ in` to the 2 remaining closure callsites (lines 544, 568 in PushNotificationManagerTests.swift).

## Verification
- [x] Build succeeds locally
- [x] All 4 PushNotificationManager foreground tests pass locally

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*