### PR TITLE
App Attestation support in SalesforceSDKCore

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on:
   # pull_request_target is used so secrets are available to fork PRs.
   # Mitigated by per-job Member Check (see "Check Write Permission" / "Validate Write Permission").
   pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    branches: [dev, master, app-attestation]
+    branches: [dev, master]
     paths-ignore:
       - '**/*.md'
       - 'LICENSE'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,7 +4,7 @@ on:
   # pull_request_target is used so secrets are available to fork PRs.
   # Mitigated by per-job Member Check (see "Check Write Permission" / "Validate Write Permission").
   pull_request_target:  # zizmor: ignore[dangerous-triggers]
-    branches: [dev, master]
+    branches: [dev, master, app-attestation]
     paths-ignore:
       - '**/*.md'
       - 'LICENSE'

--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		6900D805243D521C00888336 /* SFRestAPI+Notifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 6900D803243D521C00888336 /* SFRestAPI+Notifications.m */; };
 		6924966A2444E50500D3F63B /* SFFormatUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 692496682444E50500D3F63B /* SFFormatUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6924966B2444E50500D3F63B /* SFFormatUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 692496692444E50500D3F63B /* SFFormatUtils.m */; };
+		692D36662F95F83A002FBFF3 /* AppAttestationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 692D36652F95F83A002FBFF3 /* AppAttestationTests.swift */; };
 		6931E954248B5C7100417362 /* SFDirectoryManager+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 6931E94E248ADD8E00417362 /* SFDirectoryManager+Internal.h */; };
 		6931EA49248F000600417362 /* SFUserIdUpgradeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6931EA48248F000600417362 /* SFUserIdUpgradeTests.m */; };
 		69341D22266FF61700227CB0 /* Encryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69341D21266FF61700227CB0 /* Encryptor.swift */; };
@@ -166,6 +167,7 @@
 		69848CB82364035300893E57 /* SFSDKEncryptedPushNotificationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 69848CB72364035300893E57 /* SFSDKEncryptedPushNotificationTests.m */; };
 		69848CBD2364063E00893E57 /* SFSDKPushNotificationDataProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 69848CBC2364063E00893E57 /* SFSDKPushNotificationDataProvider.m */; };
 		6990CBC029F5AF56004A5F8D /* SFSDKIDPAuthCodeLoginRequestCommandTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6990CBBF29F5AF56004A5F8D /* SFSDKIDPAuthCodeLoginRequestCommandTest.m */; };
+		699205492FFF0B740032ECD7 /* AppAttestation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699205482FFF0B740032ECD7 /* AppAttestation.swift */; };
 		699202FD2FEF11D70032ECD7 /* SFSDKTokenRefreshCoordinatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 699202FC2FEF11D70032ECD7 /* SFSDKTokenRefreshCoordinatorTests.m */; };
 		699203052FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.m in Sources */ = {isa = PBXBuildFile; fileRef = 699203042FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.m */; };
 		699203062FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 699203032FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.h */; };
@@ -758,6 +760,7 @@
 		691D129F23296A93000D6D41 /* SFSDKURLCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SFSDKURLCacheTests.m; path = SalesforceSDKCoreTests/SFSDKURLCacheTests.m; sourceTree = SOURCE_ROOT; };
 		692496682444E50500D3F63B /* SFFormatUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFFormatUtils.h; sourceTree = "<group>"; };
 		692496692444E50500D3F63B /* SFFormatUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFFormatUtils.m; sourceTree = "<group>"; };
+		692D36652F95F83A002FBFF3 /* AppAttestationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAttestationTests.swift; sourceTree = "<group>"; };
 		6931E94E248ADD8E00417362 /* SFDirectoryManager+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SFDirectoryManager+Internal.h"; sourceTree = "<group>"; };
 		6931EA48248F000600417362 /* SFUserIdUpgradeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFUserIdUpgradeTests.m; path = SalesforceSDKCoreTests/SFUserIdUpgradeTests.m; sourceTree = SOURCE_ROOT; };
 		69341D21266FF61700227CB0 /* Encryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encryptor.swift; sourceTree = "<group>"; };
@@ -789,6 +792,7 @@
 		69848CBB2364063E00893E57 /* SFSDKPushNotificationDataProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SFSDKPushNotificationDataProvider.h; path = SalesforceSDKCoreTests/SFSDKPushNotificationDataProvider.h; sourceTree = SOURCE_ROOT; };
 		69848CBC2364063E00893E57 /* SFSDKPushNotificationDataProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKPushNotificationDataProvider.m; path = SalesforceSDKCoreTests/SFSDKPushNotificationDataProvider.m; sourceTree = SOURCE_ROOT; };
 		6990CBBF29F5AF56004A5F8D /* SFSDKIDPAuthCodeLoginRequestCommandTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SFSDKIDPAuthCodeLoginRequestCommandTest.m; path = SalesforceSDKCoreTests/SFSDKIDPAuthCodeLoginRequestCommandTest.m; sourceTree = SOURCE_ROOT; };
+		699205482FFF0B740032ECD7 /* AppAttestation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAttestation.swift; sourceTree = "<group>"; };
 		699202FC2FEF11D70032ECD7 /* SFSDKTokenRefreshCoordinatorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKTokenRefreshCoordinatorTests.m; sourceTree = "<group>"; };
 		699203032FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKTokenRefreshCoordinator.h; sourceTree = "<group>"; };
 		699203042FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKTokenRefreshCoordinator.m; sourceTree = "<group>"; };
@@ -1073,6 +1077,7 @@
 				68FE805F2FD0E35D00947FFF /* SFSDKDPoPTests.swift */,
 				68FE80612FD0E35D00947FFF /* EncryptorTests.swift */,
 				699202FC2FEF11D70032ECD7 /* SFSDKTokenRefreshCoordinatorTests.m */,
+				692D36652F95F83A002FBFF3 /* AppAttestationTests.swift */,
 				AA9154472F59E3C900A0A41C /* SFRestAPIDataTaskRaceTests.m */,
 				23F200AB2E551C890091C5F5 /* ActionTypeTests.swift */,
 				4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */,
@@ -1239,6 +1244,7 @@
 				68FE80552FD0DE4E00947FFF /* DPoP */,
 				699203032FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.h */,
 				699203042FEF146F0032ECD7 /* SFSDKTokenRefreshCoordinator.m */,
+				699205482FFF0B740032ECD7 /* AppAttestation.swift */,
 				4F5A494F2E98711600C89DDD /* ScopeParser.swift */,
 				23D96B6E2E145AC20004B06A /* DomainDiscoveryCoordinator.swift */,
 				4F8A3B002CEC202F00ECDC76 /* JwtAccessToken.swift */,
@@ -2299,6 +2305,7 @@
 				009D77521CA4A92200D5183A /* SFPushNotificationManagerTests.m in Sources */,
 				699202FD2FEF11D70032ECD7 /* SFSDKTokenRefreshCoordinatorTests.m in Sources */,
 				696E91472AD0A14A00205884 /* BiometricAuthenticationManagerTests.swift in Sources */,
+				692D36662F95F83A002FBFF3 /* AppAttestationTests.swift in Sources */,
 				B7E8A2AF1E77062E007C0D92 /* SFUserAccountManagerPersisterTests.m in Sources */,
 				23EDDF022DE0F9EF0024AD39 /* URLRequest+RestRequestTests.swift in Sources */,
 				CEB98EDF1F86E7CA0083AB9C /* SFSDKAuthErrorCommandTest.m in Sources */,
@@ -2476,6 +2483,7 @@
 				4F3139652331C5A1007B3705 /* SFSDKAuthRootController.m in Sources */,
 				23CE44212DEE258800ADC770 /* RestClient+WebSocket.swift in Sources */,
 				CE4CE3A61C0E5279009F6029 /* SFDirectoryManager.m in Sources */,
