### PR TITLE
feat(W-23195020): register RT per-user flag on Refresh Token Rotation detection

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.h
@@ -43,6 +43,7 @@ extern NSString * const kSFAppFeatureAiltnEnabled;
 extern NSString * const kSFSPAppFeatureIDPLogin;
 extern NSString * const kSFIDPAppFeatureIDPLogin;
 extern NSString * const kSFAppFeatureQrCodeLogin;
+extern NSString * const kSFAppFeatureRTR;
 
 /**
  Class to register and unregister feature markers associated with SDK facilities being used in

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.m
@@ -41,6 +41,7 @@ NSString * const kSFAppFeatureAiltnEnabled = @"AI";
 NSString * const kSFSPAppFeatureIDPLogin = @"SP";
 NSString * const kSFIDPAppFeatureIDPLogin = @"IP";
 NSString * const kSFAppFeatureQrCodeLogin = @"QR";
+NSString * const kSFAppFeatureRTR = @"RT";
 
 static NSMutableSet<NSString *> *SFSDKAppFeatureMarkersSet = nil;
 static dispatch_queue_t SFSDKAppFeatureDispatchQueue = nil;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -27,6 +27,7 @@
 #import "SFOAuthCredentials+Internal.h"
 #import "SFOAuthInfo.h"
 #import "SFSDKOAuth2.h"
+#import "SFSDKAppFeatureMarkers.h"
 
 @interface SFOAuthSessionRefresher()
 
@@ -90,9 +91,21 @@
         if (response.hasError) {
             [strongSelf completeWithError:response.error.error];
         } else {
+            NSString *oldRefreshToken = strongSelf.credentials.refreshToken;
             [strongSelf.credentials updateCredentials:[response asDictionary]];
             if (response.additionalOAuthFields)
                 strongSelf.credentials.additionalOAuthFields = response.additionalOAuthFields;
+
+            // Detect Refresh Token Rotation: server sent a new, different refresh token
+            if (strongSelf.credentials.refreshToken.length > 0
+                && ![strongSelf.credentials.refreshToken isEqualToString:oldRefreshToken]) {
+                SFUserAccount *account = [[SFUserAccountManager sharedInstance]
+                                           accountForCredentials:strongSelf.credentials];
+                if (account) {
+                    [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureRTR forUser:account];
+                }
+            }
+
             [strongSelf completeWithSuccess];
         }
     }];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
@@ -28,6 +28,31 @@
 #import "SFOAuthCoordinator+Internal.h"
 #import "SFUserAccount+Internal.h"
 #import "SFOAuthCredentials+Internal.h"
+#import "SFSDKOAuth2+Internal.h"
+#import "SFSDKAppFeatureMarkers.h"
+#import "SFSDKOAuthConstants.h"
+
+// Expose the private initializer used in production code.
+@interface SFSDKOAuthTokenEndpointResponse ()
+- (instancetype)initWithDictionary:(NSDictionary *)nvPairs parseAdditionalFields:(NSArray<NSString *> *)additionalOAuthParameterKeys;
+@end
+
+// Minimal SFSDKOAuthProtocol stub that immediately calls the completion block with a preset response.
+@interface SFSDKOAuthClientStub : NSObject <SFSDKOAuthProtocol>
+@property (nonatomic, strong) SFSDKOAuthTokenEndpointResponse *stubbedResponse;
+@end
+
+@implementation SFSDKOAuthClientStub
+- (void)accessTokenForRefresh:(SFSDKOAuthTokenEndpointRequest *)endpointReq
+                   completion:(void (^)(SFSDKOAuthTokenEndpointResponse *))completionBlock {
+    completionBlock(self.stubbedResponse);
+}
+- (void)accessTokenForApprovalCode:(SFSDKOAuthTokenEndpointRequest *)endpointReq
+                        completion:(void (^)(SFSDKOAuthTokenEndpointResponse *))completionBlock {}
+- (void)openIDTokenForRefresh:(SFSDKOAuthTokenEndpointRequest *)endpointReq
+                   completion:(void (^)(NSString *))completionBlock {}
+- (void)revokeRefreshToken:(SFOAuthCredentials *)credentials reason:(SFLogoutReason)reason {}
+@end
 
 @interface SFOAuthSessionRefresherTests : XCTestCase
 
@@ -123,6 +148,87 @@
     }];
 }
 
+- (void)test_givenRotatedRefreshToken_whenRefreshSucceeds_thenRTFlagRegisteredPerUser {
+    // Arrange: register a user account whose credentials match the refresher's.
+    SFOAuthCredentials *creds = self.oauthSessionRefresher.credentials;
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    [[SFUserAccountManager sharedInstance] saveAccountForUser:account error:nil];
+
+    NSString *newRefreshToken = [NSString stringWithFormat:@"rotated_token_%u", arc4random()];
+    NSDictionary *responseDict = @{
+        kSFOAuthAccessToken: @"new_access_token",
+        kSFOAuthRefreshToken: newRefreshToken,
+    };
+    SFSDKOAuthTokenEndpointResponse *response = [[SFSDKOAuthTokenEndpointResponse alloc]
+                                                  initWithDictionary:responseDict
+                                                  parseAdditionalFields:nil];
+    SFSDKOAuthClientStub *stub = [[SFSDKOAuthClientStub alloc] init];
+    stub.stubbedResponse = response;
+    SFAuthClientFactoryBlock originalFactory = [SFUserAccountManager sharedInstance].authClient;
+    [SFUserAccountManager sharedInstance].authClient = ^{ return stub; };
+
+    // Pre-condition: RT flag not set
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureRTR forUser:account];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Refresh with rotated token"];
+    [self.oauthSessionRefresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
+        [expectation fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Refresh should not fail: %@", error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+
+    // Assert: RT flag registered for the user
+    NSSet *features = [SFSDKAppFeatureMarkers appFeaturesForUser:account];
+    XCTAssertTrue([features containsObject:kSFAppFeatureRTR],
+                  @"RT flag should be registered after refresh token rotation");
+
+    // Cleanup
+    [SFUserAccountManager sharedInstance].authClient = originalFactory;
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureRTR forUser:account];
+    [[SFUserAccountManager sharedInstance] deleteAccountForUser:account error:nil];
+}
+
+- (void)test_givenUnchangedRefreshToken_whenRefreshSucceeds_thenRTFlagNotRegistered {
+    // Arrange: same refresh token in response — no rotation
+    SFOAuthCredentials *creds = self.oauthSessionRefresher.credentials;
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
+    [[SFUserAccountManager sharedInstance] saveAccountForUser:account error:nil];
+
+    NSDictionary *responseDict = @{
+        kSFOAuthAccessToken: @"new_access_token",
+        kSFOAuthRefreshToken: creds.refreshToken,  // same token — no rotation
+    };
+    SFSDKOAuthTokenEndpointResponse *response = [[SFSDKOAuthTokenEndpointResponse alloc]
+                                                  initWithDictionary:responseDict
+                                                  parseAdditionalFields:nil];
+    SFSDKOAuthClientStub *stub = [[SFSDKOAuthClientStub alloc] init];
+    stub.stubbedResponse = response;
+    SFAuthClientFactoryBlock originalFactory = [SFUserAccountManager sharedInstance].authClient;
+    [SFUserAccountManager sharedInstance].authClient = ^{ return stub; };
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Refresh without rotation"];
+    [self.oauthSessionRefresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
+        [expectation fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Refresh should not fail: %@", error);
+        [expectation fulfill];
+    }];
+
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+
+    // Assert: RT flag NOT registered
+    NSSet *features = [SFSDKAppFeatureMarkers appFeaturesForUser:account];
+    XCTAssertFalse([features containsObject:kSFAppFeatureRTR],
+                   @"RT flag should not be registered when refresh token did not rotate");
+
+    // Cleanup
+    [SFUserAccountManager sharedInstance].authClient = originalFactory;
+    [[SFUserAccountManager sharedInstance] deleteAccountForUser:account error:nil];
+}
+
 #pragma mark - Private methods
 
 - (void)setupCoordinatorFlow {
@@ -135,6 +241,10 @@
     creds.instanceUrl = [NSURL URLWithString:@"https://cs1.salesforce.com"];
     creds.accessToken = credsAccessToken;
     creds.refreshToken = credsRefreshToken;
+    // Set userId and orgId as valid 15-char Salesforce entity IDs so matchesCredentials: can compare them.
+    // (sfsdk_entityId18 returns nil for non-conforming strings, making isEqualToString:nil == NO.)
+    creds.userId = @"005000000000001";
+    creds.organizationId = @"00D000000000001";
     self.oauthSessionRefresher = [[SFOAuthSessionRefresher alloc] initWithCredentials:creds];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAppFeatureMarkersTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAppFeatureMarkersTests.m
@@ -59,6 +59,7 @@
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureSafariBrowserForLogin forUser:self.userA];
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureWelcomeDiscovery forUser:self.userA];
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureQrCodeLogin forUser:self.userA];
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureRTR forUser:self.userA];
     self.userA = nil;
     self.userB = nil;
     [self clearExistingMarkers];
@@ -272,6 +273,27 @@
 
     XCTAssertFalse([[SFSDKAppFeatureMarkers appFeaturesForUser:self.userA] containsObject:kSFAppFeatureQrCodeLogin],
                    @"QR should NOT be per-user when global QR was not set");
+}
+
+#pragma mark - Refresh Token Rotation (RTR) flag tests
+
+- (void)test_givenRTRDetected_whenRTFlagRegistered_thenFlagAppearsInPerUserFeaturesNotGlobal {
+    // Arrange: use userA as the account that experienced token rotation
+
+    // Act: simulate RTR detection registering the flag
+    [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureRTR forUser:self.userA];
+
+    // Assert: RT in per-user features (union with global)
+    NSSet *features = [SFSDKAppFeatureMarkers appFeaturesForUser:self.userA];
+    XCTAssertTrue([features containsObject:kSFAppFeatureRTR],
+                  @"RT flag should appear in per-user feature set after rotation");
+
+    // Assert: RT NOT in global-only set
+    XCTAssertFalse([[SFSDKAppFeatureMarkers appFeatures] containsObject:kSFAppFeatureRTR],
+                   @"RT flag should not bleed into global feature set");
+
+    // Cleanup
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureRTR forUser:self.userA];
 }
 
 #pragma mark - Private helpers

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -645,15 +645,22 @@ class BaseAuthFlowTester: XCTestCase {
 
         if usesWelcomeDiscovery {
             XCTAssertTrue(flagSet.contains("WD"), "User agent should contain 'WD' flag when welcome discovery is used; flags: \(flagSet), ua: \(ua)")
+        } else {
+            XCTAssertFalse(flagSet.contains("WD"), "User agent should NOT contain 'WD' flag when welcome discovery is not used; flags: \(flagSet), ua: \(ua)")
         }
 
         if isMultiUser {
             XCTAssertTrue(flagSet.contains("MU"), "User agent should contain 'MU' flag when multiple users are logged in; flags: \(flagSet), ua: \(ua)")
+        } else {
+            XCTAssertFalse(flagSet.contains("MU"), "User agent should NOT contain 'MU' flag when only one user is logged in; flags: \(flagSet), ua: \(ua)")
         }
 
         if isRtr {
             XCTAssertTrue(flagSet.contains("RT"),
                           "User agent should contain 'RT' flag after Refresh Token Rotation; flags: \(flagSet), ua: \(ua)")
+        } else {
+            XCTAssertFalse(flagSet.contains("RT"),
+                           "User agent should NOT contain 'RT' flag when Refresh Token Rotation has not occurred; flags: \(flagSet), ua: \(ua)")
         }
     }
 

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -935,12 +935,9 @@ class BaseAuthFlowTester: XCTestCase {
             )
         }
 
-        if isRtr {
-            let credentialsAfterFlag = getUserCredentials()
-            validateUserAgent(userCredentials: credentialsAfterFlag,
-                              loginHost: loginHost,
-                              isRtr: true)
-        }
+        validateUserAgent(userCredentials: credentialsAfterRefresh,
+                          loginHost: loginHost,
+                          isRtr: isRtr)
     }
     
     private func sortedScopes(_ value: String) -> String {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -609,8 +609,9 @@ class BaseAuthFlowTester: XCTestCase {
     ///   - expectAdvancedAuth: Whether advanced auth (browser-based) was used, which sets the BW flag. Defaults to `false`.
     ///   - usesWelcomeDiscovery: Whether welcome domain discovery was used. Defaults to `false`.
     ///   - isMultiUser: Whether multiple users are currently logged in. Defaults to `false`.
-    func validateUserAgent(userCredentials: UserCredentialsData, loginHost: KnownLoginHostConfig, expectAdvancedAuth: Bool = false, usesWelcomeDiscovery: Bool = false, isMultiUser: Bool = false) {
-        validateUserAgent(ua: userCredentials.userAgent, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, usesWelcomeDiscovery: usesWelcomeDiscovery, isMultiUser: isMultiUser)
+    ///   - isRtr: Whether Refresh Token Rotation is enabled, which sets the RT flag. Defaults to `false`.
+    func validateUserAgent(userCredentials: UserCredentialsData, loginHost: KnownLoginHostConfig, expectAdvancedAuth: Bool = false, usesWelcomeDiscovery: Bool = false, isMultiUser: Bool = false, isRtr: Bool = false) {
+        validateUserAgent(ua: userCredentials.userAgent, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, usesWelcomeDiscovery: usesWelcomeDiscovery, isMultiUser: isMultiUser, isRtr: isRtr)
     }
 
     /// Validates a pre-fetched user agent string. Called from validate() which already has the UA.
@@ -621,7 +622,8 @@ class BaseAuthFlowTester: XCTestCase {
     ///   - expectAdvancedAuth: Whether advanced auth (browser-based) was used, which sets the BW flag. Defaults to `false`.
     ///   - usesWelcomeDiscovery: Whether welcome domain discovery was used. Defaults to `false`.
     ///   - isMultiUser: Whether multiple users are currently logged in. Defaults to `false`.
-    private func validateUserAgent(ua: String, loginHost: KnownLoginHostConfig, expectAdvancedAuth: Bool = false, usesWelcomeDiscovery: Bool = false, isMultiUser: Bool = false) {
+    ///   - isRtr: Whether Refresh Token Rotation is enabled, which sets the RT flag. Defaults to `false`.
+    private func validateUserAgent(ua: String, loginHost: KnownLoginHostConfig, expectAdvancedAuth: Bool = false, usesWelcomeDiscovery: Bool = false, isMultiUser: Bool = false, isRtr: Bool = false) {
         XCTAssertTrue(ua.contains("SalesforceMobileSDK/"), "User agent should contain 'SalesforceMobileSDK/' prefix; got: \(ua)")
         XCTAssertTrue(ua.contains("ftr_"), "User agent should contain 'ftr_' feature flag segment; got: \(ua)")
 
@@ -647,6 +649,11 @@ class BaseAuthFlowTester: XCTestCase {
 
         if isMultiUser {
             XCTAssertTrue(flagSet.contains("MU"), "User agent should contain 'MU' flag when multiple users are logged in; flags: \(flagSet), ua: \(ua)")
+        }
+
+        if isRtr {
+            XCTAssertTrue(flagSet.contains("RT"),
+                          "User agent should contain 'RT' flag after Refresh Token Rotation; flags: \(flagSet), ua: \(ua)")
         }
     }
 
@@ -757,7 +764,7 @@ class BaseAuthFlowTester: XCTestCase {
 
         // Revoke and refresh cycle
         let userAppConfig = getAppConfig(named: userAppConfigName)
-        assertRevokeAndRefreshWorks(previousCredentials: userCredentials, isRtr: userAppConfig.isRtr)
+        assertRevokeAndRefreshWorks(previousCredentials: userCredentials, isRtr: userAppConfig.isRtr, loginHost: loginHost)
 
         // Check the oauth configuration
         _ = checkOauthConfiguration(
@@ -886,11 +893,11 @@ class BaseAuthFlowTester: XCTestCase {
     }
     
     /// Captures current credentials then performs a revoke/refresh cycle and validates the result.
-    func assertRevokeAndRefreshWorks(isRtr: Bool) {
-        assertRevokeAndRefreshWorks(previousCredentials: getUserCredentials(), isRtr: isRtr)
+    func assertRevokeAndRefreshWorks(isRtr: Bool, loginHost: KnownLoginHostConfig = .regularAuth) {
+        assertRevokeAndRefreshWorks(previousCredentials: getUserCredentials(), isRtr: isRtr, loginHost: loginHost)
     }
 
-    private func assertRevokeAndRefreshWorks(previousCredentials: UserCredentialsData, isRtr: Bool) {
+    private func assertRevokeAndRefreshWorks(previousCredentials: UserCredentialsData, isRtr: Bool, loginHost: KnownLoginHostConfig = .regularAuth) {
         // Revoke access token
         XCTAssert(mainPage.revokeAccessToken(), "Failed to revoke access token")
 
@@ -919,6 +926,13 @@ class BaseAuthFlowTester: XCTestCase {
                 credentialsAfterRefresh.refreshToken,
                 "Refresh token should not have changed (non-RTR app)"
             )
+        }
+
+        if isRtr {
+            let credentialsAfterFlag = getUserCredentials()
+            validateUserAgent(userCredentials: credentialsAfterFlag,
+                              loginHost: loginHost,
+                              isRtr: true)
         }
     }
     


### PR DESCRIPTION
## Summary

- Add `kSFAppFeatureRTR` (`@"RT"`) constant to `SFSDKAppFeatureMarkers` (`.h` + `.m`)
- In `SFOAuthSessionRefresher`, capture the old refresh token before calling `updateCredentials:`, then compare after; if the server returned a new, non-empty, different refresh token (Refresh Token Rotation), register `kSFAppFeatureRTR` per-user via `SFSDKAppFeatureMarkers`
- Add unit test `test_givenRTRDetected_whenRTFlagRegistered_thenFlagAppearsInPerUserFeaturesNotGlobal` to `SFSDKAppFeatureMarkersTests` verifying the flag appears in the per-user set and does not bleed into the global set

## Test plan

- [x] `SFSDKAppFeatureMarkersTests` — all 18 tests pass (including new RTR test)
- [x] Pre-existing full-suite failures (46) are unrelated sandbox-auth tests; not caused by this change
- [ ] Manual verification: configure a Connected App / External Client App with Refresh Token Rotation enabled and confirm `RT` appears in telemetry after a token refresh

## GUS

W-23195020