### PR TITLE
Fix login-host recovery on iOS 26: broaden classifier + surface prefetch errors

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		A3C7476129F709EB00D72B7F /* BiometricAuthenticationManagerInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C7476029F709EB00D72B7F /* BiometricAuthenticationManagerInternal.swift */; };
 		AA9154482F59E3C900A0A41C /* SFRestAPIDataTaskRaceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9154472F59E3C900A0A41C /* SFRestAPIDataTaskRaceTests.m */; };
 		B70135621F87F63900995171 /* SFSDKAuthErrorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B70135601F87F63900995171 /* SFSDKAuthErrorManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		B70135631F87F63900995171 /* SFSDKAuthErrorManager+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B70135651F87F63900995171 /* SFSDKAuthErrorManager+Internal.h */; };
 		B70135641F87F63900995171 /* SFSDKAuthErrorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B70135611F87F63900995171 /* SFSDKAuthErrorManager.m */; };
 		B711290D1F8A780800436CFB /* SFSDKAlertView.m in Sources */ = {isa = PBXBuildFile; fileRef = B71129071F8A780700436CFB /* SFSDKAlertView.m */; };
 		B711290E1F8A780800436CFB /* SFSDKAlertMessageBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = B71129081F8A780800436CFB /* SFSDKAlertMessageBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -824,6 +825,7 @@
 		AA9154472F59E3C900A0A41C /* SFRestAPIDataTaskRaceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFRestAPIDataTaskRaceTests.m; path = SalesforceSDKCoreTests/SFRestAPIDataTaskRaceTests.m; sourceTree = SOURCE_ROOT; };
 		B70135601F87F63900995171 /* SFSDKAuthErrorManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKAuthErrorManager.h; sourceTree = "<group>"; };
 		B70135611F87F63900995171 /* SFSDKAuthErrorManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKAuthErrorManager.m; sourceTree = "<group>"; };
+		B70135651F87F63900995171 /* SFSDKAuthErrorManager+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SFSDKAuthErrorManager+Internal.h"; sourceTree = "<group>"; };
 		B71129071F8A780700436CFB /* SFSDKAlertView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFSDKAlertView.m; sourceTree = "<group>"; };
 		B71129081F8A780800436CFB /* SFSDKAlertMessageBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKAlertMessageBuilder.h; sourceTree = "<group>"; };
 		B71129091F8A780800436CFB /* SFSDKAlertView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SFSDKAlertView.h; sourceTree = "<group>"; };
@@ -1380,6 +1382,7 @@
 				4F96FCF41BFD32130022F021 /* SFAuthErrorHandlerList.h */,
 				4F96FCF51BFD32130022F021 /* SFAuthErrorHandlerList.m */,
 				B70135601F87F63900995171 /* SFSDKAuthErrorManager.h */,
+				B70135651F87F63900995171 /* SFSDKAuthErrorManager+Internal.h */,
 				B70135611F87F63900995171 /* SFSDKAuthErrorManager.m */,
 				6935FB9E23FDEC92002BEFCC /* ViewControllers */,
 			);
@@ -1858,6 +1861,7 @@
 				B7FB26E31F78096300FB25A2 /* SFSDKURLHandlerManager.h in Headers */,
 				CE4CE3091C0E523B009F6029 /* NSURL+SFAdditions.h in Headers */,
 				B70135621F87F63900995171 /* SFSDKAuthErrorManager.h in Headers */,
+				B70135631F87F63900995171 /* SFSDKAuthErrorManager+Internal.h in Headers */,
 				CE4CE32A1C0E523B009F6029 /* SalesforceSDKConstants.h in Headers */,
 				B7C274481F814BF500CE539D /* SFSDKSPLoginRequestCommand.h in Headers */,
 				CE4CE39B1C0E5272009F6029 /* SFSDKTestCredentialsData.h in Headers */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -28,6 +28,7 @@
 #import "SFOAuthCoordinator+Internal.h"
 #import "SFOAuthInfo.h"
 #import "SFSDKAuthConfigUtil.h"
+#import "SFSDKAuthErrorManager.h"
 #import "SFSDKCryptoUtils.h"
 #import "NSData+SFSDKUtils.h"
 #import "NSString+SFAdditions.h"
@@ -55,6 +56,14 @@
 #import <SalesforceSDKCommon/SFSDKDatasharingHelper.h>
 #import <LocalAuthentication/LocalAuthentication.h>
 #import "SFSDKResourceUtils.h"
+// Forward declaration of the shared host-connection classifier so this file
+// stays in sync with the classifier block in SFSDKAuthErrorManager. Not in the
+// public header: this is an internal predicate, tested directly in
+// SFSDKErrorManagerTests.
+@interface SFSDKAuthErrorManager (SFOAuthCoordinatorInternalUse)
++ (BOOL)errorIsHostConnectionFailure:(NSError *)error;
+@end
+
 @interface SFOAuthCoordinator()
 
 @property (nonatomic) NSString *networkIdentifier;
