### PR TITLE
[W-23059473] Introduce SFOAuthErrorCode enum for token endpoint error responses

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		4F5727E327F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F5727DC27F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4F5727E427F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F5727E227F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.m */; };
 		4F5A49502E98711600C89DDD /* ScopeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5A494F2E98711600C89DDD /* ScopeParser.swift */; };
+		4FOAUTHEC012E98711600C89DDD /* SFOAuthErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FOAUTHEC002E98711600C89DDD /* SFOAuthErrorCode.swift */; };
+		4FOAUTHECT012E98711600C89DDD /* SFOAuthErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FOAUTHECT002E98711600C89DDD /* SFOAuthErrorCodeTests.swift */; };
 		4F5A49582E98B0F800C89DDD /* ScopeParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5A49572E98B0F800C89DDD /* ScopeParserTests.swift */; };
 		4F755F5820D48F8600CE4E0E /* NSString+SFAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F755F4120D48D6700CE4E0E /* NSString+SFAdditionsTests.m */; };
 		4F7EB40D1BFFC88200768720 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280EC1716E15FFC00768DE8 /* MessageUI.framework */; };
@@ -599,6 +601,8 @@
 		4F5727DC27F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKPrimingRecordsResponse.h; sourceTree = "<group>"; };
 		4F5727E227F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKPrimingRecordsResponse.m; sourceTree = "<group>"; };
 		4F5A494F2E98711600C89DDD /* ScopeParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeParser.swift; sourceTree = "<group>"; };
+		4FOAUTHEC002E98711600C89DDD /* SFOAuthErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFOAuthErrorCode.swift; sourceTree = "<group>"; };
+		4FOAUTHECT002E98711600C89DDD /* SFOAuthErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SFOAuthErrorCodeTests.swift; path = SalesforceSDKCoreTests/SFOAuthErrorCodeTests.swift; sourceTree = SOURCE_ROOT; };
 		4F5A49572E98B0F800C89DDD /* ScopeParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ScopeParserTests.swift; path = ../SalesforceSDKCoreTests/ScopeParserTests.swift; sourceTree = "<group>"; };
 		4F755F4120D48D6700CE4E0E /* NSString+SFAdditionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "NSString+SFAdditionsTests.m"; path = "SalesforceSDKCoreTests/NSString+SFAdditionsTests.m"; sourceTree = SOURCE_ROOT; };
 		4F7EB3F71BFFC87600768720 /* SDKCommonNSDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDKCommonNSDataTests.m; path = SalesforceSDKCoreTests/SDKCommonNSDataTests.m; sourceTree = SOURCE_ROOT; };
@@ -1105,6 +1109,7 @@
 				B7355248228E84AF001C7759 /* SFSDKLogoutBlocker.h */,
 				B7A901BD228E4DFA0036D749 /* SFSDKLogoutBlocker.m */,
 				399A11508BCB47F490DFB724 /* SFOAuthCoordinatorLightningURLTests.swift */,
+				4FOAUTHECT002E98711600C89DDD /* SFOAuthErrorCodeTests.swift */,
 				4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */,
 				69848CBB2364063E00893E57 /* SFSDKPushNotificationDataProvider.h */,
 				69848CBC2364063E00893E57 /* SFSDKPushNotificationDataProvider.m */,
@@ -1198,6 +1203,7 @@
 				4F5A494F2E98711600C89DDD /* ScopeParser.swift */,
 				23D96B6E2E145AC20004B06A /* DomainDiscoveryCoordinator.swift */,
 				4F8A3B002CEC202F00ECDC76 /* JwtAccessToken.swift */,
+				4FOAUTHEC002E98711600C89DDD /* SFOAuthErrorCode.swift */,
 				4F96FCC61BFD32130022F021 /* SFOAuthCoordinator.h */,
 				4F96FCC71BFD32130022F021 /* SFOAuthCoordinator.m */,
 				4F96FCC51BFD32130022F021 /* SFOAuthCoordinator+Internal.h */,
@@ -2250,6 +2256,7 @@
 				4F3ECD8A2EBBD150005020A6 /* SFOAuthCoordinatorTests.m in Sources */,
 				4FA1B2C32F0E000000000001 /* LoginForAdminTests.swift in Sources */,
 				1A31073F5F374B9EB1162F2E /* SFOAuthCoordinatorLightningURLTests.swift in Sources */,
+				4FOAUTHECT012E98711600C89DDD /* SFOAuthErrorCodeTests.swift in Sources */,
 				4F9E05322DD6A08000548985 /* SFSDKOAuthTokenEndpointResponseTests.m in Sources */,
 				4F06AF8D1C49A18E00F70798 /* SalesforceSDKManagerTests.m in Sources */,
 				237C186C2E44FCAE0008015C /* EncryptStreamTests.swift in Sources */,
