### PR TITLE
ci: run all UI tests on PR when AuthFlowTester changes

### DIFF
--- a/.github/DangerFiles/TestOrchestrator.rb
+++ b/.github/DangerFiles/TestOrchestrator.rb
@@ -24,3 +24,9 @@ modifed_libs.add(SCHEMES[2]) if modifed_libs.empty?
 # Set Github Job output so we know which tests to run
 json_libs = modifed_libs.map { |l| "'#{l}'"}.join(", ")
 `echo "libs=[#{json_libs}]" >> $GITHUB_OUTPUT`
+
+# Detect AuthFlowTester changes — if any, run the full UI suite instead of the fixed PR test
+authflowtester_changed = (git.modified_files + git.added_files).any? { |f|
+  f.start_with?("native/SampleApps/AuthFlowTester/")
+}
+`echo "run_all_ui_tests=#{authflowtester_changed}" >> $GITHUB_OUTPUT`

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,6 +83,7 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/.github/DangerFiles/Gemfile
     outputs:
       libs: ${{ steps.test-orchestrator.outputs.libs }}
+      run_all_ui_tests: ${{ steps.test-orchestrator.outputs.run_all_ui_tests }}
     steps:
       - name: Check Write Permission
         uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d  # v2.4.0
@@ -189,6 +190,7 @@ jobs:
       is_pr: true
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      run_all_ui_tests: ${{ needs.test-orchestrator.outputs.run_all_ui_tests == 'true' }}
       pr_test: "AuthFlowTesterUITests/LegacyLoginTests/testCAOpaque_DefaultScopes_WebServerFlow"
       short_timeout: "3"
       long_timeout: "15"

--- a/.github/workflows/reusable-ui-test-workflow.yaml
+++ b/.github/workflows/reusable-ui-test-workflow.yaml
@@ -16,6 +16,11 @@ on:
         default: macos-latest
         required: false
         type: string
+      run_all_ui_tests:
+        description: "When true, ignore pr_test and run the full UI suite."
+        default: false
+        required: false
+        type: boolean
       pr_test:
         description: "Test identifier to run for PR (e.g. 'AuthFlowTesterUITests/LegacyLoginTests/testMethod'). Empty = run all tests."
         default: ""
@@ -123,6 +128,7 @@ jobs:
           fi
       - name: Run UI tests
         id: xcodebuild
+        if: ${{ !inputs.run_all_ui_tests }}
         env:
           CODE_COVERAGE: YES
           DESTINATION: ${{ steps.resolve_destination.outputs.destination }}
@@ -148,8 +154,26 @@ jobs:
             -resultBundlePath test \
             -enableCodeCoverage YES \
             | xcbeautify
+      - name: Run All UI Tests (AuthFlowTester changed in PR)
+        id: xcodebuild_all
+        if: ${{ inputs.run_all_ui_tests }}
+        env:
+          CODE_COVERAGE: YES
+          DESTINATION: ${{ steps.resolve_destination.outputs.destination }}
+          TEST_RUNNER_UI_TEST_SHORT_TIMEOUT: ${{ inputs.short_timeout }}
+          TEST_RUNNER_UI_TEST_LONG_TIMEOUT: ${{ inputs.long_timeout }}
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -workspace SalesforceMobileSDK.xcworkspace \
+            -scheme AuthFlowTester \
+            -testPlan AuthFlowTester \
+            -destination "$DESTINATION" \
+            -resultBundlePath test \
+            -enableCodeCoverage YES \
+            | xcbeautify
       - name: Archive xcodebuild logs on build failure
-        if: failure() && steps.xcodebuild.outcome == 'failure'
+        if: failure() && (steps.xcodebuild.outcome == 'failure' || steps.xcodebuild_all.outcome == 'failure')
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: xcodebuild-logs-authflowtester-ui-ios${{ inputs.ios }}-${{ steps.result_suffix.outputs.suffix }}


### PR DESCRIPTION
## What

When a PR modifies anything under `native/SampleApps/AuthFlowTester/`, the full UI suite runs instead of the single fixed smoke test.

**How it works:**
- `TestOrchestrator.rb` detects changes under `native/SampleApps/AuthFlowTester/` and emits `run_all_ui_tests=true`
- `pr.yaml` wires that output through `test-orchestrator` → `ui-tests-pr` via the new `run_all_ui_tests` input
- `reusable-ui-test-workflow.yaml` adds a `run_all_ui_tests` boolean input:
  - `false` (default): existing "Run UI tests" step runs with `pr_test` filter (single smoke test)
  - `true`: new "Run All UI Tests" step runs with no `-only-testing` filter (full suite)

This mirrors the equivalent change already merged on Android (#2941 + #2942).

## Testing

Validated with `actionlint` — no errors on `pr.yaml` and `reusable-ui-test-workflow.yaml`.

Note: `pull_request_target` cannot be triggered within a personal fork (it only fires on cross-repo PRs), so live CI validation was not possible on the fork. The `actionlint` clean pass is equivalent to the signal we had before merging the Android fix.