@@ -197,8 +206,19 @@
             [SFSDKAuthConfigUtil getMyDomainAuthConfig:^(SFOAuthOrgAuthConfiguration *authConfig, NSError *error) {
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    // Ignore any errors why retrieving authconfig. Default to WKWebView
-                    // Errors should have already been logged.
+                    // A prefetch error against an unreachable login host is the earliest
+                    // authoritative signal that the host itself is bad. Falling through to
+                    // beginWebViewFlow would dispatch a WKWebView load against the same host
+                    // and hang silently, stranding the user on a blank screen and leaving the
+                    // bad host set as the sticky loginHost across app restarts. Surface it to
+                    // the failure delegate so the error manager's hostConnectionErrorHandler
+                    // can present an alert and roll loginHost back to the previous good host.
+                    // Non-host errors (parse failures, non-2xx responses, endpoint absent on
+                    // standard orgs) continue to fall through — auth-config is optional.
+                    if ([SFSDKAuthErrorManager errorIsHostConnectionFailure:error]) {
+                        [strongSelf notifyDelegateOfFailure:error authInfo:strongSelf.authInfo];
+                        return;
+                    }
                     if (!self.frontdoorBridgeLoginOverride &&
                         (authConfig.useNativeBrowserForAuth ||
                          [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication)) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -56,13 +56,7 @@
 #import <SalesforceSDKCommon/SFSDKDatasharingHelper.h>
 #import <LocalAuthentication/LocalAuthentication.h>
 #import "SFSDKResourceUtils.h"
-// Forward declaration of the shared host-connection classifier so this file
-// stays in sync with the classifier block in SFSDKAuthErrorManager. Not in the
-// public header: this is an internal predicate, tested directly in
-// SFSDKErrorManagerTests.
-@interface SFSDKAuthErrorManager (SFOAuthCoordinatorInternalUse)
-+ (BOOL)errorIsHostConnectionFailure:(NSError *)error;
-@end
+#import "SFSDKAuthErrorManager+Internal.h"
 
 @interface SFOAuthCoordinator()
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFSDKAuthErrorManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFSDKAuthErrorManager+Internal.h
@@ -1,0 +1,40 @@
+/*
+ Copyright (c) 2017-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "SFSDKAuthErrorManager.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+// Internal-only surface for SFSDKAuthErrorManager. Not published in the umbrella
+// header — kept off the public API but shared between SFOAuthCoordinator.m (for
+// the auth-config prefetch gate) and SFSDKErrorManagerTests.m (for direct
+// predicate coverage). A single compiler-visible declaration keeps both call
+// sites in sync if the signature ever changes.
+@interface SFSDKAuthErrorManager (Internal)
+
++ (BOOL)errorIsHostConnectionFailure:(nullable NSError *)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFSDKAuthErrorManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFSDKAuthErrorManager.m
@@ -28,6 +28,7 @@
  */
 
 #import "SFSDKAuthErrorManager.h"
+#import "SFSDKAuthErrorManager+Internal.h"
 #import "SFAuthErrorHandlerList.h"
 #import "SFAuthErrorHandler.h"
 #import "SFOAuthCoordinator+Internal.h"
@@ -135,7 +136,13 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
                                            }];
     [authHandlerList addAuthErrorHandler:self.networkFailureAuthErrorHandler];
     
-    // Host connection error handler
+    // Host connection error handler.
+    //
+    // NSURLErrorTimedOut / CannotConnectToHost / NetworkConnectionLost / NotConnectedToInternet
+    // also appear in +errorIsNetworkFailure:. NetworkFailureErrorHandler runs first in the chain
+    // and claims those codes only on Refresh flows with an existing access token; all other
+    // contexts return NO there and fall through to this handler. Ordering is guarded by
+    // testNetworkFailureClaimsFirst_RefreshWithToken.
     self.hostConnectionErrorHandler = [[SFAuthErrorHandler alloc] initWithName:kSFHostConnectionErrorHandler
                                      authSessionBlock:^BOOL(NSError *error, SFSDKAuthSession *authSession, NSDictionary *options) {
                                         if ([[weakSelf class] errorIsHostConnectionFailure:error]) {
@@ -186,10 +193,11 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 }
 
 /**
- * Evaluates an NSError object to see if it represents a network failure during
- * an attempted connection.
+ * Evaluates an NSError object to see if it represents a host-connection failure —
+ * an unreachable or non-existent login host — rather than a transient network
+ * failure on an otherwise reachable host.
  * @param error The NSError to evaluate.
- * @return YES if the error represents a network failure, NO otherwise.
+ * @return YES if the error should trigger the host-connection recovery path, NO otherwise.
  */
 + (BOOL)errorIsHostConnectionFailure:(NSError *)error
 {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFSDKAuthErrorManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFSDKAuthErrorManager.m
@@ -138,23 +138,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     // Host connection error handler
     self.hostConnectionErrorHandler = [[SFAuthErrorHandler alloc] initWithName:kSFHostConnectionErrorHandler
                                      authSessionBlock:^BOOL(NSError *error, SFSDKAuthSession *authSession, NSDictionary *options) {
-                                        BOOL cfStreamHostError = (error.userInfo[@"_kCFStreamErrorCodeKey"] && error.userInfo[@"_kCFStreamErrorDomainKey"]);
-                                        BOOL oauthInvalidURL   = ([error.domain isEqualToString:kSFOAuthErrorDomain] && error.code == kSFOAuthErrorInvalidURL);
-                                        BOOL urlHostError      = NO;
-                                        if ([error.domain isEqualToString:NSURLErrorDomain]) {
-                                            switch (error.code) {
-                                                case NSURLErrorCannotFindHost:            // -1003
-                                                case NSURLErrorDNSLookupFailed:           // -1006
-                                                case NSURLErrorCannotConnectToHost:       // -1004
-                                                case NSURLErrorTimedOut:                  // -1001
-                                                case NSURLErrorNotConnectedToInternet:    // -1009
-                                                case NSURLErrorNetworkConnectionLost:     // -1005
-                                                    urlHostError = YES;
-                                                    break;
-                                                default: break;
-                                            }
-                                        }
-                                        if (cfStreamHostError || oauthInvalidURL || urlHostError) {
+                                        if ([[weakSelf class] errorIsHostConnectionFailure:error]) {
                                             if (self.hostConnectionErrorHandlerBlock) {
                                                 self.hostConnectionErrorHandlerBlock(error, authSession, options);
                                                 return YES;
@@ -207,6 +191,37 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
  * @param error The NSError to evaluate.
  * @return YES if the error represents a network failure, NO otherwise.
  */
++ (BOOL)errorIsHostConnectionFailure:(NSError *)error
+{
+    if (error == nil || error.domain == nil) {
+        return NO;
+    }
+    // Legacy iOS <= 18 shape: CFNetwork stream stack attached _kCFStreamError* keys to userInfo.
+    if (error.userInfo[@"_kCFStreamErrorCodeKey"] && error.userInfo[@"_kCFStreamErrorDomainKey"]) {
+        return YES;
+    }
+    // OAuth invalid-URL is a bad-host signal.
+    if ([error.domain isEqualToString:kSFOAuthErrorDomain] && error.code == kSFOAuthErrorInvalidURL) {
+        return YES;
+    }
+    // iOS 26+ shape: DNS resolution moved to Network.framework, so the CFStream keys are absent.
+    // NSURLErrorDomain surfaces these codes with a bare userInfo instead.
+    if ([error.domain isEqualToString:NSURLErrorDomain]) {
+        switch (error.code) {
+            case NSURLErrorCannotFindHost:            // -1003
+            case NSURLErrorDNSLookupFailed:           // -1006
+            case NSURLErrorCannotConnectToHost:       // -1004
+            case NSURLErrorTimedOut:                  // -1001
+            case NSURLErrorNotConnectedToInternet:    // -1009
+            case NSURLErrorNetworkConnectionLost:     // -1005
+                return YES;
+            default:
+                break;
+        }
+    }
+    return NO;
+}
+
 + (BOOL)errorIsNetworkFailure:(NSError *)error
 {
     BOOL isNetworkFailure = NO;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFSDKAuthErrorManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFSDKAuthErrorManager.m
@@ -138,11 +138,26 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     // Host connection error handler
     self.hostConnectionErrorHandler = [[SFAuthErrorHandler alloc] initWithName:kSFHostConnectionErrorHandler
                                      authSessionBlock:^BOOL(NSError *error, SFSDKAuthSession *authSession, NSDictionary *options) {
-                                        if ((error.userInfo[@"_kCFStreamErrorCodeKey"] && error.userInfo[@"_kCFStreamErrorDomainKey"]) ||
-                                            ([error.domain isEqualToString:kSFOAuthErrorDomain] && error.code == kSFOAuthErrorInvalidURL)) {
+                                        BOOL cfStreamHostError = (error.userInfo[@"_kCFStreamErrorCodeKey"] && error.userInfo[@"_kCFStreamErrorDomainKey"]);
+                                        BOOL oauthInvalidURL   = ([error.domain isEqualToString:kSFOAuthErrorDomain] && error.code == kSFOAuthErrorInvalidURL);
+                                        BOOL urlHostError      = NO;
+                                        if ([error.domain isEqualToString:NSURLErrorDomain]) {
+                                            switch (error.code) {
+                                                case NSURLErrorCannotFindHost:            // -1003
+                                                case NSURLErrorDNSLookupFailed:           // -1006
+                                                case NSURLErrorCannotConnectToHost:       // -1004
+                                                case NSURLErrorTimedOut:                  // -1001
+                                                case NSURLErrorNotConnectedToInternet:    // -1009
+                                                case NSURLErrorNetworkConnectionLost:     // -1005
+                                                    urlHostError = YES;
+                                                    break;
+                                                default: break;
+                                            }
+                                        }
+                                        if (cfStreamHostError || oauthInvalidURL || urlHostError) {
                                             if (self.hostConnectionErrorHandlerBlock) {
                                                 self.hostConnectionErrorHandlerBlock(error, authSession, options);
-                                                 return YES;
+                                                return YES;
                                             }
                                         }
                                         return NO;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKErrorManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKErrorManagerTests.m
@@ -127,14 +127,208 @@
     XCTestExpectation *errorExpectation =  [self expectationWithDescription:@"genericErrorExpectation"];
     NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
     NSError *error = [NSError errorWithDomain:@"someError" code:-999 userInfo:userInfo];
-    
+
     errorManager.genericErrorHandlerBlock  = ^(NSError * error, SFSDKAuthSession *authSession, NSDictionary *options) {
         [errorExpectation fulfill];
     };
-    
+
     XCTAssertNotNil(errorManager.genericErrorHandlerBlock);
     BOOL handled = [errorManager processAuthError:error authContext:authSession options:userInfo];
     XCTAssertTrue(handled,@"Generic Error should have been handled by the ErrorManager");
+    [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
+#pragma mark - Host connection classifier tests
+
+// Shared helper: assert that the host connection handler claims a bare NSError
+// (no CFStream keys) constructed with the given domain and code, when the
+// session is not a Refresh-with-existing-token flow.
+- (void)assertHostConnectionClaimsDomain:(NSString *)domain code:(NSInteger)code description:(NSString *)description {
+    SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
+    SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
+    XCTAssertNotNil(errorManager);
+    XCTestExpectation *expectation = [self expectationWithDescription:description];
+    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSError *error = [NSError errorWithDomain:domain code:code userInfo:userInfo];
+
+    errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
+        [expectation fulfill];
+    };
+    XCTAssertNotNil(errorManager.hostConnectionErrorHandlerBlock);
+    BOOL handled = [errorManager processAuthError:error authContext:authSession options:userInfo];
+    XCTAssertTrue(handled, @"Host connection error should have been handled by the ErrorManager");
+    [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
+// NSURLErrorDomain host-connection codes with NO CFStream keys claim the host handler.
+// This is the iOS 26 shape — DNS resolution moved to Network.framework, so the legacy
+// _kCFStreamError* keys are absent from top-level userInfo.
+- (void)testHostConnectionError_NSURLErrorCannotFindHost {
+    [self assertHostConnectionClaimsDomain:NSURLErrorDomain
+                                      code:NSURLErrorCannotFindHost
+                               description:@"hostConnectionExpectation_CannotFindHost"];
+}
+
+- (void)testHostConnectionError_NSURLErrorDNSLookupFailed {
+    [self assertHostConnectionClaimsDomain:NSURLErrorDomain
+                                      code:NSURLErrorDNSLookupFailed
+                               description:@"hostConnectionExpectation_DNSLookupFailed"];
+}
+
+- (void)testHostConnectionError_NSURLErrorCannotConnectToHost {
+    [self assertHostConnectionClaimsDomain:NSURLErrorDomain
+                                      code:NSURLErrorCannotConnectToHost
+                               description:@"hostConnectionExpectation_CannotConnectToHost"];
+}
+
+- (void)testHostConnectionError_NSURLErrorTimedOut {
+    [self assertHostConnectionClaimsDomain:NSURLErrorDomain
+                                      code:NSURLErrorTimedOut
+                               description:@"hostConnectionExpectation_TimedOut"];
+}
+
+- (void)testHostConnectionError_NSURLErrorNotConnectedToInternet {
+    [self assertHostConnectionClaimsDomain:NSURLErrorDomain
+                                      code:NSURLErrorNotConnectedToInternet
+                               description:@"hostConnectionExpectation_NotConnectedToInternet"];
+}
+
+- (void)testHostConnectionError_NSURLErrorNetworkConnectionLost {
+    [self assertHostConnectionClaimsDomain:NSURLErrorDomain
+                                      code:NSURLErrorNetworkConnectionLost
+                               description:@"hostConnectionExpectation_NetworkConnectionLost"];
+}
+
+// Legacy iOS <= 18 shape — NSURLErrorDomain / -1003 with CFStream keys in userInfo — still claimed.
+- (void)testHostConnectionError_LegacyCFStreamKeys {
+    SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
+    SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
+    XCTAssertNotNil(errorManager);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"hostConnectionExpectation_LegacyCFStreamKeys"];
+    NSDictionary *userInfo = @{ @"_kCFStreamErrorCodeKey": @8,
+                                @"_kCFStreamErrorDomainKey": @12 };
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCannotFindHost userInfo:userInfo];
+
+    errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
+        [expectation fulfill];
+    };
+    XCTAssertNotNil(errorManager.hostConnectionErrorHandlerBlock);
+    BOOL handled = [errorManager processAuthError:error authContext:authSession options:userInfo];
+    XCTAssertTrue(handled, @"Legacy CFStream-shaped host connection error should have been handled by the ErrorManager");
+    [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
+// kSFOAuthErrorInvalidURL still claimed by the host handler.
+- (void)testHostConnectionError_SFOAuthInvalidURL {
+    SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
+    SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
+    XCTAssertNotNil(errorManager);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"hostConnectionExpectation_SFOAuthInvalidURL"];
+    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain code:kSFOAuthErrorInvalidURL userInfo:userInfo];
+
+    errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
+        [expectation fulfill];
+    };
+    XCTAssertNotNil(errorManager.hostConnectionErrorHandlerBlock);
+    BOOL handled = [errorManager processAuthError:error authContext:authSession options:userInfo];
+    XCTAssertTrue(handled, @"kSFOAuthErrorInvalidURL should have been handled by the ErrorManager host connection handler");
+    [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
+// Unrelated NSURLErrorDomain codes are not host-connectivity — fall through to generic.
+- (void)testGenericError_Cancelled {
+    SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
+    SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
+    XCTAssertNotNil(errorManager);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"genericErrorExpectation_Cancelled"];
+    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo];
+
+    errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
+        XCTFail(@"Cancelled error must not be claimed by the host connection handler");
+    };
+    errorManager.genericErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
+        [expectation fulfill];
+    };
+    BOOL handled = [errorManager processAuthError:error authContext:authSession options:userInfo];
+    XCTAssertTrue(handled, @"Cancelled error should have been handled by the generic handler");
+    [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
+- (void)testGenericError_UserAuthRequired {
+    SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
+    SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
+    XCTAssertNotNil(errorManager);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"genericErrorExpectation_UserAuthRequired"];
+    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorUserAuthenticationRequired userInfo:userInfo];
+
+    errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
+        XCTFail(@"UserAuthenticationRequired must not be claimed by the host connection handler");
+    };
+    errorManager.genericErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
+        [expectation fulfill];
+    };
+    BOOL handled = [errorManager processAuthError:error authContext:authSession options:userInfo];
+    XCTAssertTrue(handled, @"UserAuthenticationRequired error should have been handled by the generic handler");
+    [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
+// kSFOAuthErrorInvalidGrant must not be claimed by the host connection handler.
+- (void)testHostConnectionDoesNotClaim_SFOAuthInvalidGrant {
+    SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
+    SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
+    XCTAssertNotNil(errorManager);
+    XCTestExpectation *expectation = [self expectationWithDescription:@"invalidGrantExpectation"];
+    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain code:kSFOAuthErrorInvalidGrant userInfo:userInfo];
+
+    errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
+        XCTFail(@"kSFOAuthErrorInvalidGrant must not be claimed by the host connection handler");
+    };
+    errorManager.invalidAuthCredentialsErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
+        [expectation fulfill];
+    };
+    BOOL handled = [errorManager processAuthError:error authContext:authSession options:userInfo];
+    XCTAssertTrue(handled, @"kSFOAuthErrorInvalidGrant should have been handled by the invalid credentials handler");
+    [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
+// On a Refresh flow with an existing access token, the network handler still
+// claims -1001 TimedOut before the host connection handler sees it.
+- (void)testNetworkFailureClaimsFirst_RefreshWithToken {
+    SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
+
+    SFOAuthCredentials *credentials = [TestSetupUtils newClientCredentials];
+    credentials.accessToken = @"__ACCESS_TOKEN__";
+    credentials.refreshToken = @"__REFRESH_TOKEN__";
+    credentials.userId = @"USER123";
+    credentials.organizationId = @"ORG123";
+
+    SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:credentials];
+    [[SFUserAccountManager sharedInstance] saveAccountForUser:account error:nil];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:account];
+    SFSDKAuthRequest *request = [[SFSDKAuthRequest alloc] init];
+    SFSDKAuthSession *session = [[SFSDKAuthSession alloc] initWith:request credentials:credentials spAppCredentials:nil];
+    session.oauthCoordinator.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
+
+    XCTAssertNotNil(errorManager);
+    XCTestExpectation *networkErrorExpectation = [self expectationWithDescription:@"networkErrorExpectation_RefreshWithToken"];
+    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:userInfo];
+
+    errorManager.networkErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
+        [networkErrorExpectation fulfill];
+    };
+    errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
+        XCTFail(@"Host connection handler must not claim network errors on Refresh-with-token flows");
+    };
+
+    XCTAssertNotNil(errorManager.networkErrorHandlerBlock);
+    BOOL handled = [errorManager processAuthError:error authContext:session options:userInfo];
+    XCTAssertTrue(handled, @"Network Error Should have been handled by the ErrorManager on Refresh flow");
+    [[SFUserAccountManager sharedInstance] deleteAccountForUser:account error:nil];
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKErrorManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKErrorManagerTests.m
@@ -23,14 +23,8 @@
  */
 #import <XCTest/XCTest.h>
 #import "SFSDKAuthErrorManager.h"
+#import "SFSDKAuthErrorManager+Internal.h"
 #import "SFOAuthInfo.h"
-
-// Same shared-predicate forward declaration used by SFOAuthCoordinator.m. Keeps
-// the classifier tested at its public entry point without expanding the SDK's
-// public header surface for what is an internal helper.
-@interface SFSDKAuthErrorManager (SFSDKErrorManagerTestsInternalUse)
-+ (BOOL)errorIsHostConnectionFailure:(NSError *)error;
-@end
 #import "SFOAuthCoordinator+Internal.h"
 #import "SFUserAccountManager+Internal.h"
 #import "SFOAuthCredentials+Internal.h"
@@ -153,15 +147,13 @@
 - (void)assertHostConnectionClaimsDomain:(NSString *)domain code:(NSInteger)code description:(NSString *)description {
     SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
     SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
-    XCTAssertNotNil(errorManager);
     XCTestExpectation *expectation = [self expectationWithDescription:description];
-    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSDictionary *userInfo = @{};
     NSError *error = [NSError errorWithDomain:domain code:code userInfo:userInfo];
 
     errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
         [expectation fulfill];
     };
-    XCTAssertNotNil(errorManager.hostConnectionErrorHandlerBlock);
     BOOL handled = [errorManager processAuthError:error authContext:authSession options:userInfo];
     XCTAssertTrue(handled, @"Host connection error should have been handled by the ErrorManager");
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
@@ -210,7 +202,6 @@
 - (void)testHostConnectionError_LegacyCFStreamKeys {
     SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
     SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
-    XCTAssertNotNil(errorManager);
     XCTestExpectation *expectation = [self expectationWithDescription:@"hostConnectionExpectation_LegacyCFStreamKeys"];
     NSDictionary *userInfo = @{ @"_kCFStreamErrorCodeKey": @8,
                                 @"_kCFStreamErrorDomainKey": @12 };
@@ -219,7 +210,6 @@
     errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
         [expectation fulfill];
     };
-    XCTAssertNotNil(errorManager.hostConnectionErrorHandlerBlock);
     BOOL handled = [errorManager processAuthError:error authContext:authSession options:userInfo];
     XCTAssertTrue(handled, @"Legacy CFStream-shaped host connection error should have been handled by the ErrorManager");
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
@@ -229,15 +219,13 @@
 - (void)testHostConnectionError_SFOAuthInvalidURL {
     SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
     SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
-    XCTAssertNotNil(errorManager);
     XCTestExpectation *expectation = [self expectationWithDescription:@"hostConnectionExpectation_SFOAuthInvalidURL"];
-    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSDictionary *userInfo = @{};
     NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain code:kSFOAuthErrorInvalidURL userInfo:userInfo];
 
     errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
         [expectation fulfill];
     };
-    XCTAssertNotNil(errorManager.hostConnectionErrorHandlerBlock);
     BOOL handled = [errorManager processAuthError:error authContext:authSession options:userInfo];
     XCTAssertTrue(handled, @"kSFOAuthErrorInvalidURL should have been handled by the ErrorManager host connection handler");
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
@@ -247,9 +235,8 @@
 - (void)testGenericError_Cancelled {
     SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
     SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
-    XCTAssertNotNil(errorManager);
     XCTestExpectation *expectation = [self expectationWithDescription:@"genericErrorExpectation_Cancelled"];
-    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSDictionary *userInfo = @{};
     NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:userInfo];
 
     errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
@@ -266,9 +253,8 @@
 - (void)testGenericError_UserAuthRequired {
     SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
     SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
-    XCTAssertNotNil(errorManager);
     XCTestExpectation *expectation = [self expectationWithDescription:@"genericErrorExpectation_UserAuthRequired"];
-    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSDictionary *userInfo = @{};
     NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorUserAuthenticationRequired userInfo:userInfo];
 
     errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
@@ -286,9 +272,8 @@
 - (void)testHostConnectionDoesNotClaim_SFOAuthInvalidGrant {
     SFSDKAuthErrorManager *errorManager = [[SFSDKAuthErrorManager alloc] init];
     SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] init];
-    XCTAssertNotNil(errorManager);
     XCTestExpectation *expectation = [self expectationWithDescription:@"invalidGrantExpectation"];
-    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSDictionary *userInfo = @{};
     NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain code:kSFOAuthErrorInvalidGrant userInfo:userInfo];
 
     errorManager.hostConnectionErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
@@ -320,9 +305,8 @@
     SFSDKAuthSession *session = [[SFSDKAuthSession alloc] initWith:request credentials:credentials spAppCredentials:nil];
     session.oauthCoordinator.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
 
-    XCTAssertNotNil(errorManager);
     XCTestExpectation *networkErrorExpectation = [self expectationWithDescription:@"networkErrorExpectation_RefreshWithToken"];
-    NSDictionary *userInfo = [[NSMutableDictionary alloc] init];
+    NSDictionary *userInfo = @{};
     NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorTimedOut userInfo:userInfo];
 
     errorManager.networkErrorHandlerBlock = ^(NSError *e, SFSDKAuthSession *s, NSDictionary *o) {
@@ -332,11 +316,10 @@
         XCTFail(@"Host connection handler must not claim network errors on Refresh-with-token flows");
     };
 
