### PR TITLE
App attestation for code exchange + refresh flow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on:
   # pull_request_target is used so secrets are available to fork PRs.
   # Mitigated by per-job Member Check (see "Check Write Permission" / "Validate Write Permission").
   pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    branches: [dev, master]
+    branches: [dev, master, app-attestation]
     paths-ignore:
       - '**/*.md'
       - 'LICENSE'

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -25,9 +25,10 @@
 		009D77521CA4A92200D5183A /* SFPushNotificationManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 009D77511CA4A92200D5183A /* SFPushNotificationManagerTests.m */; };
 		010A9B551CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 010A9B511CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h */; };
 		010A9B591CC1A147002AF4D3 /* SFCryptoStreamTestUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 010A9B521CC1A131002AF4D3 /* SFCryptoStreamTestUtils.m */; };
+		092F3EB14B5A4FFEA77B21BC /* SFSDKOAuth2RefreshInstanceUrlTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3168ED77C1354C30BA9DB766 /* SFSDKOAuth2RefreshInstanceUrlTests.m */; };
+		12B74FEE769B03E0935DE852 /* SFUserAccountManagerLoginHostRecoveryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 06FEB66C3E3DAC225240738C /* SFUserAccountManagerLoginHostRecoveryTests.m */; };
 		1A31073F5F374B9EB1162F2E /* SFOAuthCoordinatorLightningURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 399A11508BCB47F490DFB724 /* SFOAuthCoordinatorLightningURLTests.swift */; };
 		230834842DF7838200C7CBF7 /* URLSessionTask+RetryPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230834832DF7837400C7CBF7 /* URLSessionTask+RetryPolicy.swift */; };
-		3D012B381C4D4D97BCDA30E6 /* SFSDKOAuth2TokenExchangeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4746050277064A9790E3470A /* SFSDKOAuth2TokenExchangeErrorTests.swift */; };
 		230834862DF8938D00C7CBF7 /* URLSessionTask+RetryPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230834852DF8938D00C7CBF7 /* URLSessionTask+RetryPolicyTests.swift */; };
 		230834882DF8A8F300C7CBF7 /* WebSocketClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230834872DF8A8F300C7CBF7 /* WebSocketClientTests.swift */; };
 		23350C562DCAB19D009A10DE /* RestClient+Blocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23350C552DCAB190009A10DE /* RestClient+Blocks.swift */; };
@@ -58,6 +59,8 @@
 		23EED8912E2ACF3900646B10 /* MockNavigationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23EED8902E2ACF3100646B10 /* MockNavigationAction.swift */; };
 		23F200AC2E551C890091C5F5 /* ActionTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F200AB2E551C890091C5F5 /* ActionTypeTests.swift */; };
 		23F200AE2E551C890091C5F5 /* BootconfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23F200AD2E551C890091C5F5 /* BootconfigTests.swift */; };
+		3D012B381C4D4D97BCDA30E6 /* SFSDKOAuth2TokenExchangeErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4746050277064A9790E3470A /* SFSDKOAuth2TokenExchangeErrorTests.swift */; };
+		42996EA8CCEB33EF9E258033 /* SFUserAccountThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB0265069ECCAE8F59F5CD0 /* SFUserAccountThreadSafetyTests.swift */; };
 		444B95D01E83251900908C61 /* UIColor+SFColorsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */; };
 		4F06AF731C49A16A00F70798 /* NSURL+SFStringUtilsTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F06AF5D1C49A16A00F70798 /* NSURL+SFStringUtilsTests.h */; };
 		4F06AF751C49A16A00F70798 /* SalesforceOAuthUnitTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F06AF5F1C49A16A00F70798 /* SalesforceOAuthUnitTests.h */; };
@@ -85,8 +88,6 @@
 		4F5727E327F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F5727DC27F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4F5727E427F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F5727E227F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.m */; };
 		4F5A49502E98711600C89DDD /* ScopeParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5A494F2E98711600C89DDD /* ScopeParser.swift */; };
-		4FOAUTHEC012E98711600C89DDD /* SFOAuthErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FOAUTHEC002E98711600C89DDD /* SFOAuthErrorCode.swift */; };
-		4FOAUTHECT012E98711600C89DDD /* SFOAuthErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FOAUTHECT002E98711600C89DDD /* SFOAuthErrorCodeTests.swift */; };
 		4F5A49582E98B0F800C89DDD /* ScopeParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5A49572E98B0F800C89DDD /* ScopeParserTests.swift */; };
 		4F755F5820D48F8600CE4E0E /* NSString+SFAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F755F4120D48D6700CE4E0E /* NSString+SFAdditionsTests.m */; };
 		4F7EB40D1BFFC88200768720 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280EC1716E15FFC00768DE8 /* MessageUI.framework */; };
@@ -98,7 +99,6 @@
 		4F9E05322DD6A08000548985 /* SFSDKOAuthTokenEndpointResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */; };
 		4F9E05342DD7BE1500548985 /* SFOAuthCredentialsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9E05332DD7BE0A00548985 /* SFOAuthCredentialsTests.m */; };
 		4FA1B2C32F0E000000000001 /* LoginForAdminTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA1B2C32F0E000000000002 /* LoginForAdminTests.swift */; };
-		092F3EB14B5A4FFEA77B21BC /* SFSDKOAuth2RefreshInstanceUrlTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3168ED77C1354C30BA9DB766 /* SFSDKOAuth2RefreshInstanceUrlTests.m */; };
 		4FAUTHFLOW001234567890ABC /* AuthFlowTypesViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */; };
 		4FBOOTCP001234567890ABCD /* LoginOptionsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FBOOTCP112345678901ABCD /* LoginOptionsViewControllerTests.swift */; };
 		4FDEVINFO001234567890ABCD /* DevInfoViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDEVINFO112345678901ABCD /* DevInfoViewControllerTests.swift */; };
@@ -119,12 +119,15 @@
 		4FE006E02EBEBC0000CFD66F /* NativeLoginManagerInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE006DF2EBEBC0000CFD66F /* NativeLoginManagerInternal.swift */; };
 		4FE006E12EBEBC0000CFD66F /* NativeLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE006DE2EBEBC0000CFD66F /* NativeLoginManager.swift */; };
 		4FE0070F2EBED6C000CFD66F /* SFSDKLoginHost.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FE006CB2EBEBBF300CFD66F /* SFSDKLoginHost.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4FOAUTHEC012E98711600C89DDD /* SFOAuthErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FOAUTHEC002E98711600C89DDD /* SFOAuthErrorCode.swift */; };
+		4FOAUTHECT012E98711600C89DDD /* SFOAuthErrorCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FOAUTHECT002E98711600C89DDD /* SFOAuthErrorCodeTests.swift */; };
 		6900B62C24B64DD800500923 /* NSURLResponse+SFAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6900B62A24B64DD800500923 /* NSURLResponse+SFAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6900B62D24B64DD800500923 /* NSURLResponse+SFAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 6900B62B24B64DD800500923 /* NSURLResponse+SFAdditions.m */; };
 		6900D804243D521C00888336 /* SFRestAPI+Notifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 6900D802243D521C00888336 /* SFRestAPI+Notifications.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6900D805243D521C00888336 /* SFRestAPI+Notifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 6900D803243D521C00888336 /* SFRestAPI+Notifications.m */; };
 		6924966A2444E50500D3F63B /* SFFormatUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 692496682444E50500D3F63B /* SFFormatUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6924966B2444E50500D3F63B /* SFFormatUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 692496692444E50500D3F63B /* SFFormatUtils.m */; };
+		692D36662F95F83A002FBFF3 /* AppAttestationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692D36652F95F83A002FBFF3 /* AppAttestationTests.swift */; };
 		6931E954248B5C7100417362 /* SFDirectoryManager+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6931E94E248ADD8E00417362 /* SFDirectoryManager+Internal.h */; };
 		6931EA49248F000600417362 /* SFUserIdUpgradeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6931EA48248F000600417362 /* SFUserIdUpgradeTests.m */; };
 		69341D22266FF61700227CB0 /* Encryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69341D21266FF61700227CB0 /* Encryptor.swift */; };
