### PR TITLE
Fix thread-safety race on SFUserAccount.notificationTypes

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		CE7F662B1E556CA800DC3FBB /* SFNetwork.h in Headers */ = {isa = PBXBuildFile; fileRef = CE7F66291E556CA800DC3FBB /* SFNetwork.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE7F662C1E556CA800DC3FBB /* SFNetwork.m in Sources */ = {isa = PBXBuildFile; fileRef = CE7F662A1E556CA800DC3FBB /* SFNetwork.m */; };
 		CE81A9C81E9C26F900F3D0AD /* SFUserAccountManagerNotificationsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE81A9C61E9C26EF00F3D0AD /* SFUserAccountManagerNotificationsTests.m */; };
+		42996EA8CCEB33EF9E258033 /* SFUserAccountThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB0265069ECCAE8F59F5CD0 /* SFUserAccountThreadSafetyTests.swift */; };
 		CE88BD521D17065C00AE3BF7 /* SFSDKAILTNPublisher.h in Headers */ = {isa = PBXBuildFile; fileRef = CE88BD4F1D17065B00AE3BF7 /* SFSDKAILTNPublisher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE88BD531D17065C00AE3BF7 /* SFSDKAILTNPublisher.m in Sources */ = {isa = PBXBuildFile; fileRef = CE88BD501D17065C00AE3BF7 /* SFSDKAILTNPublisher.m */; };
 		CE88BD541D17065C00AE3BF7 /* SFSDKAnalyticsPublisher.h in Headers */ = {isa = PBXBuildFile; fileRef = CE88BD511D17065C00AE3BF7 /* SFSDKAnalyticsPublisher.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -933,6 +934,7 @@
 		CE7F66291E556CA800DC3FBB /* SFNetwork.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFNetwork.h; sourceTree = "<group>"; };
 		CE7F662A1E556CA800DC3FBB /* SFNetwork.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFNetwork.m; sourceTree = "<group>"; };
 		CE81A9C61E9C26EF00F3D0AD /* SFUserAccountManagerNotificationsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFUserAccountManagerNotificationsTests.m; path = SalesforceSDKCoreTests/SFUserAccountManagerNotificationsTests.m; sourceTree = SOURCE_ROOT; };
+		0DB0265069ECCAE8F59F5CD0 /* SFUserAccountThreadSafetyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SFUserAccountThreadSafetyTests.swift; path = SalesforceSDKCoreTests/SFUserAccountThreadSafetyTests.swift; sourceTree = SOURCE_ROOT; };
 		CE88BD4F1D17065B00AE3BF7 /* SFSDKAILTNPublisher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFSDKAILTNPublisher.h; path = Analytics/SFSDKAILTNPublisher.h; sourceTree = "<group>"; };
 		CE88BD501D17065C00AE3BF7 /* SFSDKAILTNPublisher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFSDKAILTNPublisher.m; path = Analytics/SFSDKAILTNPublisher.m; sourceTree = "<group>"; };
 		CE88BD511D17065C00AE3BF7 /* SFSDKAnalyticsPublisher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFSDKAnalyticsPublisher.h; path = Analytics/SFSDKAnalyticsPublisher.h; sourceTree = "<group>"; };
@@ -1116,6 +1118,7 @@
 				CE81A9C61E9C26EF00F3D0AD /* SFUserAccountManagerNotificationsTests.m */,
 				B7E8A2AE1E77062E007C0D92 /* SFUserAccountManagerPersisterTests.m */,
 				4F06AF721C49A16A00F70798 /* SFUserAccountManagerTests.m */,
+				0DB0265069ECCAE8F59F5CD0 /* SFUserAccountThreadSafetyTests.swift */,
 				B7E8A2B01E770A57007C0D92 /* SFUserAccountPersisterEphemeral.h */,
 				B7E8A2B11E770A57007C0D92 /* SFUserAccountPersisterEphemeral.m */,
 				FDD7D7A0232039D000F5FB2D /* SFUserAccountPhotoTests.m */,
@@ -2218,6 +2221,7 @@
 				4F3ECD8C2EBBD182005020A6 /* SFOAuthInfoTests.m in Sources */,
 				4F7EB4161BFFC8D700768720 /* SDKCommonNSDataTests.m in Sources */,
 				CE81A9C81E9C26F900F3D0AD /* SFUserAccountManagerNotificationsTests.m in Sources */,
+				42996EA8CCEB33EF9E258033 /* SFUserAccountThreadSafetyTests.swift in Sources */,
 				23F200AC2E551C890091C5F5 /* ActionTypeTests.swift in Sources */,
 				4FAUTHFLOW001234567890ABC /* AuthFlowTypesViewTests.swift in Sources */,
 				23F200AE2E551C890091C5F5 /* BootconfigTests.swift in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.m
@@ -145,11 +145,17 @@ NSString * const kUserAccountPhotoEncryptionKeyLabel = @"com.salesforce.userAcco
 
 
 - (NSArray<NotificationType *> *)notificationTypes {
-    return _notificationTypes;
+    __block NSArray<NotificationType *> *types = nil;
+    dispatch_sync(_syncQueue, ^{
+        types = self->_notificationTypes;
+    });
+    return types;
 }
 
 - (void)setNotificationTypes:(NSArray<NotificationType *> *)notificationTypes {
-    _notificationTypes = [notificationTypes copy];
+    dispatch_barrier_async(_syncQueue, ^{
+        self->_notificationTypes = [notificationTypes copy];
+    });
 }
 
 - (NSString *)userPhotoDirectory {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountThreadSafetyTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountThreadSafetyTests.swift
@@ -1,0 +1,164 @@
+/*
+ Copyright (c) 2017-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+@testable import SalesforceSDKCore
+
+class UserAccountThreadSafetyTests: XCTestCase {
+    var account: UserAccount!
+    var poolA: [NotificationType]!
+    var poolB: [NotificationType]!
+
+    override func setUp() {
+        super.setUp()
+
+        let credentials = OAuthCredentials(identifier: "thread-safety-test", clientId: "test-client-id", encrypted: true)!
+        credentials.userId = "005R0000000ThreadSafety"
+        credentials.organizationId = "00D000000ThreadSafety"
+        credentials.identityUrl = URL(string: "https://login.salesforce.com/id/00D000000ThreadSafety/005R0000000ThreadSafety")
+        account = UserAccount(credentials: credentials)
+
+        poolA = (0..<50).map { i in
+            NotificationType(type: "type-A-\(i)", apiName: "TypeA\(i)", label: "Type A \(i)", actionGroups: nil)
+        }
+
+        poolB = (0..<50).map { i in
+            NotificationType(type: "type-B-\(i)", apiName: "TypeB\(i)", label: "Type B \(i)", actionGroups: nil)
+        }
+    }
+
+    override func tearDown() {
+        account = nil
+        poolA = nil
+        poolB = nil
+        super.tearDown()
+    }
+
+    func test_notificationTypes_concurrent_reads_and_writes_do_not_crash() {
+        let group = DispatchGroup()
+        let queue = DispatchQueue.global(qos: .userInitiated)
+
+        for _ in 0..<8 {
+            group.enter()
+            queue.async {
+                for i in 0..<10000 {
+                    self.account.notificationTypes = (i % 2 == 0) ? self.poolA : self.poolB
+                }
+                group.leave()
+            }
+
+            group.enter()
+            queue.async {
+                for _ in 0..<10000 {
+                    let snapshot = self.account.notificationTypes
+                    _ = snapshot?.count
+                }
+                group.leave()
+            }
+        }
+
+        let result = group.wait(timeout: .now() + 30)
+        XCTAssertEqual(.success, result, "Concurrent reads and writes timed out")
+    }
+
+    func test_setNotificationTypes_takes_a_snapshot() {
+        var mutableArray: [NotificationType] = []
+
+        let type1 = NotificationType(type: "type1", apiName: "Type1", label: "Type One", actionGroups: nil)
+        let type2 = NotificationType(type: "type2", apiName: "Type2", label: "Type Two", actionGroups: nil)
+        mutableArray.append(type1)
+        mutableArray.append(type2)
+
+        account.notificationTypes = mutableArray
+
+        let snapshotAfterSet = account.notificationTypes
+        XCTAssertEqual(snapshotAfterSet?.count, 2)
+
+        let type3 = NotificationType(type: "type3", apiName: "Type3", label: "Type Three", actionGroups: nil)
+        mutableArray.append(type3)
+
+        let snapshotAfterMutate = account.notificationTypes
+        XCTAssertEqual(snapshotAfterMutate?.count, 2, "Snapshot should remain unchanged after external mutation")
+    }
+
+    func test_notificationTypes_returns_assigned_value_after_drain() {
+        let arrayA = [NotificationType(type: "approval", apiName: "Approval", label: "Approval Request", actionGroups: nil)]
+
+        account.notificationTypes = arrayA
+        let readA = account.notificationTypes
+        XCTAssertEqual(readA?.count, arrayA.count)
+        XCTAssertEqual(readA?.first?.type, arrayA.first?.type)
+
+        let arrayB = [
+            NotificationType(type: "task", apiName: "Task", label: "Task Assignment", actionGroups: nil),
+            NotificationType(type: "case", apiName: "Case", label: "Case Update", actionGroups: nil)
+        ]
+
+        account.notificationTypes = arrayB
+        let readB = account.notificationTypes
+        XCTAssertEqual(readB?.count, arrayB.count)
+        XCTAssertEqual(readB?.first?.type, arrayB.first?.type)
+    }
+
+    func test_encodeWithCoder_under_contention_does_not_throw() {
+        let group = DispatchGroup()
+        let queue = DispatchQueue.global(qos: .userInitiated)
+
+        group.enter()
+        queue.async {
+            for i in 0..<5000 {
+                self.account.notificationTypes = (i % 2 == 0) ? self.poolA : self.poolB
+            }
+            group.leave()
+        }
+
+        var lastEncodedData: Data?
+
+        for _ in 0..<500 {
+            do {
+                let data = try NSKeyedArchiver.archivedData(withRootObject: account!, requiringSecureCoding: true)
+                XCTAssertFalse(data.isEmpty, "Encode should succeed under contention")
+                lastEncodedData = data
+            } catch {
+                XCTFail("Encode should not throw exception: \(error)")
+            }
+        }
+
+        let result = group.wait(timeout: .now() + 30)
+        XCTAssertEqual(.success, result, "Background write thread timed out")
+
+        if let data = lastEncodedData {
+            do {
+                let decoded = try NSKeyedUnarchiver.unarchivedObject(ofClass: UserAccount.self, from: data)
+                XCTAssertNotNil(decoded, "Should decode last encoded account")
+
+                if let types = decoded?.notificationTypes {
+                    XCTAssertFalse(types.isEmpty, "Decoded notificationTypes should not be empty under contention")
+                }
+            } catch {
+                XCTFail("Decode should not error: \(error)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`SFUserAccount.notificationTypes` is the only mutable property on `SFUserAccount` whose getter and setter touch the backing ivar directly without synchronization. Every other property on this class (`accessScopes`, `idData`, `credentials`, `accountIdentity`, `photo`, `customData`, `featureFlags`) routes through a private concurrent `_syncQueue` (`dispatch_sync` for reads, `dispatch_barrier_async` for writes), and `encodeWithCoder:` itself already reads `_notificationTypes` from inside that queue. The accessors were the gap.

When two callers write `account.notificationTypes` concurrently — or one writes while another reads — the previously assigned `NSArray` can be released twice or read mid-deallocation, producing `EXC_BAD_ACCESS (KERN_INVALID_ADDRESS)` inside `swift_arrayDestroy` / `_ContiguousArrayStorage.__deallocating_deinit`.

### Fix

In `libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccount.m`:

- `- (NSArray<NotificationType *> *)notificationTypes` now reads through `dispatch_sync(_syncQueue, ...)` with `__block` capture — matches the existing `accountIdentity` getter.
- `- (void)setNotificationTypes:` now writes through `dispatch_barrier_async(_syncQueue, ...)` with `[notificationTypes copy]` preserved inside the barrier block — matches the existing `setAccessScopes:` setter.

No public API change. `SFUserAccount.h` is unchanged. NSSecureCoding archive layout is unchanged. The fix is internal to `SFUserAccount.m`.

### Test coverage

Added `libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountThreadSafetyTests.swift` with four XCTests:

- `test_notificationTypes_concurrent_reads_and_writes_do_not_crash` — 8 writer + 8 reader threads × 10,000 iterations each, 30 s timeout.
- `test_setNotificationTypes_takes_a_snapshot` — assigns an array, mutates the source, asserts snapshot unchanged (verifies the `[copy]` semantics survive).
- `test_notificationTypes_returns_assigned_value_after_drain` — sequential assign / read pairs confirm the barrier-async write drains in order.
- `test_encodeWithCoder_under_contention_does_not_throw` — 5,000 background writes interleaved with 500 `NSKeyedArchiver` encodes; decode must succeed and yield a non-empty array.

All four tests pass on `iPhone 16` simulator (iOS 18.6).

## Test plan

- [x] `xcodebuild test -workspace SalesforceMobileSDK.xcworkspace -scheme SalesforceSDKCore -only-testing:SalesforceSDKCoreTests/UserAccountThreadSafetyTests` — 4/4 PASS.
- [x] Targeted regression sweep on `SFUserAccount*` and `PushNotificationManager*` test classes — no new failures.
- [ ] Address Sanitizer pass on the new test class (recommended pre-merge).
- [ ] Thread Sanitizer pass on the new test class (recommended pre-merge).