### PR TITLE
Add token refresh coordinator

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		009D77521CA4A92200D5183A /* SFPushNotificationManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 009D77511CA4A92200D5183A /* SFPushNotificationManagerTests.m */; };
 		010A9B551CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 010A9B511CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h */; };
 		010A9B591CC1A147002AF4D3 /* SFCryptoStreamTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 010A9B521CC1A131002AF4D3 /* SFCryptoStreamTestUtils.m */; };
+		092F3EB14B5A4FFEA77B21BC /* SFSDKOAuth2RefreshInstanceUrlTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3168ED77C1354C30BA9DB766 /* SFSDKOAuth2RefreshInstanceUrlTests.m */; };
 		1A31073F5F374B9EB1162F2E /* SFOAuthCoordinatorLightningURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399A11508BCB47F490DFB724 /* SFOAuthCoordinatorLightningURLTests.swift */; };
 		230834842DF7838200C7CBF7 /* URLSessionTask+RetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230834832DF7837400C7CBF7 /* URLSessionTask+RetryPolicy.swift */; };
 		230834862DF8938D00C7CBF7 /* URLSessionTask+RetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230834852DF8938D00C7CBF7 /* URLSessionTask+RetryPolicyTests.swift */; };
@@ -95,7 +96,6 @@
 		4F9E05322DD6A08000548985 /* SFSDKOAuthTokenEndpointResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */; };
 		4F9E05342DD7BE1500548985 /* SFOAuthCredentialsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9E05332DD7BE0A00548985 /* SFOAuthCredentialsTests.m */; };
 		4FA1B2C32F0E000000000001 /* LoginForAdminTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA1B2C32F0E000000000002 /* LoginForAdminTests.swift */; };
-		092F3EB14B5A4FFEA77B21BC /* SFSDKOAuth2RefreshInstanceUrlTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3168ED77C1354C30BA9DB766 /* SFSDKOAuth2RefreshInstanceUrlTests.m */; };
 		4FAUTHFLOW001234567890ABC /* AuthFlowTypesViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */; };
 		4FBOOTCP001234567890ABCD /* LoginOptionsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FBOOTCP112345678901ABCD /* LoginOptionsViewControllerTests.swift */; };
 		4FDEVINFO001234567890ABCD /* DevInfoViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDEVINFO112345678901ABCD /* DevInfoViewControllerTests.swift */; };
@@ -153,6 +153,9 @@
 		69848CB82364035300893E57 /* SFSDKEncryptedPushNotificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69848CB72364035300893E57 /* SFSDKEncryptedPushNotificationTests.m */; };
 		69848CBD2364063E00893E57 /* SFSDKPushNotificationDataProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 69848CBC2364063E00893E57 /* SFSDKPushNotificationDataProvider.m */; };
 		6990CBC029F5AF56004A5F8D /* SFSDKIDPAuthCodeLoginRequestCommandTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6990CBBF29F5AF56004A5F8D /* SFSDKIDPAuthCodeLoginRequestCommandTest.m */; };
+		699202FD2FEF11D70032ECD7 /* SFSDKTokenRefreshCoordinatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 699202FC2FEF11D70032ECD7 /* SFSDKTokenRefreshCoordinatorTests.m */; };
+		699203052FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = 699203042FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.m */; };
+		699203062FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 699203032FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.h */; };
 		69B36F492D30C34F00EFF84A /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B36F482D30C34F00EFF84A /* ColorExtension.swift */; };
 		69BDD7E926F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 69BDD7E226F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.h */; };
 		69BDD7EA26F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 69BDD7E826F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.m */; };
@@ -572,6 +575,7 @@
 		23EED8902E2ACF3100646B10 /* MockNavigationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationAction.swift; sourceTree = "<group>"; };
 		23F200AB2E551C890091C5F5 /* ActionTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ActionTypeTests.swift; path = SalesforceSDKCoreTests/ActionTypeTests.swift; sourceTree = SOURCE_ROOT; };
 		23F200AD2E551C890091C5F5 /* BootconfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BootconfigTests.swift; path = SalesforceSDKCoreTests/BootconfigTests.swift; sourceTree = SOURCE_ROOT; };
+		3168ED77C1354C30BA9DB766 /* SFSDKOAuth2RefreshInstanceUrlTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKOAuth2RefreshInstanceUrlTests.m; path = ../SalesforceSDKCoreTests/SFSDKOAuth2RefreshInstanceUrlTests.m; sourceTree = "<group>"; };
 		399A11508BCB47F490DFB724 /* SFOAuthCoordinatorLightningURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SFOAuthCoordinatorLightningURLTests.swift; path = ../SalesforceSDKCoreTests/SFOAuthCoordinatorLightningURLTests.swift; sourceTree = "<group>"; };
 		444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+SFColorsTests.m"; path = "SalesforceSDKCoreTests/UIColor+SFColorsTests.m"; sourceTree = SOURCE_ROOT; };
 		4F06AF5D1C49A16A00F70798 /* NSURL+SFStringUtilsTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSURL+SFStringUtilsTests.h"; path = "SalesforceSDKCoreTests/NSURL+SFStringUtilsTests.h"; sourceTree = SOURCE_ROOT; };
@@ -685,7 +689,6 @@
 		4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKOAuthTokenEndpointResponseTests.m; path = ../SalesforceSDKCoreTests/SFSDKOAuthTokenEndpointResponseTests.m; sourceTree = "<group>"; };
 		4F9E05332DD7BE0A00548985 /* SFOAuthCredentialsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFOAuthCredentialsTests.m; path = ../SalesforceSDKCoreTests/SFOAuthCredentialsTests.m; sourceTree = "<group>"; };
 		4FA1B2C32F0E000000000002 /* LoginForAdminTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginForAdminTests.swift; sourceTree = "<group>"; };
-		3168ED77C1354C30BA9DB766 /* SFSDKOAuth2RefreshInstanceUrlTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKOAuth2RefreshInstanceUrlTests.m; path = ../SalesforceSDKCoreTests/SFSDKOAuth2RefreshInstanceUrlTests.m; sourceTree = "<group>"; };
 		4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AuthFlowTypesViewTests.swift; path = SalesforceSDKCoreTests/AuthFlowTypesViewTests.swift; sourceTree = SOURCE_ROOT; };
 		4FBOOTCP112345678901ABCD /* LoginOptionsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LoginOptionsViewControllerTests.swift; path = SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift; sourceTree = SOURCE_ROOT; };
 		4FDEVINFO112345678901ABCD /* DevInfoViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DevInfoViewControllerTests.swift; path = SalesforceSDKCoreTests/DevInfoViewControllerTests.swift; sourceTree = SOURCE_ROOT; };
@@ -759,6 +762,9 @@
 		69848CBB2364063E00893E57 /* SFSDKPushNotificationDataProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SFSDKPushNotificationDataProvider.h; path = SalesforceSDKCoreTests/SFSDKPushNotificationDataProvider.h; sourceTree = SOURCE_ROOT; };
 		69848CBC2364063E00893E57 /* SFSDKPushNotificationDataProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKPushNotificationDataProvider.m; path = SalesforceSDKCoreTests/SFSDKPushNotificationDataProvider.m; sourceTree = SOURCE_ROOT; };
 		6990CBBF29F5AF56004A5F8D /* SFSDKIDPAuthCodeLoginRequestCommandTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKIDPAuthCodeLoginRequestCommandTest.m; path = SalesforceSDKCoreTests/SFSDKIDPAuthCodeLoginRequestCommandTest.m; sourceTree = SOURCE_ROOT; };
+		699202FC2FEF11D70032ECD7 /* SFSDKTokenRefreshCoordinatorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKTokenRefreshCoordinatorTests.m; sourceTree = "<group>"; };
+		699203032FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKTokenRefreshCoordinator.h; sourceTree = "<group>"; };
+		699203042FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKTokenRefreshCoordinator.m; sourceTree = "<group>"; };
 		69B2B4F2261EA6F500AB86C2 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/Library/Frameworks/CoreTelephony.framework; sourceTree = DEVELOPER_DIR; };
 		69B36F482D30C34F00EFF84A /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		69BDD7E226F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKSalesforceSDKUpgradeManager.h; sourceTree = "<group>"; };
@@ -1034,6 +1040,7 @@
 		4F7EB3F61BFFC84700768720 /* SalesforceSDKCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				699202FC2FEF11D70032ECD7 /* SFSDKTokenRefreshCoordinatorTests.m */,
 				AA9154472F59E3C900A0A41C /* SFRestAPIDataTaskRaceTests.m */,
 				23F200AB2E551C890091C5F5 /* ActionTypeTests.swift */,
 				4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */,
@@ -1192,6 +1199,8 @@
 		4F96FCC41BFD32130022F021 /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
+				699203032FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.h */,
+				699203042FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.m */,
 				4F5A494F2E98711600C89DDD /* ScopeParser.swift */,
 				23D96B6E2E145AC20004B06A /* DomainDiscoveryCoordinator.swift */,
 				4F8A3B002CEC202F00ECDC76 /* JwtAccessToken.swift */,
@@ -1928,6 +1937,7 @@
 				CE4CE3421C0E5252009F6029 /* SFOAuthCoordinator+Internal.h in Headers */,
 				CED452BC1D808D0C009266EB /* SFRestAPI+QueryBuilder.h in Headers */,
 				CE4CE3301C0E523B009F6029 /* SFSDKAppConfig.h in Headers */,
+				699203062FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.h in Headers */,
 				CE675A371E0B2CC6002DBF5A /* SFSDKSoslReturningBuilder.h in Headers */,
 				4F06AF861C49A16A00F70798 /* SFTestSDKManagerFlow.h in Headers */,
 				CE4CE3691C0E526A009F6029 /* SFDefaultUserManagementViewController+Internal.h in Headers */,
@@ -2230,6 +2240,7 @@
 				FDD7D7A1232039D000F5FB2D /* SFUserAccountPhotoTests.m in Sources */,
 				444B95D01E83251900908C61 /* UIColor+SFColorsTests.m in Sources */,
 				009D77521CA4A92200D5183A /* SFPushNotificationManagerTests.m in Sources */,
+				699202FD2FEF11D70032ECD7 /* SFSDKTokenRefreshCoordinatorTests.m in Sources */,
 				696E91472AD0A14A00205884 /* BiometricAuthenticationManagerTests.swift in Sources */,
 				B7E8A2AF1E77062E007C0D92 /* SFUserAccountManagerPersisterTests.m in Sources */,
 				23EDDF022DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift in Sources */,
@@ -2318,6 +2329,7 @@
 				CE4CE3261C0E523B009F6029 /* UIScreen+SFAdditions.m in Sources */,
 				B7C273F01F7EEFB700CE539D /* SFSDKIDPConstants.m in Sources */,
 				D3D675DB2D39EF01008E468E /* ChatGenerationsRequestBody.swift in Sources */,
