### PR TITLE
Add tests for OAuth2 token endpoint error classification

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		010A9B591CC1A147002AF4D3 /* SFCryptoStreamTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 010A9B521CC1A131002AF4D3 /* SFCryptoStreamTestUtils.m */; };
 		1A31073F5F374B9EB1162F2E /* SFOAuthCoordinatorLightningURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399A11508BCB47F490DFB724 /* SFOAuthCoordinatorLightningURLTests.swift */; };
 		230834842DF7838200C7CBF7 /* URLSessionTask+RetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230834832DF7837400C7CBF7 /* URLSessionTask+RetryPolicy.swift */; };
+		3D012B381C4D4D97BCDA30E6 /* SFSDKOAuth2TokenExchangeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4746050277064A9790E3470A /* SFSDKOAuth2TokenExchangeErrorTests.swift */; };
 		230834862DF8938D00C7CBF7 /* URLSessionTask+RetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230834852DF8938D00C7CBF7 /* URLSessionTask+RetryPolicyTests.swift */; };
 		230834882DF8A8F300C7CBF7 /* WebSocketClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230834872DF8A8F300C7CBF7 /* WebSocketClientTests.swift */; };
 		23350C562DCAB19D009A10DE /* RestClient+Blocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23350C552DCAB190009A10DE /* RestClient+Blocks.swift */; };
@@ -577,6 +578,7 @@
 		23F200AD2E551C890091C5F5 /* BootconfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BootconfigTests.swift; path = SalesforceSDKCoreTests/BootconfigTests.swift; sourceTree = SOURCE_ROOT; };
 		399A11508BCB47F490DFB724 /* SFOAuthCoordinatorLightningURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SFOAuthCoordinatorLightningURLTests.swift; path = ../SalesforceSDKCoreTests/SFOAuthCoordinatorLightningURLTests.swift; sourceTree = "<group>"; };
 		444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+SFColorsTests.m"; path = "SalesforceSDKCoreTests/UIColor+SFColorsTests.m"; sourceTree = SOURCE_ROOT; };
+		4746050277064A9790E3470A /* SFSDKOAuth2TokenExchangeErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SFSDKOAuth2TokenExchangeErrorTests.swift; path = ../SalesforceSDKCoreTests/SFSDKOAuth2TokenExchangeErrorTests.swift; sourceTree = "<group>"; };
 		4F06AF5D1C49A16A00F70798 /* NSURL+SFStringUtilsTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSURL+SFStringUtilsTests.h"; path = "SalesforceSDKCoreTests/NSURL+SFStringUtilsTests.h"; sourceTree = SOURCE_ROOT; };
 		4F06AF5E1C49A16A00F70798 /* NSURL+SFStringUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSURL+SFStringUtilsTests.m"; path = "SalesforceSDKCoreTests/NSURL+SFStringUtilsTests.m"; sourceTree = SOURCE_ROOT; };
 		4F06AF5F1C49A16A00F70798 /* SalesforceOAuthUnitTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SalesforceOAuthUnitTests.h; path = SalesforceSDKCoreTests/SalesforceOAuthUnitTests.h; sourceTree = SOURCE_ROOT; };
@@ -1110,6 +1112,7 @@
 				B7A901BD228E4DFA0036D749 /* SFSDKLogoutBlocker.m */,
 				399A11508BCB47F490DFB724 /* SFOAuthCoordinatorLightningURLTests.swift */,
 				4FOAUTHECT002E98711600C89DDD /* SFOAuthErrorCodeTests.swift */,
+				4746050277064A9790E3470A /* SFSDKOAuth2TokenExchangeErrorTests.swift */,
 				4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */,
 				69848CBB2364063E00893E57 /* SFSDKPushNotificationDataProvider.h */,
 				69848CBC2364063E00893E57 /* SFSDKPushNotificationDataProvider.m */,
@@ -2257,6 +2260,7 @@
 				4FA1B2C32F0E000000000001 /* LoginForAdminTests.swift in Sources */,
 				1A31073F5F374B9EB1162F2E /* SFOAuthCoordinatorLightningURLTests.swift in Sources */,
 				4FOAUTHECT012E98711600C89DDD /* SFOAuthErrorCodeTests.swift in Sources */,