-    XCTAssertNotNil(errorManager.networkErrorHandlerBlock);
     BOOL handled = [errorManager processAuthError:error authContext:session options:userInfo];
     XCTAssertTrue(handled, @"Network Error Should have been handled by the ErrorManager on Refresh flow");
-    [[SFUserAccountManager sharedInstance] deleteAccountForUser:account error:nil];
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
+    [[SFUserAccountManager sharedInstance] deleteAccountForUser:account error:nil];
 }
 
 #pragma mark - errorIsHostConnectionFailure predicate
@@ -346,10 +329,14 @@
 // auth-config prefetch callback consult it, so exercising it directly guards
 // both call sites against silent classification drift.
 
-- (void)testErrorIsHostConnectionFailure_NilInputs {
+- (void)testErrorIsHostConnectionFailure_NilAndEmptyDomain {
     XCTAssertFalse([SFSDKAuthErrorManager errorIsHostConnectionFailure:nil]);
-    NSError *nilDomain = [NSError errorWithDomain:@"" code:0 userInfo:nil];
-    XCTAssertFalse([SFSDKAuthErrorManager errorIsHostConnectionFailure:nilDomain]);
+    // A truly nil domain cannot be constructed here: +errorWithDomain:code:userInfo:
+    // raises NSInvalidArgumentException on a nil domain. The nil-domain branch in
+    // +errorIsHostConnectionFailure: is exercised only via the nil-error path
+    // above; an empty-string domain covers the "unknown foreign domain" fallthrough.
+    NSError *emptyDomain = [NSError errorWithDomain:@"" code:0 userInfo:nil];
+    XCTAssertFalse([SFSDKAuthErrorManager errorIsHostConnectionFailure:emptyDomain]);
 }
 
 - (void)testErrorIsHostConnectionFailure_LegacyCFStreamKeys {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKErrorManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKErrorManagerTests.m
@@ -24,6 +24,13 @@
 #import <XCTest/XCTest.h>
 #import "SFSDKAuthErrorManager.h"
 #import "SFOAuthInfo.h"
+
+// Same shared-predicate forward declaration used by SFOAuthCoordinator.m. Keeps
+// the classifier tested at its public entry point without expanding the SDK's
+// public header surface for what is an internal helper.
+@interface SFSDKAuthErrorManager (SFSDKErrorManagerTestsInternalUse)
++ (BOOL)errorIsHostConnectionFailure:(NSError *)error;
+@end
 #import "SFOAuthCoordinator+Internal.h"
 #import "SFUserAccountManager+Internal.h"
 #import "SFOAuthCredentials+Internal.h"
@@ -330,6 +337,62 @@
     XCTAssertTrue(handled, @"Network Error Should have been handled by the ErrorManager on Refresh flow");
     [[SFUserAccountManager sharedInstance] deleteAccountForUser:account error:nil];
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
+#pragma mark - errorIsHostConnectionFailure predicate
+
+// The shared predicate is the single source of truth for what counts as a
+// host-connection failure. Both the classifier block and SFOAuthCoordinator's
+// auth-config prefetch callback consult it, so exercising it directly guards
+// both call sites against silent classification drift.
+
+- (void)testErrorIsHostConnectionFailure_NilInputs {
+    XCTAssertFalse([SFSDKAuthErrorManager errorIsHostConnectionFailure:nil]);
+    NSError *nilDomain = [NSError errorWithDomain:@"" code:0 userInfo:nil];
+    XCTAssertFalse([SFSDKAuthErrorManager errorIsHostConnectionFailure:nilDomain]);
+}
+
+- (void)testErrorIsHostConnectionFailure_LegacyCFStreamKeys {
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain
+                                         code:NSURLErrorCannotFindHost
+                                     userInfo:@{ @"_kCFStreamErrorCodeKey": @8,
+                                                 @"_kCFStreamErrorDomainKey": @12 }];
+    XCTAssertTrue([SFSDKAuthErrorManager errorIsHostConnectionFailure:error]);
+}
+
+- (void)testErrorIsHostConnectionFailure_SFOAuthInvalidURL {
+    NSError *error = [NSError errorWithDomain:kSFOAuthErrorDomain
+                                         code:kSFOAuthErrorInvalidURL
+                                     userInfo:nil];
+    XCTAssertTrue([SFSDKAuthErrorManager errorIsHostConnectionFailure:error]);
+}
+
+- (void)testErrorIsHostConnectionFailure_ModernNSURLCodes {
+    NSArray<NSNumber *> *codes = @[ @(NSURLErrorCannotFindHost),
+                                    @(NSURLErrorDNSLookupFailed),
+                                    @(NSURLErrorCannotConnectToHost),
+                                    @(NSURLErrorTimedOut),
+                                    @(NSURLErrorNotConnectedToInternet),
+                                    @(NSURLErrorNetworkConnectionLost) ];
+    for (NSNumber *code in codes) {
+        NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:code.integerValue userInfo:nil];
+        XCTAssertTrue([SFSDKAuthErrorManager errorIsHostConnectionFailure:error],
+                      @"Expected NSURLError %ld to be classified as a host connection failure", (long)code.integerValue);
+    }
+}
+
+- (void)testErrorIsHostConnectionFailure_UnrelatedCodesReturnNO {
+    NSError *cancelled = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled userInfo:nil];
+    XCTAssertFalse([SFSDKAuthErrorManager errorIsHostConnectionFailure:cancelled]);
+
+    NSError *userAuth = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorUserAuthenticationRequired userInfo:nil];
+    XCTAssertFalse([SFSDKAuthErrorManager errorIsHostConnectionFailure:userAuth]);
+
+    NSError *invalidGrant = [NSError errorWithDomain:kSFOAuthErrorDomain code:kSFOAuthErrorInvalidGrant userInfo:nil];
+    XCTAssertFalse([SFSDKAuthErrorManager errorIsHostConnectionFailure:invalidGrant]);
+
+    NSError *foreign = [NSError errorWithDomain:@"com.example.some-other-domain" code:-1001 userInfo:nil];
+    XCTAssertFalse([SFSDKAuthErrorManager errorIsHostConnectionFailure:foreign]);
 }
 
 @end