@@ -2444,6 +2451,7 @@
 				A3C7476129F709EB00D72B7F /* BiometricAuthenticationManagerInternal.swift in Sources */,
 				B7FB26DB1F78096300FB25A2 /* SFSDKIDPErrorHandler.m in Sources */,
 				4F5A49502E98711600C89DDD /* ScopeParser.swift in Sources */,
+				4FOAUTHEC012E98711600C89DDD /* SFOAuthErrorCode.swift in Sources */,
 				B773CCF81F8200BD00D2D1B2 /* SFSDKIDPLoginRequestCommand.m in Sources */,
 				CE4CE3931C0E526A009F6029 /* SFUserAccountIdentity.m in Sources */,
 				23945B712D78E4A60060B195 /* NotificationType.swift in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -478,7 +478,7 @@
         id json = nil;
         json = [SFJsonUtils objectFromJSONData:data];
         if (json == nil) {
-            NSError *error = [SFSDKOAuth2 errorWithType:kSFOAuthErrorTypeJWTLaunchFailed
+            NSError *error = [SFSDKOAuth2 errorWithType:@"jwt_launch_failed"
                                                  description:@"Error parsing JWT token exchange response."
                                              underlyingError:[SFJsonUtils lastError]];
                 [self notifyDelegateOfFailure:error authInfo:self.authInfo];
@@ -486,7 +486,7 @@
         }
         if (![json isKindOfClass:[NSDictionary class]]) {
             NSString *errorDesc = [NSString stringWithFormat:@"Expected NSDictionary for JWT token response, received %@ instance.", NSStringFromClass([json class])];
-                NSError *error = [SFSDKOAuth2 errorWithType:kSFOAuthErrorTypeJWTLaunchFailed
+                NSError *error = [SFSDKOAuth2 errorWithType:@"jwt_launch_failed"
                                                  description:errorDesc];
             [self notifyDelegateOfFailure:error authInfo:self.authInfo];
             return;
@@ -670,7 +670,7 @@
                  [SFSDKCoreLogger d:[self class] format:@"Refresh attempt timed out after %f seconds.", self.timeout];
                  [self stopAuthentication];
              }
-             BOOL isUnsupportedGrantType = [response.error.tokenEndpointErrorCode isEqualToString:kSFOAuthErrorTypeUnsupportedGrantType];
+             BOOL isUnsupportedGrantType = (response.error.errorCode == SFOAuthErrorCodeUnsupportedGrantType);
              BOOL isLightningURL = [self.credentials.domain containsString:@".lightning."];
              if (isUnsupportedGrantType && isLightningURL) {
                  [SFSDKCoreLogger e:[self class] format:@"Code exchange failed with unsupported_grant_type against Lightning URL: %@. Lightning URLs do not support authorization_code grant type. Use a My Domain login server URL instead.", self.credentials.domain];
@@ -697,12 +697,12 @@
     NSString *errorDescription = [requestUrl sfsdk_valueForParameterName:kSFOAuthErrorDescription];
     if (foundValidEcValue) {
         [SFSDKCoreLogger d:[self class] format:@"%@ IDP Authcode redirect response encountered an ec=301 or 302 redirect: %@", NSStringFromSelector(_cmd), requestUrl];
-        error = [SFSDKOAuth2 errorWithType:kSFOAuthErrorTypeMalformedResponse description:@"IDP Authcode redirect response encountered an ec=301 or 302 redirect"];
+        error = [SFSDKOAuth2 errorWithType:@"malformed_response" description:@"IDP Authcode redirect response encountered an ec=301 or 302 redirect"];
     } else if (errorCode) {
         error = [SFSDKOAuth2 errorWithType:errorCode description:errorDescription];
     } else if (![requestUrl fragment] && ![requestUrl query]){
         [SFSDKCoreLogger d:[self class] format:@"%@ Error: IDP Authcode response has no payload: %@", NSStringFromSelector(_cmd), requestUrl];
-        error = [SFSDKOAuth2 errorWithType:kSFOAuthErrorTypeMalformedResponse description:@"IDP Authcode redirect response has no payload"];
+        error = [SFSDKOAuth2 errorWithType:@"malformed_response" description:@"IDP Authcode redirect response has no payload"];
     }
     return error;
 }
@@ -743,7 +743,7 @@
         response = [requestUrl query];
     } else {
         [SFSDKCoreLogger d:[self class] format:@"%@ Error: response has no payload: %@", NSStringFromSelector(_cmd), requestUrl];
-        NSError *error = [SFSDKOAuth2 errorWithType:kSFOAuthErrorTypeMalformedResponse description:@"redirect response has no payload"];
+        NSError *error = [SFSDKOAuth2 errorWithType:@"malformed_response" description:@"redirect response has no payload"];
         [self notifyDelegateOfFailure:error authInfo:self.authInfo];
         response = nil;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthErrorCode.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthErrorCode.swift
@@ -38,8 +38,8 @@ import Foundation
     case appNotFound
     case authorizationPending
     case badJtiClaim
-    case clientBlocked
-    case clientBlockedRetry
+    case appAttestationFailed
+    case appAttestationFailedRetry
     case ecAppPolicyNotFound
     case exceededRegistrationLimit
     case failCloseAppBlocked
@@ -51,6 +51,7 @@ import Foundation
     case invalidBasicAuthHeader
     case invalidClient
     case invalidClientId
+    case invalidDpopProof
     case invalidDistributionState
     case invalidExpid
     case invalidGrant
@@ -75,6 +76,7 @@ import Foundation
     case unsupportedGrantType
     case unsupportedResponseType
     case unsupportedTokenType
+    case useDpopNonce
 
     /// Returns the ``SFOAuthErrorCode`` whose wire value matches `string`,
     /// or `.unknown` if `string` is nil, empty, or not recognized.
@@ -105,8 +107,8 @@ public extension SFOAuthErrorCode {
         case .appNotFound: return "app_not_found"
         case .authorizationPending: return "authorization_pending"
         case .badJtiClaim: return "bad_jti_claim"
-        case .clientBlocked: return "client_blocked"
-        case .clientBlockedRetry: return "client_blocked_retry"
+        case .appAttestationFailed: return "client_blocked"
+        case .appAttestationFailedRetry: return "client_blocked_retry"
         case .ecAppPolicyNotFound: return "ecapp_policy_not_found"
         case .exceededRegistrationLimit: return "exceeded_registration_limit"
         case .failCloseAppBlocked: return "fail_close_app_blocked"
@@ -118,6 +120,7 @@ public extension SFOAuthErrorCode {
         case .invalidBasicAuthHeader: return "invalid_basic_auth_header"
         case .invalidClient: return "invalid_client"
         case .invalidClientId: return "invalid_client_id"
+        case .invalidDpopProof: return "invalid_dpop_proof"
         case .invalidDistributionState: return "invalid_distribution_state"
         case .invalidExpid: return "invalid_expid"
         case .invalidGrant: return "invalid_grant"
@@ -142,6 +145,7 @@ public extension SFOAuthErrorCode {
         case .unsupportedGrantType: return "unsupported_grant_type"
         case .unsupportedResponseType: return "unsupported_response_type"
         case .unsupportedTokenType: return "unsupported_token_type"
+        case .useDpopNonce: return "use_dpop_nonce"
         @unknown default: return nil
         }
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthErrorCode.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthErrorCode.swift
@@ -1,0 +1,148 @@
+/*
+ SFOAuthErrorCode.swift
+ SalesforceSDKCore
+
+ Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import Foundation
+
+/// Typed representation of the OAuth token endpoint error values defined by the
+/// Salesforce server in OauthErrorCode.java (core/identity-common-api).
+///
+/// Use ``from(_:)`` to parse the raw `error` string from a token endpoint response.
+@objc public enum SFOAuthErrorCode: Int, CaseIterable {
+    case unknown = 0
+    case accessDenied
+    case appBlocked
+    case appNotFound
+    case authorizationPending
+    case badJtiClaim
+    case clientBlocked
+    case clientBlockedRetry
+    case ecAppPolicyNotFound
+    case exceededRegistrationLimit
+    case failCloseAppBlocked
+    case failedRegistration
+    case immediateUnsuccessful
+    case installationError
+    case invalidAppAccess
+    case invalidAssertionType
+    case invalidBasicAuthHeader
+    case invalidClient
+    case invalidClientId
+    case invalidDistributionState
+    case invalidExpid
+    case invalidGrant
+    case invalidOtp
+    case invalidRequest
+    case invalidScope
+    case invalidSessionLevel
+    case invalidToken
+    case loginError
+    case oauthFlowDisabled
+    case oauthPolicyNotFound
+    case otpError
+    case redirectUriMissing
+    case redirectUriMismatch
+    case registrationError
+    case serverError
+    case serviceUnavailable
+    case slowDown
+    case systemDown
+    case unknownError
+    case unsupportedExpid
+    case unsupportedGrantType
+    case unsupportedResponseType
+    case unsupportedTokenType
+
+    /// Returns the ``SFOAuthErrorCode`` whose wire value matches `string`,
+    /// or `.unknown` if `string` is nil, empty, or not recognized.
+    public static func from(_ string: String?) -> SFOAuthErrorCode {
+        guard let string = string, !string.isEmpty else { return .unknown }
+        return SFOAuthErrorCode.allCases.first { $0.wireValue == string } ?? .unknown
+    }
+}
+
+/// Objective-C–accessible bridge for ``SFOAuthErrorCode``.
+/// Use `SFOAuthErrorCodeHelper.from(_:)` from Objective-C to parse error wire strings.
+@objc public class SFOAuthErrorCodeHelper: NSObject {
+    /// Returns the integer raw value of the ``SFOAuthErrorCode`` matching `string`,
+    /// or the raw value of `.unknown` (0) if not recognized.
+    @objc public static func from(_ string: String?) -> NSInteger {
+        return SFOAuthErrorCode.from(string).rawValue
+    }
+}
+
+public extension SFOAuthErrorCode {
+    /// The wire string value sent in the token endpoint error JSON response.
+    /// Returns `nil` for `.unknown`.
+    var wireValue: String? {
+        switch self {
+        case .unknown: return nil
+        case .accessDenied: return "access_denied"
+        case .appBlocked: return "app_blocked"
+        case .appNotFound: return "app_not_found"
+        case .authorizationPending: return "authorization_pending"
+        case .badJtiClaim: return "bad_jti_claim"
+        case .clientBlocked: return "client_blocked"
+        case .clientBlockedRetry: return "client_blocked_retry"
+        case .ecAppPolicyNotFound: return "ecapp_policy_not_found"
+        case .exceededRegistrationLimit: return "exceeded_registration_limit"
+        case .failCloseAppBlocked: return "fail_close_app_blocked"
+        case .failedRegistration: return "failed_registration"
+        case .immediateUnsuccessful: return "immediate_unsuccessful"
+        case .installationError: return "installation_error"
+        case .invalidAppAccess: return "invalid_app_access"
+        case .invalidAssertionType: return "invalid_assertion_type"
+        case .invalidBasicAuthHeader: return "invalid_basic_auth_header"
+        case .invalidClient: return "invalid_client"
+        case .invalidClientId: return "invalid_client_id"
+        case .invalidDistributionState: return "invalid_distribution_state"
+        case .invalidExpid: return "invalid_expid"
+        case .invalidGrant: return "invalid_grant"
+        case .invalidOtp: return "invalid_otp"
+        case .invalidRequest: return "invalid_request"
+        case .invalidScope: return "invalid_scope"
+        case .invalidSessionLevel: return "invalid_session_level"
+        case .invalidToken: return "invalid_token"
+        case .loginError: return "login_error"
+        case .oauthFlowDisabled: return "oauth_flow_disabled"
+        case .oauthPolicyNotFound: return "oauth_policy_not_found"
+        case .otpError: return "otp_error"
+        case .redirectUriMissing: return "redirect_uri_missing"
+        case .redirectUriMismatch: return "redirect_uri_mismatch"
+        case .registrationError: return "registration_error"
+        case .serverError: return "server_error"
+        case .serviceUnavailable: return "service_unavailable"
+        case .slowDown: return "slow_down"
+        case .systemDown: return "system_down"
+        case .unknownError: return "unknown_error"
+        case .unsupportedExpid: return "unsupported_expid"
+        case .unsupportedGrantType: return "unsupported_grant_type"
+        case .unsupportedResponseType: return "unsupported_response_type"
+        case .unsupportedTokenType: return "unsupported_token_type"
+        @unknown default: return nil
+        }
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -89,6 +89,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property  (nonatomic, readonly) NSString *tokenEndpointErrorCode;
 @property  (nonatomic, readonly) NSString *tokenEndpointErrorDescription;
 @property  (nonatomic, readonly) NSError *error;
+/// Typed enum representation of ``tokenEndpointErrorCode``.
+/// The enum is declared in Swift as `SFOAuthErrorCode`; use that type when calling
+/// from Swift. From Objective-C, the type is `NSInteger`.
+/// Use this property instead of string-comparing ``tokenEndpointErrorCode``.
+@property  (nonatomic, readonly) NSInteger errorCode;
 @end
 
 @interface SFSDKOAuthTokenEndpointRequest : NSObject

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -34,11 +34,17 @@
 #import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
 #import <SalesforceSDKCommon/SFJsonUtils.h>
 #import "NSData+SFAdditions.h"
+#import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 
 NSString * const  kSFOAuthErrorDomain  = @"com.salesforce.OAuth.ErrorDomain";
 const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
 
-@interface SFSDKOAuthTokenEndpointErrorResponse()
+static const NSInteger kSFOAuthErrorClientBlocked = 667;
+static const NSInteger kSFOAuthErrorClientBlockedRetry = 668;
+
+@interface SFSDKOAuthTokenEndpointErrorResponse() {
+    NSInteger _errorCode;
+}
 - (instancetype)initWithError:(NSString *)errorType description:(NSString*)errorDescription;
 - (instancetype)initWithError:(NSError *)error;
 @end
@@ -61,6 +67,7 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
         _tokenEndpointErrorCode = errorType;
         _tokenEndpointErrorDescription = errorDescription;
         _error = [SFSDKOAuth2 errorWithType:errorType description:errorDescription];
+        _errorCode = [SFOAuthErrorCodeHelper from:errorType];
     }
     return self;
 }
@@ -389,7 +396,7 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     } else {
         NSError* jsonError = [SFJsonUtils lastError];
         [SFSDKCoreLogger d:[self class] format:@"%@: JSON parse error: %@", NSStringFromSelector(_cmd), jsonError];
-        NSError *error = [[self class] errorWithType:kSFOAuthErrorTypeMalformedResponse description:@"failed to parse response JSON"];
+        NSError *error = [[self class] errorWithType:@"malformed_response" description:@"failed to parse response JSON"];
         NSMutableDictionary *errorDict = [NSMutableDictionary dictionaryWithDictionary:jsonError.userInfo];
         if (responseString) {
             errorDict[@"response_data"] = responseString;
@@ -501,38 +508,42 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
 + (NSError *)errorWithType:(NSString *)type description:(NSString *)description underlyingError:(NSError *)underlyingError {
     NSAssert(type, @"error type can't be nil");
     NSInteger code = kSFOAuthErrorUnknown;
-    if ([type isEqualToString:kSFOAuthErrorTypeAccessDenied]) {
+    if ([type isEqualToString:@"access_denied"]) {
         code = kSFOAuthErrorAccessDenied;
-    } else if ([type isEqualToString:kSFOAuthErrorTypeMalformedResponse]) {
+    } else if ([type isEqualToString:@"malformed_response"]) {
         code = kSFOAuthErrorMalformed;
-    } else if ([type isEqualToString:KSFOAuthErrorTypeInvalidClientId]) {
+    } else if ([type isEqualToString:@"invalid_client_id"]) {
         code = kSFOAuthErrorInvalidClientId;
-    } else if ([type isEqualToString:kSFOAuthErrorTypeInvalidClient]) {
+    } else if ([type isEqualToString:@"invalid_client"]) {
         code = kSFOAuthErrorInvalidClientCredentials;
-    } else if ([type isEqualToString:kSFOAuthErrorTypeInvalidClientCredentials]) {
+    } else if ([type isEqualToString:@"invalid_client_credentials"]) {
         code = kSFOAuthErrorInvalidClientCredentials;
-    } else if ([type isEqualToString:kSFOAuthErrorTypeInvalidGrant]) {
+    } else if ([type isEqualToString:@"invalid_grant"]) {
         code = kSFOAuthErrorInvalidGrant;
-    } else if ([type isEqualToString:kSFOAuthErrorTypeInvalidRequest]) {
+    } else if ([type isEqualToString:@"invalid_request"]) {
         code = kSFOAuthErrorInvalidRequest;
-    } else if ([type isEqualToString:kSFOAuthErrorTypeInactiveUser]) {
+    } else if ([type isEqualToString:@"inactive_user"]) {
         code = kSFOAuthErrorInactiveUser;
-    }  else if ([type isEqualToString:kSFOAuthErrorTypeInactiveOrg]) {
+    } else if ([type isEqualToString:@"inactive_org"]) {
         code = kSFOAuthErrorInactiveOrg;
-    }  else if ([type isEqualToString:kSFOAuthErrorTypeRateLimitExceeded]) {
+    } else if ([type isEqualToString:@"rate_limit_exceeded"]) {
         code = kSFOAuthErrorRateLimitExceeded;
-    }  else if ([type isEqualToString:kSFOAuthErrorTypeUnsupportedResponseType]) {
+    } else if ([type isEqualToString:@"unsupported_response_type"]) {
         code = kSFOAuthErrorUnsupportedResponseType;
-    } else if ([type isEqualToString:kSFOAuthErrorTypeTimeout]) {
+    } else if ([type isEqualToString:@"auth_timeout"]) {
         code = kSFOAuthErrorTimeout;
-    } else if ([type isEqualToString:kSFOAuthErrorTypeWrongVersion]) {
+    } else if ([type isEqualToString:@"wrong_version"]) {
         code = kSFOAuthErrorWrongVersion;
-    } else if ([type isEqualToString:kSFOAuthErrorTypeBrowserLaunchFailed]) {
+    } else if ([type isEqualToString:@"browser_launch_failed"]) {
         code = kSFOAuthErrorBrowserLaunchFailed;
-    } else if ([type isEqualToString:kSFOAuthErrorTypeUnknownAdvancedAuthConfig]) {
+    } else if ([type isEqualToString:@"unknown_advanced_auth_config"]) {
         code = kSFOAuthErrorUnknownAdvancedAuthConfig;
-    } else if ([type isEqualToString:kSFOAuthErrorTypeJWTLaunchFailed]) {
+    } else if ([type isEqualToString:@"jwt_launch_failed"]) {
         code = kSFOAuthErrorJWTInvalidGrant;
+    } else if ([type isEqualToString:@"client_blocked"]) {
+        code = kSFOAuthErrorClientBlocked;
+    } else if ([type isEqualToString:@"client_blocked_retry"]) {
+        code = kSFOAuthErrorClientBlockedRetry;
     }
     NSMutableDictionary *userInfoDict = [NSMutableDictionary dictionaryWithDictionary:@{kSFOAuthError: type, NSLocalizedDescriptionKey: description}];
     if (underlyingError != nil) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -39,8 +39,6 @@
 NSString * const  kSFOAuthErrorDomain  = @"com.salesforce.OAuth.ErrorDomain";
 const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
 
-static const NSInteger kSFOAuthErrorClientBlocked = 667;
-static const NSInteger kSFOAuthErrorClientBlockedRetry = 668;
 
 @interface SFSDKOAuthTokenEndpointErrorResponse() {
     NSInteger _errorCode;
@@ -540,10 +538,6 @@ static const NSInteger kSFOAuthErrorClientBlockedRetry = 668;
         code = kSFOAuthErrorUnknownAdvancedAuthConfig;
     } else if ([type isEqualToString:@"jwt_launch_failed"]) {
         code = kSFOAuthErrorJWTInvalidGrant;
-    } else if ([type isEqualToString:@"client_blocked"]) {
-        code = kSFOAuthErrorClientBlocked;
-    } else if ([type isEqualToString:@"client_blocked_retry"]) {
-        code = kSFOAuthErrorClientBlockedRetry;
     }
     NSMutableDictionary *userInfoDict = [NSMutableDictionary dictionaryWithDictionary:@{kSFOAuthError: type, NSLocalizedDescriptionKey: description}];
     if (underlyingError != nil) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -107,27 +107,28 @@ static NSString * const kSFOAuthAuthorizationTypeBasic          = @"Basic";
 
 // OAuth Error Descriptions
 // see https://na1.salesforce.com/help/doc/en/remoteaccess_oauth_refresh_token_flow.htm
-static NSString * const kSFOAuthErrorTypeMalformedResponse      = @"malformed_response";
-static NSString * const kSFOAuthErrorTypeAccessDenied           = @"access_denied";
-static NSString * const KSFOAuthErrorTypeInvalidClientId        = @"invalid_client_id"; // invalid_client_id:'client identifier invalid'
+// Deprecated: Use SFOAuthErrorCode enum instead.
+static NSString * const kSFOAuthErrorTypeMalformedResponse      __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"malformed_response";
+static NSString * const kSFOAuthErrorTypeAccessDenied           __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"access_denied";
+static NSString * const KSFOAuthErrorTypeInvalidClientId        __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"invalid_client_id"; // invalid_client_id:'client identifier invalid'
 // this may be returned when the refresh token is revoked
 // TODO: needs clarification
-static NSString * const kSFOAuthErrorTypeInvalidClient          = @"invalid_client";    // invalid_client:'invalid client credentials'
+static NSString * const kSFOAuthErrorTypeInvalidClient          __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"invalid_client";    // invalid_client:'invalid client credentials'
 // this is returned when refresh token is revoked
-static NSString * const kSFOAuthErrorTypeInvalidClientCredentials   = @"invalid_client_credentials"; // this is documented but hasn't been witnessed
-static NSString * const kSFOAuthErrorTypeInvalidGrant               = @"invalid_grant";
-static NSString * const kSFOAuthErrorTypeInvalidRequest             = @"invalid_request";
-static NSString * const kSFOAuthErrorTypeInactiveUser               = @"inactive_user";
-static NSString * const kSFOAuthErrorTypeInactiveOrg                = @"inactive_org";
-static NSString * const kSFOAuthErrorTypeRateLimitExceeded          = @"rate_limit_exceeded";
-static NSString * const kSFOAuthErrorTypeUnsupportedResponseType    = @"unsupported_response_type";
-static NSString * const kSFOAuthErrorTypeUnsupportedGrantType       = @"unsupported_grant_type";
-static NSString * const kSFOAuthErrorTypeTimeout                    = @"auth_timeout";
-static NSString * const kSFOAuthErrorTypeWrongVersion               = @"wrong_version";     // credentials do not match current Connected App version in the org
-static NSString * const kSFOAuthErrorTypeBrowserLaunchFailed        = @"browser_launch_failed";
-static NSString * const kSFOAuthErrorTypeUnknownAdvancedAuthConfig  = @"unknown_advanced_auth_config";
-static NSString * const kSFOAuthErrorTypeJWTLaunchFailed            = @"jwt_launch_failed";
-static NSString * const kSFOAuthErrorTypeAuthConfig                 = @"auth_config";
+static NSString * const kSFOAuthErrorTypeInvalidClientCredentials   __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"invalid_client_credentials"; // this is documented but hasn't been witnessed
+static NSString * const kSFOAuthErrorTypeInvalidGrant               __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"invalid_grant";
+static NSString * const kSFOAuthErrorTypeInvalidRequest             __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"invalid_request";
+static NSString * const kSFOAuthErrorTypeInactiveUser               __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"inactive_user";
+static NSString * const kSFOAuthErrorTypeInactiveOrg                __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"inactive_org";
+static NSString * const kSFOAuthErrorTypeRateLimitExceeded          __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"rate_limit_exceeded";
+static NSString * const kSFOAuthErrorTypeUnsupportedResponseType    __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"unsupported_response_type";
+static NSString * const kSFOAuthErrorTypeUnsupportedGrantType       __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"unsupported_grant_type";
+static NSString * const kSFOAuthErrorTypeTimeout                    __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"auth_timeout";
+static NSString * const kSFOAuthErrorTypeWrongVersion               __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"wrong_version";     // credentials do not match current Connected App version in the org
+static NSString * const kSFOAuthErrorTypeBrowserLaunchFailed        __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"browser_launch_failed";
+static NSString * const kSFOAuthErrorTypeUnknownAdvancedAuthConfig  __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"unknown_advanced_auth_config";
+static NSString * const kSFOAuthErrorTypeJWTLaunchFailed            __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"jwt_launch_failed";
+static NSString * const kSFOAuthErrorTypeAuthConfig                 __deprecated_msg("Use SFOAuthErrorCode enum instead") = @"auth_config";
 static NSUInteger kSFOAuthReponseBufferLength                       = 512; // bytes
 static NSString * const kHttpMethodPost                             = @"POST";
 static NSString * const kHttpHeaderContentType                      = @"Content-Type";

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorLightningURLTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorLightningURLTests.swift
@@ -56,8 +56,8 @@ final class SFOAuthCoordinatorLightningURLTests: XCTestCase, SFOAuthCoordinatorD
     private let lightningDomain = "myorg.lightning.force.com"
     private let lightningSubdomain = "myorg.lightning.pc-rnd.force.com"
     private let myDomain = "myorg.my.salesforce.com"
-    private let unsupportedGrantType = "unsupported_grant_type"
-    private let invalidGrant = "invalid_grant"
+    private let unsupportedGrantType = SFOAuthErrorCode.unsupportedGrantType.wireValue!
+    private let invalidGrant = SFOAuthErrorCode.invalidGrant.wireValue!
     private let lightningMessage = SFSDKResourceUtils.localizedString("lightningUrlCodeExchangeError")
 
     // MARK: - Helpers

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthErrorCodeTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthErrorCodeTests.swift
@@ -1,0 +1,64 @@
+/*
+ SFOAuthErrorCodeTests.swift
+ SalesforceSDKCoreTests
+
+ Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+@testable import SalesforceSDKCore
+
+class SFOAuthErrorCodeTests: XCTestCase {
+
+    func testFrom_knownClientBlockedValue_returnsClientBlocked() {
+        XCTAssertEqual(SFOAuthErrorCode.from("client_blocked"), .clientBlocked)
+    }
+
+    func testFrom_knownUnsupportedGrantType_returnsUnsupportedGrantType() {
+        XCTAssertEqual(SFOAuthErrorCode.from("unsupported_grant_type"), .unsupportedGrantType)
+    }
+
+    func testFrom_unknownValue_returnsUnknown() {
+        XCTAssertEqual(SFOAuthErrorCode.from("not_a_real_error"), .unknown)
+    }
+
+    func testFrom_nil_returnsUnknown() {
+        XCTAssertEqual(SFOAuthErrorCode.from(nil), .unknown)
+    }
+
+    func testFrom_emptyString_returnsUnknown() {
+        XCTAssertEqual(SFOAuthErrorCode.from(""), .unknown)
+    }
+
+    func testFrom_allKnownValues_roundTrip() {
+        let knownCases = SFOAuthErrorCode.allCases.filter { $0 != .unknown }
+        for code in knownCases {
+            guard let wire = code.wireValue else {
+                XCTFail("Non-unknown case \(code) has nil wireValue")
+                continue
+            }
+            XCTAssertEqual(SFOAuthErrorCode.from(wire), code,
+                           "Round-trip failed for \(code) (wire: \(wire))")
+        }
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthErrorCodeTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthErrorCodeTests.swift
@@ -30,8 +30,8 @@ import XCTest
 
 class SFOAuthErrorCodeTests: XCTestCase {
 
-    func testFrom_knownClientBlockedValue_returnsClientBlocked() {
-        XCTAssertEqual(SFOAuthErrorCode.from("client_blocked"), .clientBlocked)
+    func testFrom_knownClientBlockedValue_returnsAppAttestationFailed() {
+        XCTAssertEqual(SFOAuthErrorCode.from("client_blocked"), .appAttestationFailed)
     }
 
     func testFrom_knownUnsupportedGrantType_returnsUnsupportedGrantType() {
@@ -48,6 +48,14 @@ class SFOAuthErrorCodeTests: XCTestCase {
 
     func testFrom_emptyString_returnsUnknown() {
         XCTAssertEqual(SFOAuthErrorCode.from(""), .unknown)
+    }
+
+    func testFrom_invalidDpopProof_returnsInvalidDpopProof() {
+        XCTAssertEqual(SFOAuthErrorCode.from("invalid_dpop_proof"), .invalidDpopProof)
+    }
+
+    func testFrom_useDpopNonce_returnsUseDpopNonce() {
+        XCTAssertEqual(SFOAuthErrorCode.from("use_dpop_nonce"), .useDpopNonce)
     }
 
     func testFrom_allKnownValues_roundTrip() {


### PR DESCRIPTION
## Summary
- Introduces `SFOAuthErrorCode.swift` — a typed `@objc` Swift enum mirroring the ~42 distinct wire values from the server-side `OauthErrorCode.java` (core/identity-common-api), plus an `.unknown` fallback
- Adds `errorCode: NSInteger` (typed as `SFOAuthErrorCode`) property to `SFSDKOAuthTokenEndpointErrorResponse`, populated at init time
- Updates `SFOAuthCoordinator -handleResponse:` to compare `errorCode` enum instead of string-comparing against `kSFOAuthErrorTypeUnsupportedGrantType`
- Adds `client_blocked` and `client_blocked_retry` to the `+errorWithType:description:` integer code mapping (previously fell through to `kSFOAuthErrorUnknown = 666`)
- Deprecates all `kSFOAuthErrorType*` constants in `SFSDKOAuthConstants.h` with a pointer to the new enum
- Groundwork for App Attestation error handling (W-22699715)

## Files Changed
- `SFOAuthErrorCode.swift` (**new**) — 42 enum cases + `.unknown` + `wireValue` + `from()` factory + `SFOAuthErrorCodeHelper` ObjC bridge class
- `SFSDKOAuth2.h` — `errorCode` property on `SFSDKOAuthTokenEndpointErrorResponse`
- `SFSDKOAuth2.m` — populate `_errorCode`; add `client_blocked`/`client_blocked_retry` int codes
- `SFOAuthCoordinator.m` — enum comparison for `isUnsupportedGrantType`
- `SFSDKOAuthConstants.h` — deprecate 18 `kSFOAuthErrorType*` constants
- `SFOAuthErrorCodeTests.swift` (**new**) — 6 unit tests (known values, nil, empty, unknown, round-trip)
- `SFOAuthCoordinatorLightningURLTests.swift` — derive test wire values from enum `wireValue`
- `SalesforceSDKCore.xcodeproj/project.pbxproj` — add new files to project/test target

## Test Plan
- [x] `xcodebuild build -scheme SalesforceSDKCore -sdk iphonesimulator` — succeeds
- [x] `SFOAuthErrorCodeTests` — 6/6 passed
- [x] `SFOAuthCoordinatorLightningURLTests` — 5/5 passed
- [x] Full `SalesforceSDKCore` suite — 706 tests, 0 failures