+				699205492FFF0B740032ECD7 /* AppAttestation.swift in Sources */,
 				B72171532353BFD90022510F /* SFSDKAuthSession.m in Sources */,
 				B7C274561F81507100CE539D /* SFSDKSPLoginResponseCommand.m in Sources */,
 				230834842DF7838200C7CBF7 /* URLSessionTask+RetryPolicy.swift in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.h
@@ -45,6 +45,7 @@ extern NSString * const kSFIDPAppFeatureIDPLogin;
 extern NSString * const kSFAppFeatureQrCodeLogin;
 extern NSString * const kSFAppFeatureRTR;
 extern NSString * const kSFAppFeatureDPoP;
+extern NSString * const kSFAppFeatureAppAttestation;
 
 /**
  Class to register and unregister feature markers associated with SDK facilities being used in

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.m
@@ -43,6 +43,7 @@ NSString * const kSFIDPAppFeatureIDPLogin = @"IP";
 NSString * const kSFAppFeatureQrCodeLogin = @"QR";
 NSString * const kSFAppFeatureRTR = @"RT";
 NSString * const kSFAppFeatureDPoP = @"DP";
+NSString * const kSFAppFeatureAppAttestation = @"AA";
 
 static NSMutableSet<NSString *> *SFSDKAppFeatureMarkersSet = nil;
 static dispatch_queue_t SFSDKAppFeatureDispatchQueue = nil;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
@@ -145,6 +145,7 @@ public class AppAttestation: NSObject {
         let keychainItem = AttestationKeychainItem(attestationId: attestationId, keyId: keyId)
         let keychainItemData = try JSONEncoder().encode(keychainItem)
         let keychainResult = KeychainHelper.write(service: appAttestKeyName, data: keychainItemData, account: nil)
+        // Intentional: prefer re-registration on next launch over blocking auth
         if !keychainResult.success {
             var message = "Unable to write attestation keyId to keychain"
             if let error = keychainResult.error {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
@@ -50,8 +50,9 @@ public class AppAttestation: NSObject {
     /// Returns an attestation string if attestation is enabled and the domain is a My Domain,
     /// otherwise returns nil. Callers do not need to check gating conditions themselves.
     @objc
-    public static func attestationIfEnabled(for domain: String?, consumerKey: String) async -> String? {
+    public static func attestationIfEnabled(for domain: String?, consumerKey: String?) async -> String? {
         guard let domain,
+              let consumerKey,
               shouldAttemptAttestation(for: domain, consumerKey: consumerKey, isDeviceSupported: DCAppAttestService.shared.isSupported) else {
             return nil
         }
@@ -66,7 +67,7 @@ public class AppAttestation: NSObject {
     }
 
     // Internal for unit tests
-    static func shouldAttemptAttestation(for domain: String?, consumerKey: String, isDeviceSupported: Bool) -> Bool {
+    static func shouldAttemptAttestation(for domain: String?, consumerKey: String?, isDeviceSupported: Bool) -> Bool {
         guard let domain, !domain.isEmpty else {
             return false
         }
@@ -78,7 +79,7 @@ public class AppAttestation: NSObject {
         guard UserAccountManager.shared.appAttestationEnabled,
               isDeviceSupported,
               !isLoginPool,
-              !consumerKey.isEmpty else {
+              let consumerKey, !consumerKey.isEmpty else {
             return false
         }
 
@@ -110,10 +111,7 @@ public class AppAttestation: NSObject {
         let keyId = try await keyId(for: attestationId, domain: domain, consumerKey: consumerKey)
 
         let challenge = try await requestChallengeFromSalesforce(domain: domain, consumerKey: consumerKey, attestationId: attestationId)
-        guard let challengeData = challenge.data(using: .utf8) else {
-            throw AppAttestationError.challengeEncodingFailed
-        }
-        let hash = Data(SHA256.hash(data: challengeData))
+        let hash = try sha256(of: challenge)
 
         let assertion = try await performAppAttestOperation {
             try await DCAppAttestService.shared.generateAssertion(keyId, clientDataHash: hash)
@@ -127,15 +125,19 @@ public class AppAttestation: NSObject {
 
 
     private static func generateAttestation(keyId: String, challenge: String) async throws -> String {
-        guard let challengeData = challenge.data(using: .utf8) else {
-            throw AppAttestationError.challengeEncodingFailed
-        }
-        let hash = Data(SHA256.hash(data: challengeData))
+        let hash = try sha256(of: challenge)
 
         let attestation = try await performAppAttestOperation {
             try await DCAppAttestService.shared.attestKey(keyId, clientDataHash: hash)
         }
         return attestation.base64EncodedString()
+    }
+
+    private static func sha256(of challenge: String) throws -> Data {
+        guard let challengeData = challenge.data(using: .utf8) else {
+            throw AppAttestationError.challengeEncodingFailed
+        }
+        return Data(SHA256.hash(data: challengeData))
     }
 
     //    1. Client creates a key pair

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
@@ -160,7 +160,10 @@ public class AppAttestation: NSObject {
         do {
             return try await operation()
         } catch let error as DCError {
-            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "App Attest error: \(error.code.rawValue)")
+            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "App Attest Device Check error: \(error.code.rawValue)")
+            throw error
+        } catch {
+            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "App Attest error: \(error.localizedDescription)")
             throw error
         }
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
@@ -1,0 +1,187 @@
+//
+//  AppAttestation.swift
+//  SalesforceSDKCore
+//
+//  Created by Brianna Birman on 1/5/26.
+//  Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+// 
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+// 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import CryptoKit
+import DeviceCheck
+
+
+@objc(SFSDKAppAttestation)
+public class AppAttestation: NSObject {
+    enum AppAttestationError: Error {
+        case challengeEncodingFailed
+    }
+
+    struct AttestationObject: Codable {
+        let attestationId: String
+        let attestationData: String // Base-64 encoded
+    }
+    
+    struct AttestationKeychainItem: Codable {
+        let attestationId: String
+        let keyId: String
+    }
+    
+    static let appAttestKeyName = "com.salesforce.mobilesdk.attestation"
+    
+    /// Returns an attestation string if attestation is enabled and the domain is a My Domain,
+    /// otherwise returns nil. Callers do not need to check gating conditions themselves.
+    @objc
+    public static func attestationIfEnabled(for domain: String, consumerKey: String) async -> String? {
+        let isLoginPool = domain == kSFOAuthProductionLoginURL
+            || domain == kSFOAuthSandboxLoginURL
+            || domain == kSFOAuthWelcomeLoginURL
+
+        guard UserAccountManager.shared.appAttestationEnabled,
+              !isLoginPool,
+              !consumerKey.isEmpty else {
+            return nil
+        }
+
+        do {
+            return try await attestationObject(for: domain, consumerKey: consumerKey)
+        } catch {
+            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "Attestation error: \(error.localizedDescription)")
+            // TODO: In coordination with error stories, if device error prevents attestation from being generated, should this throw and/or have a retry path like deleting old key?
+            return nil
+        }
+    }
+    
+    // Internal for unit tests
+    static func existingKeyId(for attestationId: String) throws -> String? {
+        let attestKeyQuery = KeychainHelper.read(service: appAttestKeyName, account: nil)
+        if let attestKeyData = attestKeyQuery.data,
+           let keychainItem = try? JSONDecoder().decode(AttestationKeychainItem.self, from: attestKeyData) {
+            if keychainItem.attestationId == attestationId {
+                return keychainItem.keyId
+            } else {
+                // The ID can change if app is deleted / reinstalled but an old key can remain, delete the old one
+                // and then generate a new key like normal
+                let removeResult = KeychainHelper.remove(service: appAttestKeyName, account: nil)
+                if !removeResult.success {
+                    SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "Unable to delete old attestation keyId from keychain: \(removeResult.error?.localizedDescription ?? "")")
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func attestationObject(for domain: String, consumerKey: String) async throws -> String {
+        let attestationId = SalesforceManager.shared.deviceId()
+
+        let keyId = try await keyId(for: attestationId, domain: domain, consumerKey: consumerKey)
+
+        let challenge = try await requestChallengeFromSalesforce(domain: domain, consumerKey: consumerKey, attestationId: attestationId)
+        guard let challengeData = challenge.data(using: .utf8) else {
+            throw AppAttestationError.challengeEncodingFailed
+        }
+        let hash = Data(SHA256.hash(data: challengeData))
+
+        let assertion = try await performAppAttestOperation {
+            try await DCAppAttestService.shared.generateAssertion(keyId, clientDataHash: hash)
+        }
+        let assertionString = assertion.base64EncodedString()
+
+        let attestationObject = AttestationObject(attestationId: attestationId, attestationData: assertionString)
+        let jsonData = try JSONEncoder().encode(attestationObject)
+        return jsonData.base64EncodedString()
+    }
+
+
+    private static func generateAttestation(keyId: String, challenge: String) async throws -> String {
+        guard let challengeData = challenge.data(using: .utf8) else {
+            throw AppAttestationError.challengeEncodingFailed
+        }
+        let hash = Data(SHA256.hash(data: challengeData))
+
+        let attestation = try await performAppAttestOperation {
+            try await DCAppAttestService.shared.attestKey(keyId, clientDataHash: hash)
+        }
+        return attestation.base64EncodedString()
+    }
+
+    //    1. Client creates a key pair
+    //    2. Client makes request to get challenge  - /mobile/attest/challenge
+    //    3. Client creates an Apple attestation object with obtained challenge
+    //    4. Client makes request to pre-register public key - /mobile/attest/registerkey
+    private static func keyId(for attestationId: String, domain: String, consumerKey: String) async throws -> String {
+        if let existingKey = try existingKeyId(for: attestationId) {
+            return existingKey
+        }
+
+        let keyId = try await performAppAttestOperation {
+            try await DCAppAttestService.shared.generateKey()
+        }
+
+        let challenge = try await requestChallengeFromSalesforce(domain: domain, consumerKey: consumerKey, attestationId: attestationId)
+        let attestation = try await generateAttestation(keyId: keyId, challenge: challenge)
+        try await registerKeyWithSalesforce(keyId: keyId, consumerKey: consumerKey, attestationId: attestationId, attestationObject: attestation, domain: domain)
+
+        // Only persist after successful registration — if any step above fails,
+        // the next attempt will start fresh with a new key.
+        let keychainItem = AttestationKeychainItem(attestationId: attestationId, keyId: keyId)
+        let keychainItemData = try JSONEncoder().encode(keychainItem)
+        let keychainResult = KeychainHelper.write(service: appAttestKeyName, data: keychainItemData, account: nil)
+        if !keychainResult.success {
+            var message = "Unable to write attestation keyId to keychain"
+            if let error = keychainResult.error {
+                message += ": \(error.localizedDescription)"
+            }
+            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: message)
+        }
+
+        return keyId
+    }
+
+    private static func performAppAttestOperation<T>(_ operation: () async throws -> T) async throws -> T {
+        do {
+            return try await operation()
+        } catch let error as DCError {
+            SFSDKCoreLogger.log(AppAttestation.self, level: .error, message: "App Attest error: \(error.code.rawValue)")
+            throw error
+        }
+    }
+
+    // Requests a challenge from https://<domain>/mobile/attest/challenge
+    private static func requestChallengeFromSalesforce(domain: String, consumerKey: String, attestationId: String) async throws -> String {
+        let params = ["consumerKey": consumerKey, "attestationId": attestationId]
+        let request = RestRequest(method: .GET, baseURL: "https://\(domain)", path: "/mobile/attest/challenge", queryParams: params)
+        request.endpoint = ""
+        request.requiresAuthentication = false
+        let response = try await RestClient.sharedGlobal.send(request: request)
+        return response.asString()
+    }
+    
+    private static func registerKeyWithSalesforce(keyId: String, consumerKey: String, attestationId: String, attestationObject: String, domain: String) async throws {
+        let requestBody = "consumerKey=\(consumerKey.sfsdk_stringByURLEncoding())&attestationId=\(attestationId.sfsdk_stringByURLEncoding())&keyIdentifier=\(keyId.sfsdk_stringByURLEncoding())&attestationObject=\(attestationObject.sfsdk_stringByURLEncoding())"
+        let request = RestRequest(method: .POST, baseURL: "https://\(domain)", path: "/mobile/attest/registerkey", queryParams: nil)
+        request.endpoint = ""
+        request.requiresAuthentication = false
+        request.setCustomRequestBodyString(requestBody, contentType: kHttpPostContentType)
+        
+        _ = try await RestClient.sharedGlobal.send(request: request)
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/AppAttestation.swift
@@ -50,14 +50,9 @@ public class AppAttestation: NSObject {
     /// Returns an attestation string if attestation is enabled and the domain is a My Domain,
     /// otherwise returns nil. Callers do not need to check gating conditions themselves.
     @objc
-    public static func attestationIfEnabled(for domain: String, consumerKey: String) async -> String? {
-        let isLoginPool = domain == kSFOAuthProductionLoginURL
-            || domain == kSFOAuthSandboxLoginURL
-            || domain == kSFOAuthWelcomeLoginURL
-
-        guard UserAccountManager.shared.appAttestationEnabled,
-              !isLoginPool,
-              !consumerKey.isEmpty else {
+    public static func attestationIfEnabled(for domain: String?, consumerKey: String) async -> String? {
+        guard let domain,
+              shouldAttemptAttestation(for: domain, consumerKey: consumerKey, isDeviceSupported: DCAppAttestService.shared.isSupported) else {
             return nil
         }
 
@@ -68,6 +63,26 @@ public class AppAttestation: NSObject {
             // TODO: In coordination with error stories, if device error prevents attestation from being generated, should this throw and/or have a retry path like deleting old key?
             return nil
         }
+    }
+
+    // Internal for unit tests
+    static func shouldAttemptAttestation(for domain: String?, consumerKey: String, isDeviceSupported: Bool) -> Bool {
+        guard let domain, !domain.isEmpty else {
+            return false
+        }
+
+        let isLoginPool = domain == kSFOAuthProductionLoginURL
+            || domain == kSFOAuthSandboxLoginURL
+            || domain == kSFOAuthWelcomeLoginURL
+
+        guard UserAccountManager.shared.appAttestationEnabled,
+              isDeviceSupported,
+              !isLoginPool,
+              !consumerKey.isEmpty else {
+            return false
+        }
+
+        return true
     }
     
     // Internal for unit tests

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -670,8 +670,11 @@
 }
 
 - (void)beginTokenEndpointFlow {
+    __weak typeof(self) weakSelf = self;
     [SFSDKAppAttestation attestationIfEnabledFor:self.credentials.domain consumerKey:self.credentials.clientId completionHandler:^(NSString * _Nullable attestation) {
-        [self executeTokenEndpointFlowWithAttestation:attestation];
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf executeTokenEndpointFlowWithAttestation:attestation];
     }];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -154,7 +154,7 @@
         self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
     } else if (self.useBrowserAuth) {
         self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];
-    } else if ([[SalesforceSDKManager sharedManager] useWebServerAuthentication]) {
+    } else if ([[SalesforceSDKManager sharedManager] useWebServerAuthentication] || [SFUserAccountManager sharedInstance].appAttestationEnabled) {
         self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeWebServer];
     } else {
         self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeUserAgent];
@@ -857,7 +857,7 @@
 - (NSString *)generateApprovalUrlString {
     return [self approvalURLForEndpoint:[self brandedAuthorizeURL]
                             credentials:self.credentials
-                          webServerFlow:(self.useBrowserAuth || [[SalesforceSDKManager sharedManager] useWebServerAuthentication])
+                          webServerFlow:(self.useBrowserAuth || [[SalesforceSDKManager sharedManager] useWebServerAuthentication] || [SFUserAccountManager sharedInstance].appAttestationEnabled)
                                protocol:nil
                                  domain:nil
                           codeChallenge:nil];
@@ -1013,7 +1013,7 @@
         // If a front door bridge URL override is present, use its code verifier to choose between user agent or web server authentication.
         if (self.frontdoorBridgeLoginOverride.frontdoorBridgeUrl // Check if an override is provided
             ? self.frontdoorBridgeLoginOverride.codeVerifier != nil // If yes, only proceed if it's a web server flow as indicated by a code verifier.
-            : (self.useBrowserAuth || [[SalesforceSDKManager sharedManager] useWebServerAuthentication]) // If there's no override use browser auth or the default SDK setting.
+            : (self.useBrowserAuth || [[SalesforceSDKManager sharedManager] useWebServerAuthentication] || [SFUserAccountManager sharedInstance].appAttestationEnabled) // If there's no override use browser auth or the default SDK setting.
             )
         {
             [self handleWebServerResponse:url]; // Web server flow/URLs with query string parameters.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -670,6 +670,12 @@
 }
 
 - (void)beginTokenEndpointFlow {
+    [SFSDKAppAttestation attestationIfEnabledFor:self.credentials.domain consumerKey:self.credentials.clientId completionHandler:^(NSString * _Nullable attestation) {
+        [self executeTokenEndpointFlowWithAttestation:attestation];
+    }];
+}
+
+- (void)executeTokenEndpointFlowWithAttestation:(NSString * _Nullable)attestation {
     self.responseData = [NSMutableData dataWithLength:512];
     SFSDKOAuthTokenEndpointRequest *request = [[SFSDKOAuthTokenEndpointRequest alloc] init];
     request.additionalOAuthParameterKeys = self.additionalOAuthParameterKeys;
@@ -679,6 +685,7 @@
     request.redirectURI = self.credentials.redirectUri;
     request.serverURL = [self.credentials overrideDomainIfNeeded];
     request.credentialsIdentifier = self.credentials.identifier;
+    request.attestation = attestation;
 
     __weak typeof (self) weakSelf = self;
     if (self.approvalCode) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -131,6 +131,10 @@
     _domainDiscoveryCoordinator = nil;
 }
 
+- (BOOL)shouldUseWebServerFlow {
+    return [[SalesforceSDKManager sharedManager] useWebServerAuthentication] || [SFUserAccountManager sharedInstance].appAttestationEnabled;
+}
+
 - (void)authenticate {
     NSAssert(nil != self.credentials, @"credentials cannot be nil");
     NSAssert(self.credentials.clientId.length > 0, @"credentials.clientId cannot be nil or empty");
@@ -154,7 +158,7 @@
         self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
     } else if (self.useBrowserAuth) {
         self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];
-    } else if ([[SalesforceSDKManager sharedManager] useWebServerAuthentication] || [SFUserAccountManager sharedInstance].appAttestationEnabled) {
+    } else if (self.shouldUseWebServerFlow) {
         self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeWebServer];
     } else {
         self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeUserAgent];
@@ -857,7 +861,7 @@
 - (NSString *)generateApprovalUrlString {
     return [self approvalURLForEndpoint:[self brandedAuthorizeURL]
                             credentials:self.credentials
-                          webServerFlow:(self.useBrowserAuth || [[SalesforceSDKManager sharedManager] useWebServerAuthentication] || [SFUserAccountManager sharedInstance].appAttestationEnabled)
+                          webServerFlow:(self.useBrowserAuth || self.shouldUseWebServerFlow)
                                protocol:nil
                                  domain:nil
                           codeChallenge:nil];
@@ -1013,7 +1017,7 @@
         // If a front door bridge URL override is present, use its code verifier to choose between user agent or web server authentication.
         if (self.frontdoorBridgeLoginOverride.frontdoorBridgeUrl // Check if an override is provided
             ? self.frontdoorBridgeLoginOverride.codeVerifier != nil // If yes, only proceed if it's a web server flow as indicated by a code verifier.
-            : (self.useBrowserAuth || [[SalesforceSDKManager sharedManager] useWebServerAuthentication] || [SFUserAccountManager sharedInstance].appAttestationEnabled) // If there's no override use browser auth or the default SDK setting.
+            : (self.useBrowserAuth || self.shouldUseWebServerFlow) // If there's no override use browser auth or the default SDK setting.
             )
         {
             [self handleWebServerResponse:url]; // Web server flow/URLs with query string parameters.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -147,6 +147,9 @@
          self.credentials.clientId, (nil == self.credentials.refreshToken ? @"without" : @"with"),
          self.credentials.protocol, self.credentials.domain];
     self.authenticating = YES;
+    if ([SFUserAccountManager sharedInstance].appAttestationEnabled) {
+        [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureAppAttestation];
+    }
     if (self.credentials.refreshToken) {
         self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
     } else if (self.useBrowserAuth) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -84,10 +84,8 @@ SFSDK_USE_DEPRECATED_BEGIN
         return;
     }
     
-    __weak typeof(self) weakSelf = self;
     [SFSDKAppAttestation attestationIfEnabledFor:self.credentials.domain consumerKey:self.credentials.clientId completionHandler:^(NSString * _Nullable attestation) {
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        [strongSelf executeRefreshWithAttestation:attestation];
+        [self executeRefreshWithAttestation:attestation];
     }];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -84,8 +84,11 @@ SFSDK_USE_DEPRECATED_BEGIN
         return;
     }
     
+    __weak typeof(self) weakSelf = self;
     [SFSDKAppAttestation attestationIfEnabledFor:self.credentials.domain consumerKey:self.credentials.clientId completionHandler:^(NSString * _Nullable attestation) {
-        [self executeRefreshWithAttestation:attestation];
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) return;
+        [strongSelf executeRefreshWithAttestation:attestation];
     }];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -34,6 +34,7 @@ SFSDK_USE_DEPRECATED_BEGIN
 #import "SFOAuthInfo.h"
 #import "SFSDKOAuth2.h"
 #import "SFSDKAppFeatureMarkers.h"
+#import <SalesforceSDKCore/SalesforceSDKCore-Swift.h>
 
 @interface SFOAuthSessionRefresher()
 
@@ -83,6 +84,14 @@ SFSDK_USE_DEPRECATED_BEGIN
         return;
     }
     
+    __weak typeof(self) weakSelf = self;
+    [SFSDKAppAttestation attestationIfEnabledFor:self.credentials.domain consumerKey:self.credentials.clientId completionHandler:^(NSString * _Nullable attestation) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf executeRefreshWithAttestation:attestation];
+    }];
+}
+
+- (void)executeRefreshWithAttestation:(NSString * _Nullable)attestation {
     SFSDKOAuthTokenEndpointRequest *request = [[SFSDKOAuthTokenEndpointRequest alloc] init];
     request.additionalOAuthParameterKeys = [SFUserAccountManager sharedInstance].additionalOAuthParameterKeys;
     request.additionalTokenRefreshParams = [SFUserAccountManager sharedInstance].additionalTokenRefreshParams;
@@ -91,6 +100,8 @@ SFSDK_USE_DEPRECATED_BEGIN
     request.redirectURI = self.credentials.redirectUri;
     request.serverURL = [self.credentials overrideDomainIfNeeded];
     request.credentialsIdentifier = self.credentials.identifier;
+    request.attestation = attestation;
+
     __weak typeof(self) weakSelf = self;
     id<SFSDKOAuthProtocol> authClient = [SFUserAccountManager sharedInstance].authClient();
     [authClient accessTokenForRefresh:request completion:^(SFSDKOAuthTokenEndpointResponse * response) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -394,6 +394,11 @@ NS_SWIFT_NAME(UserAccountManager)
  */
 @property (nonatomic, copy, nullable) NSArray<NotificationType*>* (^filterSupportedNotificationTypes)(NSArray<NotificationType*>* notificationTypes);
 