@@ -156,6 +159,7 @@
 		69848CB82364035300893E57 /* SFSDKEncryptedPushNotificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69848CB72364035300893E57 /* SFSDKEncryptedPushNotificationTests.m */; };
 		69848CBD2364063E00893E57 /* SFSDKPushNotificationDataProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 69848CBC2364063E00893E57 /* SFSDKPushNotificationDataProvider.m */; };
 		6990CBC029F5AF56004A5F8D /* SFSDKIDPAuthCodeLoginRequestCommandTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6990CBBF29F5AF56004A5F8D /* SFSDKIDPAuthCodeLoginRequestCommandTest.m */; };
+		699205492FFF0B740032ECD7 /* AppAttestation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699205482FFF0B740032ECD7 /* AppAttestation.swift */; };
 		69B36F492D30C34F00EFF84A /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69B36F482D30C34F00EFF84A /* ColorExtension.swift */; };
 		69BDD7E926F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 69BDD7E226F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.h */; };
 		69BDD7EA26F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 69BDD7E826F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.m */; };
@@ -213,7 +217,6 @@
 		B75233DE1F4DF0B700040B6E /* SFSDKAuthPreferences.h in Headers */ = {isa = PBXBuildFile; fileRef = B75233DC1F4DF0B700040B6E /* SFSDKAuthPreferences.h */; };
 		B75233E01F4DF0B700040B6E /* SFSDKAuthPreferences.m in Sources */ = {isa = PBXBuildFile; fileRef = B75233DD1F4DF0B700040B6E /* SFSDKAuthPreferences.m */; };
 		B759CD891F8BDBAC0081AA87 /* SDSDKAlertMessageTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B759CD881F8BDBAC0081AA87 /* SDSDKAlertMessageTest.m */; };
-		12B74FEE769B03E0935DE852 /* SFUserAccountManagerLoginHostRecoveryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 06FEB66C3E3DAC225240738C /* SFUserAccountManagerLoginHostRecoveryTests.m */; };
 		B759CD8B1F8C10DC0081AA87 /* SFSDKErrorManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B759CD8A1F8C10DC0081AA87 /* SFSDKErrorManagerTests.m */; };
 		B767369120A4AB0200F04103 /* SFSDKNavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = B767368F20A4AB0200F04103 /* SFSDKNavigationController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B767369320A4AB0200F04103 /* SFSDKNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = B767369020A4AB0200F04103 /* SFSDKNavigationController.m */; };
@@ -403,7 +406,6 @@
 		CE7F662B1E556CA800DC3FBB /* SFNetwork.h in Headers */ = {isa = PBXBuildFile; fileRef = CE7F66291E556CA800DC3FBB /* SFNetwork.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE7F662C1E556CA800DC3FBB /* SFNetwork.m in Sources */ = {isa = PBXBuildFile; fileRef = CE7F662A1E556CA800DC3FBB /* SFNetwork.m */; };
 		CE81A9C81E9C26F900F3D0AD /* SFUserAccountManagerNotificationsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CE81A9C61E9C26EF00F3D0AD /* SFUserAccountManagerNotificationsTests.m */; };