+				699203052FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.m in Sources */,
 				D3D675DC2D39EF01008E468E /* EmbeddingsRequestBody.swift in Sources */,
 				D3D675DD2D39EF01008E468E /* ChatGenerationsResponseBody.swift in Sources */,
 				D3D675DE2D39EF01008E468E /* GenerationsResponseBody.swift in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/UserAccountManager.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/UserAccountManager.swift
@@ -71,15 +71,27 @@ extension UserAccountManager: UserAccountManaging {
         }
    }
 
-    /// Kick off the login process for jwt token with credentials previously configured.
+    /// Refresh the session for the given credentials.
     /// - Parameters:
-    ///   - credentials: the OAuthCredentials object
+    ///   - credentials: The credentials to refresh.
     ///   - completionBlock: completion block to invoke with a success tuple (UserAccount, AuthInfo) or   UserAccountManagerError for failure wrapped in a Result type.
    public func refresh(credentials: OAuthCredentials, _ completionBlock: @escaping (Result<(UserAccount, AuthInfo), UserAccountManagerError>) -> Void) -> Bool {
         return __refreshCredentials(credentials, completion: { (authInfo, userAccount) in
             completionBlock(Result.success((userAccount,authInfo)))
         }) { (authInfo, error) in
             completionBlock(Result.failure(.refreshFailed(underlyingError: error, authInfo: authInfo)))
+        }
+    }
+
+    /// Refresh the session for the given credentials.
+    /// - Parameter credentials: The credentials to refresh.
+    /// - Returns: A tuple of the updated `UserAccount` and `AuthInfo` on success.
+    /// - Throws: `UserAccountManagerError.refreshFailed` if the refresh fails.
+    public func refresh(credentials: OAuthCredentials) async throws -> (UserAccount, AuthInfo) {
+        try await withCheckedThrowingContinuation { continuation in
+            _ = self.refresh(credentials: credentials) { result in
+                continuation.resume(with: result.mapError { $0 })
+            }
         }
     }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator+Internal.h
@@ -27,7 +27,6 @@
 #import "SFSDKAuthSession.h"
 #import "SFOAuthInfo.h"
 @class SFIdentityData;
-@class SFOAuthSessionRefresher;
 NS_ASSUME_NONNULL_BEGIN
 /**
  * Internal interface for the SFIdentityCoordinator.
@@ -44,10 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong, nullable) NSURLSession *session;
 
-/**
- * The OAuth sesssion refresher to use if the identity request fails with expired credentials.
- */
-@property (nonatomic, strong, nullable) SFOAuthSessionRefresher *oauthSessionRefresher;
 
 /**
  * Dictionary mapping error codes to their respective types.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Identity/SFIdentityCoordinator.m
@@ -25,7 +25,7 @@
 #import <SalesforceSDKCommon/SFJsonUtils.h>
 #import "SFIdentityCoordinator+Internal.h"
 #import "SFOAuthCredentials.h"
-#import "SFOAuthSessionRefresher.h"
+#import "SFSDKTokenRefreshCoordinator.h"
 #import "SFUserAccountManager.h"
 #import "SFNetwork.h"
 #import "SFSDKAuthSession.h"
@@ -66,7 +66,6 @@ static NSString * const kSFIdentityDataPropertyKey            = @"com.salesforce
 @synthesize timeout = _timeout;
 @synthesize retrievingData = _retrievingData;
 @synthesize session = _session;
-@synthesize oauthSessionRefresher = _oauthSessionRefresher;
 
 #pragma mark - init / dealloc
 
@@ -171,8 +170,7 @@ static NSString * const kSFIdentityDataPropertyKey            = @"com.salesforce
         if (statusCode == 401 || statusCode == 403) {
             // The session timed out.  Identity service tends to send 403s for session timeouts.  Try to refresh.
             [SFSDKCoreLogger i:[self class] format:@"%@: Identity request failed due to expired credentials.  Attempting to refresh credentials.", NSStringFromSelector(_cmd)];
-            strongSelf.oauthSessionRefresher = [[SFOAuthSessionRefresher alloc] initWithCredentials:strongSelf.credentials];
-            [strongSelf.oauthSessionRefresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
+            [[SFSDKTokenRefreshCoordinator sharedInstance] refreshSessionForCredentials:strongSelf.credentials completion:^(SFOAuthCredentials *updatedCredentials) {
                 [SFSDKCoreLogger d:[strongSelf class] format:@"%@: Credentials refresh successful.  Replaying original identity request.", NSStringFromSelector(_cmd)];
                 strongSelf.credentials = updatedCredentials;
                 dispatch_async(dispatch_get_main_queue(), ^{
@@ -221,7 +219,6 @@ static NSString * const kSFIdentityDataPropertyKey            = @"com.salesforce
     self.session = nil;
     self.credentials = nil;
     self.idData = nil;
-    self.oauthSessionRefresher = nil;
 }
 
 - (void)cleanupData
@@ -229,7 +226,6 @@ static NSString * const kSFIdentityDataPropertyKey            = @"com.salesforce
     [SFNetwork removeSharedInstanceForIdentifier:self.networkIdentifier];
     self.networkIdentifier = nil;
     self.session = nil;
-    self.oauthSessionRefresher = nil;
     self.retrievingData = NO;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher+Internal.h
@@ -22,6 +22,9 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import "SalesforceSDKConstants.h"
+
+SFSDK_USE_DEPRECATED_BEGIN
 #import "SFOAuthSessionRefresher.h"
 #import "SFOAuthCoordinator.h"
 
@@ -32,3 +35,5 @@
 @property (nonatomic, copy) void (^errorBlock)(NSError *);
 
 @end
+
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.h
@@ -23,6 +23,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -37,20 +38,23 @@ typedef NS_ENUM(NSUInteger, SFOAuthSessionRefreshErrorCode) {
 
 /** This class refreshes stale OAuth sessions, if possible.
  */
+SFSDK_DEPRECATED(14.0, 15.0, "SFOAuthSessionRefresher bypasses the centralized token refresh coordinator and will be removed from the public API.");
 @interface SFOAuthSessionRefresher : NSObject
 
 /**
  * Initializes the object with the given credentials.
  * @param credentials The OAuth credentials used to refresh the session.
  */
-- (instancetype)initWithCredentials:(nullable SFOAuthCredentials *)credentials NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCredentials:(nullable SFOAuthCredentials *)credentials NS_DESIGNATED_INITIALIZER
+    SFSDK_DEPRECATED(14.0, 15.0, "Use UserAccountManager.refresh(credentials:) instead.");
 
 /**
  * Refreshes the expired session, with the given completion and error handler blocks.
  * @param completionBlock Called once the session has been refreshed.
  * @param errorBlock Called if there was an error refreshing the session.
  */
-- (void)refreshSessionWithCompletion:(void (^) (SFOAuthCredentials *))completionBlock error:(void (^) (NSError *))errorBlock;
+- (void)refreshSessionWithCompletion:(void (^) (SFOAuthCredentials *))completionBlock error:(void (^) (NSError *))errorBlock
+    SFSDK_DEPRECATED(14.0, 15.0, "Use UserAccountManager.refresh(credentials:) instead.");
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -118,7 +118,7 @@ SFSDK_USE_DEPRECATED_BEGIN
         SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
         [userInfo setValue:authInfo forKey:kSFNotificationUserInfoAuthTypeKey];
         [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidRefreshToken
-                                                            object:self
+                                                            object:[SFUserAccountManager sharedInstance]
                                                           userInfo:userInfo];
         self.completionBlock(self.credentials);
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -22,6 +22,12 @@
  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+
+#import "SalesforceSDKConstants.h"
+
+// TODO: Remove when the class is internal in Mobile SDK 15.0
+SFSDK_USE_DEPRECATED_BEGIN
+
 #import "SFOAuthSessionRefresher+Internal.h"
 #import "SFUserAccountManager.h"
 #import "SFOAuthCredentials+Internal.h"
@@ -102,19 +108,19 @@
 - (void)completeWithSuccess {
     [SFSDKCoreLogger i:[self class] format:@"%@ Session was successfully refreshed.", NSStringFromSelector(_cmd)];
     if (self.completionBlock) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            SFUserAccount *account = [[SFUserAccountManager sharedInstance] accountForCredentials:self.credentials];
-            NSMutableDictionary *userInfo = [NSMutableDictionary new];
-            if (account) {
-                [userInfo setValue:account forKey:kSFNotificationUserInfoAccountKey];
-            } else {
-                [SFSDKCoreLogger e:[self class] format:@"%@ No account for credentials", NSStringFromSelector(_cmd)];
-            }
-            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidRefreshToken
-                                                                object:self
-                                                              userInfo:userInfo];
-            self.completionBlock(self.credentials);
-        });
+        SFUserAccount *account = [[SFUserAccountManager sharedInstance] accountForCredentials:self.credentials];
+        NSMutableDictionary *userInfo = [NSMutableDictionary new];
+        if (account) {
+            [userInfo setValue:account forKey:kSFNotificationUserInfoAccountKey];
+        } else {
+            [SFSDKCoreLogger e:[self class] format:@"%@ No account for credentials", NSStringFromSelector(_cmd)];
+        }
+        SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
+        [userInfo setValue:authInfo forKey:kSFNotificationUserInfoAuthTypeKey];
+        [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidRefreshToken
+                                                            object:self
+                                                          userInfo:userInfo];
+        self.completionBlock(self.credentials);
     }
 }
 
@@ -122,9 +128,7 @@
     [SFSDKCoreLogger e:[self class] format:@"%@ Refresh failed with error: %@", NSStringFromSelector(_cmd), error];
 
     if (self.errorBlock) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            self.errorBlock(error);
-        });
+        self.errorBlock(error);
     }
 }
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithSession:(ASWebAuthenticationSession *)session {
@@ -148,3 +152,5 @@
 }
 
 @end
+
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKTokenRefreshCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKTokenRefreshCoordinator.h
@@ -1,0 +1,72 @@
+/*
+ Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SFOAuthCredentials;
+@class SFOAuthSessionRefresher;
+
+/**
+ * Centralized coordinator that ensures at most one token refresh request is in-flight
+ * per credential at any given time. Concurrent callers for the same credential are
+ * coalesced: the first triggers the refresh, and subsequent callers wait for the same result.
+ *
+ * This prevents the "double-spend" race condition when using single-use (rotating) refresh tokens,
+ * where concurrent refresh attempts would invalidate each other's tokens.
+ */
+@interface SFSDKTokenRefreshCoordinator : NSObject
+
+/**
+ * Shared singleton instance.
+ */
+@property (class, nonatomic, readonly) SFSDKTokenRefreshCoordinator *sharedInstance;
+
+/**
+ * Request a token refresh for the given credentials.
+ *
+ * If a refresh is already in-flight for these credentials (keyed by `credentials.identifier`),
+ * the callbacks are appended to the waiting list and no new network request is made.
+ * When the single in-flight refresh completes, all registered callbacks receive the same result.
+ *
+ * Completion and error callbacks are dispatched on the main queue.
+ *
+ * @param credentials The OAuth credentials to refresh.
+ * @param completionBlock Called with the updated credentials on successful refresh.
+ * @param errorBlock Called with the error if the refresh fails.
+ */
+- (void)refreshSessionForCredentials:(SFOAuthCredentials *)credentials
+                          completion:(void (^)(SFOAuthCredentials *updatedCredentials))completionBlock
+                               error:(void (^)(NSError *error))errorBlock;
+
+/**
+ * Testing hook: inject a factory block to create mock SFOAuthSessionRefresher instances.
+ * When nil (default), the coordinator creates a standard SFOAuthSessionRefresher.
+ */
+@property (nonatomic, copy, nullable) SFOAuthSessionRefresher * (^refresherFactory)(SFOAuthCredentials *);
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKTokenRefreshCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKTokenRefreshCoordinator.m
@@ -171,19 +171,22 @@ SFSDK_USE_DEPRECATED_END
         entry.backgroundTaskId = UIBackgroundTaskInvalid;
     }
 