+/** Whether or not app attestation is enabled. When YES, the SDK will include attestation
+ *  in token endpoint requests (code exchange and refresh). Defaults to NO.
+ */
+@property (nonatomic, assign) BOOL appAttestationEnabled;
+
 /**
  Adds a delegate to this user account manager.
  @param delegate The delegate to add.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -2214,6 +2214,15 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureDPoP forUser:userAccount];
     }
 
+    // AA: write per-user and clear the transient global flag
+    BOOL usedAppAttestation = [[SFSDKAppFeatureMarkers appFeatures] containsObject:kSFAppFeatureAppAttestation];
+    if (usedAppAttestation) {
+        [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureAppAttestation forUser:userAccount];
+    } else {
+        [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureAppAttestation forUser:userAccount];
+    }
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureAppAttestation];
+
     // Async call, ignore if theres a failure. If success save the user photo locally.
     [self retrieveUserPhotoIfNeeded:userAccount];
     BOOL shouldNotify = YES;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthConfigUtil.m
@@ -27,6 +27,7 @@
  */
 
 #import "SFSDKAuthConfigUtil.h"
+#import "SFSDKOAuthConstants.h"
 #import "SFNetwork.h"
 #import <SalesforceSDKCommon/SFJsonUtils.h>
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -105,6 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSString *codeVerifier;
 @property (nonatomic, assign) NSTimeInterval timeout;
 @property (nonatomic, strong) NSURL *serverURL;