### PR DESCRIPTION
## What

On iOS 26 the login-host recovery path is never entered when a user enters an unreachable custom login host at the picker. Two independent defects contribute to the same user-visible symptom:

1. The `HostConnectionErrorHandler` classifier in `SFSDKAuthErrorManager` did not recognize modern iOS 26 error shapes.
2. `SFOAuthCoordinator` silently swallowed host-connection errors from the auth-configuration pre-flight, so the failure delegate was never invoked and the classifier never got a chance to fire.

Symptom before this PR: the app either loops on an alert (fix #1's regression) or, worse, hangs on a blank splash with no alert at all (fix #2's regression) and the bad host stays set as `loginHost` across app restarts.

## Root cause 1 — classifier misses iOS 26 error shapes

The classifier gated on:

```objc
if ((error.userInfo[@\"_kCFStreamErrorCodeKey\"] && error.userInfo[@\"_kCFStreamErrorDomainKey\"]) ||
    ([error.domain isEqualToString:kSFOAuthErrorDomain] && error.code == kSFOAuthErrorInvalidURL)) {
    ...
    return YES;
}
return NO;
```

Both iOS 18 and iOS 26 surface DNS failures at the top level as `NSURLErrorDomain / -1003 CannotFindHost`, but the two versions structure `userInfo` differently:

| | iOS 18 (works) | iOS 26 (misses) |
|---|---|---|
| Top-level CFStream keys | `_kCFStreamErrorDomainKey=12`, `_kCFStreamErrorCodeKey=8` **present** | **absent** |
| `NSUnderlyingError` | `kCFErrorDomainCFNetwork / -1003` | `kNWErrorDomainDNS / -65554 NoSuchRecord` |
| Classifier result | TRUE → host-connection recovery fires | FALSE → wrong path |

Apple moved DNS resolution from the legacy CFNetwork stream stack to Network.framework starting in iOS 26. The `_kCFStreamError*` sentinels moved to a nested `kNWErrorDomainDNS` underlying error and are no longer present at the top level of `userInfo`.

## Root cause 2 — coordinator swallows prefetch errors

`SFOAuthCoordinator.authenticate` calls `SFSDKAuthConfigUtil.getMyDomainAuthConfig` as a pre-flight probe. On failure the callback logged and fell straight through to `beginWebViewFlow`, dispatching a WKWebView load against the same unreachable host. The delegate's `oauthCoordinator:didFailWithError:authInfo:` was never called, so the error manager never saw the error, no alert was shown, and `loginHost` was never rolled back to `previousLoginHost` — hence the sticky-splash-hang across restarts.

## Fix

### 1. Broaden the classifier

Extract host-connection classification into a shared class method `+[SFSDKAuthErrorManager errorIsHostConnectionFailure:]` and keep the two existing branches (`_kCFStreamError*` keys and `kSFOAuthErrorInvalidURL`), adding a third that switches on six `NSURLErrorDomain` codes:

- `NSURLErrorCannotFindHost` (-1003)
- `NSURLErrorDNSLookupFailed` (-1006)
- `NSURLErrorCannotConnectToHost` (-1004)
- `NSURLErrorTimedOut` (-1001)
- `NSURLErrorNotConnectedToInternet` (-1009)
- `NSURLErrorNetworkConnectionLost` (-1005)

Classification now keys off `NSURLErrorDomain` top-level codes, not off `userInfo` structure — future changes to how Apple structures the underlying error will not re-break the classifier.

Handler ordering is unchanged: `NetworkFailureErrorHandler` still claims network codes for Refresh flows with an existing access token **before** the host-connection handler sees them. A dedicated ordering test guards this.

### 2. Surface prefetch host-connection errors

In `SFOAuthCoordinator.m`'s `getMyDomainAuthConfig:` callback, gate on the same shared predicate. When prefetch returns a host-connection error, route through `notifyDelegateOfFailure:` so the error manager's classifier can present the alert and let `SFUserAccountManager`'s recovery handler roll `loginHost` back to `previousLoginHost`.

Non-host errors (parse failures, non-2xx responses, endpoint absent on standard orgs) still fall through — auth-config remains optional.

The predicate is intentionally kept internal to `SFSDKAuthErrorManager`. `SFOAuthCoordinator.m` and the test file both reach it via forward-declared categories, so no public header changes and no `.xcodeproj` file changes.

## Test plan

New tests in `SFSDKErrorManagerTests.m`:

- [x] Six positive tests — one per `NSURLErrorDomain` host-connection code — assert the host-connection handler is invoked with a bare `NSError` (no CFStream keys)
- [x] Legacy iOS <= 18 shape (`NSURLErrorDomain / -1003` **with** CFStream keys in `userInfo`) still claimed by the host-connection handler
- [x] `kSFOAuthErrorInvalidURL` still claimed by the host-connection handler
- [x] Three negative tests — `NSURLErrorCancelled`, `NSURLErrorUserAuthenticationRequired`, `kSFOAuthErrorInvalidGrant` — assert the host-connection handler is **not** invoked and the correct fallback handler claims each error
- [x] Ordering guard — on a Refresh flow with an existing access token, `NetworkFailureErrorHandler` still claims `NSURLErrorTimedOut` before the host-connection handler sees it
- [x] Five predicate tests directly on `+errorIsHostConnectionFailure:` (nil inputs, legacy CFStream keys, `kSFOAuthErrorInvalidURL`, six NSURL codes, unrelated codes)
- [x] Full `SFSDKErrorManagerTests` suite (22 methods) passes on iOS 26 simulator
- [x] Manual repro on iPhone 17 Pro / iOS 26.2 simulator: entering `https://a.z` at the picker triggers the \"Server Error / Can't connect to the server: The request timed out.\" alert (previously silent splash-hang); OK dismisses; previous host resumes
- [x] Manual regression on iOS 18 simulator: same repro continues to recover as before

## Blast radius

- Two production files:
  - `libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFSDKAuthErrorManager.m` — one classifier block refactored to use a shared class method
  - `libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m` — one gate added in the auth-config callback
- One test file: `libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKErrorManagerTests.m` — appended
- No public header changes, no `.xcodeproj` changes, no `Localizable.strings` changes, no new dependencies

## Credit

Root-cause analysis and proposed classifier fix by Matt Wimmer.