### PR TITLE
Moving to SQLCipher 4.17.0

### DIFF
--- a/.claude/skills/update-sqlcipher/SKILL.md
+++ b/.claude/skills/update-sqlcipher/SKILL.md
@@ -97,6 +97,12 @@ Note: The OpenSSL version format is typically like "OpenSSL 3.0.17 1 Jul 2025" a
 Update the SQLLite version test:
 - (void) testSqliteVersion {
     NSString* version = [NSString stringWithUTF8String:sqlite3_libversion()];
+    XCTAssertEqualObjects(version, @"3.53.3");
+}
+
+Update the SQLLite version test:
+- (void) testSqliteVersion {
+    NSString* version = [NSString stringWithUTF8String:sqlite3_libversion()];
     XCTAssertEqualObjects(version, @"3.50.4");
 }
 

--- a/.claude/skills/update-sqlcipher/SKILL.md
+++ b/.claude/skills/update-sqlcipher/SKILL.md
@@ -94,16 +94,10 @@ Update the cipher provider version test:
 
 Note: The OpenSSL version format is typically like "OpenSSL 3.0.17 1 Jul 2025" and the LibTomCrypt format is like "1.18.2" - check the actual runtime value or SQLCipher release notes.
 
-Update the SQLLite version test:
+Update the SQLite version test:
 - (void) testSqliteVersion {
     NSString* version = [NSString stringWithUTF8String:sqlite3_libversion()];
-    XCTAssertEqualObjects(version, @"3.53.3");
-}
-
-Update the SQLLite version test:
-- (void) testSqliteVersion {
-    NSString* version = [NSString stringWithUTF8String:sqlite3_libversion()];
-    XCTAssertEqualObjects(version, @"3.50.4");
+    XCTAssertEqualObjects(version, @"NEW_SQLITE_VERSION");
 }
 
 ### 4. Check for API Changes

--- a/SmartStore.podspec
+++ b/SmartStore.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
       smartstore.dependency 'SalesforceSDKCore', "~>#{s.version}"
       smartstore.dependency 'FMDB/SQLCipher', '~> 2.7.12'
-      smartstore.dependency 'SQLCipher', '~> 4.16.0'
+      smartstore.dependency 'SQLCipher', '~> 4.17.0'
       smartstore.source_files = 'libs/SmartStore/SmartStore/Classes/**/*.{h,m,swift}', 'libs/SmartStore/SmartStore/SmartStore.h'
       smartstore.public_header_files = 'libs/SmartStore/SmartStore/Classes/SFAlterSoupLongOperation.h', 'libs/SmartStore/SmartStore/Classes/SFQuerySpec.h', 'libs/SmartStore/SmartStore/Classes/SFSDKSmartStoreLogger.h', 'libs/SmartStore/SmartStore/Classes/SFSDKStoreConfig.h', 'libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStore.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreDatabaseManager.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreInspectorViewController.h', 'libs/SmartStore/SmartStore/Classes/SFSmartStoreUtils.h', 'libs/SmartStore/SmartStore/Classes/SFSoupIndex.h', 'libs/SmartStore/SmartStore/Classes/SFStoreCursor.h', 'libs/SmartStore/SmartStore/Classes/SmartStoreSDKManager.h', 'libs/SmartStore/SmartStore/SmartStore.h'
       smartstore.prefix_header_contents = '#import "SFSDKSmartStoreLogger.h"', '#import <SalesforceSDKCore/SalesforceSDKConstants.h>'

--- a/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
+++ b/libs/SmartStore/SmartStore.xcodeproj/project.pbxproj
@@ -1319,7 +1319,7 @@
 			repositoryURL = "https://github.com/sqlcipher/SQLCipher.swift";
 			requirement = {
 				kind = exactVersion;
-				version = 4.16.0;
+				version = 4.17.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartStoreTests.m
@@ -104,13 +104,13 @@
 - (void) testSqliteVersion
 {
     NSString* version = [NSString stringWithUTF8String:sqlite3_libversion()];
-    XCTAssertEqualObjects(version, @"3.53.1");
+    XCTAssertEqualObjects(version, @"3.53.3");
 }
 
 - (void) testSqlCipherVersion
 {
     NSString* version = [self.store getSQLCipherVersion];
-    XCTAssertEqualObjects(version, @"4.16.0 community");
+    XCTAssertEqualObjects(version, @"4.17.0 community");
 }
 
 - (void) testCipherProviderVersion

--- a/mobilesdk_pods.rb
+++ b/mobilesdk_pods.rb
@@ -25,7 +25,7 @@ def use_mobile_sdk!(options={})
 
   source 'https://www.github.com/forcedotcom/SalesforceMobileSDK-iOS-Specs'
 
-  pod 'SQLCipher', '4.16.0'
+  pod 'SQLCipher', '4.17.0'
   pod 'SalesforceSDKCommon', :path => path
   pod 'SalesforceAnalytics', :path => path
   pod 'SalesforceSDKCore', :path => path

--- a/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
+++ b/native/SampleApps/MobileSyncExplorer/MobileSyncExplorer.xcodeproj/project.pbxproj
@@ -1178,7 +1178,7 @@
 			repositoryURL = "https://github.com/sqlcipher/SQLCipher.swift";
 			requirement = {
 				kind = exactVersion;
-				version = 4.16.0;
+				version = 4.17.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
## Summary

- Bumps SQLCipher pod dependency from 4.16.0 to 4.17.0 in `SmartStore.podspec` and `mobilesdk_pods.rb`
- Updates SPM exact version in `SmartStore.xcodeproj` and `MobileSyncExplorer.xcodeproj`
- Updates `testSqliteVersion` assertion to `3.53.3`
- Updates `testSqlCipherVersion` assertion to `"4.17.0 community"`

## Release notes
https://www.zetetic.net/blog/2026/07/08/sqlcipher-4.17.0-release/

Key changes in 4.17.0:
- SQLite 3.53.3 (fixes two FTS5 memory corruption CVEs: CVE-2026-11822, CVE-2026-11824)
- No breaking API changes
- Improved thread safety and error handling in LibTomCrypt provider

## GUS
W-23369878

## Test plan
- [ ] CI: SmartStore tests pass
- [ ] `testSqliteVersion` passes with `"3.53.3"`
- [ ] `testSqlCipherVersion` passes with `"4.16.0 community"` → `"4.17.0 community"`
- [ ] `testCipherProviderVersion` not nil and not empty
- [ ] `testCipherFIPSStatus` returns false