+@property (nonatomic, copy, nullable) NSString *attestation;
 @property (nonatomic, strong, nullable) NSDictionary * additionalTokenRefreshParams;
 @property (nonatomic, strong, nullable) NSArray<NSString *> *additionalOAuthParameterKeys;
 /// `SFOAuthCredentials.identifier` for the in-flight account. Used by the DPoP layer to

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -241,6 +241,10 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     [params appendFormat:@"&%@=%@", kSFOAuthCodeVerifierParamName, endpointReq.codeVerifier];
     NSString *grantType = [[SalesforceSDKManager sharedManager] useHybridAuthentication] ? kSFOAuthGrantTypeHybridAuthorizationCode : kSFOAuthGrantTypeAuthorizationCode;
     [params appendFormat:@"&%@=%@&%@=%@", kSFOAuthGrantType, grantType, kSFOAuthApprovalCode, endpointReq.approvalCode];
+    if (endpointReq.attestation) {
+        [params appendFormat:@"&%@=%@", kSFOAuthAttestation, [endpointReq.attestation sfsdk_stringByURLEncoding]];
+    }
+
     NSData *encodedBody = [params dataUsingEncoding:NSUTF8StringEncoding];
     [request setHTTPBody:encodedBody];
 
@@ -295,6 +299,9 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     [params appendFormat:@"&%@=%@&%@=%@", kSFOAuthGrantType, grantType, kSFOAuthRefreshToken, endpointReq.refreshToken];
     for (NSString * key in endpointReq.additionalTokenRefreshParams) {
         [params appendFormat:@"&%@=%@", [key sfsdk_stringByURLEncoding], [endpointReq.additionalTokenRefreshParams[key] sfsdk_stringByURLEncoding]];
+    }
+    if (endpointReq.attestation) {
+        [params appendFormat:@"&%@=%@", kSFOAuthAttestation, [endpointReq.attestation sfsdk_stringByURLEncoding]];
     }
     NSData *encodedBody = [params dataUsingEncoding:NSUTF8StringEncoding];
     [request setHTTPBody:encodedBody];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -80,12 +80,12 @@ static NSString * const kSFOAuthSidCookieName                   = @"sidCookieNam
 static NSString * const kSFOAuthParentSid                       = @"parent_sid";
 static NSString * const kSFOAuthTokenFormat                     = @"token_format";
 static NSString * const kSFOAuthTokenType                       = @"token_type";