-    if (error) {
-        [SFSDKCoreLogger e:[self class] format:@"Token refresh failed for credential %@. Notifying %lu waiter(s). Error: %@",
-         key, (unsigned long)entry.errorBlocks.count, error];
-        for (void (^errorBlock)(NSError *) in entry.errorBlocks) {
-            errorBlock(error);
+    // Dispatch callbacks on the main queue as documented in the header.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (error) {
+            [SFSDKCoreLogger e:[self class] format:@"Token refresh failed for credential %@. Notifying %lu waiter(s). Error: %@",
+             key, (unsigned long)entry.errorBlocks.count, error];
+            for (void (^errorBlock)(NSError *) in entry.errorBlocks) {
+                errorBlock(error);
+            }
+        } else {
+            [SFSDKCoreLogger i:[self class] format:@"Token refresh succeeded for credential %@. Notifying %lu waiter(s).",
+             key, (unsigned long)entry.completionBlocks.count];
+            for (void (^completionBlock)(SFOAuthCredentials *) in entry.completionBlocks) {
+                completionBlock(credentials);
+            }
         }
-    } else {
-        [SFSDKCoreLogger i:[self class] format:@"Token refresh succeeded for credential %@. Notifying %lu waiter(s).",
-         key, (unsigned long)entry.completionBlocks.count];
-        for (void (^completionBlock)(SFOAuthCredentials *) in entry.completionBlocks) {
-            completionBlock(credentials);
-        }
-    }
+    });
 }
 
 - (void)handleBackgroundExpirationForKey:(NSString *)key {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKTokenRefreshCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKTokenRefreshCoordinator.m
@@ -1,0 +1,203 @@
+/*
+ Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFSDKTokenRefreshCoordinator.h"
+#import "SalesforceSDKConstants.h"
+SFSDK_USE_DEPRECATED_BEGIN
+#import "SFOAuthSessionRefresher.h"
+SFSDK_USE_DEPRECATED_END
+#import "SFOAuthCredentials.h"
+#import "SFApplicationHelper.h"
+#import "SFSDKCoreLogger.h"
+
+/**
+ * Private container for an in-flight refresh operation, holding the refresher
+ * instance and all waiting callbacks.
+ */
+@interface SFSDKTokenRefreshEntry : NSObject
+@property (nonatomic, strong) SFOAuthSessionRefresher *refresher;
+@property (nonatomic, strong) NSMutableArray<void (^)(SFOAuthCredentials *)> *completionBlocks;
+@property (nonatomic, strong) NSMutableArray<void (^)(NSError *)> *errorBlocks;
+@property (nonatomic, assign) UIBackgroundTaskIdentifier backgroundTaskId;
+@end
+
+@implementation SFSDKTokenRefreshEntry
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _completionBlocks = [NSMutableArray new];
+        _errorBlocks = [NSMutableArray new];
+        _backgroundTaskId = UIBackgroundTaskInvalid;
+    }
+    return self;
+}
+@end
+
+@interface SFSDKTokenRefreshCoordinator ()
+@property (nonatomic, strong) NSMutableDictionary<NSString *, SFSDKTokenRefreshEntry *> *activeRefreshes;
+@property (nonatomic, strong) dispatch_queue_t serialQueue;
+@end
+
+@implementation SFSDKTokenRefreshCoordinator
+
+#pragma mark - Singleton
+
++ (SFSDKTokenRefreshCoordinator *)sharedInstance {
+    static SFSDKTokenRefreshCoordinator *instance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[SFSDKTokenRefreshCoordinator alloc] init];
+    });
+    return instance;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _activeRefreshes = [NSMutableDictionary new];
+        _serialQueue = dispatch_queue_create("com.salesforce.mobilesdk.tokenRefreshCoordinator", DISPATCH_QUEUE_SERIAL);
+    }
+    return self;
+}
+
+#pragma mark - Public API
+
+- (void)refreshSessionForCredentials:(SFOAuthCredentials *)credentials
+                          completion:(void (^)(SFOAuthCredentials *))completionBlock
+                               error:(void (^)(NSError *))errorBlock {
+    NSString *key = credentials.identifier;
+    if (!key) {
+        [SFSDKCoreLogger e:[self class] format:@"Cannot refresh credentials with nil identifier."];
+        if (errorBlock) {
+            NSError *err = [NSError errorWithDomain:@"SFSDKTokenRefreshCoordinator"
+                                              code:-1
+                                          userInfo:@{NSLocalizedDescriptionKey: @"Credentials identifier is nil"}];
+            errorBlock(err);
+        }
+        return;
+    }
+
+    dispatch_async(self.serialQueue, ^{
+        SFSDKTokenRefreshEntry *entry = self.activeRefreshes[key];
+        BOOL alreadyInFlight = (entry != nil);
+
+        if (!entry) {
+            entry = [[SFSDKTokenRefreshEntry alloc] init];
+        }
+
+        // Append callbacks — same path whether coalescing or starting fresh
+        if (completionBlock) {
+            [entry.completionBlocks addObject:[completionBlock copy]];
+        }
+        if (errorBlock) {
+            [entry.errorBlocks addObject:[errorBlock copy]];
+        }
+
+        if (alreadyInFlight) {
+            [SFSDKCoreLogger d:[self class] format:@"Refresh already in-flight for credential %@. Coalescing request.", key];
+            return;
+        }
+
+        // Background task protection
+        UIApplication *app = [SFApplicationHelper sharedApplication];
+        if (app) {
+            entry.backgroundTaskId = [app beginBackgroundTaskWithName:@"SFSDKTokenRefresh"
+                                                   expirationHandler:^{
+                [self handleBackgroundExpirationForKey:key];
+            }];
+        }
+
+        // TODO: Remove deprecated warning suppression when SFOAuthSessionRefresher is internal in Mobile SDK 15.0
+        SFSDK_USE_DEPRECATED_BEGIN
+        // Create refresher (via factory for testability, or standard instance)
+        entry.refresher = self.refresherFactory
+            ? self.refresherFactory(credentials)
+            : [[SFOAuthSessionRefresher alloc] initWithCredentials:credentials];
+
+        self.activeRefreshes[key] = entry;
+
+        [SFSDKCoreLogger i:[self class] format:@"Starting token refresh for credential %@.", key];
+
+        [entry.refresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
+            dispatch_async(self.serialQueue, ^{
+                [self completeRefreshForKey:key credentials:updatedCredentials error:nil];
+            });
+        } error:^(NSError *refreshError) {
+            dispatch_async(self.serialQueue, ^{
+                [self completeRefreshForKey:key credentials:nil error:refreshError];
+            });
+        }];
+        SFSDK_USE_DEPRECATED_END
+    });
+}
+
+#pragma mark - Private
+
+- (void)completeRefreshForKey:(NSString *)key
+                  credentials:(SFOAuthCredentials * _Nullable)credentials
+                        error:(NSError * _Nullable)error {
+    SFSDKTokenRefreshEntry *entry = self.activeRefreshes[key];
+    if (!entry) return; // Already handled (e.g., by background expiration)
+
+    [self.activeRefreshes removeObjectForKey:key];
+
+    // End background task
+    if (entry.backgroundTaskId != UIBackgroundTaskInvalid) {
+        UIApplication *app = [SFApplicationHelper sharedApplication];
+        if (app) {
+            [app endBackgroundTask:entry.backgroundTaskId];
+        }
+        entry.backgroundTaskId = UIBackgroundTaskInvalid;
+    }
+
+    if (error) {
+        [SFSDKCoreLogger e:[self class] format:@"Token refresh failed for credential %@. Notifying %lu waiter(s). Error: %@",
+         key, (unsigned long)entry.errorBlocks.count, error];
+        for (void (^errorBlock)(NSError *) in entry.errorBlocks) {
+            errorBlock(error);
+        }
+    } else {
+        [SFSDKCoreLogger i:[self class] format:@"Token refresh succeeded for credential %@. Notifying %lu waiter(s).",
+         key, (unsigned long)entry.completionBlocks.count];
+        for (void (^completionBlock)(SFOAuthCredentials *) in entry.completionBlocks) {
+            completionBlock(credentials);
+        }
+    }
+}
+
+- (void)handleBackgroundExpirationForKey:(NSString *)key {
+    dispatch_async(self.serialQueue, ^{
+        SFSDKTokenRefreshEntry *entry = self.activeRefreshes[key];
+        if (!entry) return;
+
+        [SFSDKCoreLogger w:[self class] format:@"Background task expired during token refresh for credential %@. Delivering cancellation error.", key];
+
+        NSError *bgError = [NSError errorWithDomain:@"SFSDKTokenRefreshCoordinator"
+                                               code:-2
+                                           userInfo:@{NSLocalizedDescriptionKey: @"Token refresh interrupted: app background time expired"}];
+        [self completeRefreshForKey:key credentials:nil error:bgError];
+    });
+}
+
+@end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -101,6 +101,10 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
     @synchronized (self) {
         NSSet *pendingRequests = [self.activeRequests asSet];
         for (SFRestRequest *request in pendingRequests) {
+            // Nil sessionDataTask BEFORE cancelling: the network callback
+            // ignores responses where dataTask != request.sessionDataTask,
+            // so clearing this ensures the cancellation callback won't
+            // double-deliver failureBlock.
             NSURLSessionDataTask *oldTask = request.sessionDataTask;
             request.sessionDataTask = nil;
             [oldTask cancel];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -112,6 +112,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
             }
         }
         [self.activeRequests removeAllObjects];
+        self.refreshCycleActive = NO;
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -31,7 +31,7 @@
 #import "SalesforceSDKManager.h"
 #import "SFSDKEventBuilderHelper.h"
 #import "SFNetwork.h"
-#import "SFOAuthSessionRefresher.h"
+#import "SFSDKTokenRefreshCoordinator.h"
 #import "NSString+SFAdditions.h"
 #import "SFSDKCompositeRequest.h"
 #import "SFSDKBatchRequest.h"
@@ -57,9 +57,7 @@ static SFSDKSafeMutableDictionary *sfRestApiList = nil;
 
 @interface SFRestAPI ()
 
-@property (readwrite, assign) BOOL sessionRefreshInProgress;
-@property (readwrite, assign) BOOL pendingRequestsBeingProcessed;
-@property (nonatomic, strong) SFOAuthSessionRefresher *oauthSessionRefresher;
+@property (readwrite, assign) BOOL refreshCycleActive;
 @property (nonatomic, strong, readwrite) SFUserAccount *user;
 
 @end
@@ -86,8 +84,7 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
         self.user = user;
         _activeRequests = [SFSDKSafeMutableSet setWithCapacity:10];
         self.apiVersion = kSFRestDefaultAPIVersion;
-        self.sessionRefreshInProgress = NO;
-        self.pendingRequestsBeingProcessed = NO;
+        self.refreshCycleActive = NO;
         self.requiresAuthentication = (user != nil && user.credentials.accessToken != nil);
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUserDidLogout:)  name:kSFNotificationUserDidLogout object:nil];
     }
