### PR TITLE
DPoP: send dpop_jkt on /authorize (RFC 9449 §10 code binding)

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPProofBuilder.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPProofBuilder.swift
@@ -32,6 +32,7 @@ public enum DPoPProofBuilderError: Int, Error {
     case jwkExportFailed = 1
     case serializationFailed = 2
     case signingFailed = 3
+    case thumbprintFailed = 4
 }
 
 /// Builds an RFC 9449 §4 DPoP proof JWS for a single token-endpoint request.
@@ -95,6 +96,36 @@ public final class DPoPProofBuilder: NSObject {
         }
         let signatureSegment = (signature as NSData).sfsdk_base64UrlString()
         return "\(signingInput).\(signatureSegment)"
+    }
+
+    /// RFC 7638 JWK thumbprint of a P-256 EC public key.
+    ///
+    /// Computes: `base64url(SHA-256(canonical_json({crv:"P-256", kty:"EC", x:<...>, y:<...>})))`
+    /// where `canonical_json` is UTF-8, no whitespace, keys in lexicographic order.
+    ///
+    /// Used at `/authorize` time to bind the authorization code to the same DPoP
+    /// key pair that will prove possession at `/token` (RFC 9449 §10 authorization
+    /// code binding via `dpop_jkt`).
+    ///
+    /// - Parameter publicKey: The P-256 `SecKey` whose thumbprint to compute.
+    ///   Same key that will later populate the DPoP proof header's `jwk` claim.
+    /// - Returns: 43-character base64url string (SHA-256 hash, base64url-encoded, no padding).
+    /// - Throws: `DPoPProofBuilderError.jwkExportFailed` if `Encryptor.jwkP256` fails;
+    ///   `DPoPProofBuilderError.thumbprintFailed` if canonicalization or hashing fails.
+    @objc public static func jwkThumbprint(publicKey: SecKey) throws -> String {
+        let jwk: [String: String]
+        do {
+            jwk = try Encryptor.jwkP256(from: publicKey)
+        } catch {
+            throw DPoPProofBuilderError.jwkExportFailed
+        }
+        // RFC 7638: canonical JSON with lexicographic key ordering, UTF-8, no whitespace.
+        guard let canonicalData = try? JSONSerialization.data(withJSONObject: jwk,
+                                                              options: [.sortedKeys, .withoutEscapingSlashes]),
+              let digest = (canonicalData as NSData).sfsdk_sha256() else {
+            throw DPoPProofBuilderError.thumbprintFailed
+        }
+        return (digest as NSData).sfsdk_base64UrlString()
     }
 
     // MARK: - Helpers

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPProofBuilder.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPProofBuilder.swift
@@ -119,10 +119,16 @@ public final class DPoPProofBuilder: NSObject {
         } catch {
             throw DPoPProofBuilderError.jwkExportFailed
         }
-        // RFC 7638: canonical JSON with lexicographic key ordering, UTF-8, no whitespace.
+        // RFC 7638 §3.2: canonical JSON must contain ONLY the required members
+        // for the key type — for P-256 that is exactly {crv, kty, x, y}. If
+        // Encryptor.jwkP256 ever grows optional fields (kid, use, key_ops...)
+        // the thumbprint computed here will silently diverge from what the
+        // server derives off the DPoP proof's `jwk` claim, breaking the
+        // authorize↔token binding. Keep jwkP256's output minimal.
         guard let canonicalData = try? JSONSerialization.data(withJSONObject: jwk,
                                                               options: [.sortedKeys, .withoutEscapingSlashes]),
               let digest = (canonicalData as NSData).sfsdk_sha256() else {
+            SFSDKCoreLogger.w(Self.self, message: "DPoP jwkThumbprint: JWK canonicalization or SHA-256 hash failed")
             throw DPoPProofBuilderError.thumbprintFailed
         }
         return (digest as NSData).sfsdk_base64UrlString()

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -866,7 +866,44 @@
       [approvalUrlString appendFormat:@"&%@=%@", @"login_hint", self.loginHint];
     }
 
+    [self appendDPoPJktIfNeededTo:approvalUrlString domain:domain credentials:credentials];
+
     return approvalUrlString;
