### PR TITLE
feat(dpop): register DP per-user feature flag on DPoP sessions

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.h
@@ -44,6 +44,7 @@ extern NSString * const kSFSPAppFeatureIDPLogin;
 extern NSString * const kSFIDPAppFeatureIDPLogin;
 extern NSString * const kSFAppFeatureQrCodeLogin;
 extern NSString * const kSFAppFeatureRTR;
+extern NSString * const kSFAppFeatureDPoP;
 
 /**
  Class to register and unregister feature markers associated with SDK facilities being used in

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.m
@@ -42,6 +42,7 @@ NSString * const kSFSPAppFeatureIDPLogin = @"SP";
 NSString * const kSFIDPAppFeatureIDPLogin = @"IP";
 NSString * const kSFAppFeatureQrCodeLogin = @"QR";
 NSString * const kSFAppFeatureRTR = @"RT";
+NSString * const kSFAppFeatureDPoP = @"DP";
 
 static NSMutableSet<NSString *> *SFSDKAppFeatureMarkersSet = nil;
 static dispatch_queue_t SFSDKAppFeatureDispatchQueue = nil;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -2208,6 +2208,12 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         }
     }
 
+    // DPoP: register unconditionally on every completed session where the server issued
+    // a DPoP-bound token (initial login OR refresh) — token_type is a per-session property.
+    if ([userAccount.credentials.tokenType isEqualToString:@"DPoP"]) {
+        [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureDPoP forUser:userAccount];
+    }
+
     // Async call, ignore if theres a failure. If success save the user photo locally.
     [self retrieveUserPhotoIfNeeded:userAccount];
     BOOL shouldNotify = YES;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAppFeatureMarkersTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAppFeatureMarkersTests.m
@@ -60,6 +60,7 @@
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureWelcomeDiscovery forUser:self.userA];
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureQrCodeLogin forUser:self.userA];
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureRTR forUser:self.userA];
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureDPoP forUser:self.userA];
     self.userA = nil;
     self.userB = nil;
     [self clearExistingMarkers];
@@ -294,6 +295,30 @@
 
     // Cleanup
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureRTR forUser:self.userA];
+}
+
+#pragma mark - DPoP feature flag tests
+
+- (void)test_givenDPoPTokenType_whenDPFlagRegistered_thenFlagAppearsInPerUserFeaturesNotGlobal {
+    // Arrange: userA is the account whose session was DPoP-bound.
+
+    // Act: simulate finalizeAuthCompletion: registering DP on tokenType match.
+    [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureDPoP forUser:self.userA];
+
+    // Assert: DP in per-user features (union with global).
+    NSSet *features = [SFSDKAppFeatureMarkers appFeaturesForUser:self.userA];
+    XCTAssertTrue([features containsObject:kSFAppFeatureDPoP],
+                  @"DP flag should appear in per-user feature set for DPoP-bound sessions");
+
+    // Assert: DP NOT in global-only set.
+    XCTAssertFalse([[SFSDKAppFeatureMarkers appFeatures] containsObject:kSFAppFeatureDPoP],
+                   @"DP flag should not bleed into global feature set");
+
+    // Assert: per-user isolation — userB (no DPoP session) does not gain DP.
+    XCTAssertFalse([[SFSDKAppFeatureMarkers appFeaturesForUser:self.userB] containsObject:kSFAppFeatureDPoP],
+                   @"userB should not have DP if only userA had a DPoP session");
+
+    // Cleanup handled in tearDown.
 }
 
 #pragma mark - Private helpers


### PR DESCRIPTION
## Summary

Registers a per-user `DP` app-feature marker in `-[SFUserAccountManager finalizeAuthCompletion:]` whenever the completing OAuth session's `credentials.tokenType` is exactly `@"DPoP"`. The marker appears in the `ftr_` segment of the user-agent for DPoP-bound sessions, giving server-side telemetry visibility into DPoP adoption.

Mirrors the Android sibling PR (`SalesforceMobileSDK-Android#2962`) verbatim — register-only, no unregister branch, runs on both initial-auth and refresh paths.

## Design notes

- **Register-only.** No `else` / no `unregister`. If a session downgrades from DPoP to Bearer (server-side revocation), the `DP` flag remains until logout. Accepted per platform parity.
- **Placement outside the `!= SFOAuthTypeRefresh` guard.** DPoP `token_type` is a per-session property re-issued on every refresh, unlike BW/WD/QR which describe how the user initially logged in. Placement is deliberately after the refresh guard so the flag stays accurate across refresh cycles.
- **Additive public API.** One new `extern NSString * const kSFAppFeatureDPoP` in `SFSDKAppFeatureMarkers.h`. No signature changes anywhere else.

## Changes

- `SFSDKAppFeatureMarkers.h`/`.m` — declare + define `kSFAppFeatureDPoP = @"DP"` next to `kSFAppFeatureRTR`.
- `SFUserAccountManager.m` — 3-line register block in `finalizeAuthCompletion:` after the WD/QR conditional.
- `SFSDKAppFeatureMarkersTests.m` — new `test_givenDPoPTokenType_whenDPFlagRegistered_thenFlagAppearsInPerUserFeaturesNotGlobal` + `tearDown` cleanup.

## Test plan

- [x] `SalesforceSDKCore` scheme builds green on iPhone 16 Pro (iOS 18.6) sim
- [x] `SFSDKAppFeatureMarkersTests` — 19/19 pass (up from 16 pre-DPoP series)
- [x] Adjacent regression slice — `SFSDKAppFeatureMarkersTests` (19) + `SFOAuthCredentialsTests` (4) + `SFSDKDPoPTests` (39) = 62/62 pass
- [ ] Follow-up: integration test in `SFUserAccountManagerTests.m` that drives `finalizeAuthCompletion:` end-to-end with a stubbed `credentials.tokenType` to lock the `isEqualToString:@"DPoP"` gate itself. Deferred — Android sibling shipped without this and the unit-level coverage is behavior-equivalent for now.