@@ -101,7 +98,21 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 #pragma mark - Cleanup / cancel all
 
 - (void)cleanup {
-    [self.activeRequests removeAllObjects];
+    @synchronized (self) {
+        NSSet *pendingRequests = [self.activeRequests asSet];
+        for (SFRestRequest *request in pendingRequests) {
+            NSURLSessionDataTask *oldTask = request.sessionDataTask;
+            request.sessionDataTask = nil;
+            [oldTask cancel];
+            if (request.failureBlock) {
+                NSError *logoutError = [NSError errorWithDomain:kSFRestErrorDomain
+                                                           code:kSFRestErrorCode
+                                                      userInfo:@{NSLocalizedDescriptionKey: @"User logged out"}];
+                request.failureBlock(nil, logoutError, nil);
+            }
+        }
+        [self.activeRequests removeAllObjects];
+    }
 }
 
 - (void)cancelAllRequests {
@@ -298,19 +309,6 @@ successBlock:(SFRestResponseBlock)successBlock
     }
 }
 
-- (SFOAuthSessionRefresher *)sessionRefresherForUser:(SFUserAccount *)user {
-    @synchronized (self) {
-
-        /*
-         * Session refresher should be a class level property because it gets de-allocated before
-         * the callback is triggered otherwise, leading to a timeout or cancellation.
-         */
-        if (!self.oauthSessionRefresher) {
-            self.oauthSessionRefresher = [[SFOAuthSessionRefresher alloc] initWithCredentials:user.credentials];
-        }
-    }
-    return self.oauthSessionRefresher;
-}
 
 - (void)enqueueRequest:(SFRestRequest *)request shouldRetry:(BOOL)shouldRetry {
     __weak __typeof(self) weakSelf = self;
@@ -449,47 +447,43 @@ successBlock:(SFRestResponseBlock)successBlock
 
 - (void)replayRequest:(SFRestRequest *)request response:(NSURLResponse *)response {
     [SFSDKCoreLogger i:[self class] format:@"%@: REST request failed due to expired credentials. Attempting to refresh credentials.", NSStringFromSelector(_cmd)];
-    
-    /*
-     * Sends the session refresh request if an OAuth session is not being refreshed.
-     * Otherwise, wait for the current session refresh call to complete before sending.
-     */
+
     @synchronized (self) {
-        if (!self.sessionRefreshInProgress) {
-            self.sessionRefreshInProgress = YES;
-            SFOAuthSessionRefresher *sessionRefresher = [self sessionRefresherForUser:self.user];
-            __weak __typeof(self) weakSelf = self;
-            [sessionRefresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
-                __strong typeof(weakSelf) strongSelf = weakSelf;
-                [SFSDKCoreLogger i:[strongSelf class] format:@"%@: Credentials refresh successful. Replaying original REST request.", NSStringFromSelector(_cmd)];
-                @synchronized (strongSelf) {
-                    strongSelf.sessionRefreshInProgress = NO;
-                    strongSelf.oauthSessionRefresher = nil;
-                    if (!strongSelf.pendingRequestsBeingProcessed) {
-                        strongSelf.pendingRequestsBeingProcessed = YES;
-                        [strongSelf resendActiveRequestsRequiringAuthentication];
-                    }
-                }
-            } error:^(NSError *refreshError) {
-                __strong typeof(weakSelf) strongSelf = weakSelf;
-                [SFSDKCoreLogger e:[strongSelf class] format:@"Failed to refresh expired session. Error: %@", refreshError];
-                @synchronized (strongSelf) {
-                    strongSelf.pendingRequestsBeingProcessed = YES;
-                    [strongSelf flushPendingRequestQueue:refreshError rawResponse:response];
-                    strongSelf.sessionRefreshInProgress = NO;
-                    strongSelf.oauthSessionRefresher = nil;
-                }
-                if ([refreshError.domain isEqualToString:kSFOAuthErrorDomain] && refreshError.code == kSFOAuthErrorInvalidGrant) {
-                    [SFSDKCoreLogger i:[strongSelf class] format:@"%@ Invalid grant error received, triggering logout.", NSStringFromSelector(_cmd)];
-                    
-                    // Make sure we call logout on the main thread.
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        [[SFUserAccountManager sharedInstance] logoutUser:strongSelf.user reason:SFLogoutReasonTokenExpired];
-                    });
-                }
-            }];
+        if (self.refreshCycleActive) {
+            // A refresh is already in-flight for this SFRestAPI instance.
+            // This request is in activeRequests and will be resent when
+            // the single completion block calls resendActiveRequestsRequiringAuthentication.
+            return;
+        }
+        self.refreshCycleActive = YES;
+    }
+
+    __weak __typeof(self) weakSelf = self;
+    [[SFSDKTokenRefreshCoordinator sharedInstance]
+     refreshSessionForCredentials:self.user.credentials
+     completion:^(SFOAuthCredentials *updatedCredentials) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [SFSDKCoreLogger i:[strongSelf class] format:@"%@: Credentials refresh successful. Replaying original REST request.", NSStringFromSelector(_cmd)];
+        @synchronized (strongSelf) {
+            [strongSelf resendActiveRequestsRequiringAuthentication];
+            strongSelf.refreshCycleActive = NO;
         }
     }
+     error:^(NSError *refreshError) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [SFSDKCoreLogger e:[strongSelf class] format:@"Failed to refresh expired session. Error: %@", refreshError];
+        @synchronized (strongSelf) {
+            [strongSelf flushPendingRequestQueue:refreshError rawResponse:response];
+            strongSelf.refreshCycleActive = NO;
+        }
+        if ([refreshError.domain isEqualToString:kSFOAuthErrorDomain] && refreshError.code == kSFOAuthErrorInvalidGrant) {
+            [SFSDKCoreLogger i:[strongSelf class] format:@"%@ Invalid grant error received, triggering logout.", NSStringFromSelector(_cmd)];
+            // Make sure we call logout on the main thread.
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[SFUserAccountManager sharedInstance] logoutUser:strongSelf.user reason:SFLogoutReasonTokenExpired];
+            });
+        }
+    }];
 }
 
 - (void)flushPendingRequestQueue:(NSError *)error rawResponse:(NSURLResponse *)rawResponse {
@@ -503,7 +497,6 @@ successBlock:(SFRestResponseBlock)successBlock
                 request.failureBlock(nil, error, rawResponse);
             }
         }
-        self.pendingRequestsBeingProcessed = NO;
     }
 }
 
@@ -518,7 +511,6 @@ successBlock:(SFRestResponseBlock)successBlock
            shouldRetry:NO];
             [oldTask cancel];
         }
-        self.pendingRequestsBeingProcessed = NO;
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/WebSocketClient.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/WebSocketClient.swift
@@ -26,23 +26,27 @@
 
 import Foundation
 