+static NSString * const kSFOAuthAttestation                     = @"attestation";
 static NSString * const kSFOAuthBeaconChildConsumerKey          = @"auto_installed_app_org_consumer_key";
 static NSString * const kSFOAuthBeaconChildConsumerSecret       = @"auto_installed_app_org_consumer_secret";
 // TODO: Remove legacy fallback constants once server version 264 has rolled out everywhere.
 static NSString * const kSFOAuthLegacyBeaconChildConsumerKey    = @"beacon_child_consumer_key";
 static NSString * const kSFOAuthLegacyBeaconChildConsumerSecret = @"beacon_child_consumer_secret";
-
 
 // Used for the IP bypass flow, Advanced auth flow
 static NSString * const kSFOAuthApprovalCode                     = @"code";
@@ -149,5 +149,10 @@ static NSString * const kSFOAuthEndPointHeadlessInitRegistration = @"services/au
 
 /// Endpoint path for Salesforce Identity API headless forgot password flow
 static NSString * const kSFOAuthEndPointHeadlessForgotPassword = @"services/auth/headless/forgot_password";
+
+// Standard login pool URLs (non-My Domain)
+static NSString * const kSFOAuthProductionLoginURL               = @"login.salesforce.com";
+static NSString * const kSFOAuthSandboxLoginURL                  = @"test.salesforce.com";
+static NSString * const kSFOAuthWelcomeLoginURL                  = @"welcome.salesforce.com/discovery";
 
 #endif /* SFSDKOAuthConstants_h */

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AppAttestationTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AppAttestationTests.swift
@@ -1,0 +1,297 @@
+//
+//  AppAttestationTests.swift
+//  SalesforceSDKCore
+//
+//  Created by Brianna Birman on 4/17/26.
+//  Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+//
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import XCTest
+import DeviceCheck
+import CryptoKit
+@testable import SalesforceSDKCore
+
+class AppAttestationTests: XCTestCase {
+
+    private var originalAppAttestationEnabled = false
+
+    override func setUp() {
+        super.setUp()
+        originalAppAttestationEnabled = UserAccountManager.shared.appAttestationEnabled
+        _ = KeychainHelper.remove(service: AppAttestation.appAttestKeyName, account: nil)
+    }
+
+    override func tearDown() {
+        UserAccountManager.shared.appAttestationEnabled = originalAppAttestationEnabled
+        _ = KeychainHelper.remove(service: AppAttestation.appAttestKeyName, account: nil)
+        super.tearDown()
+    }
+
+    // MARK: - AttestationObject Tests
+
+    func test_givenValidAttestationData_whenEncodingAttestationObject_thenReturnsBase64EncodedJSON() throws {
+        let attestationId = "testId"
+        let attestationData = "testData".data(using: .utf8)!.base64EncodedString()
+
+        let attestationObject = AppAttestation.AttestationObject(
+            attestationId: attestationId,
+            attestationData: attestationData
+        )
+
+        let jsonData = try JSONEncoder().encode(attestationObject)
+        let base64String = jsonData.base64EncodedString()
+
+        XCTAssertFalse(base64String.isEmpty, "Base64 encoded string should not be empty")
+
+        // Verify we can decode it back
+        let decodedData = try XCTUnwrap(Data(base64Encoded: base64String))
+        let decodedObject = try JSONDecoder().decode(AppAttestation.AttestationObject.self, from: decodedData)
+
+        XCTAssertEqual(decodedObject.attestationId, attestationId)
+        XCTAssertEqual(decodedObject.attestationData, attestationData)
+    }
+
+    // MARK: - Challenge Hash Tests
+
+    func test_givenChallengeString_whenGeneratingHash_thenReturnsSHA256Hash() throws {
+        let challenge = "testChallenge"
+        let challengeData = try XCTUnwrap(challenge.data(using: .utf8))
+        let hash = Data(SHA256.hash(data: challengeData))
+
+        // SHA256 always produces 32 bytes
+        XCTAssertEqual(hash.count, 32, "SHA256 hash should be 32 bytes")
+    }
+
+
+    // MARK: - Error Handling Tests
+
+    func test_givenEmptyChallenge_whenGeneratingHash_thenReturnsValidHash() throws {
+        let challenge = ""
+        let challengeData = try XCTUnwrap(challenge.data(using: .utf8))
+        let hash = Data(SHA256.hash(data: challengeData))
+
+        XCTAssertEqual(hash.count, 32, "SHA256 hash should still be 32 bytes for empty input")
+    }
+
+    // MARK: - URL Encoding Tests
+
+    func test_givenAttestationObjectWithSpecialCharacters_whenURLEncoding_thenProperlyEncoded() {
+        let attestationObject = "test+string/with=special&chars"
+        let encoded = attestationObject.sfsdk_stringByURLEncoding()
+
+        XCTAssertNotEqual(attestationObject, encoded, "Encoded string should differ from original")
+        XCTAssertTrue(encoded.contains("%"), "Encoded string should contain percent encoding")
+    }
+
+    func test_givenBase64EncodedData_whenURLEncoding_thenProperlyHandlesPaddingAndSpecialChars() {
+        let testData = "test data".data(using: .utf8)!
+        let base64String = testData.base64EncodedString()
+        let encoded = base64String.sfsdk_stringByURLEncoding()
+
+        // Base64 can contain +, /, = which should be encoded
+        XCTAssertFalse(encoded.contains("+") || encoded.contains("/") || encoded.contains("="),
+                       "Encoded string should not contain unencoded special characters")
+    }
+
+    // MARK: - JSON Encoding/Decoding Tests
+
+    func test_givenAttestationObject_whenEncodingAndDecoding_thenPreservesData() throws {
+        let original = AppAttestation.AttestationObject(
+            attestationId: "testId123",
+            attestationData: "dGVzdERhdGE="
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(AppAttestation.AttestationObject.self, from: encoded)
+
+        XCTAssertEqual(original.attestationId, decoded.attestationId)
+        XCTAssertEqual(original.attestationData, decoded.attestationData)
+    }
+
+    func test_givenMalformedJSON_whenDecodingAttestationObject_thenThrowsError() {
+        let malformedJSON = "{\"attestationId\":\"test\"}".data(using: .utf8)!
+
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(AppAttestation.AttestationObject.self, from: malformedJSON),
+            "Decoding incomplete JSON should throw error"
+        ) { error in
+            XCTAssertTrue(error is DecodingError, "Should be a DecodingError")
+        }
+    }
+
+    // MARK: - Integration-Style Tests (Note: These require mocking DCAppAttestService)
+
+    func test_givenValidInputs_whenCreatingAttestationObjectComponents_thenComponentsAreValid() throws {
+        // This tests the data transformation logic without actual attestation
+        let attestationId = "testId"
+        let mockAttestationData = Data([0x01, 0x02, 0x03, 0x04])
+        let base64Attestation = mockAttestationData.base64EncodedString()
+
+        let attestationObject = AppAttestation.AttestationObject(
+            attestationId: attestationId,
+            attestationData: base64Attestation
+        )
+
+        let jsonData = try JSONEncoder().encode(attestationObject)
+        let base64EncodedObject = jsonData.base64EncodedString()
+
+        // Verify the structure
+        XCTAssertFalse(base64EncodedObject.isEmpty)
+
+        // Verify it can be decoded
+        let decodedData = try XCTUnwrap(Data(base64Encoded: base64EncodedObject))
+        let decodedObject = try JSONDecoder().decode(AppAttestation.AttestationObject.self, from: decodedData)
+
+        XCTAssertEqual(decodedObject.attestationId, attestationId)
+        XCTAssertEqual(decodedObject.attestationData, base64Attestation)
+    }
+
+    // MARK: - Edge Cases
+
+    func test_givenVeryLongAttestationId_whenEncodingAttestationObject_thenSucceeds() throws {
+        let longId = String(repeating: "a", count: 1000)
+        let attestationData = "testData".data(using: .utf8)!.base64EncodedString()
+
+        let attestationObject = AppAttestation.AttestationObject(
+            attestationId: longId,
+            attestationData: attestationData
+        )
+
+        XCTAssertNoThrow(try JSONEncoder().encode(attestationObject))
+    }
+
+    func test_givenVeryLargeAttestationData_whenEncodingAttestationObject_thenSucceeds() throws {
+        let largeData = Data(repeating: 0xFF, count: 10000)
+        let attestationData = largeData.base64EncodedString()
+
+        let attestationObject = AppAttestation.AttestationObject(
+            attestationId: "testId",
+            attestationData: attestationData
+        )
+
+        XCTAssertNoThrow(try JSONEncoder().encode(attestationObject))
+    }
+
+    func test_givenUnicodeCharacters_whenEncodingAttestationId_thenSucceeds() throws {
+        let unicodeId = "测试🎉αβγ"
+        let attestationData = "testData".data(using: .utf8)!.base64EncodedString()
+
+        let attestationObject = AppAttestation.AttestationObject(
+            attestationId: unicodeId,
+            attestationData: attestationData
+        )
+
+        let jsonData = try JSONEncoder().encode(attestationObject)
+        let decoded = try JSONDecoder().decode(AppAttestation.AttestationObject.self, from: jsonData)
+
+        XCTAssertEqual(decoded.attestationId, unicodeId)
+    }
+
+
+    // MARK: - Constants Tests
+
+    func test_appAttestKeyName_hasExpectedValue() {
+        XCTAssertEqual(AppAttestation.appAttestKeyName, "com.salesforce.mobilesdk.attestation",
+                      "App attest key name constant should match expected value")
+    }
+
+    // MARK: - Gating Logic Tests (attestationIfEnabled)
+
+    func test_givenAttestationDisabled_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+        UserAccountManager.shared.appAttestationEnabled = false
+        let result = await AppAttestation.attestationIfEnabled(for: "mydomain.my.salesforce.com", consumerKey: "consumerKey123")
+        XCTAssertNil(result, "Should return nil when attestation is disabled")
+    }
+
+    func test_givenLoginSalesforceDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = await AppAttestation.attestationIfEnabled(for: "login.salesforce.com", consumerKey: "consumerKey123")
+        XCTAssertNil(result, "Should return nil for login.salesforce.com (login pool)")
+    }
+
+    func test_givenTestSalesforceDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = await AppAttestation.attestationIfEnabled(for: "test.salesforce.com", consumerKey: "consumerKey123")
+        XCTAssertNil(result, "Should return nil for test.salesforce.com (login pool)")
+    }
+
+    func test_givenWelcomeDiscoveryDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = await AppAttestation.attestationIfEnabled(for: "welcome.salesforce.com/discovery", consumerKey: "consumerKey123")
+        XCTAssertNil(result, "Should return nil for welcome.salesforce.com/discovery (login pool)")
+    }
+
+    func test_givenEmptyConsumerKey_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = await AppAttestation.attestationIfEnabled(for: "mydomain.my.salesforce.com", consumerKey: "")
+        XCTAssertNil(result, "Should return nil when consumer key is empty")
+    }
+
+    // MARK: - existingKeyId Tests
+
+    func test_givenNoKeychainData_whenCallingExistingKeyId_thenReturnsNil() throws {
+        let result = try AppAttestation.existingKeyId(for: "device123")
+        XCTAssertNil(result, "Should return nil when no keychain entry exists")
+    }
+
+    func test_givenMatchingAttestationId_whenCallingExistingKeyId_thenReturnsKeyId() throws {
+        let attestationId = "device123"
+        let keyId = "storedKey456"
+        let item = AppAttestation.AttestationKeychainItem(attestationId: attestationId, keyId: keyId)
+        let data = try JSONEncoder().encode(item)
+        _ = KeychainHelper.write(service: AppAttestation.appAttestKeyName, data: data, account: nil)
+
+        let result = try AppAttestation.existingKeyId(for: attestationId)
+        XCTAssertEqual(result, keyId)
+    }
+
+    func test_givenMismatchedAttestationId_whenCallingExistingKeyId_thenReturnsNilAndRemovesEntry() throws {
+        let item = AppAttestation.AttestationKeychainItem(attestationId: "oldDevice", keyId: "oldKey")
+        let data = try JSONEncoder().encode(item)
+        _ = KeychainHelper.write(service: AppAttestation.appAttestKeyName, data: data, account: nil)
+
+        let result = try AppAttestation.existingKeyId(for: "newDevice")
+        XCTAssertNil(result, "Should return nil when attestationId doesn't match")
+
+        // Verify the stale entry was removed
+        let readResult = KeychainHelper.read(service: AppAttestation.appAttestKeyName, account: nil)
+        XCTAssertNil(readResult.data, "Stale keychain entry should have been removed")
+    }
+
+    func test_givenCorruptedKeychainData_whenCallingExistingKeyId_thenReturnsNil() throws {
+        let corruptData = "not json".data(using: .utf8)!
+        _ = KeychainHelper.write(service: AppAttestation.appAttestKeyName, data: corruptData, account: nil)
+
+        let result = try AppAttestation.existingKeyId(for: "device123")
+        XCTAssertNil(result, "Should return nil when keychain data can't be decoded")
+    }
+
+    func test_givenPartialJSON_whenCallingExistingKeyId_thenReturnsNil() throws {
+        // Valid JSON but missing required keyId field
+        let partialData = "{\"attestationId\":\"device123\"}".data(using: .utf8)!
+        _ = KeychainHelper.write(service: AppAttestation.appAttestKeyName, data: partialData, account: nil)
+
+        let result = try AppAttestation.existingKeyId(for: "device123")
+        XCTAssertNil(result, "Should return nil when keychain data is missing required fields")
+    }
+
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AppAttestationTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AppAttestationTests.swift
@@ -214,36 +214,60 @@ class AppAttestationTests: XCTestCase {
                       "App attest key name constant should match expected value")
     }
 