+				3D012B381C4D4D97BCDA30E6 /* SFSDKOAuth2TokenExchangeErrorTests.swift in Sources */,
 				4F9E05322DD6A08000548985 /* SFSDKOAuthTokenEndpointResponseTests.m in Sources */,
 				4F06AF8D1C49A18E00F70798 /* SalesforceSDKManagerTests.m in Sources */,
 				237C186C2E44FCAE0008015C /* EncryptStreamTests.swift in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKOAuth2TokenExchangeErrorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKOAuth2TokenExchangeErrorTests.swift
@@ -1,0 +1,166 @@
+/*
+ SFSDKOAuth2TokenExchangeErrorTests.swift
+ SalesforceSDKCoreTests
+
+ Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+@testable import SalesforceSDKCore
+
+final class SFSDKOAuth2TokenExchangeErrorTests: XCTestCase {
+
+    // MARK: - Helper
+
+    /// Builds a response from a wire-format error dict and asserts all four
+    /// observable error fields at once. Callers pass file/line so failing
+    /// assertions carry the caller's location.
+    private func assertError(
+        wire: String,
+        description: String,
+        expectedEnum: SFOAuthErrorCode,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let params = ["error": wire, "error_description": description]
+        guard let response = SFSDKOAuthTokenEndpointResponse(dictionary: params, parseAdditionalFields: nil) else {
+            XCTFail("SFSDKOAuthTokenEndpointResponse initializer returned nil", file: file, line: line)
+            return
+        }
+
+        XCTAssertTrue(response.hasError, "response.hasError should be true", file: file, line: line)
+        XCTAssertEqual(response.error?.tokenEndpointErrorCode, wire, file: file, line: line)
+        XCTAssertEqual(response.error?.errorCode, expectedEnum.rawValue, file: file, line: line)
+        XCTAssertEqual(response.error?.tokenEndpointErrorDescription, description, file: file, line: line)
+
+        // Sanity check: response.error.error is a non-nil NSError in kSFOAuthErrorDomain
+        XCTAssertNotNil(response.error?.error, "response.error.error should be non-nil", file: file, line: line)
+        let nsError = response.error?.error as NSError?
+        XCTAssertEqual(nsError?.domain, kSFOAuthErrorDomain, file: file, line: line)
+    }
+
+    // MARK: - invalid_grant family
+    //   Invalid, expired, and redirect_uri-mismatched authorization codes all
+    //   collapse to the same client-side branch; we exercise the shared branch
+    //   three times with distinct server-provided descriptions.
+
+    func test_givenInvalidGrant_whenInitDictionary_thenClassifiedAsInvalidGrant() {
+        let wire = SFOAuthErrorCode.invalidGrant.wireValue!
+
+        // Invalid authorization code (garbage, replayed, or never issued)
+        assertError(
+            wire: wire,
+            description: "authorization code invalid",
+            expectedEnum: .invalidGrant
+        )
+
+        // Expired authorization code (>~10 min old)
+        assertError(
+            wire: wire,
+            description: "expired authorization code",
+            expectedEnum: .invalidGrant
+        )
+
+        // Mismatched redirect_uri at exchange
+        assertError(
+            wire: wire,
+            description: "redirect_uri mismatch",
+            expectedEnum: .invalidGrant
+        )
+    }
+
+    // MARK: - invalid_client_id and invalid_client
+
+    func test_givenInvalidClientId_whenInitDictionary_thenClassifiedAsInvalidClientId() {
+        let wire = SFOAuthErrorCode.invalidClientId.wireValue!
+        assertError(
+            wire: wire,
+            description: "client identifier invalid",
+            expectedEnum: .invalidClientId
+        )
+    }
+
+    func test_givenInvalidClient_whenInitDictionary_thenClassifiedAsInvalidClient() {
+        let wire = SFOAuthErrorCode.invalidClient.wireValue!
+        assertError(
+            wire: wire,
+            description: "client authentication failed",
+            expectedEnum: .invalidClient
+        )
+    }
+
+    // MARK: - unsupported_grant_type
+
+    func test_givenUnsupportedGrantType_whenInitDictionary_thenClassifiedAsUnsupportedGrantType() {
+        let wire = SFOAuthErrorCode.unsupportedGrantType.wireValue!
+        assertError(
+            wire: wire,
+            description: "grant type not supported",
+            expectedEnum: .unsupportedGrantType
+        )
+    }
+
+    // MARK: - invalid_request
+
+    func test_givenInvalidRequest_whenInitDictionary_thenClassifiedAsInvalidRequest() {
+        let wire = SFOAuthErrorCode.invalidRequest.wireValue!
+        assertError(
+            wire: wire,
+            description: "missing required parameter",
+            expectedEnum: .invalidRequest
+        )
+    }
+
+    // MARK: - Enum mapping lock-in for the five distinct wire values
+
+    func test_from_allTokenEndpointWireValues_returnCorrectEnumCase() {
+        let testCases: [(String, SFOAuthErrorCode)] = [
+            ("invalid_grant", .invalidGrant),
+            ("invalid_client_id", .invalidClientId),
+            ("invalid_client", .invalidClient),
+            ("unsupported_grant_type", .unsupportedGrantType),
+            ("invalid_request", .invalidRequest)
+        ]
+
+        for (wire, expected) in testCases {
+            XCTAssertEqual(SFOAuthErrorCode.from(wire), expected, "Wire '\(wire)' should map to \(expected)")
+        }
+    }
+
+    // MARK: - Control — success response has no error
+
+    func test_givenSuccessResponse_whenInitDictionary_thenHasErrorIsFalse() {
+        let params = [
+            "access_token": "00D1234567890abcd!ARMAQGu.test",
+            "refresh_token": "5Aep1234567890abcd!AREAQItest",
+            "instance_url": "https://na1.salesforce.com"
+        ]
+        guard let response = SFSDKOAuthTokenEndpointResponse(dictionary: params, parseAdditionalFields: nil) else {
+            XCTFail("SFSDKOAuthTokenEndpointResponse initializer returned nil")
+            return
+        }
+
+        XCTAssertFalse(response.hasError, "response.hasError should be false for success response")
+        XCTAssertNil(response.error, "response.error should be nil for success response")
+    }
+}


### PR DESCRIPTION
New unit tests exercise SFSDKOAuthTokenEndpointResponse's dictionary-based initializer against the five wire error values returned by the OAuth2 token endpoint (invalid_grant, invalid_client_id, invalid_client, unsupported_grant_type, invalid_request) and lock in the wire-to-enum mapping via SFOAuthErrorCode.from(_:).

Each test asserts hasError, tokenEndpointErrorCode, errorCode, and tokenEndpointErrorDescription in one pass. A control test verifies the success path still classifies as no-error. No production code changes.