### PR TITLE
[iOS] Grant statuses:write so Danger can post required PR commit statuses

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      statuses: write
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
     steps:
@@ -77,6 +78,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      statuses: write
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
     outputs:


### PR DESCRIPTION
## Summary
- Add `statuses: write` to the `static-analysis` and `test-orchestrator` job-level permission blocks in `.github/workflows/pr.yaml`.
- Both jobs run Danger to post the `danger/StaticAnalysis` and `danger/TestOrchestrator` commit statuses required by `dev`'s branch protection. Without `statuses: write`, Danger's status calls are rejected (`Danger does not have write access to the PR to set a PR status.`), so the required statuses never appear and PRs cannot merge even when every check completes successfully.
- Two-line diff, one new permission scope per job.

## Note (the irony)
This very PR will hit the same blocker until it merges. The required `danger/StaticAnalysis` and `danger/TestOrchestrator` commit statuses will not appear on this PR's head commit, because the workflow run evaluating it is still running with the old (insufficient) permissions. The merge button will stay disabled even after approval. Someone with admin rights will likely need to bypass branch protection once to land this. After that, every subsequent PR run picks up the new permission and unblocks automatically.

## Test plan
- [ ] After merge, observe that the next PR run posts both `danger/StaticAnalysis` and `danger/TestOrchestrator` commit statuses on its head commit.