-    // MARK: - Gating Logic Tests (attestationIfEnabled)
+    // MARK: - Gating Logic Tests (shouldAttemptAttestation)
 
-    func test_givenAttestationDisabled_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+    func test_givenAllConditionsMet_whenCheckingShouldAttempt_thenReturnsTrue() {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = AppAttestation.shouldAttemptAttestation(for: "mydomain.my.salesforce.com", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertTrue(result, "Should return true when all conditions are met")
+    }
+
+    func test_givenAttestationDisabled_whenCheckingShouldAttempt_thenReturnsFalse() {
         UserAccountManager.shared.appAttestationEnabled = false
-        let result = await AppAttestation.attestationIfEnabled(for: "mydomain.my.salesforce.com", consumerKey: "consumerKey123")
-        XCTAssertNil(result, "Should return nil when attestation is disabled")
+        let result = AppAttestation.shouldAttemptAttestation(for: "mydomain.my.salesforce.com", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false when attestation is disabled")
     }
 
-    func test_givenLoginSalesforceDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+    func test_givenDeviceNotSupported_whenCheckingShouldAttempt_thenReturnsFalse() {
         UserAccountManager.shared.appAttestationEnabled = true
-        let result = await AppAttestation.attestationIfEnabled(for: "login.salesforce.com", consumerKey: "consumerKey123")
-        XCTAssertNil(result, "Should return nil for login.salesforce.com (login pool)")
+        let result = AppAttestation.shouldAttemptAttestation(for: "mydomain.my.salesforce.com", consumerKey: "consumerKey123", isDeviceSupported: false)
+        XCTAssertFalse(result, "Should return false when device does not support App Attest")
     }
 
-    func test_givenTestSalesforceDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+    func test_givenLoginSalesforceDomain_whenCheckingShouldAttempt_thenReturnsFalse() {
         UserAccountManager.shared.appAttestationEnabled = true
-        let result = await AppAttestation.attestationIfEnabled(for: "test.salesforce.com", consumerKey: "consumerKey123")
-        XCTAssertNil(result, "Should return nil for test.salesforce.com (login pool)")
+        let result = AppAttestation.shouldAttemptAttestation(for: "login.salesforce.com", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false for login.salesforce.com (login pool)")
     }
 
-    func test_givenWelcomeDiscoveryDomain_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+    func test_givenTestSalesforceDomain_whenCheckingShouldAttempt_thenReturnsFalse() {
         UserAccountManager.shared.appAttestationEnabled = true
-        let result = await AppAttestation.attestationIfEnabled(for: "welcome.salesforce.com/discovery", consumerKey: "consumerKey123")
-        XCTAssertNil(result, "Should return nil for welcome.salesforce.com/discovery (login pool)")
+        let result = AppAttestation.shouldAttemptAttestation(for: "test.salesforce.com", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false for test.salesforce.com (login pool)")
     }
 
-    func test_givenEmptyConsumerKey_whenCallingAttestationIfEnabled_thenReturnsNil() async {
+    func test_givenWelcomeDiscoveryDomain_whenCheckingShouldAttempt_thenReturnsFalse() {
         UserAccountManager.shared.appAttestationEnabled = true
-        let result = await AppAttestation.attestationIfEnabled(for: "mydomain.my.salesforce.com", consumerKey: "")
-        XCTAssertNil(result, "Should return nil when consumer key is empty")
+        let result = AppAttestation.shouldAttemptAttestation(for: "welcome.salesforce.com/discovery", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false for welcome.salesforce.com/discovery (login pool)")
+    }
+
+    func test_givenNilDomain_whenCheckingShouldAttempt_thenReturnsFalse() {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = AppAttestation.shouldAttemptAttestation(for: nil, consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false when domain is nil")
+    }
+
+    func test_givenEmptyDomain_whenCheckingShouldAttempt_thenReturnsFalse() {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = AppAttestation.shouldAttemptAttestation(for: "", consumerKey: "consumerKey123", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false when domain is empty")
+    }
+
+    func test_givenEmptyConsumerKey_whenCheckingShouldAttempt_thenReturnsFalse() {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = AppAttestation.shouldAttemptAttestation(for: "mydomain.my.salesforce.com", consumerKey: "", isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false when consumer key is empty")
     }
 
     // MARK: - existingKeyId Tests

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AppAttestationTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AppAttestationTests.swift
@@ -270,6 +270,12 @@ class AppAttestationTests: XCTestCase {
         XCTAssertFalse(result, "Should return false when consumer key is empty")
     }
 
+    func test_givenNilConsumerKey_whenCheckingShouldAttempt_thenReturnsFalse() {
+        UserAccountManager.shared.appAttestationEnabled = true
+        let result = AppAttestation.shouldAttemptAttestation(for: "mydomain.my.salesforce.com", consumerKey: nil, isDeviceSupported: true)
+        XCTAssertFalse(result, "Should return false when consumer key is nil")
+    }
+
     // MARK: - existingKeyId Tests
 
     func test_givenNoKeychainData_whenCallingExistingKeyId_thenReturnsNil() throws {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.m
@@ -237,5 +237,130 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
     [creds revoke];
 }
 
+#pragma mark - App Attestation Forces Web Server Flow Tests
+
+- (void)test_givenAttestationEnabled_andWebServerFlowDisabled_whenAuthenticateCalled_thenUsesWebServerFlowType {
+    // Arrange
+    BOOL originalAttestation = [SFUserAccountManager sharedInstance].appAttestationEnabled;
+    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] useWebServerAuthentication];
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = YES;
+    [SalesforceSDKManager sharedManager].useWebServerAuthentication = NO;
+
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"testFlowType" clientId:@"testClient" encrypted:NO];
+    creds.domain = @"mydomain.my.salesforce.com";
+    creds.redirectUri = @"testapp://callback";
+    creds.instanceUrl = [NSURL URLWithString:@"https://mydomain.my.salesforce.com"];
+    // No refresh token — forces the auth type selection path (not refresh flow)
+
+    SFOAuthCoordinator *coordinator = [[SFOAuthCoordinator alloc] initWithCredentials:creds];
+    coordinator.useBrowserAuth = NO;
+    SFOAuthTestFlowCoordinatorDelegate *delegate = [[SFOAuthTestFlowCoordinatorDelegate alloc] init];
+    delegate.isNetworkAvailable = NO;
+    coordinator.delegate = delegate;
+
+    // Act
+    [coordinator authenticate];
+
+    // Assert: should select web server flow despite useWebServerAuthentication = NO
+    XCTAssertEqual(coordinator.authInfo.authType, SFOAuthTypeWebServer,
+                   @"Auth type should be WebServer when attestation is enabled, even if useWebServerAuthentication is NO");
+
+    // Cleanup
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = originalAttestation;
+    [SalesforceSDKManager sharedManager].useWebServerAuthentication = originalWebServer;
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureAppAttestation];
+    [creds revoke];
+}
+
+- (void)test_givenAttestationDisabled_andWebServerFlowDisabled_whenAuthenticateCalled_thenUsesUserAgentFlowType {
+    // Arrange
+    BOOL originalAttestation = [SFUserAccountManager sharedInstance].appAttestationEnabled;
+    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] useWebServerAuthentication];
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = NO;
+    [SalesforceSDKManager sharedManager].useWebServerAuthentication = NO;
+
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"testFlowType2" clientId:@"testClient2" encrypted:NO];
+    creds.domain = @"mydomain.my.salesforce.com";
+    creds.redirectUri = @"testapp://callback";
+    creds.instanceUrl = [NSURL URLWithString:@"https://mydomain.my.salesforce.com"];
+    // No refresh token — forces the auth type selection path
+
+    SFOAuthCoordinator *coordinator = [[SFOAuthCoordinator alloc] initWithCredentials:creds];
+    coordinator.useBrowserAuth = NO;
+    SFOAuthTestFlowCoordinatorDelegate *delegate = [[SFOAuthTestFlowCoordinatorDelegate alloc] init];
+    delegate.isNetworkAvailable = NO;
+    coordinator.delegate = delegate;
+
+    // Act
+    [coordinator authenticate];
+
+    // Assert: should use user agent flow when both attestation and web server are off
+    XCTAssertEqual(coordinator.authInfo.authType, SFOAuthTypeUserAgent,
+                   @"Auth type should be UserAgent when both attestation and useWebServerAuthentication are disabled");
+
+    // Cleanup
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = originalAttestation;
+    [SalesforceSDKManager sharedManager].useWebServerAuthentication = originalWebServer;
+    [creds revoke];
+}
+
+- (void)test_givenAttestationEnabled_whenGeneratingApprovalUrl_thenContainsResponseTypeCode {
+    // Arrange
+    BOOL originalAttestation = [SFUserAccountManager sharedInstance].appAttestationEnabled;
+    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] useWebServerAuthentication];
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = YES;
+    [SalesforceSDKManager sharedManager].useWebServerAuthentication = NO;
+
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"testApprovalUrl" clientId:@"testClient" encrypted:NO];
+    creds.domain = @"mydomain.my.salesforce.com";
+    creds.redirectUri = @"testapp://callback";
+    creds.instanceUrl = [NSURL URLWithString:@"https://mydomain.my.salesforce.com"];
+
+    SFOAuthCoordinator *coordinator = [[SFOAuthCoordinator alloc] initWithCredentials:creds];
+    coordinator.useBrowserAuth = NO;
+
+    // Act
+    NSString *approvalUrl = [coordinator generateApprovalUrlString];
+
+    // Assert: URL should contain response_type=code (web server flow)
+    XCTAssertTrue([approvalUrl containsString:@"response_type=code"],
+                  @"Approval URL should use response_type=code when attestation is enabled; got: %@", approvalUrl);
+    XCTAssertFalse([approvalUrl containsString:@"response_type=token"],
+                   @"Approval URL should NOT use response_type=token when attestation is enabled; got: %@", approvalUrl);
+
+    // Cleanup
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = originalAttestation;
+    [SalesforceSDKManager sharedManager].useWebServerAuthentication = originalWebServer;
+    [creds revoke];
+}
+
+- (void)test_givenAttestationDisabled_andWebServerFlowDisabled_whenGeneratingApprovalUrl_thenDoesNotContainResponseTypeCode {
+    // Arrange
+    BOOL originalAttestation = [SFUserAccountManager sharedInstance].appAttestationEnabled;
+    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] useWebServerAuthentication];
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = NO;
+    [SalesforceSDKManager sharedManager].useWebServerAuthentication = NO;
+
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"testApprovalUrl2" clientId:@"testClient2" encrypted:NO];
+    creds.domain = @"mydomain.my.salesforce.com";
+    creds.redirectUri = @"testapp://callback";
+    creds.instanceUrl = [NSURL URLWithString:@"https://mydomain.my.salesforce.com"];
+
+    SFOAuthCoordinator *coordinator = [[SFOAuthCoordinator alloc] initWithCredentials:creds];
+    coordinator.useBrowserAuth = NO;
+
+    // Act
+    NSString *approvalUrl = [coordinator generateApprovalUrlString];
+
+    // Assert: URL should NOT contain response_type=code (user agent flow uses token or hybrid_token)
+    XCTAssertFalse([approvalUrl containsString:@"response_type=code"],
+                   @"Approval URL should NOT use response_type=code when attestation and web server flow are both disabled; got: %@", approvalUrl);
+
+    // Cleanup
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = originalAttestation;
+    [SalesforceSDKManager sharedManager].useWebServerAuthentication = originalWebServer;
+    [creds revoke];
+}
+
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.m
@@ -29,6 +29,8 @@
 #import "SFOAuthCredentials+Internal.h"
 #import "SFSDKAuthSession.h"
 #import "SFSDKAuthRequest.h"