+}
+
+// Appends `&dpop_jkt=<base64url-sha256>` to the approval URL when DPoP is enabled
+// and the login server is a my-domain server (RFC 9449 §10 authorization code
+// binding). Soft-fails on key-material / crypto errors: logs a warning and leaves
+// the URL untouched so login proceeds — the server will surface an RFC-shaped
+// `invalid_request` error if the ECA requires code binding.
+- (void)appendDPoPJktIfNeededTo:(NSMutableString *)approvalUrlString
+                         domain:(NSString *)domain
+                    credentials:(SFOAuthCredentials *)credentials {
+    if (![[SalesforceSDKManager sharedManager] useDPoP]) {
+        return;
+    }
+    if (domain == nil || [SFSDKAuthConfigUtil isPoolLoginHost:domain]) {
+        return;
+    }
+    if (credentials.identifier.length == 0) {
+        [SFSDKCoreLogger w:[self class] format:@"DPoP dpop_jkt skipped: missing credentials.identifier"];
+        return;
+    }
+
+    NSError *err = nil;
+    SFSDKDPoPKeyPair *pair = [SFSDKDPoPKeyStore.shared keyPairForCredentials:credentials error:&err];
+    if (!pair || err) {
+        [SFSDKCoreLogger w:[self class] format:@"DPoP dpop_jkt skipped: key pair load failed (%@)", err.localizedDescription];
+        return;
+    }
+
+    NSString *thumbprint = [SFSDKDPoPProofBuilder jwkThumbprintWithPublicKey:pair.publicKey error:&err];
+    if (thumbprint.length == 0 || err) {
+        [SFSDKCoreLogger w:[self class] format:@"DPoP dpop_jkt skipped: thumbprint failed (%@)", err.localizedDescription];
+        return;
+    }
+
+    [approvalUrlString appendFormat:@"&%@=%@", kSFOAuthDPoPJktParamName, thumbprint];
 }
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.h
@@ -30,10 +30,22 @@
 #import <SalesforceSDKCore/SFOAuthCredentials.h>
 #import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
+/// Salesforce pool-server host strings. Exact-match constants used by
+/// `SFSDKAuthConfigUtil` and by DPoP `dpop_jkt` gating to distinguish
+/// pool hosts from my-domain hosts.
+FOUNDATION_EXTERN NSString * _Nonnull const kSFSDKSandboxLoginURL;      // test.salesforce.com
+FOUNDATION_EXTERN NSString * _Nonnull const kSFSDKProductionLoginURL;   // login.salesforce.com
+FOUNDATION_EXTERN NSString * _Nonnull const kSFSDKWelcomeLoginURL;      // welcome.salesforce.com/discovery
+
 @interface SFSDKAuthConfigUtil : NSObject
 
 typedef void (^ _Nonnull MyDomainAuthConfigBlock)(SFOAuthOrgAuthConfiguration * _Nullable authConfig, NSError * _Nullable error);
 
 + (void)getMyDomainAuthConfig:(nonnull MyDomainAuthConfigBlock)authConfigBlock loginDomain:(nonnull NSString *)loginDomain;
+
+/// YES when `host` is one of the three Salesforce pool servers
+/// (login.salesforce.com, test.salesforce.com, welcome.salesforce.com/discovery).
+/// NO for my-domain servers. Exact string match; no normalization.
++ (BOOL)isPoolLoginHost:(nonnull NSString *)host;
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
@@ -31,15 +31,22 @@
 #import <SalesforceSDKCommon/SFJsonUtils.h>
 
 static NSString * const kSFOAuthEndPointAuthConfiguration = @"/.well-known/auth-configuration";
-static NSString * const kSandboxLoginURL = @"test.salesforce.com";
-static NSString * const kProductionLoginURL = @"login.salesforce.com";
-static NSString * const kWelcomeLoginURL = @"welcome.salesforce.com/discovery";
+
+NSString * const kSFSDKSandboxLoginURL    = @"test.salesforce.com";
+NSString * const kSFSDKProductionLoginURL = @"login.salesforce.com";
+NSString * const kSFSDKWelcomeLoginURL    = @"welcome.salesforce.com/discovery";
 
 @implementation SFSDKAuthConfigUtil
 