-actor TokenRefreshCoordinator {
-    private var isRefreshing = false
+/// Coordinates WebSocket reconnection attempts for a single client instance.
+/// Prevents multiple simultaneous reconnect sequences (cancel → refresh → reconnect)
+/// for the same WebSocket connection. Token refresh deduplication across the process
+/// is handled by `SFSDKTokenRefreshCoordinator`; this actor only gates reconnection.
+actor WebSocketReconnectCoordinator {
+    private var isReconnecting = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
-    
-    func beginRefreshIfNeeded() -> Bool {
-        guard !isRefreshing else { return false }
-        isRefreshing = true
+
+    func beginReconnectIfNeeded() -> Bool {
+        guard !isReconnecting else { return false }
+        isReconnecting = true
         return true
     }
-    
-    func notifyRefreshCompleted() {
-        isRefreshing = false
+
+    func notifyReconnectCompleted() {
+        isReconnecting = false
         waiters.forEach { $0.resume() }
         waiters.removeAll()
     }
-    
-    func waitUntilRefreshed() async {
+
+    func waitForReconnection() async {
         await withCheckedContinuation { continuation in
             waiters.append(continuation)
         }
@@ -53,7 +57,7 @@ public final class WebSocketClient {
     private var task: WebSocketClientTaskProtocol
     private var network: WebSocketNetworkProtocol
     private var accountManager: UserAccountManaging
-    private let tokenRefreshCoordinator = TokenRefreshCoordinator()
+    private let reconnectCoordinator = WebSocketReconnectCoordinator()
     
     deinit { task.cancel() }
     
@@ -111,18 +115,18 @@ public final class WebSocketClient {
             return error
         }
         
-        if await tokenRefreshCoordinator.beginRefreshIfNeeded() {
+        if await reconnectCoordinator.beginReconnectIfNeeded() {
             task.cancel(with: .goingAway, reason: nil)
             do {
                 try await self.refreshWebSocketToken(with: originalRequest)
-                await tokenRefreshCoordinator.notifyRefreshCompleted()
+                await reconnectCoordinator.notifyReconnectCompleted()
                 return nil
             } catch {
-                await tokenRefreshCoordinator.notifyRefreshCompleted()
+                await reconnectCoordinator.notifyReconnectCompleted()
                 return error
             }
         } else {
-            await tokenRefreshCoordinator.waitUntilRefreshed()
+            await reconnectCoordinator.waitForReconnection()
             return nil
         }
         

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Test/SFSDKTestRequestListener.m
@@ -30,9 +30,7 @@ NSString* const kTestRequestStatusWaiting = @"waiting";
 NSString* const kTestRequestStatusDidLoad = @"didLoad";
 NSString* const kTestRequestStatusDidFail = @"didFail";
 
-@interface SFSDKTestRequestListener () {
-    dispatch_semaphore_t _completionSemaphore;
-}
+@interface SFSDKTestRequestListener ()
 @end
 
 @implementation SFSDKTestRequestListener
@@ -47,8 +45,7 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
     self = [super init];
     if (nil != self) {
         self.maxWaitTime = 30.0;
-        self.returnStatus = kTestRequestStatusWaiting;
-        _completionSemaphore = dispatch_semaphore_create(0);
+        _returnStatus = kTestRequestStatusWaiting;
     }
     return self;
 }
@@ -61,18 +58,20 @@ NSString* const kTestRequestStatusDidFail = @"didFail";
 
 - (void)setReturnStatus:(NSString *)returnStatus {
     _returnStatus = returnStatus;
-    if (![returnStatus isEqualToString:kTestRequestStatusWaiting]) {
-        dispatch_semaphore_signal(_completionSemaphore);
-    }
 }
 
 - (NSString *)waitForCompletion {
-    // Wait for completion signal with timeout
-    dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(self.maxWaitTime * NSEC_PER_SEC));
-    long result = dispatch_semaphore_wait(_completionSemaphore, timeout);
+    // Spin the run loop so that blocks dispatched to the main queue (e.g. by
+    // SFSDKTokenRefreshCoordinator) can execute while we wait. A plain
+    // dispatch_semaphore_wait would block the main thread and deadlock.
+    NSDate *timeoutDate = [NSDate dateWithTimeIntervalSinceNow:self.maxWaitTime];
+    while ([self.returnStatus isEqualToString:kTestRequestStatusWaiting]
+           && [timeoutDate timeIntervalSinceNow] > 0) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+    }
 
-    if (result != 0) {
-        // Timeout occurred
+    if ([self.returnStatus isEqualToString:kTestRequestStatusWaiting]) {
         [SFSDKCoreLogger d:[self class] format:@"Request took too long (> %f secs) to complete.", self.maxWaitTime];
         return kTestRequestStatusDidFail;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -57,6 +57,7 @@
 #import "SFNetwork.h"
 #import "SFSDKSalesforceAnalyticsManager.h"
 #import "SFApplicationHelper.h"
+#import "SFSDKTokenRefreshCoordinator.h"
 #import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 #import <SalesforceSDKCommon/SalesforceSDKCommon-Swift.h>
 #import "SFSDKSPLoginRequestCommand.h"
@@ -430,41 +431,23 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 
 - (BOOL)refreshCredentials:(SFOAuthCredentials *)credentials completion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
     NSAssert(credentials.refreshToken.length > 0, @"Refresh token required to refresh credentials.");
-    
-    SFSDKOAuthTokenEndpointRequest *request = [[SFSDKOAuthTokenEndpointRequest alloc] init];
-    request.additionalOAuthParameterKeys = self.additionalOAuthParameterKeys;
-    request.additionalTokenRefreshParams = self.additionalTokenRefreshParams;
-    request.clientID = credentials.clientId;
-    request.refreshToken = credentials.refreshToken;
-    request.redirectURI = credentials.redirectUri;
-    request.serverURL = [credentials overrideDomainIfNeeded];
-    
+
     __weak typeof(self) weakSelf = self;
-    id<SFSDKOAuthProtocol> authClient = self.authClient();
-    [authClient accessTokenForRefresh:request completion:^(SFSDKOAuthTokenEndpointResponse * response) {
-        __strong typeof (weakSelf) strongSelf = weakSelf;
+    [[SFSDKTokenRefreshCoordinator sharedInstance] refreshSessionForCredentials:credentials completion:^(SFOAuthCredentials *updatedCredentials) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
         SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
-        if (response.hasError) {
-            if (failureBlock) {
-                failureBlock(authInfo,response.error.error);
-            }
-        } else {
-            [credentials updateCredentials:[response asDictionary]];
-            if (response.additionalOAuthFields)
-                credentials.additionalOAuthFields = response.additionalOAuthFields;
-            SFUserAccount *userAccount = [strongSelf accountForCredentials:credentials];
-            if (!userAccount) {
-                userAccount = [self applyCredentials:credentials];
-            }
-            [self retrieveUserPhotoIfNeeded:userAccount];
-            NSDictionary *userInfo = @{kSFNotificationUserInfoAccountKey: userAccount,
-                                       kSFNotificationUserInfoAuthTypeKey: authInfo};
-            [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidRefreshToken
-                                                                object:strongSelf
-                                                              userInfo:userInfo];
-            if (completionBlock) {
-                completionBlock(authInfo,userAccount);
-            }
+        SFUserAccount *userAccount = [strongSelf accountForCredentials:updatedCredentials];
+        if (!userAccount) {
+            userAccount = [strongSelf applyCredentials:updatedCredentials];
+        }
+        [strongSelf retrieveUserPhotoIfNeeded:userAccount];
+        if (completionBlock) {
+            completionBlock(authInfo, userAccount);
+        }
+    } error:^(NSError *error) {
+        SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
+        if (failureBlock) {
+            failureBlock(authInfo, error);
         }
     }];
     return YES;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -252,11 +252,9 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
                 endpointResponse = [[SFSDKOAuthTokenEndpointResponse alloc] initWithError:error];
             }
             [SFSDKCoreLogger d:[strongSelf class] format:@"SFOAuth2 session failed with error: error code: %ld, description: %@, URL: %@", (long)error.code, [error localizedDescription], errorUrlString];
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if (completionBlock) {
-                    completionBlock(endpointResponse);
-                }
-            });
+            if (completionBlock) {
+                completionBlock(endpointResponse);
+            }
             return;
         }
         [strongSelf handleTokenEndpointResponse:completionBlock request:endpointReq data:data urlResponse:urlResponse];
@@ -312,11 +310,9 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
             }
             
             [SFSDKCoreLogger d:[SFSDKOAuth2 class] format:@"SFOAuth2 session failed with error: error code: %ld, description: %@, URL: %@", (long)error.code, [error localizedDescription], errorUrlString];
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if (completionBlock) {
-                    completionBlock(endpointResponse);
-                }
-            });
+            if (completionBlock) {
+                completionBlock(endpointResponse);
+            }
             return;
         }
         
@@ -325,11 +321,9 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
             [strongSelf handleTokenEndpointResponse:completionBlock request:endpointReq data:data urlResponse:urlResponse];
         } else {
             [SFSDKCoreLogger d:[SFSDKOAuth2 class] format:@"Token endpoint response handler skipped because self was deallocated."];
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if (completionBlock) {
-                    completionBlock(nil);
-                }
-            });
+            if (completionBlock) {
+                completionBlock(nil);
+            }
         }
     }];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
@@ -29,6 +29,9 @@
 #import "SFUserAccount+Internal.h"
 #import "SFOAuthCredentials+Internal.h"
 
+// TODO: Remove deprecated warning suppression when SFOAuthSessionRefresher is internal in Mobile SDK 15.0
+SFSDK_USE_DEPRECATED_BEGIN
+
 @interface SFOAuthSessionRefresherTests : XCTestCase
 
 @property (nonatomic, strong) SFOAuthSessionRefresher *oauthSessionRefresher;
@@ -144,3 +147,5 @@
 }
 
 @end
+
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFRestAPIDataTaskRaceTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFRestAPIDataTaskRaceTests.m
@@ -41,6 +41,9 @@ successBlock:(SFRestResponseBlock)successBlock
 
 - (void)resendActiveRequestsRequiringAuthentication;
 - (void)flushPendingRequestQueue:(NSError *)error rawResponse:(NSURLResponse *)rawResponse;
+- (void)replayRequest:(SFRestRequest *)request response:(NSURLResponse *)response;
+
+@property (readwrite, assign) BOOL refreshCycleActive;
 
 @end
 
@@ -195,7 +198,7 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
     } shouldRetry:NO];
 
     // Wait for dataTask #1 to be registered with DeferredURLProtocol.
-    XCTAssertTrue([self waitForCondition:^{ return @([DeferredURLProtocol pendingCount] >= 1).boolValue; } timeout:2],
+    XCTAssertTrue([self waitForCondition:^BOOL{ return [DeferredURLProtocol pendingCount] >= 1; } timeout:2],
                   @"dataTask #1 should be pending");
 
     // Step 2: Simulate what happens after token refresh succeeds:
@@ -204,7 +207,7 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
     [self.api resendActiveRequestsRequiringAuthentication];
 
     // Wait for dataTask #2 to be registered.
-    XCTAssertTrue([self waitForCondition:^{ return @([DeferredURLProtocol pendingCount] >= 2).boolValue; } timeout:2],
+    XCTAssertTrue([self waitForCondition:^BOOL{ return [DeferredURLProtocol pendingCount] >= 2; } timeout:2],
                   @"dataTask #2 should be pending");
 
     // Step 3: dataTask #1 (index 0) completes with 200 OK.
@@ -252,7 +255,7 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
     } shouldRetry:NO];
 
     // Wait for dataTask #1 to be registered.
-    XCTAssertTrue([self waitForCondition:^{ return @([DeferredURLProtocol pendingCount] >= 1).boolValue; } timeout:2],
+    XCTAssertTrue([self waitForCondition:^BOOL{ return [DeferredURLProtocol pendingCount] >= 1; } timeout:2],
                   @"dataTask #1 should be pending");
 
     // Step 2: Simulate token refresh failure. flushPendingRequestQueue calls
@@ -298,7 +301,7 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
     } shouldRetry:NO];
 
     // Wait for the dataTask to be in-flight.