+#import "SFOAuthTestFlowCoordinatorDelegate.h"
+#import "SFSDKAppFeatureMarkers.h"
 
 @interface SFOAuthCoordinatorTests : XCTestCase
 
@@ -172,6 +174,67 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
 
     XCTAssertNotNil(options, @"Options must never be nil");
     XCTAssertEqual(options.count, (NSUInteger)0, @"A nil sceneId must yield an empty options dictionary so nil is never inserted and the handler falls back to the default scene");
+}
+
+#pragma mark - App Attestation Feature Flag Tests
+
+- (void)test_givenAttestationEnabled_whenAuthenticateCalled_thenAAFlagRegisteredGlobally {
+    // Arrange
+    BOOL originalValue = [SFUserAccountManager sharedInstance].appAttestationEnabled;
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = YES;
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureAppAttestation];
+
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"testAttest" clientId:@"testClient" encrypted:NO];
+    creds.domain = @"mydomain.my.salesforce.com";
+    creds.refreshToken = @"testRefreshToken";
+    creds.redirectUri = @"testapp://callback";
+    creds.instanceUrl = [NSURL URLWithString:@"https://mydomain.my.salesforce.com"];
+
+    SFOAuthCoordinator *coordinator = [[SFOAuthCoordinator alloc] initWithCredentials:creds];
+    SFOAuthTestFlowCoordinatorDelegate *delegate = [[SFOAuthTestFlowCoordinatorDelegate alloc] init];
+    delegate.isNetworkAvailable = NO; // Prevent actual network calls
+    coordinator.delegate = delegate;
+
+    // Act
+    [coordinator authenticate];
+
+    // Assert: AA flag should be registered globally
+    XCTAssertTrue([[SFSDKAppFeatureMarkers appFeatures] containsObject:kSFAppFeatureAppAttestation],
+                  @"AA flag should be registered globally when attestation is enabled");
+
+    // Cleanup
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureAppAttestation];
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = originalValue;
+    [creds revoke];
+}
+
+- (void)test_givenAttestationDisabled_whenAuthenticateCalled_thenAAFlagNotRegistered {
+    // Arrange
+    BOOL originalValue = [SFUserAccountManager sharedInstance].appAttestationEnabled;
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = NO;
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureAppAttestation];
+
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"testAttest2" clientId:@"testClient2" encrypted:NO];
+    creds.domain = @"mydomain.my.salesforce.com";
+    creds.refreshToken = @"testRefreshToken";
+    creds.redirectUri = @"testapp://callback";
+    creds.instanceUrl = [NSURL URLWithString:@"https://mydomain.my.salesforce.com"];
+
+    SFOAuthCoordinator *coordinator = [[SFOAuthCoordinator alloc] initWithCredentials:creds];
+    SFOAuthTestFlowCoordinatorDelegate *delegate = [[SFOAuthTestFlowCoordinatorDelegate alloc] init];
+    delegate.isNetworkAvailable = NO; // Prevent actual network calls
+    coordinator.delegate = delegate;
+
+    // Act
+    [coordinator authenticate];
+
+    // Assert: AA flag should NOT be registered
+    XCTAssertFalse([[SFSDKAppFeatureMarkers appFeatures] containsObject:kSFAppFeatureAppAttestation],
+                   @"AA flag should not be registered when attestation is disabled");
+
+    // Cleanup
+    [SFUserAccountManager sharedInstance].appAttestationEnabled = originalValue;
+    [creds revoke];
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAppFeatureMarkersTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKAppFeatureMarkersTests.m
@@ -61,6 +61,7 @@
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureQrCodeLogin forUser:self.userA];
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureRTR forUser:self.userA];
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureDPoP forUser:self.userA];
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureAppAttestation forUser:self.userA];
     self.userA = nil;
     self.userB = nil;
     [self clearExistingMarkers];