++ (BOOL)isPoolLoginHost:(NSString *)host {
+    return [host isEqualToString:kSFSDKSandboxLoginURL]
+        || [host isEqualToString:kSFSDKProductionLoginURL]
+        || [host isEqualToString:kSFSDKWelcomeLoginURL];
+}
+
 + (void)getMyDomainAuthConfig:(MyDomainAuthConfigBlock)authConfigBlock loginDomain:(NSString *)loginDomain {
     NSString *orgConfigUrl = [NSString stringWithFormat:@"https://%@%@", loginDomain, kSFOAuthEndPointAuthConfiguration];
-    if ([loginDomain isEqualToString:kSandboxLoginURL] || [loginDomain isEqualToString:kProductionLoginURL] || [loginDomain isEqualToString:kWelcomeLoginURL]) {
+    if ([SFSDKAuthConfigUtil isPoolLoginHost:loginDomain]) {
         [SFSDKCoreLogger d:[self class] format:@"%@ Skipping auth config retrieval for login pool URL", NSStringFromSelector(_cmd)];
         authConfigBlock(nil, nil);
         return;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -38,6 +38,7 @@ static NSString * const kSFRevokePath                           = @"/services/oa
 static NSUInteger const kSFOAuthCodeVerifierByteLength          = 128;
 static NSString * const kSFOAuthCodeVerifierParamName           = @"code_verifier";
 static NSString * const kSFOAuthCodeChallengeParamName          = @"code_challenge";
+static NSString * const kSFOAuthDPoPJktParamName                = @"dpop_jkt";
 static NSString * const kSFOAuthResponseTypeCode                = @"code";
 static NSString * const kSFOAuthAccessToken                     = @"access_token";
 static NSString * const kSFOAuthClientId                        = @"client_id";

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
@@ -2,6 +2,29 @@ import XCTest
 @testable import SalesforceSDKCore
 
 class SFOAuthCoordinatorTests: XCTestCase {
+
+    // Tracked so the DPoP URL tests can restore the flag they toggle.
+    private var priorUsesDPoP: Bool = false
+    // Per-test scope identifiers so DPoP key material never bleeds across tests.
+    private var trackedScopes: [String] = []
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        priorUsesDPoP = SalesforceManager.shared.usesDPoP
+        trackedScopes.removeAll()
+    }
+
+    override func tearDownWithError() throws {
+        SalesforceManager.shared.usesDPoP = priorUsesDPoP
+        for scope in trackedScopes {
+            DPoPKeyStore.shared.delete(forScope: scope)
+        }
+        trackedScopes.removeAll()
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Existing coverage
+
     func testDecidePolicyForNavigationAction_DomainDiscoveryCallback() {
         // Given
         let expectedLoginHint = "testuser@example.com"
@@ -20,20 +43,294 @@ class SFOAuthCoordinatorTests: XCTestCase {
         credentials?.testDomain = "foo.bar.com/discovery"
         credentials?.testRedirectURI = "sfdc://callback"
         coordinator.credentials = credentials
-        
+
         // When
         coordinator.authenticate(with: credentials!)
-        
+
         // Then
         var didCallDecisionHandlerPolicy: WKNavigationActionPolicy = .allow
         coordinator.webView(WKWebView(), decidePolicyFor: mockNavigationAction, decisionHandler: { policy in
             didCallDecisionHandlerPolicy = policy
         })
-        
+
         // Assert
         XCTAssertEqual(didCallDecisionHandlerPolicy, .cancel)
         XCTAssertEqual(coordinator.testLoginHint, expectedLoginHint)
         XCTAssertEqual(coordinator.credentials?.domain, mockDomain)
+    }
+
+    // MARK: - dpop_jkt URL-shape tests (RFC 9449 §10 authorization code binding)
+
+    /// When DPoP is enabled, the login server is a my-domain host, and
+    /// `credentials.identifier` is present, the approval URL includes
+    /// `dpop_jkt=<43-char base64url>` matching the RFC 7638 shape.
+    func test_givenDPoPEnabledAndMyDomainAndIdentifier_whenGenerateApprovalUrlString_thenUrlContainsDPoPJktMatchingBase64UrlShape() throws {
+        SalesforceManager.shared.usesDPoP = true
+
+        let scope = trackedScope("sc1-dpop-jkt")
+        let credentials = try makeCredentials(identifier: scope, domain: "acme.my.salesforce.com")
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+
+        let url = coordinator.generateApprovalUrlString()
+        let jktValue = try XCTUnwrap(queryValue(name: "dpop_jkt", in: url),
+                                     "dpop_jkt must be present under DPoP + my-domain + identifier")
+        let pattern = try NSRegularExpression(pattern: "^[A-Za-z0-9_-]{43}$")
+        let range = NSRange(location: 0, length: jktValue.utf16.count)
+        XCTAssertNotNil(pattern.firstMatch(in: jktValue, options: [], range: range),
+                        "dpop_jkt must be a 43-char base64url string, got: \(jktValue)")
+    }
+
+    /// The `dpop_jkt` value in the authorize URL equals the RFC 7638
+    /// thumbprint of the same key pair that `DPoPKeyStore` will later return at
+    /// token-endpoint time. This is the invariant that binds `/authorize` to
+    /// `/token`.
+    func test_givenDPoPEnabled_whenGenerateApprovalUrlString_thenDPoPJktEqualsThumbprintOfKeyPairFromStore() throws {
+        SalesforceManager.shared.usesDPoP = true
+
+        let scope = trackedScope("sc3-thumbprint-match")
+        let credentials = try makeCredentials(identifier: scope, domain: "acme.my.salesforce.com")
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+
+        let url = coordinator.generateApprovalUrlString()
+        let jktValue = try XCTUnwrap(queryValue(name: "dpop_jkt", in: url))
+
+        // Independently load the same-scope key pair the coordinator uses and
+        // recompute the thumbprint — must match byte-for-byte.
+        let pair = try DPoPKeyStore.shared.keyPair(forScope: scope)
+        let expectedThumbprint = try DPoPProofBuilder.jwkThumbprint(publicKey: pair.publicKey)
+        XCTAssertEqual(jktValue, expectedThumbprint,
+                       "dpop_jkt on /authorize must equal jwkThumbprint of the token-endpoint key pair")
+    }
+
+    /// Pool login hosts (`login.salesforce.com`) must never receive
+    /// `dpop_jkt`, even when DPoP is enabled. Salesforce blocks DPoP at the
+    /// pool servers.
+    func test_givenDPoPEnabledAndProductionPoolHost_whenGenerateApprovalUrlString_thenUrlHasNoDPoPJkt() throws {
+        SalesforceManager.shared.usesDPoP = true
+
+        let scope = trackedScope("sc4-pool-prod")
+        let credentials = try makeCredentials(identifier: scope, domain: "login.salesforce.com")
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+
+        let url = coordinator.generateApprovalUrlString()
+        XCTAssertNil(queryValue(name: "dpop_jkt", in: url),
+                     "login.salesforce.com is a pool host; dpop_jkt must not be sent")
+    }
+
+    /// Sandbox pool host `test.salesforce.com` must not receive `dpop_jkt`.
+    func test_givenDPoPEnabledAndSandboxPoolHost_whenGenerateApprovalUrlString_thenUrlHasNoDPoPJkt() throws {
+        SalesforceManager.shared.usesDPoP = true
+
+        let scope = trackedScope("sc4-pool-sandbox")
+        let credentials = try makeCredentials(identifier: scope, domain: "test.salesforce.com")
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+
+        let url = coordinator.generateApprovalUrlString()
+        XCTAssertNil(queryValue(name: "dpop_jkt", in: url),
+                     "test.salesforce.com is a pool host; dpop_jkt must not be sent")
+    }
+
+    /// Welcome / discovery pool host `welcome.salesforce.com/discovery`
+    /// must not receive `dpop_jkt`.
+    func test_givenDPoPEnabledAndWelcomePoolHost_whenGenerateApprovalUrlString_thenUrlHasNoDPoPJkt() throws {
+        SalesforceManager.shared.usesDPoP = true
+
+        let scope = trackedScope("sc4-pool-welcome")
+        let credentials = try makeCredentials(identifier: scope,
+                                              domain: "welcome.salesforce.com/discovery")
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+
+        let url = coordinator.generateApprovalUrlString()
+        XCTAssertNil(queryValue(name: "dpop_jkt", in: url),
+                     "welcome.salesforce.com/discovery is a pool host; dpop_jkt must not be sent")
+    }
+
+    /// When `usesDPoP` is `NO`, the approval URL must be byte-identical
+    /// to the pre-change baseline (the coordinator behaves exactly as it did
+    /// before the dpop_jkt feature landed). We construct the baseline from the
+    /// same known inputs — no magic strings — so any future URL-parameter drift
+    /// under the DPoP-off flag will fail loudly here.
+    func test_givenDPoPDisabled_whenGenerateApprovalUrlString_thenUrlIsByteIdenticalBaseline() throws {
+        SalesforceManager.shared.usesDPoP = false
+
+        let scope = trackedScope("sc5-baseline")
+        let credentials = try makeCredentials(identifier: scope, domain: "acme.my.salesforce.com")
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+
+        let url = coordinator.generateApprovalUrlString()
+
+        // No dpop_jkt regardless of my-domain, because the feature is off.
+        XCTAssertFalse(url.contains("dpop_jkt"),
+                       "dpop_jkt must not appear when usesDPoP is disabled")
+
+        // Byte-identical baseline: reconstruct the URL from known inputs and
+        // strip the volatile params (device_id which is per-installation, and
+        // code_challenge which is a fresh SHA-256 per call). The rest must
+        // match exactly — this catches accidental new parameters appearing.
+        let baselinePrefix = "https://acme.my.salesforce.com/services/oauth2/authorize" +
+            "?client_id=test-client-id" +
+            "&redirect_uri=testapp://callback" +
+            "&display=touch" +
+            "&device_id="
+        XCTAssertTrue(url.hasPrefix(baselinePrefix),
+                      "URL prefix drifted from baseline. url=\(url)")
+
+        // Assert on the ordered tail structure. `display=touch` is followed by
+        // device_id (variable), then response_type=code, then code_challenge=<sha256>.
+        // This guards against unrelated param additions/reorderings sneaking in.
+        let responseTypeToken = "&response_type=code"
+        let codeChallengeToken = "&code_challenge="
+        XCTAssertTrue(url.contains(responseTypeToken),
+                      "response_type=code missing from baseline URL")
+        XCTAssertTrue(url.contains(codeChallengeToken),
+                      "code_challenge= missing from baseline URL")
+        // scope / login_hint / dpop_jkt are the only optional trailing params.
+        // With no scopes and no loginHint set, and DPoP off, none of them
+        // should be present.
+        XCTAssertFalse(url.contains("&scope="),
+                       "scope should not appear when credentials.scopes is unset")
+        XCTAssertFalse(url.contains("&login_hint="),
+                       "login_hint should not appear when coordinator.loginHint is unset")
+    }
+
+    /// Soft-fail — When key-material lookup is impossible, the append
+    /// path must log a warning and leave the URL untouched. `DPoPKeyStore.shared`
+    /// is a non-injectable singleton, so a throwing stub cannot be installed
+    /// without production DI plumbing. This test exercises the same soft-fail
+    /// branch via the natural precondition failure: an empty
+    /// `credentials.identifier` bypasses the append and continues login.
+    func test_givenDPoPEnabledAndEmptyCredentialsIdentifier_whenGenerateApprovalUrlString_thenUrlHasNoDPoPJktAndNoException() throws {
+        SalesforceManager.shared.usesDPoP = true
+
+        // A valid identifier is needed to construct SFOAuthCredentials (the
+        // designated initializer rejects empty), so we set it non-empty at
+        // init and then null out via the +Internal (readwrite) property so the
+        // dpop_jkt gate observes the empty-identifier path.
+        let credentials = try makeCredentials(identifier: "will-be-erased",
+                                              domain: "acme.my.salesforce.com")
+        credentials.identifier = ""
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+
+        // The line below must not throw. If the soft-fail path throws or if
+        // the append logic doesn't gate on empty identifier, this test fails.
+        let url = coordinator.generateApprovalUrlString()
+        XCTAssertNil(queryValue(name: "dpop_jkt", in: url),
+                     "empty credentials.identifier must skip the dpop_jkt append")
+    }
+
+    /// The `migrateRefreshToken:` flow constructs its single-access
+    /// request path from `generateApprovalUrlString()`. Under the same gate
+    /// (DPoP enabled + my-domain + identifier set), the URL it feeds to
+    /// `requestForSingleAccess` therefore includes `dpop_jkt`. Because the
+    /// downstream `SFRestAPI sendRequest:` invocation makes a real network
+    /// call, this test verifies the URL produced by the same coordinator
+    /// method that migrateRefreshToken invokes — no REST mocking needed.
+    func test_givenDPoPEnabledMigrateRefreshTokenSetup_whenGenerateApprovalUrlString_thenUrlContainsDPoPJkt() throws {
+        SalesforceManager.shared.usesDPoP = true
+
+        let scope = trackedScope("sc7-migrate-refresh")
+        let credentials = try makeCredentials(identifier: scope, domain: "acme.my.salesforce.com")
+        credentials.refreshToken = "test-refresh-token"
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+
+        // migrateRefreshToken: internally does:
+        //   NSURL *approvalUrl = [NSURL URLWithString:[self generateApprovalUrlString]];
+        // so the URL passed to the SFRestAPI single-access call is exactly
+        // this string. The dpop_jkt binding therefore propagates end-to-end.
+        let url = coordinator.generateApprovalUrlString()
+        let jktValue = try XCTUnwrap(queryValue(name: "dpop_jkt", in: url),
+                                     "migrateRefreshToken path must produce a URL with dpop_jkt under DPoP + my-domain gate")
+        XCTAssertEqual(jktValue.count, 43,
+                       "dpop_jkt on migrateRefreshToken path must be a 43-char base64url string")
+    }
+
+    /// Entry-point coverage — user-agent flow (webServerFlow resolves to `NO`
+    /// when `useBrowserAuth=NO` and web-server auth is off). The URL builder
+    /// emits `response_type=token` (or `hybrid_token` when hybrid mode is on),
+    /// but the dpop_jkt append happens after the flow branch, so the gate
+    /// result must be identical.
+    func test_givenDPoPEnabledAndUserAgentFlow_whenGenerateApprovalUrlString_thenUrlStillContainsDPoPJkt() throws {
+        SalesforceManager.shared.usesDPoP = true
+
+        let scope = trackedScope("entry-user-agent")
+        let credentials = try makeCredentials(identifier: scope, domain: "acme.my.salesforce.com")
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+
+        // Force the user-agent branch: no browser auth, no web-server flag.
+        coordinator.useBrowserAuth = false
+        let priorWebServer = SalesforceManager.shared.useWebServerAuthentication
+        SalesforceManager.shared.useWebServerAuthentication = false
+        defer { SalesforceManager.shared.useWebServerAuthentication = priorWebServer }
+
+        let url = coordinator.generateApprovalUrlString()
+        XCTAssertNotNil(queryValue(name: "dpop_jkt", in: url),
+                        "dpop_jkt must be appended for the user-agent-flow entry point as well")
+        let responseType = queryValue(name: "response_type", in: url) ?? ""
+        XCTAssertTrue(responseType == "token" || responseType == "hybrid_token",
+                      "user-agent branch expected — response_type should be token or hybrid_token, got \(responseType)")
+    }
+
+    /// Entry-point coverage — advanced-browser / web-server flow. Forces
+    /// `webServerFlow=YES` so the URL builder appends `response_type=code` plus
+    /// a `code_challenge`. The dpop_jkt append still fires under the same gate.
+    func test_givenDPoPEnabledAndWebServerFlow_whenGenerateApprovalUrlString_thenUrlContainsDPoPJktAndCodeChallenge() throws {
+        SalesforceManager.shared.usesDPoP = true
+
+        let scope = trackedScope("entry-web-server")
+        let credentials = try makeCredentials(identifier: scope, domain: "acme.my.salesforce.com")
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+        coordinator.useBrowserAuth = true
+
+        let url = coordinator.generateApprovalUrlString()
+        XCTAssertNotNil(queryValue(name: "dpop_jkt", in: url),
+                        "dpop_jkt must be appended for the web-server-flow entry point as well")
+        XCTAssertEqual(queryValue(name: "response_type", in: url), "code",
+                       "web-server branch expected — response_type should be `code`")
+        XCTAssertNotNil(queryValue(name: "code_challenge", in: url),
+                        "web-server branch expected — code_challenge should be present")
+    }
+
+    // MARK: - Helpers
+
+    /// Registers a per-test DPoP scope so its keychain entry is cleaned up in
+    /// tearDown. Returns a unique scope string that never collides across
+    /// tests, even under `xcodebuild -parallel-testing`.
+    private func trackedScope(_ label: String) -> String {
+        let scope = "\(label)-\(UUID().uuidString)"
+        trackedScopes.append(scope)
+        return scope
+    }
+
+    /// Builds a minimally viable `OAuthCredentials` for URL construction.
+    /// The public initializer accepts identifier + clientId; domain and
+    /// redirectUri are readonly publicly but readwrite via the +Internal
+    /// header (already imported in the bridging header).
+    private func makeCredentials(identifier: String,
+                                 domain: String) throws -> OAuthCredentials {
+        let creds = try XCTUnwrap(OAuthCredentials(identifier: identifier,
+                                                   clientId: "test-client-id",
+                                                   encrypted: false))
+        creds.testDomain = domain
+        creds.testRedirectURI = "testapp://callback"
+        return creds
+    }
+
+    /// Extracts the first value of `name` from a URL's query string using
+    /// `URLComponents` so we don't hand-roll query parsing that could disagree
+    /// with the coordinator's URL encoder in edge cases.
+    private func queryValue(name: String, in urlString: String) -> String? {
+        guard let comps = URLComponents(string: urlString) else { return nil }
+        return comps.queryItems?.first(where: { $0.name == name })?.value
     }
 }
 
@@ -53,7 +350,7 @@ extension OAuthCredentials {
         get { return self.domain }
         set { self.setValue(newValue, forKey: "domain") }
     }
-    
+
     var testRedirectURI: String? {
         get { return self.redirectUri }
         set { self.setValue(newValue, forKey: "redirectUri") }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
@@ -161,6 +161,78 @@ class SFSDKDPoPTests: XCTestCase {
         XCTAssertTrue(ok, "Signature should verify against public key. error=\(String(describing: error))")
     }
 
+    // MARK: - JWK thumbprint (RFC 7638)
+
+    /// Precomputed RFC 7638 thumbprint for a fixed P-256 public key.
+    /// The point (X, Y) is drawn from RFC 6979 §A.2.5. The expected thumbprint
+    /// is computed offline as `base64url(SHA-256(canonical_json({crv:"P-256",
+    /// kty:"EC", x:<...>, y:<...>})))` where the canonical JSON has sorted keys,
+    /// UTF-8 encoding, and no whitespace. Any drift in canonicalization
+    /// (unsorted keys, added whitespace, wrong base64 flavor, or a bad SHA-256)
+    /// will make this fixture fail.
+    func test_givenFixedTestKeyPair_whenJwkThumbprint_thenMatchesPrecomputedRFC7638Value() throws {
+        let publicKey = try Self.makeTestPublicKey()
+        let thumbprint = try DPoPProofBuilder.jwkThumbprint(publicKey: publicKey)
+        XCTAssertEqual(thumbprint, Self.expectedThumbprintForTestKey)
+    }
+
+    /// Result must be a 43-character base64url string with no padding.
+    func test_givenFixedTestKeyPair_whenJwkThumbprint_thenMatchesBase64UrlShape() throws {
+        let publicKey = try Self.makeTestPublicKey()
+        let thumbprint = try DPoPProofBuilder.jwkThumbprint(publicKey: publicKey)
+        XCTAssertEqual(thumbprint.count, 43)
+        let pattern = try NSRegularExpression(pattern: "^[A-Za-z0-9_-]{43}$")
+        let range = NSRange(location: 0, length: thumbprint.utf16.count)
+        XCTAssertNotNil(pattern.firstMatch(in: thumbprint, options: [], range: range),
+                        "thumbprint must be a 43-char base64url string")
+    }
+
+    /// Two independent key pairs must produce different thumbprints — sanity
+    /// that the helper is actually reading key material, not returning a constant.
+    func test_givenTwoIndependentKeyPairs_whenJwkThumbprint_thenValuesDiffer() throws {
+        let scopeA = "thumbprint-a-\(UUID().uuidString)"
+        let scopeB = "thumbprint-b-\(UUID().uuidString)"
+        defer {
+            DPoPKeyStore.shared.delete(forScope: scopeA)
+            DPoPKeyStore.shared.delete(forScope: scopeB)
+        }
+        let pairA = try DPoPKeyStore.shared.keyPair(forScope: scopeA)
+        let pairB = try DPoPKeyStore.shared.keyPair(forScope: scopeB)
+        let thumbA = try DPoPProofBuilder.jwkThumbprint(publicKey: pairA.publicKey)
+        let thumbB = try DPoPProofBuilder.jwkThumbprint(publicKey: pairB.publicKey)
+        XCTAssertNotEqual(thumbA, thumbB)
+        XCTAssertEqual(thumbA.count, 43)
+        XCTAssertEqual(thumbB.count, 43)
+    }
+
+    /// The thumbprint of a key pair equals the RFC 7638
+    /// thumbprint recomputed from the `jwk` claim of a DPoP proof built with
+    /// the same key pair. This is the invariant that binds `/authorize` to
+    /// `/token`: whatever thumbprint the SDK sends in `dpop_jkt`, the server
+    /// will later independently compute from the proof's `jwk` claim and
+    /// compare byte-for-byte.
+    func test_givenSameKeyPair_whenJwkThumbprintAndProofJwkRehashed_thenValuesMatch() throws {
+        let pair = try DPoPKeyStore.shared.keyPair(forScope: testScope)
+        let thumbprint = try DPoPProofBuilder.jwkThumbprint(publicKey: pair.publicKey)
+
+        let proof = try DPoPProofBuilder.buildProof(httpMethod: "POST",
+                                                    htu: tokenURL,
+                                                    nonce: nil,
+                                                    keyPair: pair)
+        let segments = proof.split(separator: ".")
+        let header = try decodeBase64UrlJSON(String(segments[0]))
+        let jwk = try XCTUnwrap(header["jwk"] as? [String: String])
+
+        // Recompute the thumbprint from the proof's jwk claim using the same
+        // RFC 7638 canonicalization (sorted keys, no whitespace, UTF-8).
+        let canonicalData = try JSONSerialization.data(withJSONObject: jwk,
+                                                       options: [.sortedKeys, .withoutEscapingSlashes])
+        let digest = try XCTUnwrap((canonicalData as NSData).sfsdk_sha256())
+        let recomputed = (digest as NSData).sfsdk_base64UrlString()
+        XCTAssertEqual(thumbprint, recomputed,
+                       "dpop_jkt (authorize) must equal RFC 7638 thumbprint of jwk (token proof)")
+    }
+
     // MARK: - Key store
 
     func test_givenSameScope_whenKeyPairCalledTwice_thenSameKeyIsReturned() throws {
@@ -707,6 +779,65 @@ class SFSDKDPoPTests: XCTestCase {
                        "photo request must have been issued exactly once")
         XCTAssertNil(DPoPNonceCache.shared.nonce(htu: photoURL, scope: scope),
                      "Bearer photo response must not write to the DPoP nonce cache")
+    }
+
+    // MARK: - Test key fixture (RFC 6979 §A.2.5 P-256 point)
+
+    /// P-256 public key point (X, Y) from RFC 6979 §A.2.5. Fixed across all
+    /// runs, so tests derived from it can compare against a precomputed
+    /// RFC 7638 thumbprint fixture below.
+    private static let testKeyXHex =
+        "60FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6"
+    private static let testKeyYHex =
+        "7903FE1008B8BC99A41AE9E95628BC64F2F1B20C2D7E9F5177A3C294D4462299"
+
+    /// Precomputed offline (Python: base64url(SHA-256(canonical_json(jwk)))) using
+    /// the RFC 7638 canonical form `{"crv":"P-256","kty":"EC","x":"…","y":"…"}`.
+    /// If this value ever changes without a corresponding RFC 7638 spec change,
+    /// something canonicalization-related has drifted in the implementation.
+    private static let expectedThumbprintForTestKey =
+        "DOvxvJiAdIqVWIkFt5hDtCunXLF0BV4-JGv4f-ALSm0"
+
+    /// Builds a P-256 `SecKey` public key from the fixed test point above,
+    /// using the uncompressed SEC1 encoding `0x04 || X(32) || Y(32)`.
+    private static func makeTestPublicKey() throws -> SecKey {
+        let xBytes = try hexToBytes(testKeyXHex)
+        let yBytes = try hexToBytes(testKeyYHex)
+        var raw = Data([0x04])
+        raw.append(xBytes)
+        raw.append(yBytes)
+        let attrs: [String: Any] = [
+            String(kSecAttrKeyType): kSecAttrKeyTypeECSECPrimeRandom,
+            String(kSecAttrKeyClass): kSecAttrKeyClassPublic,
+            String(kSecAttrKeySizeInBits): 256
+        ]
+        var error: Unmanaged<CFError>?
+        guard let key = SecKeyCreateWithData(raw as CFData, attrs as CFDictionary, &error) else {
+            throw NSError(domain: "DPoPTest",
+                          code: -3,
+                          userInfo: [NSLocalizedDescriptionKey:
+                                     "SecKeyCreateWithData failed: \(String(describing: error?.takeRetainedValue()))"])
+        }
+        return key
+    }
+
+    private static func hexToBytes(_ hex: String) throws -> Data {
+        guard hex.count % 2 == 0 else {
+            throw NSError(domain: "DPoPTest", code: -4,
+                          userInfo: [NSLocalizedDescriptionKey: "odd-length hex"])
+        }
+        var data = Data(capacity: hex.count / 2)
+        var index = hex.startIndex
+        while index < hex.endIndex {
+            let next = hex.index(index, offsetBy: 2)
+            guard let byte = UInt8(hex[index..<next], radix: 16) else {
+                throw NSError(domain: "DPoPTest", code: -5,
+                              userInfo: [NSLocalizedDescriptionKey: "bad hex byte"])
+            }
+            data.append(byte)
+            index = next
+        }
+        return data
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

Bind the authorization code returned by `/authorize` to the DPoP key pair that will later prove possession at `/token`, per **RFC 9449 §10**. Mirrors the Android implementation.

When `SalesforceSDKManager.usesDPoP` is `YES`, the login server is a my-domain host, and `credentials.identifier` is set, the approval URL now carries `dpop_jkt=<RFC 7638 thumbprint>`. Pool hosts (`login/test/welcome.salesforce.com`) are excluded — Salesforce blocks DPoP at the pool servers.

### Changes

- **`DPoPProofBuilder.jwkThumbprint(publicKey:)`** — new `@objc` static that returns the 43-char base64url RFC 7638 thumbprint. Composed from existing primitives (`Encryptor.jwkP256`, `JSONSerialization(.sortedKeys)`, `sfsdk_sha256`, `sfsdk_base64UrlString`). New `.thumbprintFailed` error case.
- **`SFSDKAuthConfigUtil.isPoolLoginHost:`** — new predicate. The three pool-host string constants are lifted from `.m` file-locals into the header as `FOUNDATION_EXTERN` so both the auth-config prefetch check and the dpop_jkt gate share one source of truth.
- **`SFOAuthCoordinator.approvalURLForEndpoint:…`** — after the existing scope/login-hint appends, invokes a new private helper `-appendDPoPJktIfNeededTo:domain:credentials:` that gates on `usesDPoP` + `isPoolLoginHost` + non-empty identifier, loads the key pair via `DPoPKeyStore.keyPair(forCredentials:)`, and appends `&dpop_jkt=…`. Crypto/keychain errors soft-fail (warn-log, URL untouched, login proceeds).
- **`kSFOAuthDPoPJktParamName`** — new constant next to `kSFOAuthCodeChallengeParamName`.

### Tests

- `DPoPProofBuilder.jwkThumbprint` — RFC 7638 fixture against RFC 6979 §A.2.5 P-256 test key, uniqueness across pairs, 43-char base64url shape.
- `SFOAuthCoordinator.generateApprovalUrlString`:
  - `dpop_jkt` present + shape correct under DPoP + my-domain + identifier
  - `dpop_jkt` value equals `jwkThumbprint(publicKey:)` of the pair `DPoPKeyStore` returns at `/token` time (authorize↔token binding invariant)
  - All three pool hosts (`login`, `test`, `welcome.../discovery`) — no `dpop_jkt`
  - `usesDPoP=NO` — byte-identical baseline; no `dpop_jkt`
  - Empty `credentials.identifier` — soft-fail path, no `dpop_jkt`, no exception
  - `migrateRefreshToken:` construction path carries `dpop_jkt`
  - Both entry points: user-agent (response_type=token/hybrid_token) and web-server (response_type=code + code_challenge)

## Test plan

- [x] Manual: log into a `Require DPoP` ECA on a my-domain org via RestAPIExplorer with `usesDPoP=YES`; confirm `dpop_jkt` present on the `/authorize` request and matches the token-endpoint JWK thumbprint.
- [x] Verify pool-host login still works (`login.salesforce.com`) — no `dpop_jkt` sent, flow unchanged.