-		42996EA8CCEB33EF9E258033 /* SFUserAccountThreadSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DB0265069ECCAE8F59F5CD0 /* SFUserAccountThreadSafetyTests.swift */; };
 		CE88BD521D17065C00AE3BF7 /* SFSDKAILTNPublisher.h in Headers */ = {isa = PBXBuildFile; fileRef = CE88BD4F1D17065B00AE3BF7 /* SFSDKAILTNPublisher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE88BD531D17065C00AE3BF7 /* SFSDKAILTNPublisher.m in Sources */ = {isa = PBXBuildFile; fileRef = CE88BD501D17065C00AE3BF7 /* SFSDKAILTNPublisher.m */; };
 		CE88BD541D17065C00AE3BF7 /* SFSDKAnalyticsPublisher.h in Headers */ = {isa = PBXBuildFile; fileRef = CE88BD511D17065C00AE3BF7 /* SFSDKAnalyticsPublisher.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -546,6 +548,8 @@
 		009D77511CA4A92200D5183A /* SFPushNotificationManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFPushNotificationManagerTests.m; path = SalesforceSDKCoreTests/SFPushNotificationManagerTests.m; sourceTree = SOURCE_ROOT; };
 		010A9B511CC1A131002AF4D3 /* SFCryptoStreamTestUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFCryptoStreamTestUtils.h; path = SalesforceSDKCoreTests/SFCryptoStreamTestUtils.h; sourceTree = SOURCE_ROOT; };
 		010A9B521CC1A131002AF4D3 /* SFCryptoStreamTestUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFCryptoStreamTestUtils.m; path = SalesforceSDKCoreTests/SFCryptoStreamTestUtils.m; sourceTree = SOURCE_ROOT; };
+		06FEB66C3E3DAC225240738C /* SFUserAccountManagerLoginHostRecoveryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFUserAccountManagerLoginHostRecoveryTests.m; path = SalesforceSDKCoreTests/SFUserAccountManagerLoginHostRecoveryTests.m; sourceTree = SOURCE_ROOT; };
+		0DB0265069ECCAE8F59F5CD0 /* SFUserAccountThreadSafetyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SFUserAccountThreadSafetyTests.swift; path = SalesforceSDKCoreTests/SFUserAccountThreadSafetyTests.swift; sourceTree = SOURCE_ROOT; };
 		230834832DF7837400C7CBF7 /* URLSessionTask+RetryPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSessionTask+RetryPolicy.swift"; sourceTree = "<group>"; };
 		230834852DF8938D00C7CBF7 /* URLSessionTask+RetryPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "URLSessionTask+RetryPolicyTests.swift"; path = "SalesforceSDKCoreTests/URLSessionTask+RetryPolicyTests.swift"; sourceTree = SOURCE_ROOT; };
 		230834872DF8A8F300C7CBF7 /* WebSocketClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WebSocketClientTests.swift; path = SalesforceSDKCoreTests/WebSocketClientTests.swift; sourceTree = SOURCE_ROOT; };
@@ -577,6 +581,7 @@
 		23EED8902E2ACF3100646B10 /* MockNavigationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNavigationAction.swift; sourceTree = "<group>"; };
 		23F200AB2E551C890091C5F5 /* ActionTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ActionTypeTests.swift; path = SalesforceSDKCoreTests/ActionTypeTests.swift; sourceTree = SOURCE_ROOT; };
 		23F200AD2E551C890091C5F5 /* BootconfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BootconfigTests.swift; path = SalesforceSDKCoreTests/BootconfigTests.swift; sourceTree = SOURCE_ROOT; };
+		3168ED77C1354C30BA9DB766 /* SFSDKOAuth2RefreshInstanceUrlTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKOAuth2RefreshInstanceUrlTests.m; path = ../SalesforceSDKCoreTests/SFSDKOAuth2RefreshInstanceUrlTests.m; sourceTree = "<group>"; };
 		399A11508BCB47F490DFB724 /* SFOAuthCoordinatorLightningURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SFOAuthCoordinatorLightningURLTests.swift; path = ../SalesforceSDKCoreTests/SFOAuthCoordinatorLightningURLTests.swift; sourceTree = "<group>"; };
 		444B95CF1E83251900908C61 /* UIColor+SFColorsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+SFColorsTests.m"; path = "SalesforceSDKCoreTests/UIColor+SFColorsTests.m"; sourceTree = SOURCE_ROOT; };
 		4746050277064A9790E3470A /* SFSDKOAuth2TokenExchangeErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SFSDKOAuth2TokenExchangeErrorTests.swift; path = ../SalesforceSDKCoreTests/SFSDKOAuth2TokenExchangeErrorTests.swift; sourceTree = "<group>"; };
@@ -604,8 +609,6 @@
 		4F5727DC27F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKPrimingRecordsResponse.h; sourceTree = "<group>"; };
 		4F5727E227F27F1A0008CDA4 /* SFSDKPrimingRecordsResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKPrimingRecordsResponse.m; sourceTree = "<group>"; };
 		4F5A494F2E98711600C89DDD /* ScopeParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScopeParser.swift; sourceTree = "<group>"; };
-		4FOAUTHEC002E98711600C89DDD /* SFOAuthErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFOAuthErrorCode.swift; sourceTree = "<group>"; };
-		4FOAUTHECT002E98711600C89DDD /* SFOAuthErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SFOAuthErrorCodeTests.swift; path = SalesforceSDKCoreTests/SFOAuthErrorCodeTests.swift; sourceTree = SOURCE_ROOT; };
 		4F5A49572E98B0F800C89DDD /* ScopeParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ScopeParserTests.swift; path = ../SalesforceSDKCoreTests/ScopeParserTests.swift; sourceTree = "<group>"; };
 		4F755F4120D48D6700CE4E0E /* NSString+SFAdditionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "NSString+SFAdditionsTests.m"; path = "SalesforceSDKCoreTests/NSString+SFAdditionsTests.m"; sourceTree = SOURCE_ROOT; };
 		4F7EB3F71BFFC87600768720 /* SDKCommonNSDataTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SDKCommonNSDataTests.m; path = SalesforceSDKCoreTests/SDKCommonNSDataTests.m; sourceTree = SOURCE_ROOT; };
@@ -693,7 +696,6 @@
 		4F9E052C2DD6A06F00548985 /* SFSDKOAuthTokenEndpointResponseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKOAuthTokenEndpointResponseTests.m; path = ../SalesforceSDKCoreTests/SFSDKOAuthTokenEndpointResponseTests.m; sourceTree = "<group>"; };
 		4F9E05332DD7BE0A00548985 /* SFOAuthCredentialsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFOAuthCredentialsTests.m; path = ../SalesforceSDKCoreTests/SFOAuthCredentialsTests.m; sourceTree = "<group>"; };
 		4FA1B2C32F0E000000000002 /* LoginForAdminTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginForAdminTests.swift; sourceTree = "<group>"; };
-		3168ED77C1354C30BA9DB766 /* SFSDKOAuth2RefreshInstanceUrlTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKOAuth2RefreshInstanceUrlTests.m; path = ../SalesforceSDKCoreTests/SFSDKOAuth2RefreshInstanceUrlTests.m; sourceTree = "<group>"; };
 		4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AuthFlowTypesViewTests.swift; path = SalesforceSDKCoreTests/AuthFlowTypesViewTests.swift; sourceTree = SOURCE_ROOT; };
 		4FBOOTCP112345678901ABCD /* LoginOptionsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LoginOptionsViewControllerTests.swift; path = SalesforceSDKCoreTests/LoginOptionsViewControllerTests.swift; sourceTree = SOURCE_ROOT; };
 		4FDEVINFO112345678901ABCD /* DevInfoViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DevInfoViewControllerTests.swift; path = SalesforceSDKCoreTests/DevInfoViewControllerTests.swift; sourceTree = SOURCE_ROOT; };
@@ -729,6 +731,8 @@
 		4FF946221BFFF663005368C5 /* NSURL+SFAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+SFAdditions.m"; sourceTree = "<group>"; };
 		4FF946251BFFF7AD005368C5 /* SFIdentityData+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SFIdentityData+Internal.h"; sourceTree = "<group>"; };
 		4FFE4A001BFE522F00F15E01 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		4FOAUTHEC002E98711600C89DDD /* SFOAuthErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFOAuthErrorCode.swift; sourceTree = "<group>"; };
+		4FOAUTHECT002E98711600C89DDD /* SFOAuthErrorCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SFOAuthErrorCodeTests.swift; path = SalesforceSDKCoreTests/SFOAuthErrorCodeTests.swift; sourceTree = SOURCE_ROOT; };
 		6900B62A24B64DD800500923 /* NSURLResponse+SFAdditions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLResponse+SFAdditions.h"; sourceTree = "<group>"; };
 		6900B62B24B64DD800500923 /* NSURLResponse+SFAdditions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURLResponse+SFAdditions.m"; sourceTree = "<group>"; };
 		6900D802243D521C00888336 /* SFRestAPI+Notifications.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SFRestAPI+Notifications.h"; sourceTree = "<group>"; };
@@ -736,6 +740,7 @@
 		691D129F23296A93000D6D41 /* SFSDKURLCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFSDKURLCacheTests.m; path = SalesforceSDKCoreTests/SFSDKURLCacheTests.m; sourceTree = SOURCE_ROOT; };
 		692496682444E50500D3F63B /* SFFormatUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFFormatUtils.h; sourceTree = "<group>"; };
 		692496692444E50500D3F63B /* SFFormatUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFFormatUtils.m; sourceTree = "<group>"; };
+		692D36652F95F83A002FBFF3 /* AppAttestationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAttestationTests.swift; sourceTree = "<group>"; };
 		6931E94E248ADD8E00417362 /* SFDirectoryManager+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SFDirectoryManager+Internal.h"; sourceTree = "<group>"; };
 		6931EA48248F000600417362 /* SFUserIdUpgradeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFUserIdUpgradeTests.m; path = SalesforceSDKCoreTests/SFUserIdUpgradeTests.m; sourceTree = SOURCE_ROOT; };
 		69341D21266FF61700227CB0 /* Encryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encryptor.swift; sourceTree = "<group>"; };
@@ -767,6 +772,7 @@
 		69848CBB2364063E00893E57 /* SFSDKPushNotificationDataProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SFSDKPushNotificationDataProvider.h; path = SalesforceSDKCoreTests/SFSDKPushNotificationDataProvider.h; sourceTree = SOURCE_ROOT; };
 		69848CBC2364063E00893E57 /* SFSDKPushNotificationDataProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKPushNotificationDataProvider.m; path = SalesforceSDKCoreTests/SFSDKPushNotificationDataProvider.m; sourceTree = SOURCE_ROOT; };
 		6990CBBF29F5AF56004A5F8D /* SFSDKIDPAuthCodeLoginRequestCommandTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKIDPAuthCodeLoginRequestCommandTest.m; path = SalesforceSDKCoreTests/SFSDKIDPAuthCodeLoginRequestCommandTest.m; sourceTree = SOURCE_ROOT; };
+		699205482FFF0B740032ECD7 /* AppAttestation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAttestation.swift; sourceTree = "<group>"; };
 		69B2B4F2261EA6F500AB86C2 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/System/Library/Frameworks/CoreTelephony.framework; sourceTree = DEVELOPER_DIR; };
 		69B36F482D30C34F00EFF84A /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		69BDD7E226F16C9000C26D77 /* SFSDKSalesforceSDKUpgradeManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKSalesforceSDKUpgradeManager.h; sourceTree = "<group>"; };
@@ -846,7 +852,6 @@
 		B75233DC1F4DF0B700040B6E /* SFSDKAuthPreferences.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKAuthPreferences.h; sourceTree = "<group>"; };
 		B75233DD1F4DF0B700040B6E /* SFSDKAuthPreferences.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKAuthPreferences.m; sourceTree = "<group>"; };
 		B759CD881F8BDBAC0081AA87 /* SDSDKAlertMessageTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SDSDKAlertMessageTest.m; path = SalesforceSDKCoreTests/SDSDKAlertMessageTest.m; sourceTree = SOURCE_ROOT; };
-		06FEB66C3E3DAC225240738C /* SFUserAccountManagerLoginHostRecoveryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFUserAccountManagerLoginHostRecoveryTests.m; path = SalesforceSDKCoreTests/SFUserAccountManagerLoginHostRecoveryTests.m; sourceTree = SOURCE_ROOT; };
 		B759CD8A1F8C10DC0081AA87 /* SFSDKErrorManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKErrorManagerTests.m; path = SalesforceSDKCoreTests/SFSDKErrorManagerTests.m; sourceTree = SOURCE_ROOT; };
 		B767368F20A4AB0200F04103 /* SFSDKNavigationController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKNavigationController.h; sourceTree = "<group>"; };
 		B767369020A4AB0200F04103 /* SFSDKNavigationController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKNavigationController.m; sourceTree = "<group>"; };
@@ -942,7 +947,6 @@
 		CE7F66291E556CA800DC3FBB /* SFNetwork.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFNetwork.h; sourceTree = "<group>"; };
 		CE7F662A1E556CA800DC3FBB /* SFNetwork.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFNetwork.m; sourceTree = "<group>"; };
 		CE81A9C61E9C26EF00F3D0AD /* SFUserAccountManagerNotificationsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFUserAccountManagerNotificationsTests.m; path = SalesforceSDKCoreTests/SFUserAccountManagerNotificationsTests.m; sourceTree = SOURCE_ROOT; };
-		0DB0265069ECCAE8F59F5CD0 /* SFUserAccountThreadSafetyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SFUserAccountThreadSafetyTests.swift; path = SalesforceSDKCoreTests/SFUserAccountThreadSafetyTests.swift; sourceTree = SOURCE_ROOT; };
 		CE88BD4F1D17065B00AE3BF7 /* SFSDKAILTNPublisher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFSDKAILTNPublisher.h; path = Analytics/SFSDKAILTNPublisher.h; sourceTree = "<group>"; };
 		CE88BD501D17065C00AE3BF7 /* SFSDKAILTNPublisher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFSDKAILTNPublisher.m; path = Analytics/SFSDKAILTNPublisher.m; sourceTree = "<group>"; };
 		CE88BD511D17065C00AE3BF7 /* SFSDKAnalyticsPublisher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SFSDKAnalyticsPublisher.h; path = Analytics/SFSDKAnalyticsPublisher.h; sourceTree = "<group>"; };
@@ -1044,6 +1048,7 @@
 		4F7EB3F61BFFC84700768720 /* SalesforceSDKCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				692D36652F95F83A002FBFF3 /* AppAttestationTests.swift */,
 				AA9154472F59E3C900A0A41C /* SFRestAPIDataTaskRaceTests.m */,
 				23F200AB2E551C890091C5F5 /* ActionTypeTests.swift */,
 				4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */,
@@ -1206,6 +1211,7 @@
 		4F96FCC41BFD32130022F021 /* OAuth */ = {
 			isa = PBXGroup;
 			children = (
+				699205482FFF0B740032ECD7 /* AppAttestation.swift */,
 				4F5A494F2E98711600C89DDD /* ScopeParser.swift */,
 				23D96B6E2E145AC20004B06A /* DomainDiscoveryCoordinator.swift */,
 				4F8A3B002CEC202F00ECDC76 /* JwtAccessToken.swift */,
@@ -2250,6 +2256,7 @@
 				696E91472AD0A14A00205884 /* BiometricAuthenticationManagerTests.swift in Sources */,
 				B7E8A2AF1E77062E007C0D92 /* SFUserAccountManagerPersisterTests.m in Sources */,
 				23EDDF022DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift in Sources */,
+				692D36662F95F83A002FBFF3 /* AppAttestationTests.swift in Sources */,
 				CEB98EDF1F86E7CA0083AB9C /* SFSDKAuthErrorCommandTest.m in Sources */,
 				696E91482AD0A14A00205884 /* ScreenLockManagerTests.m in Sources */,
 				8263FED31E7336BF0038F694 /* SFSDKAppFeatureMarkersTests.m in Sources */,
@@ -2419,6 +2426,7 @@
 				23CE44212DEE258800ADC770 /* RestClient+WebSocket.swift in Sources */,
 				CE4CE3A61C0E5279009F6029 /* SFDirectoryManager.m in Sources */,
 				B72171532353BFD90022510F /* SFSDKAuthSession.m in Sources */,
+				699205492FFF0B740032ECD7 /* AppAttestation.swift in Sources */,
 				B7C274561F81507100CE539D /* SFSDKSPLoginResponseCommand.m in Sources */,
 				230834842DF7838200C7CBF7 /* URLSessionTask+RetryPolicy.swift in Sources */,
 				B7FB26C81F78094A00FB25A2 /* SFSDKUserSelectionTableViewController.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
@@ -145,6 +145,7 @@ public class AppAttestation: NSObject {
         let keychainItem = AttestationKeychainItem(attestationId: attestationId, keyId: keyId)
         let keychainItemData = try JSONEncoder().encode(keychainItem)
         let keychainResult = KeychainHelper.write(service: appAttestKeyName, data: keychainItemData, account: nil)
+        // Intentional: prefer re-registration on next launch over blocking auth
         if !keychainResult.success {
             var message = "Unable to write attestation keyId to keychain"
             if let error = keychainResult.error {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
@@ -160,7 +160,10 @@ public class AppAttestation: NSObject {
         do {
             return try await operation()
         } catch let error as DCError {
-            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "App Attest error: \(error.code.rawValue)")
+            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "App Attest Device Check error: \(error.code.rawValue)")
+            throw error
+        } catch {
+            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "App Attest error: \(error.localizedDescription)")
             throw error
         }
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
@@ -1,0 +1,187 @@
+//
+//  AppAttestation.swift
+//  SalesforceSDKCore
+//
+//  Created by Brianna Birman on 1/5/26.
+//  Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+// 
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+// 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import CryptoKit
+import DeviceCheck
+
+
+@objc(SFSDKAppAttestation)
+public class AppAttestation: NSObject {
+    enum AppAttestationError: Error {
+        case challengeEncodingFailed
+    }
+
+    struct AttestationObject: Codable {
+        let attestationId: String
+        let attestationData: String // Base-64 encoded
+    }
+    
+    struct AttestationKeychainItem: Codable {
+        let attestationId: String
+        let keyId: String
+    }
+    
+    static let appAttestKeyName = "com.salesforce.mobilesdk.attestation"
+    
+    /// Returns an attestation string if attestation is enabled and the domain is a My Domain,
+    /// otherwise returns nil. Callers do not need to check gating conditions themselves.
+    @objc
+    public static func attestationIfEnabled(for domain: String, consumerKey: String) async -> String? {
+        let isLoginPool = domain == kSFOAuthProductionLoginURL
+            || domain == kSFOAuthSandboxLoginURL
+            || domain == kSFOAuthWelcomeLoginURL
+
+        guard UserAccountManager.shared.appAttestationEnabled,
+              !isLoginPool,
+              !consumerKey.isEmpty else {
+            return nil
+        }
+
+        do {
+            return try await attestationObject(for: domain, consumerKey: consumerKey)
+        } catch {
+            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "Attestation error: \(error.localizedDescription)")
+            // TODO: In coordination with error stories, if device error prevents attestation from being generated, should this throw and/or have a retry path like deleting old key?
+            return nil
+        }
+    }
+    
+    // Internal for unit tests
+    static func existingKeyId(for attestationId: String) throws -> String? {
+        let attestKeyQuery = KeychainHelper.read(service: appAttestKeyName, account: nil)
+        if let attestKeyData = attestKeyQuery.data,
+           let keychainItem = try? JSONDecoder().decode(AttestationKeychainItem.self, from: attestKeyData) {
+            if keychainItem.attestationId == attestationId {
+                return keychainItem.keyId
+            } else {
+                // The ID can change if app is deleted / reinstalled but an old key can remain, delete the old one
+                // and then generate a new key like normal
+                let removeResult = KeychainHelper.remove(service: appAttestKeyName, account: nil)
+                if !removeResult.success {
+                    SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "Unable to delete old attestation keyId from keychain: \(removeResult.error?.localizedDescription ?? "")")
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func attestationObject(for domain: String, consumerKey: String) async throws -> String {
+        let attestationId = SalesforceManager.shared.deviceId()
+
+        let keyId = try await keyId(for: attestationId, domain: domain, consumerKey: consumerKey)
+
+        let challenge = try await requestChallengeFromSalesforce(domain: domain, consumerKey: consumerKey, attestationId: attestationId)
+        guard let challengeData = challenge.data(using: .utf8) else {
+            throw AppAttestationError.challengeEncodingFailed
+        }
+        let hash = Data(SHA256.hash(data: challengeData))
+
+        let assertion = try await performAppAttestOperation {
+            try await DCAppAttestService.shared.generateAssertion(keyId, clientDataHash: hash)
+        }
+        let assertionString = assertion.base64EncodedString()
+
+        let attestationObject = AttestationObject(attestationId: attestationId, attestationData: assertionString)
+        let jsonData = try JSONEncoder().encode(attestationObject)
+        return jsonData.base64EncodedString()
+    }
+
+
+    private static func generateAttestation(keyId: String, challenge: String) async throws -> String {
+        guard let challengeData = challenge.data(using: .utf8) else {
+            throw AppAttestationError.challengeEncodingFailed
+        }
+        let hash = Data(SHA256.hash(data: challengeData))
+
+        let attestation = try await performAppAttestOperation {
+            try await DCAppAttestService.shared.attestKey(keyId, clientDataHash: hash)
+        }
+        return attestation.base64EncodedString()
+    }
+
+    //    1. Client creates a key pair
+    //    2. Client makes request to get challenge  - /mobile/attest/challenge
+    //    3. Client creates an Apple attestation object with obtained challenge
+    //    4. Client makes request to pre-register public key - /mobile/attest/registerkey
+    private static func keyId(for attestationId: String, domain: String, consumerKey: String) async throws -> String {
+        if let existingKey = try existingKeyId(for: attestationId) {
+            return existingKey
+        }
+
+        let keyId = try await performAppAttestOperation {
+            try await DCAppAttestService.shared.generateKey()
+        }
+
+        let challenge = try await requestChallengeFromSalesforce(domain: domain, consumerKey: consumerKey, attestationId: attestationId)
+        let attestation = try await generateAttestation(keyId: keyId, challenge: challenge)
+        try await registerKeyWithSalesforce(keyId: keyId, consumerKey: consumerKey, attestationId: attestationId, attestationObject: attestation, domain: domain)
+
+        // Only persist after successful registration — if any step above fails,
+        // the next attempt will start fresh with a new key.
+        let keychainItem = AttestationKeychainItem(attestationId: attestationId, keyId: keyId)
+        let keychainItemData = try JSONEncoder().encode(keychainItem)
+        let keychainResult = KeychainHelper.write(service: appAttestKeyName, data: keychainItemData, account: nil)
+        if !keychainResult.success {
+            var message = "Unable to write attestation keyId to keychain"
+            if let error = keychainResult.error {
+                message += ": \(error.localizedDescription)"
+            }
+            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: message)
+        }
+
+        return keyId
+    }
+
+    private static func performAppAttestOperation<T>(_ operation: () async throws -> T) async throws -> T {
+        do {
+            return try await operation()
+        } catch let error as DCError {
+            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "App Attest error: \(error.code.rawValue)")
+            throw error
+        }
+    }
+
+    // Requests a challenge from https://<domain>/mobile/attest/challenge
+    private static func requestChallengeFromSalesforce(domain: String, consumerKey: String, attestationId: String) async throws -> String {
+        let params = ["consumerKey": consumerKey, "attestationId": attestationId]
+        let request = RestRequest(method: .GET, baseURL: "https://\(domain)", path: "/mobile/attest/challenge", queryParams: params)
+        request.endpoint = ""
+        request.requiresAuthentication = false
+        let response = try await RestClient.sharedGlobal.send(request: request)
+        return response.asString()
+    }
+    
+    private static func registerKeyWithSalesforce(keyId: String, consumerKey: String, attestationId: String, attestationObject: String, domain: String) async throws {
+        let requestBody = "consumerKey=\(consumerKey.sfsdk_stringByURLEncoding())&attestationId=\(attestationId.sfsdk_stringByURLEncoding())&keyIdentifier=\(keyId.sfsdk_stringByURLEncoding())&attestationObject=\(attestationObject.sfsdk_stringByURLEncoding())"
+        let request = RestRequest(method: .POST, baseURL: "https://\(domain)", path: "/mobile/attest/registerkey", queryParams: nil)
+        request.endpoint = ""
+        request.requiresAuthentication = false
+        request.setCustomRequestBodyString(requestBody, contentType: kHttpPostContentType)
+        
+        _ = try await RestClient.sharedGlobal.send(request: request)
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
@@ -50,14 +50,9 @@ public class AppAttestation: NSObject {
     /// Returns an attestation string if attestation is enabled and the domain is a My Domain,
     /// otherwise returns nil. Callers do not need to check gating conditions themselves.
     @objc
-    public static func attestationIfEnabled(for domain: String, consumerKey: String) async -> String? {
-        let isLoginPool = domain == kSFOAuthProductionLoginURL
-            || domain == kSFOAuthSandboxLoginURL
-            || domain == kSFOAuthWelcomeLoginURL
-
-        guard UserAccountManager.shared.appAttestationEnabled,
-              !isLoginPool,
-              !consumerKey.isEmpty else {
+    public static func attestationIfEnabled(for domain: String?, consumerKey: String) async -> String? {
+        guard let domain,
+              shouldAttemptAttestation(for: domain, consumerKey: consumerKey, isDeviceSupported: DCAppAttestService.shared.isSupported) else {
             return nil
         }
 
@@ -68,6 +63,26 @@ public class AppAttestation: NSObject {
             // TODO: In coordination with error stories, if device error prevents attestation from being generated, should this throw and/or have a retry path like deleting old key?
             return nil
         }
+    }
+
+    // Internal for unit tests
+    static func shouldAttemptAttestation(for domain: String?, consumerKey: String, isDeviceSupported: Bool) -> Bool {
+        guard let domain, !domain.isEmpty else {
+            return false
+        }
+
+        let isLoginPool = domain == kSFOAuthProductionLoginURL
+            || domain == kSFOAuthSandboxLoginURL
+            || domain == kSFOAuthWelcomeLoginURL
+
+        guard UserAccountManager.shared.appAttestationEnabled,
+              isDeviceSupported,
+              !isLoginPool,
+              !consumerKey.isEmpty else {
+            return false
+        }
+
+        return true
     }
     
     // Internal for unit tests

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -618,8 +618,11 @@
 }
 
 - (void)beginTokenEndpointFlow {
+    __weak typeof(self) weakSelf = self;
     [SFSDKAppAttestation attestationIfEnabledFor:self.credentials.domain consumerKey:self.credentials.clientId completionHandler:^(NSString * _Nullable attestation) {
-        [self executeTokenEndpointFlowWithAttestation:attestation];
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf executeTokenEndpointFlowWithAttestation:attestation];
     }];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -618,6 +618,12 @@
 }
 
 - (void)beginTokenEndpointFlow {
+    [SFSDKAppAttestation attestationIfEnabledFor:self.credentials.domain consumerKey:self.credentials.clientId completionHandler:^(NSString * _Nullable attestation) {
+        [self executeTokenEndpointFlowWithAttestation:attestation];
+    }];
+}
+
+- (void)executeTokenEndpointFlowWithAttestation:(NSString * _Nullable)attestation {
     self.responseData = [NSMutableData dataWithLength:512];
     SFSDKOAuthTokenEndpointRequest *request = [[SFSDKOAuthTokenEndpointRequest alloc] init];
     request.additionalOAuthParameterKeys = self.additionalOAuthParameterKeys;
@@ -626,6 +632,7 @@
     request.refreshToken = self.credentials.refreshToken;
     request.redirectURI = self.credentials.redirectUri;
     request.serverURL = [self.credentials overrideDomainIfNeeded];
+    request.attestation = attestation;
 
     __weak typeof (self) weakSelf = self;
     if (self.approvalCode) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -78,10 +78,8 @@
         return;
     }
     
-    __weak typeof(self) weakSelf = self;
     [SFSDKAppAttestation attestationIfEnabledFor:self.credentials.domain consumerKey:self.credentials.clientId completionHandler:^(NSString * _Nullable attestation) {
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        [strongSelf executeRefreshWithAttestation:attestation];
+        [self executeRefreshWithAttestation:attestation];
     }];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -28,6 +28,7 @@
 #import "SFOAuthInfo.h"
 #import "SFSDKOAuth2.h"
 #import "SFSDKAppFeatureMarkers.h"
+#import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 
 @interface SFOAuthSessionRefresher()
 
@@ -77,6 +78,14 @@
         return;
     }
     
+    __weak typeof(self) weakSelf = self;
+    [SFSDKAppAttestation attestationIfEnabledFor:self.credentials.domain consumerKey:self.credentials.clientId completionHandler:^(NSString * _Nullable attestation) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf executeRefreshWithAttestation:attestation];
+    }];
+}
+
+- (void)executeRefreshWithAttestation:(NSString * _Nullable)attestation {
     SFSDKOAuthTokenEndpointRequest *request = [[SFSDKOAuthTokenEndpointRequest alloc] init];
     request.additionalOAuthParameterKeys = [SFUserAccountManager sharedInstance].additionalOAuthParameterKeys;
     request.additionalTokenRefreshParams = [SFUserAccountManager sharedInstance].additionalTokenRefreshParams;
@@ -84,6 +93,7 @@
     request.refreshToken = self.credentials.refreshToken;
     request.redirectURI = self.credentials.redirectUri;
     request.serverURL = [self.credentials overrideDomainIfNeeded];
+    request.attestation = attestation;
     __weak typeof(self) weakSelf = self;
     id<SFSDKOAuthProtocol> authClient = [SFUserAccountManager sharedInstance].authClient();
     [authClient accessTokenForRefresh:request completion:^(SFSDKOAuthTokenEndpointResponse * response) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -394,6 +394,11 @@ NS_SWIFT_NAME(UserAccountManager)
  */
 @property (nonatomic, copy, nullable) NSArray<NotificationType*>* (^filterSupportedNotificationTypes)(NSArray<NotificationType*>* notificationTypes);
 
+/** Whether or not app attestation is enabled. When YES, the SDK will include attestation
+ *  in token endpoint requests (code exchange and refresh). Defaults to NO.
+ */
+@property (nonatomic, assign) BOOL appAttestationEnabled;
+
 /**
  Adds a delegate to this user account manager.
  @param delegate The delegate to add.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
@@ -27,19 +27,17 @@
  */
 
 #import "SFSDKAuthConfigUtil.h"
+#import "SFSDKOAuthConstants.h"
 #import "SFNetwork.h"
 #import <SalesforceSDKCommon/SFJsonUtils.h>
 
 static NSString * const kSFOAuthEndPointAuthConfiguration = @"/.well-known/auth-configuration";
-static NSString * const kSandboxLoginURL = @"test.salesforce.com";
-static NSString * const kProductionLoginURL = @"login.salesforce.com";
-static NSString * const kWelcomeLoginURL = @"welcome.salesforce.com/discovery";
 
 @implementation SFSDKAuthConfigUtil
 
 + (void)getMyDomainAuthConfig:(MyDomainAuthConfigBlock)authConfigBlock loginDomain:(NSString *)loginDomain {
     NSString *orgConfigUrl = [NSString stringWithFormat:@"https://%@%@", loginDomain, kSFOAuthEndPointAuthConfiguration];
-    if ([loginDomain isEqualToString:kSandboxLoginURL] || [loginDomain isEqualToString:kProductionLoginURL] || [loginDomain isEqualToString:kWelcomeLoginURL]) {
+    if ([loginDomain isEqualToString:kSFOAuthSandboxLoginURL] || [loginDomain isEqualToString:kSFOAuthProductionLoginURL] || [loginDomain isEqualToString:kSFOAuthWelcomeLoginURL]) {
         [SFSDKCoreLogger d:[self class] format:@"%@ Skipping auth config retrieval for login pool URL", NSStringFromSelector(_cmd)];
         authConfigBlock(nil, nil);
         return;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -104,6 +104,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSString *codeVerifier;
 @property (nonatomic, assign) NSTimeInterval timeout;
 @property (nonatomic, strong) NSURL *serverURL;
+@property (nonatomic, copy, nullable) NSString *attestation;
 @property (nonatomic, strong, nullable) NSDictionary * additionalTokenRefreshParams;
 @property (nonatomic, strong, nullable) NSArray<NSString *> *additionalOAuthParameterKeys;
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -237,9 +237,13 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     [params appendFormat:@"&%@=%@", kSFOAuthCodeVerifierParamName, endpointReq.codeVerifier];
     NSString *grantType = [[SalesforceSDKManager sharedManager] useHybridAuthentication] ? kSFOAuthGrantTypeHybridAuthorizationCode : kSFOAuthGrantTypeAuthorizationCode;
     [params appendFormat:@"&%@=%@&%@=%@", kSFOAuthGrantType, grantType, kSFOAuthApprovalCode, endpointReq.approvalCode];
+    if (endpointReq.attestation) {
+        [params appendFormat:@"&%@=%@", kSFOAuthAttestation, [endpointReq.attestation sfsdk_stringByURLEncoding]];
+    }
+
     NSData *encodedBody = [params dataUsingEncoding:NSUTF8StringEncoding];
     [request setHTTPBody:encodedBody];
-    
+
     __block NSString *networkIdentifier = [SFNetwork uniqueInstanceIdentifier];
     SFNetwork *network = [SFNetwork sharedEphemeralInstanceWithIdentifier:networkIdentifier];
     __weak typeof(self) weakSelf = self;
@@ -293,6 +297,9 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     [params appendFormat:@"&%@=%@&%@=%@", kSFOAuthGrantType, grantType, kSFOAuthRefreshToken, endpointReq.refreshToken];
     for (NSString * key in endpointReq.additionalTokenRefreshParams) {
         [params appendFormat:@"&%@=%@", [key sfsdk_stringByURLEncoding], [endpointReq.additionalTokenRefreshParams[key] sfsdk_stringByURLEncoding]];
+    }
+    if (endpointReq.attestation) {
+        [params appendFormat:@"&%@=%@", kSFOAuthAttestation, [endpointReq.attestation sfsdk_stringByURLEncoding]];
     }
     NSData *encodedBody = [params dataUsingEncoding:NSUTF8StringEncoding];
     [request setHTTPBody:encodedBody];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -78,12 +78,12 @@ static NSString * const kSFOAuthCookieSidClient                 = @"cookie-sid_C
 static NSString * const kSFOAuthSidCookieName                   = @"sidCookieName";
 static NSString * const kSFOAuthParentSid                       = @"parent_sid";
 static NSString * const kSFOAuthTokenFormat                     = @"token_format";
+static NSString * const kSFOAuthAttestation                     = @"attestation";
 static NSString * const kSFOAuthBeaconChildConsumerKey          = @"auto_installed_app_org_consumer_key";
 static NSString * const kSFOAuthBeaconChildConsumerSecret       = @"auto_installed_app_org_consumer_secret";
 // TODO: Remove legacy fallback constants once server version 264 has rolled out everywhere.
 static NSString * const kSFOAuthLegacyBeaconChildConsumerKey    = @"beacon_child_consumer_key";
 static NSString * const kSFOAuthLegacyBeaconChildConsumerSecret = @"beacon_child_consumer_secret";
-
 
 // Used for the IP bypass flow, Advanced auth flow
 static NSString * const kSFOAuthApprovalCode                     = @"code";
@@ -146,5 +146,10 @@ static NSString * const kSFOAuthEndPointHeadlessInitRegistration = @"services/au
 
 /// Endpoint path for Salesforce Identity API headless forgot password flow
 static NSString * const kSFOAuthEndPointHeadlessForgotPassword = @"services/auth/headless/forgot_password";
+
+// Standard login pool URLs (non-My Domain)
+static NSString * const kSFOAuthProductionLoginURL               = @"login.salesforce.com";
+static NSString * const kSFOAuthSandboxLoginURL                  = @"test.salesforce.com";
+static NSString * const kSFOAuthWelcomeLoginURL                  = @"welcome.salesforce.com/discovery";
 
 #endif /* SFSDKOAuthConstants_h */

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AppAttestationTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AppAttestationTests.swift
@@ -1,0 +1,297 @@
+//
+//  AppAttestationTests.swift
+//  SalesforceSDKCore
+//
+//  Created by Brianna Birman on 4/17/26.
+//  Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+//
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import XCTest
+import DeviceCheck
+import CryptoKit
+@testable import SalesforceSDKCore
+
+class AppAttestationTests: XCTestCase {
+
+    private var originalAppAttestationEnabled = false
+
+    override func setUp() {
+        super.setUp()
+        originalAppAttestationEnabled = UserAccountManager.shared.appAttestationEnabled
+        _ = KeychainHelper.remove(service: AppAttestation.appAttestKeyName, account: nil)
+    }
+
+    override func tearDown() {
+        UserAccountManager.shared.appAttestationEnabled = originalAppAttestationEnabled
+        _ = KeychainHelper.remove(service: AppAttestation.appAttestKeyName, account: nil)
+        super.tearDown()
+    }
+
+    // MARK: - AttestationObject Tests
+
+    func test_givenValidAttestationData_whenEncodingAttestationObject_thenReturnsBase64EncodedJSON() throws {
+        let attestationId = "testId"
+        let attestationData = "testData".data(using: .utf8)!.base64EncodedString()
+
+        let attestationObject = AppAttestation.AttestationObject(
+            attestationId: attestationId,
+            attestationData: attestationData
+        )
+
+        let jsonData = try JSONEncoder().encode(attestationObject)
+        let base64String = jsonData.base64EncodedString()
+
+        XCTAssertFalse(base64String.isEmpty, "Base64 encoded string should not be empty")
+
+        // Verify we can decode it back
+        let decodedData = try XCTUnwrap(Data(base64Encoded: base64String))
+        let decodedObject = try JSONDecoder().decode(AppAttestation.AttestationObject.self, from: decodedData)
+
+        XCTAssertEqual(decodedObject.attestationId, attestationId)
+        XCTAssertEqual(decodedObject.attestationData, attestationData)
+    }
+
+    // MARK: - Challenge Hash Tests
+
+    func test_givenChallengeString_whenGeneratingHash_thenReturnsSHA256Hash() throws {
+        let challenge = "testChallenge"
+        let challengeData = try XCTUnwrap(challenge.data(using: .utf8))
+        let hash = Data(SHA256.hash(data: challengeData))
+
+        // SHA256 always produces 32 bytes
+        XCTAssertEqual(hash.count, 32, "SHA256 hash should be 32 bytes")
+    }
+
+
+    // MARK: - Error Handling Tests
+
+    func test_givenEmptyChallenge_whenGeneratingHash_thenReturnsValidHash() throws {
+        let challenge = ""
+        let challengeData = try XCTUnwrap(challenge.data(using: .utf8))
+        let hash = Data(SHA256.hash(data: challengeData))
+
+        XCTAssertEqual(hash.count, 32, "SHA256 hash should still be 32 bytes for empty input")
+    }
+
+    // MARK: - URL Encoding Tests
+
+    func test_givenAttestationObjectWithSpecialCharacters_whenURLEncoding_thenProperlyEncoded() {
+        let attestationObject = "test+string/with=special&chars"
+        let encoded = attestationObject.sfsdk_stringByURLEncoding()
+
+        XCTAssertNotEqual(attestationObject, encoded, "Encoded string should differ from original")
+        XCTAssertTrue(encoded.contains("%"), "Encoded string should contain percent encoding")
+    }
+
+    func test_givenBase64EncodedData_whenURLEncoding_thenProperlyHandlesPaddingAndSpecialChars() {
+        let testData = "test data".data(using: .utf8)!
+        let base64String = testData.base64EncodedString()
+        let encoded = base64String.sfsdk_stringByURLEncoding()
+
+        // Base64 can contain +, /, = which should be encoded
+        XCTAssertFalse(encoded.contains("+") || encoded.contains("/") || encoded.contains("="),
+                       "Encoded string should not contain unencoded special characters")
+    }
+
+    // MARK: - JSON Encoding/Decoding Tests
+
+    func test_givenAttestationObject_whenEncodingAndDecoding_thenPreservesData() throws {
+        let original = AppAttestation.AttestationObject(
+            attestationId: "testId123",
+            attestationData: "dGVzdERhdGE="
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(AppAttestation.AttestationObject.self, from: encoded)
+
+        XCTAssertEqual(original.attestationId, decoded.attestationId)
+        XCTAssertEqual(original.attestationData, decoded.attestationData)
+    }
+
+    func test_givenMalformedJSON_whenDecodingAttestationObject_thenThrowsError() {
+        let malformedJSON = "{\"attestationId\":\"test\"}".data(using: .utf8)!
+
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(AppAttestation.AttestationObject.self, from: malformedJSON),
+            "Decoding incomplete JSON should throw error"
+        ) { error in
+            XCTAssertTrue(error is DecodingError, "Should be a DecodingError")
+        }
+    }
+
+    // MARK: - Integration-Style Tests (Note: These require mocking DCAppAttestService)
+
+    func test_givenValidInputs_whenCreatingAttestationObjectComponents_thenComponentsAreValid() throws {
+        // This tests the data transformation logic without actual attestation
+        let attestationId = "testId"
+        let mockAttestationData = Data([0x01, 0x02, 0x03, 0x04])
+        let base64Attestation = mockAttestationData.base64EncodedString()
+
+        let attestationObject = AppAttestation.AttestationObject(
+            attestationId: attestationId,
+            attestationData: base64Attestation
+        )
+
+        let jsonData = try JSONEncoder().encode(attestationObject)
+        let base64EncodedObject = jsonData.base64EncodedString()
+
+        // Verify the structure
+        XCTAssertFalse(base64EncodedObject.isEmpty)
+
+        // Verify it can be decoded
+        let decodedData = try XCTUnwrap(Data(base64Encoded: base64EncodedObject))
+        let decodedObject = try JSONDecoder().decode(AppAttestation.AttestationObject.self, from: decodedData)
+
+        XCTAssertEqual(decodedObject.attestationId, attestationId)
+        XCTAssertEqual(decodedObject.attestationData, base64Attestation)
+    }
+
+    // MARK: - Edge Cases
+
+    func test_givenVeryLongAttestationId_whenEncodingAttestationObject_thenSucceeds() throws {
+        let longId = String(repeating: "a", count: 1000)
+        let attestationData = "testData".data(using: .utf8)!.base64EncodedString()
+
+        let attestationObject = AppAttestation.AttestationObject(
+            attestationId: longId,
+            attestationData: attestationData
+        )
+
+        XCTAssertNoThrow(try JSONEncoder().encode(attestationObject))
+    }
+
+    func test_givenVeryLargeAttestationData_whenEncodingAttestationObject_thenSucceeds() throws {
+        let largeData = Data(repeating: 0xFF, count: 10000)
+        let attestationData = largeData.base64EncodedString()
+
+        let attestationObject = AppAttestation.AttestationObject(
+            attestationId: "testId",
+            attestationData: attestationData
+        )
+
+        XCTAssertNoThrow(try JSONEncoder().encode(attestationObject))
+    }
+
+    func test_givenUnicodeCharacters_whenEncodingAttestationId_thenSucceeds() throws {
+        let unicodeId = "测试🎉αβγ"
+        let attestationData = "testData".data(using: .utf8)!.base64EncodedString()
+
+        let attestationObject = AppAttestation.AttestationObject(
+            attestationId: unicodeId,
+            attestationData: attestationData
+        )
+
+        let jsonData = try JSONEncoder().encode(attestationObject)
+        let decoded = try JSONDecoder().decode(AppAttestation.AttestationObject.self, from: jsonData)
+
+        XCTAssertEqual(decoded.attestationId, unicodeId)
+    }
+
+
+    // MARK: - Constants Tests
+
+    func test_appAttestKeyName_hasExpectedValue() {
+        XCTAssertEqual(AppAttestation.appAttestKeyName, "com.salesforce.mobilesdk.attestation",
+                      "App attest key name constant should match expected value")
+    }
+
+    // MARK: - Gating Logic Tests (attestationIfEnabled)
+
+    func test_givenAttestationDisabled_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+        UserAccountManager.shared.appAttestationEnabled = false
+        let result = await AppAttestation.attestationIfEnabled(for: "mydomain.my.salesforce.com", consumerKey: "consumerKey123")
+        XCTAssertNil(result, "Should return nil when attestation is disabled")
+    }
+
+    func test_givenLoginSalesforceDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = await AppAttestation.attestationIfEnabled(for: "login.salesforce.com", consumerKey: "consumerKey123")
+        XCTAssertNil(result, "Should return nil for login.salesforce.com (login pool)")
+    }
+
+    func test_givenTestSalesforceDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = await AppAttestation.attestationIfEnabled(for: "test.salesforce.com", consumerKey: "consumerKey123")
+        XCTAssertNil(result, "Should return nil for test.salesforce.com (login pool)")
+    }
+
+    func test_givenWelcomeDiscoveryDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = await AppAttestation.attestationIfEnabled(for: "welcome.salesforce.com/discovery", consumerKey: "consumerKey123")
+        XCTAssertNil(result, "Should return nil for welcome.salesforce.com/discovery (login pool)")
+    }
+
+    func test_givenEmptyConsumerKey_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = await AppAttestation.attestationIfEnabled(for: "mydomain.my.salesforce.com", consumerKey: "")
+        XCTAssertNil(result, "Should return nil when consumer key is empty")
+    }
+
+    // MARK: - existingKeyId Tests
+
+    func test_givenNoKeychainData_whenCallingExistingKeyId_thenReturnsNil() throws {
+        let result = try AppAttestation.existingKeyId(for: "device123")
+        XCTAssertNil(result, "Should return nil when no keychain entry exists")
+    }
+
+    func test_givenMatchingAttestationId_whenCallingExistingKeyId_thenReturnsKeyId() throws {
+        let attestationId = "device123"
+        let keyId = "storedKey456"
+        let item = AppAttestation.AttestationKeychainItem(attestationId: attestationId, keyId: keyId)
+        let data = try JSONEncoder().encode(item)
+        _ = KeychainHelper.write(service: AppAttestation.appAttestKeyName, data: data, account: nil)
+
+        let result = try AppAttestation.existingKeyId(for: attestationId)
+        XCTAssertEqual(result, keyId)
+    }
+
+    func test_givenMismatchedAttestationId_whenCallingExistingKeyId_thenReturnsNilAndRemovesEntry() throws {
+        let item = AppAttestation.AttestationKeychainItem(attestationId: "oldDevice", keyId: "oldKey")
+        let data = try JSONEncoder().encode(item)
+        _ = KeychainHelper.write(service: AppAttestation.appAttestKeyName, data: data, account: nil)
+
+        let result = try AppAttestation.existingKeyId(for: "newDevice")
+        XCTAssertNil(result, "Should return nil when attestationId doesn't match")
+
+        // Verify the stale entry was removed
+        let readResult = KeychainHelper.read(service: AppAttestation.appAttestKeyName, account: nil)
+        XCTAssertNil(readResult.data, "Stale keychain entry should have been removed")
+    }
+
+    func test_givenCorruptedKeychainData_whenCallingExistingKeyId_thenReturnsNil() throws {
+        let corruptData = "not json".data(using: .utf8)!
+        _ = KeychainHelper.write(service: AppAttestation.appAttestKeyName, data: corruptData, account: nil)
+
+        let result = try AppAttestation.existingKeyId(for: "device123")
+        XCTAssertNil(result, "Should return nil when keychain data can't be decoded")
+    }
+
+    func test_givenPartialJSON_whenCallingExistingKeyId_thenReturnsNil() throws {
+        // Valid JSON but missing required keyId field
+        let partialData = "{\"attestationId\":\"device123\"}".data(using: .utf8)!
+        _ = KeychainHelper.write(service: AppAttestation.appAttestKeyName, data: partialData, account: nil)
+
+        let result = try AppAttestation.existingKeyId(for: "device123")
+        XCTAssertNil(result, "Should return nil when keychain data is missing required fields")
+    }
+
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AppAttestationTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AppAttestationTests.swift
@@ -214,36 +214,60 @@ class AppAttestationTests: XCTestCase {
                       "App attest key name constant should match expected value")
     }
 
-    // MARK: - Gating Logic Tests (attestationIfEnabled)
+    // MARK: - Gating Logic Tests (shouldAttemptAttestation)
 
-    func test_givenAttestationDisabled_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+    func test_givenAllConditionsMet_whenCheckingShouldAttempt_thenReturnsTrue() {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = AppAttestation.shouldAttemptAttestation(for: "mydomain.my.salesforce.com", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertTrue(result, "Should return true when all conditions are met")
+    }
+
+    func test_givenAttestationDisabled_whenCheckingShouldAttempt_thenReturnsFalse() {
         UserAccountManager.shared.appAttestationEnabled = false
-        let result = await AppAttestation.attestationIfEnabled(for: "mydomain.my.salesforce.com", consumerKey: "consumerKey123")
-        XCTAssertNil(result, "Should return nil when attestation is disabled")
+        let result = AppAttestation.shouldAttemptAttestation(for: "mydomain.my.salesforce.com", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false when attestation is disabled")
     }
 
-    func test_givenLoginSalesforceDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+    func test_givenDeviceNotSupported_whenCheckingShouldAttempt_thenReturnsFalse() {
         UserAccountManager.shared.appAttestationEnabled = true
-        let result = await AppAttestation.attestationIfEnabled(for: "login.salesforce.com", consumerKey: "consumerKey123")
-        XCTAssertNil(result, "Should return nil for login.salesforce.com (login pool)")
+        let result = AppAttestation.shouldAttemptAttestation(for: "mydomain.my.salesforce.com", consumerKey: "consumerKey123", isDeviceSupported: false)
+        XCTAssertFalse(result, "Should return false when device does not support App Attest")
     }
 
-    func test_givenTestSalesforceDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+    func test_givenLoginSalesforceDomain_whenCheckingShouldAttempt_thenReturnsFalse() {
         UserAccountManager.shared.appAttestationEnabled = true
-        let result = await AppAttestation.attestationIfEnabled(for: "test.salesforce.com", consumerKey: "consumerKey123")
-        XCTAssertNil(result, "Should return nil for test.salesforce.com (login pool)")
+        let result = AppAttestation.shouldAttemptAttestation(for: "login.salesforce.com", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false for login.salesforce.com (login pool)")
     }
 
-    func test_givenWelcomeDiscoveryDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+    func test_givenTestSalesforceDomain_whenCheckingShouldAttempt_thenReturnsFalse() {
         UserAccountManager.shared.appAttestationEnabled = true
-        let result = await AppAttestation.attestationIfEnabled(for: "welcome.salesforce.com/discovery", consumerKey: "consumerKey123")
-        XCTAssertNil(result, "Should return nil for welcome.salesforce.com/discovery (login pool)")
+        let result = AppAttestation.shouldAttemptAttestation(for: "test.salesforce.com", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false for test.salesforce.com (login pool)")
     }
 
-    func test_givenEmptyConsumerKey_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+    func test_givenWelcomeDiscoveryDomain_whenCheckingShouldAttempt_thenReturnsFalse() {
         UserAccountManager.shared.appAttestationEnabled = true
-        let result = await AppAttestation.attestationIfEnabled(for: "mydomain.my.salesforce.com", consumerKey: "")
-        XCTAssertNil(result, "Should return nil when consumer key is empty")
+        let result = AppAttestation.shouldAttemptAttestation(for: "welcome.salesforce.com/discovery", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false for welcome.salesforce.com/discovery (login pool)")
+    }
+
+    func test_givenNilDomain_whenCheckingShouldAttempt_thenReturnsFalse() {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = AppAttestation.shouldAttemptAttestation(for: nil, consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false when domain is nil")
+    }
+
+    func test_givenEmptyDomain_whenCheckingShouldAttempt_thenReturnsFalse() {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = AppAttestation.shouldAttemptAttestation(for: "", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false when domain is empty")
+    }
+
+    func test_givenEmptyConsumerKey_whenCheckingShouldAttempt_thenReturnsFalse() {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = AppAttestation.shouldAttemptAttestation(for: "mydomain.my.salesforce.com", consumerKey: "", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false when consumer key is empty")
     }
 
     // MARK: - existingKeyId Tests

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -54,6 +54,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return .allow
         }
         
+        // Uncomment following line to enable app attestation
+        // Need to add "App Attest" entitlement to project under "Signing & Capabilities"
+        // UserAccountManager.shared.appAttestationEnabled = true
+        
         // Uncomment following block to enable IDP Login flow.
         //SalesforceManager.shared.identityProviderURLScheme = "sampleidpapp"
     }


### PR DESCRIPTION
Created new branch off of dev

This PR includes:
- Attestation structure for key generation & challenge generation
- Flag to enable / disable
- Using attestation on code exchange and refresh

Doesn't include:
- Enforcing web server if attestation is enabled (upcoming PR)
- Feature flag (upcoming PR)
- Native login
- Error handling / retryable errors