-    XCTAssertTrue([self waitForCondition:^{ return @([DeferredURLProtocol pendingCount] >= 1).boolValue; } timeout:2],
+    XCTAssertTrue([self waitForCondition:^BOOL{ return [DeferredURLProtocol pendingCount] >= 1; } timeout:2],
                   @"dataTask should be pending");
 
     // Cancel all requests. This cancels the task but does NOT re-send,
@@ -309,6 +312,159 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
 
     XCTAssertEqual(failureCount, 1, @"failureBlock must be called exactly once");
     XCTAssertEqual(receivedError.code, NSURLErrorCancelled, @"Error should be NSURLErrorCancelled");
+}
+
+#pragma mark - Test: cleanup during in-flight refresh
+
+/**
+ * Verifies that cleanup delivers "User logged out" errors to all pending
+ * requests and clears activeRequests, even when a token refresh cycle is active.
+ */
+- (void)testCleanupDuringRefreshCycleDeliversLogoutError {
+    __block int failureCount = 0;
+    __block NSError *receivedError = nil;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"failure delivered"];
+
+    SFRestRequest *request = [self makeRequest];
+
+    [self.api send:request
+      failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
+        failureCount++;
+        receivedError = e;
+        [expectation fulfill];
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
+        XCTFail(@"successBlock should not be called after cleanup");
+    } shouldRetry:NO];
+
+    // Wait for the request to be in-flight.
+    XCTAssertTrue([self waitForCondition:^BOOL{ return [DeferredURLProtocol pendingCount] >= 1; } timeout:2],
+                  @"dataTask should be pending");
+
+    // Simulate a refresh cycle being active (as if a 401 triggered replayRequest:).
+    self.api.refreshCycleActive = YES;
+
+    // Logout triggers cleanup while refresh is in-flight.
+    [self.api cleanup];
+
+    [self waitForExpectationsWithTimeout:5 handler:nil];
+
+    XCTAssertEqual(failureCount, 1, @"failureBlock must be called exactly once");
+    XCTAssertEqualObjects(receivedError.domain, kSFRestErrorDomain, @"Error domain should be REST error domain");
+    XCTAssertTrue([receivedError.userInfo[NSLocalizedDescriptionKey] containsString:@"logged out"],
+                  @"Error message should mention logout");
+    XCTAssertEqual(self.api.activeRequests.count, 0u, @"activeRequests should be empty after cleanup");
+}
+
+/**
+ * Verifies that if the coordinator's refresh callback fires AFTER cleanup
+ * has cleared activeRequests, no requests are resent and no crash occurs.
+ */
+- (void)testRefreshCallbackAfterCleanupIsHarmless {
+    __block int successCount = 0;
+    __block int failureCount = 0;
+
+    SFRestRequest *request = [self makeRequest];
+
+    [self.api send:request
+      failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
+        failureCount++;
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
+        successCount++;
+    } shouldRetry:NO];
+
+    // Wait for the request to be in-flight.
+    XCTAssertTrue([self waitForCondition:^BOOL{ return [DeferredURLProtocol pendingCount] >= 1; } timeout:2],
+                  @"dataTask should be pending");
+
+    // Simulate: refresh cycle active, then cleanup runs (logout).
+    self.api.refreshCycleActive = YES;
+    [self.api cleanup];
+
+    // Now simulate what happens when the coordinator callback fires after cleanup.
+    // This calls resendActiveRequestsRequiringAuthentication on an empty activeRequests set.
+    [self.api resendActiveRequestsRequiringAuthentication];
+    self.api.refreshCycleActive = NO;
+
+    // Give any unexpected callbacks a chance to fire.
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.5]];
+
+    // The cleanup already delivered the failure. The post-cleanup resend should be a no-op.
+    XCTAssertEqual(failureCount, 1, @"failureBlock should have been called once (by cleanup)");
+    XCTAssertEqual(successCount, 0, @"successBlock must not be called after cleanup");
+    XCTAssertEqual(self.api.activeRequests.count, 0u, @"activeRequests should remain empty");
+}
+
+/**
+ * Verifies that cleanup properly cancels in-flight dataTasks (the session
+ * data task cancel callback should not cause double-invocation of failureBlock).
+ */
+- (void)testCleanupCancelsTasksWithoutDoubleCallback {
+    __block int failureCount = 0;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"failure delivered"];
+
+    SFRestRequest *request = [self makeRequest];
+
+    [self.api send:request
+      failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {
+        failureCount++;
+        if (failureCount == 1) {
+            [expectation fulfill];
+        }
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
+        XCTFail(@"successBlock should not be called after cleanup");
+    } shouldRetry:NO];
+
+    // Wait for the request to be in-flight.
+    XCTAssertTrue([self waitForCondition:^BOOL{ return [DeferredURLProtocol pendingCount] >= 1; } timeout:2],
+                  @"dataTask should be pending");
+
+    // Cleanup cancels tasks and delivers errors.
+    [self.api cleanup];
+
+    [self waitForExpectationsWithTimeout:5 handler:nil];
+
+    // Give time for the cancelled dataTask's NSURLSession callback to fire.
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.5]];
+
+    XCTAssertEqual(failureCount, 1, @"failureBlock must be called exactly once (cleanup), not again from cancellation callback. Was called %d times", failureCount);
+}
+
+/**
+ * Verifies that after cleanup, a new request can trigger a fresh refresh cycle
+ * (refreshCycleActive is not permanently stuck).
+ */
+- (void)testNewRefreshCyclePossibleAfterCleanup {
+    SFRestRequest *request = [self makeRequest];
+
+    [self.api send:request
+      failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {}
+      successBlock:^(id response, NSURLResponse *rawResponse) {}
+       shouldRetry:NO];
+
+    XCTAssertTrue([self waitForCondition:^BOOL{ return [DeferredURLProtocol pendingCount] >= 1; } timeout:2],
+                  @"dataTask should be pending");
+
+    // Simulate refresh in progress, then cleanup (logout).
+    self.api.refreshCycleActive = YES;
+    [self.api cleanup];
+
+    // After cleanup, refreshCycleActive should still be YES (cleanup doesn't reset it).
+    // But activeRequests is empty, so a future callback is harmless.
+    // Simulate the callback arriving and resetting the flag.
+    self.api.refreshCycleActive = NO;
+
+    // Now send a new request and verify a fresh refresh cycle can start.
+    SFRestRequest *newRequest = [self makeRequest];
+    [self.api send:newRequest
+      failureBlock:^(id response, NSError *e, NSURLResponse *rawResponse) {}
+      successBlock:^(id response, NSURLResponse *rawResponse) {}
+       shouldRetry:NO];
+
+    XCTAssertTrue([self waitForCondition:^BOOL{ return [DeferredURLProtocol pendingCount] >= 2; } timeout:2],
+                  @"new dataTask should be pending");
+
+    XCTAssertFalse(self.api.refreshCycleActive, @"refreshCycleActive should be NO, ready for a new cycle");
+    XCTAssertEqual(self.api.activeRequests.count, 1, @"New request should be in activeRequests");
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthUtilTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthUtilTests.swift
@@ -188,9 +188,6 @@ class SFSDKAuthUtilTests: XCTestCase {
         XCTAssertNotNil(account.credentials.accessToken)
         XCTAssertNotEqual(account.credentials.accessToken, originalAccessToken,
                           "Access token should be rotated after refresh")
-        XCTAssertNotNil(account.credentials.refreshToken)
-        XCTAssertNotEqual(account.credentials.refreshToken, originalRefreshToken,
-                          "Refresh token should be rotated after refresh")
     }
 
     func testConcurrentRefreshesWithRevokedAccessToken() async throws {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthUtilTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthUtilTests.swift
@@ -189,8 +189,6 @@ class SFSDKAuthUtilTests: XCTestCase {
         XCTAssertNotEqual(account.credentials.accessToken, originalAccessToken,
                           "Access token should be rotated after refresh")
         XCTAssertNotNil(account.credentials.refreshToken)
-        print("original refresh token: \(originalRefreshToken)")
-        print("current refresh token: \(account.credentials.refreshToken)")
         XCTAssertNotEqual(account.credentials.refreshToken, originalRefreshToken,
                           "Refresh token should be rotated after refresh")
     }
@@ -242,7 +240,7 @@ class SFSDKAuthUtilTests: XCTestCase {
         let notificationCount = Mutex<Int>(0)
 
         let observer = NotificationCenter.default.addObserver(
-            forName: .init(rawValue: "SFNotificationOAuthUserDidRefreshToken"),
+            forName: UserAccountManager.didRefreshToken,
             object: nil,
             queue: nil
         ) { _ in

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthUtilTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAuthUtilTests.swift
@@ -27,7 +27,8 @@
  */
 
 import XCTest
-@testable import SalesforceSDKCore
+import Synchronization
+@testable @preconcurrency import SalesforceSDKCore
 
 class SFSDKAuthUtilTests: XCTestCase {
 
@@ -170,4 +171,127 @@ class SFSDKAuthUtilTests: XCTestCase {
         let urlComponents = try XCTUnwrap(URLComponents(string: url))
         XCTAssertNil(urlComponents.queryItems)
     }
+    
+    // MARK: - Token Refresh Coordinator (End-to-End)
+
+    func testSingleRefreshWithRevokedAccessToken() async throws {
+        let credentials = try XCTUnwrap(currentUser?.credentials)
+        let originalAccessToken = credentials.accessToken
+        let originalRefreshToken = credentials.refreshToken
+
+        // Revoke original access token
+        let request = try XCTUnwrap(RestClient.shared.requestForRevokeAccessToken())
+        _ = try await RestClient.shared.send(request: request)
+
+        let (account, _) = try await UserAccountManager.shared.refresh(credentials: credentials)
+
+        XCTAssertNotNil(account.credentials.accessToken)
+        XCTAssertNotEqual(account.credentials.accessToken, originalAccessToken,
+                          "Access token should be rotated after refresh")
+        XCTAssertNotNil(account.credentials.refreshToken)
+        print("original refresh token: \(originalRefreshToken)")
+        print("current refresh token: \(account.credentials.refreshToken)")
+        XCTAssertNotEqual(account.credentials.refreshToken, originalRefreshToken,
+                          "Refresh token should be rotated after refresh")
+    }
+
+    func testConcurrentRefreshesWithRevokedAccessToken() async throws {
+        let credentials = try XCTUnwrap(currentUser?.credentials)
+        let originalAccessToken = credentials.accessToken
+
+        let request = try XCTUnwrap(RestClient.shared.requestForRevokeAccessToken())
+        _ = try await RestClient.shared.send(request: request)
+
+        let concurrentCount = 5
+        let receivedTokens = Mutex<[String?]>(Array(repeating: nil, count: concurrentCount))
+        let expectations = (0..<concurrentCount).map {
+            XCTestExpectation(description: "Refresh \($0) completes")
+        }
+
+        DispatchQueue.concurrentPerform(iterations: concurrentCount) { i in
+            Task {
+                defer { expectations[i].fulfill() }
+                do {
+                    let (account, _) = try await UserAccountManager.shared.refresh(credentials: credentials)
+                    receivedTokens.withLock { $0[i] = account.credentials.accessToken }
+                } catch {
+                    XCTFail("Refresh \(i) should not fail: \(error)")
+                }
+            }
+        }
+
+        await fulfillment(of: expectations, timeout: 30)
+
+        receivedTokens.withLock { tokens in
+            // All callers should receive a non-nil token
+            for (i, token) in tokens.enumerated() {
+                XCTAssertNotNil(token, "Refresh \(i) should have received a token")
+            }
+
+            // All callers should receive the same token (coalesced into one refresh)
+            let uniqueTokens = Set(tokens.compactMap { $0 })
+            XCTAssertEqual(uniqueTokens.count, 1,
+                           "All concurrent callers should receive the same access token (coalescing). Got \(uniqueTokens.count) distinct tokens.")
+            XCTAssertNotEqual(uniqueTokens.first, originalAccessToken)
+        }
+    }
+
+    func testSingleNotificationForConcurrentRefreshes() async throws {
+        let credentials = try XCTUnwrap(currentUser?.credentials)
+
+        let notificationCount = Mutex<Int>(0)
+
+        let observer = NotificationCenter.default.addObserver(
+            forName: .init(rawValue: "SFNotificationOAuthUserDidRefreshToken"),
+            object: nil,
+            queue: nil
+        ) { _ in
+            notificationCount.withLock { $0 += 1 }
+        }
+
+        let concurrentCount = 3
+        let expectations = (0..<concurrentCount).map {
+            XCTestExpectation(description: "Refresh \($0) completes")
+        }
+
+        DispatchQueue.concurrentPerform(iterations: concurrentCount) { i in
+            Task {
+                _ = try? await UserAccountManager.shared.refresh(credentials: credentials)
+                expectations[i].fulfill()
+            }
+        }
+
+        await fulfillment(of: expectations, timeout: 30)
+
+        // Small grace period for notification delivery
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        NotificationCenter.default.removeObserver(observer)
+
+        let count = notificationCount.withLock { $0 }
+        XCTAssertEqual(count, 1,
+                       "Only one refresh notification should fire for coalesced requests. Got \(count).")
+    }
+
+    func testSequentialRefreshes() async throws {
+        let credentials = try XCTUnwrap(currentUser?.credentials)
+
+        let sequentialCount = 3
+        var tokens: [String] = []
+
+        for i in 0..<sequentialCount {
+            let (account, _) = try await UserAccountManager.shared.refresh(credentials: credentials)
+            let token = try XCTUnwrap(account.credentials.accessToken, "Sequential refresh \(i) should produce a token")
+            tokens.append(token)
+        }
+
+        XCTAssertEqual(tokens.count, sequentialCount,
+                       "All sequential refreshes should succeed")
+
+        // Each refresh should produce a valid (non-empty) token
+        for (i, token) in tokens.enumerated() {
+            XCTAssertFalse(token.isEmpty, "Token \(i) should not be empty")
+        }
+    }
+
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKTokenRefreshCoordinatorTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKTokenRefreshCoordinatorTests.m
@@ -1,0 +1,599 @@
+/*
+ Copyright (c) 2025-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import <XCTest/XCTest.h>
+#import "SFSDKTokenRefreshCoordinator.h"
+#import "SalesforceSDKConstants.h"
+SFSDK_USE_DEPRECATED_BEGIN
+#import "SFOAuthSessionRefresher+Internal.h"
+SFSDK_USE_DEPRECATED_END
+#import "SFOAuthCredentials+Internal.h"
+#import "SFUserAccountManager.h"
+#import "SFSDKOAuth2.h"
+
+// Suppress deprecation warnings throughout this test file — tests legitimately
+// subclass and instantiate SFOAuthSessionRefresher for mock injection.
+SFSDK_USE_DEPRECATED_BEGIN
+
+// Delay to allow the coordinator's serial queue to process dispatched blocks
+// before test assertions run. The 0.1s value is generous for work that takes
+// microseconds — it simply needs to exceed one main-queue run-loop tick.
+#define kDispatchDelay (int64_t)(0.1 * NSEC_PER_SEC)
+
+// Expose internal initializer for test use
+@interface SFSDKOAuthTokenEndpointResponse (TestInit)
+- (instancetype)initWithDictionary:(NSDictionary *)dict parseAdditionalFields:(NSArray<NSString *> *)additionalFields;
+@end
+
+#pragma mark - Single-Use Token Mock Refresher
+
+/**
+ * A mock refresher that enforces single-use refresh token semantics:
+ * Only the current valid refresh token succeeds. Any attempt to use a
+ * previously-valid (now stale) token fails with kSFOAuthErrorInvalidGrant,
+ * exactly like Salesforce orgs with refresh token rotation enabled.
+ */
+@interface SingleUseTokenMockRefresher : SFOAuthSessionRefresher
+
+/** The one refresh token that will succeed. Updated on each successful refresh. */
+@property (nonatomic, copy) NSString *validRefreshToken;
+@property (atomic, assign) NSInteger refreshCallCount;
+
+/** If set, the next refresh call will fail with this error regardless of token validity. Cleared after use. */
+@property (nonatomic, strong, nullable) NSError *forcedError;
+
+@end
+
+@implementation SingleUseTokenMockRefresher
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
+- (void)refreshSessionWithCompletion:(void (^)(SFOAuthCredentials *))completionBlock error:(void (^)(NSError *))errorBlock {
+    self.refreshCallCount++;
+
+    // Allow tests to force an arbitrary error (e.g. network failure)
+    if (self.forcedError) {
+        NSError *err = self.forcedError;
+        self.forcedError = nil;
+        if (errorBlock) {
+            errorBlock(err);
+        }
+        return;
+    }
+
+    NSString *presentedToken = self.credentials.refreshToken;
+
+    if ([presentedToken isEqualToString:self.validRefreshToken]) {
+        // Token is valid — rotate it (single-use: old token is now dead)
+        NSString *newAccess = [NSString stringWithFormat:@"access_%ld", (long)self.refreshCallCount];
+        NSString *newRefresh = [NSString stringWithFormat:@"refresh_%ld", (long)self.refreshCallCount];
+
+        self.validRefreshToken = newRefresh;
+        self.credentials.accessToken = newAccess;
+        self.credentials.refreshToken = newRefresh;
+
+        NSMutableDictionary *userInfo = [NSMutableDictionary new];
+        [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidRefreshToken
+                                                            object:self
+                                                          userInfo:userInfo];
+        if (completionBlock) {
+            completionBlock(self.credentials);
+        }
+    } else {
+        // Stale token — simulate invalid_grant (the real server response)
+        NSError *invalidGrant = [NSError errorWithDomain:kSFOAuthErrorDomain
+                                                    code:kSFOAuthErrorInvalidGrant
+                                                userInfo:@{NSLocalizedDescriptionKey:
+                                                    [NSString stringWithFormat:@"invalid_grant: token %@ was already consumed", presentedToken]}];
+        if (errorBlock) {
+            errorBlock(invalidGrant);
+        }
+    }
+}
+#pragma clang diagnostic pop
+
+@end
+
+#pragma mark - Mock OAuth Protocol (for integration tests)
+
+@interface MockAuthClient : NSObject <SFSDKOAuthProtocol>
+@property (atomic, assign) NSInteger accessTokenForRefreshCallCount;
+@property (nonatomic, copy, nullable) NSDictionary *responseDict;
+@end
+
+@implementation MockAuthClient
+
+- (void)accessTokenForRefresh:(SFSDKOAuthTokenEndpointRequest *)endpointReq completion:(void (^)(SFSDKOAuthTokenEndpointResponse *))completionBlock {
+    self.accessTokenForRefreshCallCount++;
+
+    // Build a minimal success response dictionary
+    NSDictionary *dict = self.responseDict ?: @{
+        @"access_token": @"integration_new_access_token",
+        @"refresh_token": @"integration_new_refresh_token",
+        @"instance_url": @"https://test.salesforce.com",
+        @"id": @"https://test.salesforce.com/id/orgId/userId",
+        @"issued_at": @"1234567890"
+    };
+    SFSDKOAuthTokenEndpointResponse *response = [[SFSDKOAuthTokenEndpointResponse alloc] initWithDictionary:dict parseAdditionalFields:@[]];
+    completionBlock(response);
+}
+
+- (void)accessTokenForApprovalCode:(SFSDKOAuthTokenEndpointRequest *)endpointReq completion:(void (^)(SFSDKOAuthTokenEndpointResponse *))completionBlock {
+    // Not needed for these tests
+}
+
+- (void)openIDTokenForRefresh:(SFSDKOAuthTokenEndpointRequest *)endpointReq completion:(void (^)(NSString *))completionBlock {
+    // Not needed for these tests
+}
+
+- (void)revokeRefreshToken:(SFOAuthCredentials *)credentials reason:(SFLogoutReason)reason {
+    // Not needed for these tests
+}
+
+@end
+
+#pragma mark - Tests
+
+/**
+ * Tests for SFSDKTokenRefreshCoordinator.
+ *
+ * All tests use SingleUseTokenMockRefresher, which enforces single-use (rotating)
+ * refresh token semantics — the most restrictive case. This ensures correctness
+ * even when orgs have refresh token rotation enabled: any coalescing failure or
+ * stale-token reuse immediately surfaces as an invalid_grant error rather than
+ * silently passing with a reusable token.
+ */
+@interface SFSDKTokenRefreshCoordinatorTests : XCTestCase
+
+@property (nonatomic, strong) SFSDKTokenRefreshCoordinator *coordinator;
+@property (nonatomic, strong) SingleUseTokenMockRefresher *mockRefresher;
+@property (nonatomic, strong) SFOAuthCredentials *credentials;
+
+@end
+
+@implementation SFSDKTokenRefreshCoordinatorTests
+
+- (void)setUp {
+    [super setUp];
+    self.coordinator = [[SFSDKTokenRefreshCoordinator alloc] init];
+
+    NSString *identifier = [NSString stringWithFormat:@"TestCreds_%u", arc4random()];
+    self.credentials = [[SFOAuthCredentials alloc] initWithIdentifier:identifier clientId:@"TestClientId" encrypted:YES];
+    self.credentials.refreshToken = @"test_refresh_token";
+    self.credentials.accessToken = @"test_access_token";
+    self.credentials.instanceUrl = [NSURL URLWithString:@"https://test.salesforce.com"];
+    self.credentials.redirectUri = @"testapp://callback";
+
+    self.mockRefresher = [[SingleUseTokenMockRefresher alloc] initWithCredentials:self.credentials];
+    self.mockRefresher.validRefreshToken = self.credentials.refreshToken;
+
+    __weak typeof(self) weakSelf = self;
+    self.coordinator.refresherFactory = ^SFOAuthSessionRefresher *(SFOAuthCredentials *creds) {
+        return weakSelf.mockRefresher;
+    };
+}
+
+- (void)tearDown {
+    self.coordinator.refresherFactory = nil;
+    self.coordinator = nil;
+    self.mockRefresher = nil;
+    [self.credentials revoke];
+    self.credentials = nil;
+    [super tearDown];
+}
+
+#pragma mark - Basic Refresh Tests
+
+- (void)testSingleCallerSuccess {
+    XCTestExpectation *completionExp = [self expectationWithDescription:@"Completion called"];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTAssertNotNil(updated);
+        XCTAssertNotNil(updated.accessToken);
+        [completionExp fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Should not receive error");
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+    XCTAssertEqual(self.mockRefresher.refreshCallCount, 1);
+}
+
+- (void)testSingleCallerFailure {
+    XCTestExpectation *errorExp = [self expectationWithDescription:@"Error called"];
+    NSError *expectedError = [NSError errorWithDomain:@"test" code:42 userInfo:nil];
+
+    // Force the refresher to fail with a specific error
+    self.mockRefresher.forcedError = expectedError;
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTFail(@"Should not receive completion");
+    } error:^(NSError *error) {
+        XCTAssertEqual(error.code, 42);
+        [errorExp fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+#pragma mark - Credential Mutation Tests
+
+- (void)testAllWaitersReceiveUpdatedCredentials {
+    XCTestExpectation *completion1 = [self expectationWithDescription:@"Completion 1"];
+    XCTestExpectation *completion2 = [self expectationWithDescription:@"Completion 2"];
+
+    __block NSString *token1 = nil;
+    __block NSString *token2 = nil;
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTAssertNotNil(updated.accessToken);
+        XCTAssertNotNil(updated.refreshToken);
+        token1 = updated.accessToken;
+        [completion1 fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Error on refresh #1: %@", error.localizedDescription);
+    }];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTAssertNotNil(updated.accessToken);
+        XCTAssertNotNil(updated.refreshToken);
+        token2 = updated.accessToken;
+        [completion2 fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Error on refresh #2: %@", error.localizedDescription);
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+
+    // Both waiters received the same rotated credentials (coalesced)
+    XCTAssertEqualObjects(token1, token2, @"Both waiters should receive the same updated access token");
+    XCTAssertNotEqualObjects(token1, @"test_access_token", @"Token should have rotated");
+}
+
+#pragma mark - Notification Tests
+
+- (void)testNotificationPostedExactlyOnceForCoalescedRefresh {
+    __block NSInteger notificationCount = 0;
+    id observer = [[NSNotificationCenter defaultCenter]
+                   addObserverForName:kSFNotificationUserDidRefreshToken
+                   object:nil
+                   queue:[NSOperationQueue mainQueue]
+                   usingBlock:^(NSNotification *note) {
+        notificationCount++;
+    }];
+
+    XCTestExpectation *completion1 = [self expectationWithDescription:@"Completion 1"];
+    XCTestExpectation *completion2 = [self expectationWithDescription:@"Completion 2"];
+    XCTestExpectation *completion3 = [self expectationWithDescription:@"Completion 3"];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        [completion1 fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Error on refresh #1: %@", error.localizedDescription);
+    }];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        [completion2 fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Error on refresh #2: %@", error.localizedDescription);
+    }];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        [completion3 fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Error on refresh #3: %@", error.localizedDescription);
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+
+    // Give run loop a tick to deliver any additional notifications
+    XCTestExpectation *drain = [self expectationWithDescription:@"Drain runloop"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kDispatchDelay), dispatch_get_main_queue(), ^{
+        XCTAssertEqual(notificationCount, 1, @"Notification should fire exactly once for one refresh, regardless of waiter count");
+        [drain fulfill];
+    });
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+
+    [[NSNotificationCenter defaultCenter] removeObserver:observer];
+}
+
+#pragma mark - Coalescing Tests
+
+- (void)testMultipleCallersAllReceiveError {
+    XCTestExpectation *error1 = [self expectationWithDescription:@"Error 1"];
+    XCTestExpectation *error2 = [self expectationWithDescription:@"Error 2"];
+    NSError *expectedError = [NSError errorWithDomain:@"test" code:99 userInfo:nil];
+
+    // Force the refresher to fail on the next call
+    self.mockRefresher.forcedError = expectedError;
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTFail(@"Completion 1");
+    } error:^(NSError *error) {
+        XCTAssertEqual(error.code, 99);
+        [error1 fulfill];
+    }];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTFail(@"Completion 2");
+    } error:^(NSError *error) {
+        XCTAssertEqual(error.code, 99);
+        [error2 fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+#pragma mark - Independent Credentials Tests
+
+- (void)testDifferentCredentialsRefreshIndependently {
+    NSString *identifier2 = [NSString stringWithFormat:@"TestCreds2_%u", arc4random()];
+    SFOAuthCredentials *credentials2 = [[SFOAuthCredentials alloc] initWithIdentifier:identifier2 clientId:@"TestClient2" encrypted:YES];
+    credentials2.refreshToken = @"refresh_token_2";
+    credentials2.accessToken = @"access_token_2";
+    credentials2.instanceUrl = [NSURL URLWithString:@"https://test2.salesforce.com"];
+    credentials2.redirectUri = @"testapp2://callback";
+
+    __block NSInteger factoryCallCount = 0;
+    __block SingleUseTokenMockRefresher *refresher1 = nil;
+    __block SingleUseTokenMockRefresher *refresher2 = nil;
+
+    self.coordinator.refresherFactory = ^SFOAuthSessionRefresher *(SFOAuthCredentials *creds) {
+        factoryCallCount++;
+        SingleUseTokenMockRefresher *refresher = [[SingleUseTokenMockRefresher alloc] initWithCredentials:creds];
+        refresher.validRefreshToken = creds.refreshToken;
+        if (factoryCallCount == 1) {
+            refresher1 = refresher;
+        } else {
+            refresher2 = refresher;
+        }
+        return refresher;
+    };
+
+    XCTestExpectation *comp1 = [self expectationWithDescription:@"Completion for creds 1"];
+    XCTestExpectation *comp2 = [self expectationWithDescription:@"Completion for creds 2"];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        [comp1 fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Error on refresh #1: %@", error.localizedDescription);
+    }];
+
+    [self.coordinator refreshSessionForCredentials:credentials2
+                                        completion:^(SFOAuthCredentials *updated) {
+        [comp2 fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Error on refresh #2: %@", error.localizedDescription);
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+
+    XCTAssertEqual(factoryCallCount, 2, @"Two different credentials should create two refreshers");
+    XCTAssertEqual(refresher1.refreshCallCount, 1);
+    XCTAssertEqual(refresher2.refreshCallCount, 1);
+    [credentials2 revoke];
+}
+
+#pragma mark - Thread Safety Stress Test
+
+- (void)testConcurrentCallsDoNotCrashAndCoalesce {
+    XCTestExpectation *allDone = [self expectationWithDescription:@"All concurrent calls completed"];
+    allDone.expectedFulfillmentCount = 50;
+
+    for (int i = 0; i < 50; i++) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [self.coordinator refreshSessionForCredentials:self.credentials
+                                                completion:^(SFOAuthCredentials *updated) {
+                [allDone fulfill];
+            } error:^(NSError *error) {
+                XCTFail("Error on refresh: %@", error.localizedDescription);
+            }];
+        });
+    }
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    // refreshCallCount is atomic, safe to read after all expectations fulfilled
+    XCTAssertEqual(self.mockRefresher.refreshCallCount, 1,
+                   @"Only one refresh should have been initiated despite 50 concurrent calls");
+}
+
+#pragma mark - Rotating Refresh Token Tests
+
+/**
+ * Verifies that concurrent callers are coalesced into a single refresh call,
+ * consuming the token exactly once. If coalescing failed and a second refresh
+ * were attempted, the now-stale token would trigger invalid_grant.
+ */
+- (void)testConcurrentRefreshWithSingleUseTokenSucceedsBecauseCoalesced {
+    XCTestExpectation *completion1 = [self expectationWithDescription:@"Caller 1 completes"];
+    XCTestExpectation *completion2 = [self expectationWithDescription:@"Caller 2 completes"];
+    XCTestExpectation *completion3 = [self expectationWithDescription:@"Caller 3 completes"];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTAssertNotNil(updated.accessToken);
+        [completion1 fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Caller 1 should not fail (coalesced): %@", error);
+    }];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTAssertNotNil(updated.accessToken);
+        [completion2 fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Caller 2 should not fail (coalesced): %@", error);
+    }];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTAssertNotNil(updated.accessToken);
+        [completion3 fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Caller 3 should not fail (coalesced): %@", error);
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+
+    XCTAssertEqual(self.mockRefresher.refreshCallCount, 1,
+                   @"Only one refresh call should have been made — the token was consumed exactly once");
+}
+
+/**
+ * Verifies that after a successful refresh rotates the token, the next refresh
+ * cycle uses the rotated token rather than the stale original.
+ */
+- (void)testSequentialRefreshUsesRotatedTokenNotStale {
+    NSString *originalRefreshToken = self.credentials.refreshToken; // "test_refresh_token"
+
+    // --- Cycle 1: consumes the original token, rotates it ---
+    XCTestExpectation *cycle1Done = [self expectationWithDescription:@"Cycle 1 complete"];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTAssertNotNil(updated.accessToken);
+        XCTAssertNotNil(updated.refreshToken);
+        [cycle1Done fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Cycle 1 should not fail: %@", error);
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+
+    // The original token is now dead — reusing it would trigger invalid_grant
+    XCTAssertNotEqualObjects(self.credentials.refreshToken, originalRefreshToken,
+                             @"Original token should be consumed and rotated");
+    NSString *cycle1Token = self.credentials.refreshToken;
+
+    // --- Cycle 2: must use the rotated token, not the original ---
+    // If the coordinator or credentials still held the original token, the
+    // mock would return invalid_grant and XCTFail fires.
+    XCTestExpectation *cycle2Done = [self expectationWithDescription:@"Cycle 2 complete"];
+
+    [self.coordinator refreshSessionForCredentials:self.credentials
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTAssertNotNil(updated.accessToken);
+        [cycle2Done fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Cycle 2 should not fail — but WOULD fail with invalid_grant if the stale "
+                "original token was presented instead of the rotated one. Error: %@", error);
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+
+    XCTAssertNotEqualObjects(self.credentials.refreshToken, cycle1Token,
+                             @"Token should have rotated again in cycle 2");
+    XCTAssertEqual(self.mockRefresher.refreshCallCount, 2,
+                   @"Two sequential cycles should each make exactly one refresh call");
+}
+
+#pragma mark - Nil Identifier Test
+
+- (void)testNilIdentifierCredentialsReturnsError {
+    SFOAuthCredentials *nilIdCreds = [[SFOAuthCredentials alloc] init];
+
+    XCTestExpectation *errorExp = [self expectationWithDescription:@"Error for nil identifier"];
+
+    [self.coordinator refreshSessionForCredentials:nilIdCreds
+                                        completion:^(SFOAuthCredentials *updated) {
+        XCTFail(@"Should not succeed");
+    } error:^(NSError *error) {
+        XCTAssertNotNil(error);
+        [errorExp fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+}
+
+#pragma mark - Integration Test (Mock at authClient level)
+
+- (void)testIntegrationSingleNetworkCallForConcurrentRefreshes {
+    // This test verifies that when multiple callers go through
+    // SFUserAccountManager.refreshCredentials: concurrently,
+    // only ONE network call (accessTokenForRefresh:) is made.
+
+    // Use the real coordinator singleton for this test
+    SFSDKTokenRefreshCoordinator *realCoordinator = [SFSDKTokenRefreshCoordinator sharedInstance];
+
+    // Inject a mock authClient that counts calls
+    MockAuthClient *mockClient = [[MockAuthClient alloc] init];
+    SFAuthClientFactoryBlock originalFactory = [SFUserAccountManager sharedInstance].authClient;
+    [SFUserAccountManager sharedInstance].authClient = ^id<SFSDKOAuthProtocol> {
+        return mockClient;
+    };
+
+    // Use the real refresher (not our test mock) to exercise the full path
+    realCoordinator.refresherFactory = nil;
+
+    // Create credentials for this integration test
+    NSString *integrationId = [NSString stringWithFormat:@"IntegrationCreds_%u", arc4random()];
+    SFOAuthCredentials *integrationCreds = [[SFOAuthCredentials alloc] initWithIdentifier:integrationId clientId:@"IntegClientId" encrypted:YES];
+    integrationCreds.refreshToken = @"integration_refresh_token";
+    integrationCreds.accessToken = @"old_access_token";
+    integrationCreds.instanceUrl = [NSURL URLWithString:@"https://test.salesforce.com"];
+    integrationCreds.redirectUri = @"testapp://callback";
+
+    XCTestExpectation *allDone = [self expectationWithDescription:@"All concurrent refreshes completed"];
+    allDone.expectedFulfillmentCount = 5;
+
+    // Fire 5 concurrent refreshes through the coordinator
+    for (int i = 0; i < 5; i++) {
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [realCoordinator refreshSessionForCredentials:integrationCreds
+                                              completion:^(SFOAuthCredentials *updated) {
+                XCTAssertEqualObjects(updated.accessToken, @"integration_new_access_token");
+                [allDone fulfill];
+            } error:^(NSError *error) {
+                XCTFail(@"Integration refresh should not fail: %@", error);
+                [allDone fulfill];
+            }];
+        });
+    }
+
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+
+    // THE KEY ASSERTION: Only one network call was made
+    XCTAssertEqual(mockClient.accessTokenForRefreshCallCount, 1,
+                   @"Only one accessTokenForRefresh: call should have been made despite 5 concurrent callers");
+
+    // Cleanup
+    [SFUserAccountManager sharedInstance].authClient = originalFactory;
+    realCoordinator.refresherFactory = nil;
+    [integrationCreds revoke];
+}
+
+@end
+
+SFSDK_USE_DEPRECATED_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKTokenRefreshCoordinatorTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKTokenRefreshCoordinatorTests.m
@@ -95,7 +95,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 
         NSMutableDictionary *userInfo = [NSMutableDictionary new];
         [[NSNotificationCenter defaultCenter] postNotificationName:kSFNotificationUserDidRefreshToken
-                                                            object:self
+                                                            object:[SFUserAccountManager sharedInstance]
                                                           userInfo:userInfo];
         if (completionBlock) {
             completionBlock(self.credentials);
@@ -584,6 +584,9 @@ SFSDK_USE_DEPRECATED_BEGIN
 
     [self waitForExpectationsWithTimeout:5.0 handler:nil];
 
+    // Guard: verify the mock was actually exercised (not vacuously passing)
+    XCTAssertGreaterThan(mockClient.accessTokenForRefreshCallCount, 0,
+                         @"Mock authClient was never called — the test is not exercising the intended path");
     // THE KEY ASSERTION: Only one network call was made
     XCTAssertEqual(mockClient.accessTokenForRefreshCallCount, 1,
                    @"Only one accessTokenForRefresh: call should have been made despite 5 concurrent callers");


### PR DESCRIPTION
- Adds a layer to coordinate token refreshes so that only a single refresh is requested at a time across `SFRestAPI`,  `SFIdentityCoordinator` and `SFUserAccountManager`
- Consumers calling refresh directly should go through `SFUserAccountManager`
- Deprecates `SFOAuthSessionRefresher` so that it will be internal only in the future