### PR TITLE
W-23212499: Fix iOS 18 / Xcode 16 CI jobs broken by macos-latest → macOS 26 migration

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -21,6 +21,7 @@ jobs:
             xcode: ^26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-test-workflow.yaml
     permissions:
       contents: read
@@ -29,6 +30,7 @@ jobs:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
     secrets:
       TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -44,6 +46,7 @@ jobs:
             xcode: ^26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-build-workflow.yaml
     permissions:
       contents: read
@@ -51,3 +54,4 @@ jobs:
       app: ${{ matrix.app }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -137,6 +137,7 @@ jobs:
             xcode: ^26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-test-workflow.yaml
     permissions:
       contents: read
@@ -145,6 +146,7 @@ jobs:
       lib: ${{ matrix.lib }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
       is_pr: true
     secrets:
       TEST_CREDENTIALS: ${{ secrets.TEST_CREDENTIALS }}
@@ -162,6 +164,7 @@ jobs:
             xcode: ^26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-build-workflow.yaml
     permissions:
       contents: read
@@ -169,6 +172,7 @@ jobs:
       app: ${{ matrix.app }}
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
       is_pr: true
 
   ui-tests-pr:
@@ -182,6 +186,7 @@ jobs:
             xcode: ^26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-ui-test-workflow.yaml
     permissions:
       contents: read
@@ -190,6 +195,7 @@ jobs:
       is_pr: true
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
       run_all_ui_tests: ${{ needs.test-orchestrator.outputs.run_all_ui_tests == 'true' }}
       pr_test: "AuthFlowTesterUITests/LegacyLoginTests/testCAOpaque_DefaultScopes_WebServerFlow"
       short_timeout: "3"

--- a/.github/workflows/ui-test-nightly.yaml
+++ b/.github/workflows/ui-test-nightly.yaml
@@ -19,6 +19,7 @@ jobs:
             xcode: ^26
           - ios: ^18
             xcode: ^16
+            macos: macos-15
     uses: ./.github/workflows/reusable-ui-test-workflow.yaml
     permissions:
       contents: read
@@ -26,6 +27,7 @@ jobs:
     with:
       ios: ${{ matrix.ios }}
       xcode: ${{ matrix.xcode }}
+      macos: ${{ matrix.macos }}
       short_timeout: "3"
       long_timeout: "15"
     secrets:


### PR DESCRIPTION
## Summary

- GitHub migrated `macos-latest` to macOS 26 on June 15, 2026, which no longer ships Xcode 16 or iOS 18 simulators.
- Jobs using `ios: ^18` / `xcode: ^16` were failing because they landed on macOS 26 via `macos-latest`.
- Added `macos: macos-15` to the `^18`/`^16` matrix `include` entry in all three caller workflows, and threaded `macos: ${{ matrix.macos }}` through to the reusable workflow `with:` blocks.
- The `^26`/`^26` entries are left unchanged — they should continue using `macos-latest` (now macOS 26).
- The reusable workflow files are not modified; they already accept `macos` as an optional input with `default: macos-latest`.

## Files changed

- `.github/workflows/pr.yaml` — jobs: `ios-pr`, `native-samples-pr`, `ui-tests-pr`
- `.github/workflows/nightly.yaml` — jobs: `ios-nightly`, `native-samples-nightly`
- `.github/workflows/ui-test-nightly.yaml` — job: `ios-ui-test-nightly`

## Test plan

- [ ] Verify PR CI (`ios-pr`, `native-samples-pr`, `ui-tests-pr`) picks up `macos-15` runner for the `^18`/`^16` matrix leg
- [ ] Verify `^26`/`^26` matrix leg still runs on `macos-latest`
- [ ] Confirm nightly run succeeds after merge