@@ -319,6 +320,26 @@
                    @"userB should not have DP if only userA had a DPoP session");
 
     // Cleanup handled in tearDown.
+}
+
+#pragma mark - App Attestation (AA) flag tests
+
+- (void)test_givenAttestationUsed_whenPerUserFlagRegistered_thenFlagAppearsInPerUserFeaturesNotGlobal {
+    // Act: simulate finalizeAuthCompletion persisting per-user and clearing global
+    [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureAppAttestation forUser:self.userA];
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureAppAttestation];
+
+    // Assert: AA in per-user features
+    NSSet *features = [SFSDKAppFeatureMarkers appFeaturesForUser:self.userA];
+    XCTAssertTrue([features containsObject:kSFAppFeatureAppAttestation],
+                  @"AA flag should appear in per-user feature set after attestation");
+
+    // Assert: AA NOT in global-only set
+    XCTAssertFalse([[SFSDKAppFeatureMarkers appFeatures] containsObject:kSFAppFeatureAppAttestation],
+                   @"AA flag should not remain in global feature set after finalization");
+
+    // Cleanup
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureAppAttestation forUser:self.userA];
 }
 
 #pragma mark - Private helpers

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
@@ -112,6 +112,7 @@ class DPoPLoginTests: BaseAuthFlowTester {
             staticScopeSelection: .subset,
             migrationAppConfigName: .ecaJwtDpop,
             migrationScopeSelection: .all,
+            forceAdvancedAuthentication: false,
             useDPoP: true
         )
 
@@ -130,11 +131,12 @@ class DPoPLoginTests: BaseAuthFlowTester {
             staticAppConfigName: .ecaJwtDpop,
             migrationAppConfigName: .ecaJwtDpopRtr,
             migrationUseHybridFlow: false,
+            forceAdvancedAuthentication: false,
             useDPoP: true
         )
 
         // Verify RTR is enabled post-migration
-        assertRevokeAndRefreshWorks(isRtr: true, isDPoP: true)
+        assertRevokeAndRefreshWorks(isRtr: true, isDPoP: true, expectAdvancedAuth: false)
     }
 
     // MARK: - Restart

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -736,7 +736,7 @@ class BaseAuthFlowTester: XCTestCase {
         let flagSet: Set<String>
         if let ftrRange = ua.range(of: "ftr_") {
             let afterFtr = String(ua[ftrRange.upperBound...])
-            let flagString = afterFtr.components(separatedBy: " ").first ?? ""
+            let flagString = afterFtr.components(separatedBy: " ").first ?? "" 
             flagSet = Set(flagString.components(separatedBy: ".").filter { !$0.isEmpty })
         } else {
             flagSet = []

--- a/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
+++ b/native/SampleApps/RestAPIExplorer/RestAPIExplorer/AppDelegate.swift
@@ -54,6 +54,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return .allow
         }
         
+        // Uncomment following line to enable app attestation
+        // Need to add "App Attest" entitlement to project under "Signing & Capabilities"
+        // UserAccountManager.shared.appAttestationEnabled = true
+        
         // Uncomment following block to enable IDP Login flow.
         //SalesforceManager.shared.identityProviderURLScheme = "sampleidpapp"
     }


### PR DESCRIPTION
## Summary

Adds Apple App Attestation to the SalesforceSDKCore OAuth code exchange and refresh flows.

- Merging `app-attestation` feature branch into the `dev` branch. I branched `app-attestation` to `app-attestation-dev-merge` branch so I can first rebase it with `dev` locally. All commits in `app-attestation` have been previously reviewed and approved by the team. So there is no net new code in this PR.
- New `AppAttestation.swift` (production) and `AppAttestationTests.swift` (unit tests) under SalesforceSDKCore.
- `SFSDKAppAttestation.attestationIfEnabledFor:consumerKey:completionHandler:` produces the `attestation` value for the token endpoint; returns `nil` when the feature is disabled, unsupported on the device (simulator, older OS), or the domain is not attestation-enabled.
- Refresh (`SFOAuthSessionRefresher`) and code-exchange (`SFOAuthCoordinator`) paths were refactored to a small two-step form so the async attestation lookup can complete before the token request is dispatched. When attestation is off, both paths behave exactly as before (`attestation` param is skipped).
- Introduces `SFUserAccountManager.appAttestationEnabled` (public opt-in).
- Adds `kSFOAuthAttestation` constant and the `AA` per-user app-feature marker (registered per-user on the completed session, cleared from the global set on finalization).
- Switches to the web server flow when app attestation is configured.
- Consumer-facing wiring: `RestAPIExplorer/AppDelegate.swift` enables the flag.

## Test plan

- [x] `SalesforceSDKCore` scheme builds
- [x] Unit tests pass in Xcode (App Attestation, feature-flag markers, DPoP scene tests)
- [x] Existing DPoP UI automation continues to pass
- [x] Verify against an attestation-enabled Connected App (device only; simulator is expected to short-circuit to `nil`)