### PR TITLE
Surface refresh token rotation state in dev info screen

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -555,6 +555,19 @@ SFNativeLoginManagerInternal *nativeLogin;
     return [actions copy];
 }
 
+static NSString *SFSDKISO8601StringFromDate(NSDate *date) {
+    if (!date) return nil;
+    static NSDateFormatter *formatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        formatter = [[NSDateFormatter alloc] init];
+        formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        formatter.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
+        formatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss'Z'";
+    });
+    return [formatter stringFromDate:date];
+}
+
 - (NSArray<NSString *>*) getDevSupportInfos
 {
     SFUserAccountManager* userAccountManager = [SFUserAccountManager sharedInstance];
@@ -640,7 +653,31 @@ SFNativeLoginManagerInternal *nativeLogin;
         [devInfos addObjectsFromArray:@[@"Managed", [managedPreferences hasManagedPreferences] ? @"YES" : @"NO"]];
         [devInfos addObjectsFromArray:[self dictToDevInfos:managedPreferences.rawPreferences]];
     }
-    
+
+    // section:RTR — refresh-token-rotation observability
+    [devInfos addObject:@"section:RTR"];
+    {
+        SFUserAccount *rtrUser = [SFUserAccountManager sharedInstance].currentUser;
+        NSString *rtrActive;
+        if (!rtrUser) {
+            rtrActive = @"N/A";
+        } else {
+            NSSet<NSString *> *features = [SFSDKAppFeatureMarkers appFeaturesForUser:rtrUser];
+            rtrActive = [features containsObject:kSFAppFeatureRTR] ? @"YES" : @"NO";
+        }
+        NSString *lastRotation = @"Never";
+        if (rtrUser.credentials.lastTokenRotationDate) {
+            NSString *iso = SFSDKISO8601StringFromDate(rtrUser.credentials.lastTokenRotationDate);
+            if (iso.length > 0) {
+                lastRotation = iso;
+            }
+        }
+        [devInfos addObjectsFromArray:@[
+            @"RTR Active", rtrActive,
+            @"Last Rotation", lastRotation
+        ]];
+    }
+
     return devInfos;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
@@ -63,6 +63,7 @@ extern NSException * _Nullable SFOAuthInvalidIdentifierException(void);
 @property (nonatomic, readwrite, nullable) NSString *communityId;
 @property (nonatomic, readwrite, nullable) NSURL *communityUrl;
 @property (nonatomic, readwrite, nullable) NSDate *issuedAt;
+@property (nonatomic, readwrite, nullable) NSDate *lastTokenRotationDate;
 @property (nonatomic, readwrite, nullable) NSURL *identityUrl;
 @property (nonatomic, readwrite, nullable) NSURL *apiUrl;
 @property (nonatomic, readwrite, nullable) NSString *userId;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
@@ -190,10 +190,19 @@ NS_SWIFT_NAME(OAuthCredentials)
 @property (nonatomic, readonly, nullable) NSURL *communityUrl;
 
 /** The timestamp when the session access token was issued.
- 
+
  This property is set by the `SFOAuthCoordinator` after authentication has successfully completed.
  */
 @property (nonatomic, readonly, nullable) NSDate *issuedAt;
+
+/** The timestamp of the most recent refresh-token rotation observed for this credential.
+
+ Set by `SFOAuthSessionRefresher` when a token refresh returns a `refresh_token`
+ that differs from the previously-stored one. `nil` if no rotation has been observed
+ for this credential (or if this credential predates the field's introduction — older
+ archives decode this field as `nil`).
+ */
+@property (nonatomic, readonly, nullable) NSDate *lastTokenRotationDate;
 
 /** The identity URL for the user returned as part of a successful authentication response.
  The format of the URL is: _https://login.salesforce.com/ID/orgID/userID_ where orgId is the ID of the Salesforce organization 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -65,6 +65,7 @@ NSException * SFOAuthInvalidIdentifierException(void) {
 @synthesize apiInstanceUrl            = _apiInstanceUrl;
 @synthesize scopes                    = _scopes;
 @synthesize issuedAt                  = _issuedAt;
+@synthesize lastTokenRotationDate     = _lastTokenRotationDate;
 @synthesize protocol                  = _protocol;
 @synthesize encrypted                 = _encrypted;
 @synthesize additionalOAuthFields     = _additionalOAuthFields;
@@ -98,6 +99,7 @@ NSException * SFOAuthInvalidIdentifierException(void) {
             self.communityId    = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthCommunityId"];
             self.communityUrl   = [coder decodeObjectOfClass:[NSURL class]    forKey:@"SFOAuthCommunityUrl"];
             self.issuedAt       = [coder decodeObjectOfClass:[NSDate class]   forKey:@"SFOAuthIssuedAt"];
+            self.lastTokenRotationDate = [coder decodeObjectOfClass:[NSDate class] forKey:@"SFOAuthLastTokenRotationDate"];
             self.additionalOAuthFields = [coder decodeObjectOfClasses:[NSSet setWithObjects:[NSDictionary class], [NSString class], nil] forKey:@"SFOAuthAdditionalFields"];
             NSString *protocolVal = [coder decodeObjectOfClass:[NSString class] forKey:@"SFOAuthProtocol"];
             if (nil != protocolVal) {
@@ -152,6 +154,7 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     [coder encodeObject:self.communityId        forKey:@"SFOAuthCommunityId"];
     [coder encodeObject:self.communityUrl       forKey:@"SFOAuthCommunityUrl"];
     [coder encodeObject:self.issuedAt           forKey:@"SFOAuthIssuedAt"];
+    [coder encodeObject:self.lastTokenRotationDate forKey:@"SFOAuthLastTokenRotationDate"];
     [coder encodeObject:self.protocol           forKey:@"SFOAuthProtocol"];
     [coder encodeObject:self.lightningDomain    forKey:@"SFOAuthLightningDomain"];
     [coder encodeObject:self.vfDomain           forKey:@"SFOAuthVFDomain"];
@@ -213,6 +216,7 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     copyCreds.communityId = self.communityId;
     copyCreds.communityUrl = self.communityUrl;
     copyCreds.issuedAt = self.issuedAt;
+    copyCreds.lastTokenRotationDate = self.lastTokenRotationDate;
 
     // NB: Intentionally ordering the copying of these, because setting the identity URL automatically
     // sets the OrgID and UserID.  This ensures the values stay in sync.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -121,6 +121,7 @@ SFSDK_USE_DEPRECATED_BEGIN
                 SFUserAccount *account = [[SFUserAccountManager sharedInstance]
                                            accountForCredentials:strongSelf.credentials];
                 if (account) {
+                    strongSelf.credentials.lastTokenRotationDate = [NSDate date];
                     [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureRTR forUser:account];
                 }
             }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
@@ -188,6 +188,11 @@ SFSDK_USE_DEPRECATED_BEGIN
     XCTAssertTrue([features containsObject:kSFAppFeatureRTR],
                   @"RT flag should be registered after refresh token rotation");
 
+    // Assert: timestamp was stamped
+    XCTAssertNotNil(account.credentials.lastTokenRotationDate, @"Expected rotation timestamp to be stamped");
+    XCTAssertLessThan(fabs([account.credentials.lastTokenRotationDate timeIntervalSinceNow]), 5.0,
+                      @"Rotation timestamp should be within 5 seconds of now");
+
     // Cleanup
     [SFUserAccountManager sharedInstance].authClient = originalFactory;
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureRTR forUser:account];
@@ -199,6 +204,9 @@ SFSDK_USE_DEPRECATED_BEGIN
     SFOAuthCredentials *creds = self.oauthSessionRefresher.credentials;
     SFUserAccount *account = [[SFUserAccount alloc] initWithCredentials:creds];
     [[SFUserAccountManager sharedInstance] saveAccountForUser:account error:nil];
+
+    // Pre-seed a known prior timestamp
+    account.credentials.lastTokenRotationDate = [NSDate dateWithTimeIntervalSince1970:1234567890];
 
     NSDictionary *responseDict = @{
         kSFOAuthAccessToken: @"new_access_token",
@@ -226,6 +234,10 @@ SFSDK_USE_DEPRECATED_BEGIN
     NSSet *features = [SFSDKAppFeatureMarkers appFeaturesForUser:account];
     XCTAssertFalse([features containsObject:kSFAppFeatureRTR],
                    @"RT flag should not be registered when refresh token did not rotate");
+
+    // Assert: timestamp preserved
+    XCTAssertEqualWithAccuracy([account.credentials.lastTokenRotationDate timeIntervalSince1970], 1234567890, 0.001,
+                               @"Rotation timestamp must be preserved when no rotation occurred");
 
     // Cleanup
     [SFUserAccountManager sharedInstance].authClient = originalFactory;

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceOAuthUnitTests.m
@@ -133,6 +133,7 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     credsIn.apiInstanceUrl  = [NSURL URLWithString:@"http://api.salesforce.com"];
     credsIn.scopes          = @[@"api", @"refresh_token"];
     credsIn.issuedAt        = [NSDate date];
+    credsIn.lastTokenRotationDate = [NSDate dateWithTimeIntervalSince1970:1700000000];
     credsIn.contentDomain   = @"mobilesdk.my.salesforce.com";
     credsIn.contentSid      = @"contentsid";
     credsIn.lightningDomain = @"mobilesdk.lightning.force.com";
@@ -178,6 +179,7 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     XCTAssertEqualObjects(credsIn.apiInstanceUrl,      credsOut.apiInstanceUrl,      @"apiInstanceUrl mismatch");
     XCTAssertEqualObjects(credsIn.scopes,              credsOut.scopes,              @"scopes mismatch");
     XCTAssertEqualObjects(credsIn.issuedAt,            credsOut.issuedAt,            @"issuedAt mismatch");
+    XCTAssertEqualObjects(credsIn.lastTokenRotationDate, credsOut.lastTokenRotationDate, @"lastTokenRotationDate mismatch");
     XCTAssertEqualObjects(credsIn.contentDomain,       credsOut.contentDomain,       @"contentDomain mismatch");
     XCTAssertEqualObjects(credsIn.contentSid,          credsOut.contentSid,          @"contentSid mismatch");
     XCTAssertEqualObjects(credsIn.lightningDomain,     credsOut.lightningDomain,     @"lightningDomain mismatch");
@@ -196,6 +198,21 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     XCTAssertEqualObjects(credsIn.additionalOAuthFields, credsOut.additionalOAuthFields, @"additionalFields mismatch");
     
     credsIn = nil;
+
+    // Test nil round-trip for lastTokenRotationDate
+    SFOAuthKeychainCredentials *nilCredsIn = [[SFOAuthKeychainCredentials alloc] initWithIdentifier:kIdentifier clientId:kClientId encrypted:YES];
+    // Deliberately NOT setting lastTokenRotationDate
+
+    NSKeyedArchiver *nilArchiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:NO];
+    [nilArchiver encodeObject:nilCredsIn forKey:@"creds"];
+    [nilArchiver finishEncoding];
+    NSData *nilData = nilArchiver.encodedData;
+
+    NSKeyedUnarchiver *nilUnarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:nilData error:nil];
+    nilUnarchiver.requiresSecureCoding = YES;
+    SFOAuthCredentials *nilCredsOut = [nilUnarchiver decodeObjectOfClass:[SFOAuthCredentials class] forKey:@"creds"];
+
+    XCTAssertNil(nilCredsOut.lastTokenRotationDate, @"lastTokenRotationDate should be nil when not set");
 }
 
 - (void)testCredentialsCopying {
@@ -211,6 +228,7 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     NSString *communityIdToCheck = @"communityID";
     NSURL *communityUrlToCheck = [NSURL URLWithString:@"https://mycomm.my.salesforce.com/customers"];
     NSDate *issuedAtToCheck = [NSDate date];
+    NSDate *lastTokenRotationDateToCheck = [NSDate dateWithTimeIntervalSince1970:1700000000];
     NSURL *identityUrlToCheck = [NSURL URLWithString:@"https://login.salesforce.com/id/someOrg/someUser"];
     NSString *userIdToCheck = @"userID";
     NSString *contentDomainToCheck = @"mobilesdk.my.salesforce.com";
@@ -242,6 +260,7 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     origCreds.communityId = communityIdToCheck;
     origCreds.communityUrl = communityUrlToCheck;
     origCreds.issuedAt = issuedAtToCheck;
+    origCreds.lastTokenRotationDate = lastTokenRotationDateToCheck;
     origCreds.contentDomain = contentDomainToCheck;
     origCreds.contentSid = contentSidToCheck;
     origCreds.lightningDomain = lightningDomainToCheck;
@@ -280,6 +299,7 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     origCreds.communityId = nil;
     origCreds.communityUrl = nil;
     origCreds.issuedAt = nil;
+    origCreds.lastTokenRotationDate = nil;
     origCreds.identityUrl = nil;
     origCreds.userId = nil;
     origCreds.contentDomain = nil;
@@ -341,6 +361,8 @@ static NSString * const kTestRefreshToken = @"HowRefreshing";
     XCTAssertNotEqual(origCreds.communityUrl, copiedCreds.communityUrl);
     XCTAssertEqual(copiedCreds.issuedAt, issuedAtToCheck);
     XCTAssertNotEqual(origCreds.issuedAt, copiedCreds.issuedAt);
+    XCTAssertEqual(copiedCreds.lastTokenRotationDate, lastTokenRotationDateToCheck);
+    XCTAssertNotEqual(origCreds.lastTokenRotationDate, copiedCreds.lastTokenRotationDate);
     XCTAssertEqual(copiedCreds.identityUrl, identityUrlToCheck);
     XCTAssertNotEqual(origCreds.identityUrl, copiedCreds.identityUrl);
     XCTAssertEqual(copiedCreds.userId, userIdToCheck);

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
@@ -1743,4 +1743,67 @@ static NSString* const kTestAppName = @"OverridenAppName";
     XCTAssertFalse(hasDPoPThumbprint, @"Dev support infos should not contain DPoP Key Thumbprint when not logged in");
 }
 
+#pragma mark - Dev Support Infos Tests - RTR
+
+- (void)test_givenRTRActiveWithTimestamp_whenGetDevSupportInfosInvoked_thenRTRSectionShowsYESAndTimestamp {
+    [self createTestAppIdentity];
+    SFUserAccount *user = [self createUserAccount];
+    NSDate *rotation = [NSDate dateWithTimeIntervalSince1970:1700000000]; // 2023-11-14T22:13:20Z
+    user.credentials.lastTokenRotationDate = rotation;
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:user];
+    [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureRTR forUser:user];
+
+    NSArray<NSString *> *infos = [[SalesforceSDKManager sharedManager] getDevSupportInfos];
+
+    NSUInteger sectionIdx = [infos indexOfObject:@"section:RTR"];
+    XCTAssertNotEqual(sectionIdx, NSNotFound, @"section:RTR must be present");
+    XCTAssertEqualObjects(infos[[infos indexOfObject:@"RTR Active"] + 1], @"YES");
+    XCTAssertEqualObjects(infos[[infos indexOfObject:@"Last Rotation"] + 1], @"2023-11-14T22:13:20Z");
+
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureRTR forUser:user];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:nil];
+}
+
+- (void)test_givenRTRNotActive_whenGetDevSupportInfosInvoked_thenRTRSectionShowsNOAndNever {
+    [self createTestAppIdentity];
+    SFUserAccount *user = [self createUserAccount];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:user];
+    // Do NOT register kSFAppFeatureRTR; do NOT set lastTokenRotationDate
+
+    NSArray<NSString *> *infos = [[SalesforceSDKManager sharedManager] getDevSupportInfos];
+
+    XCTAssertNotEqual([infos indexOfObject:@"section:RTR"], NSNotFound);
+    XCTAssertEqualObjects(infos[[infos indexOfObject:@"RTR Active"] + 1], @"NO");
+    XCTAssertEqualObjects(infos[[infos indexOfObject:@"Last Rotation"] + 1], @"Never");
+
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:nil];
+}
+
+- (void)test_givenNoCurrentUser_whenGetDevSupportInfosInvoked_thenRTRSectionShowsNAAndNever {
+    [self createTestAppIdentity];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:nil];
+
+    NSArray<NSString *> *infos = [[SalesforceSDKManager sharedManager] getDevSupportInfos];
+
+    XCTAssertNotEqual([infos indexOfObject:@"section:RTR"], NSNotFound);
+    XCTAssertEqualObjects(infos[[infos indexOfObject:@"RTR Active"] + 1], @"N/A");
+    XCTAssertEqualObjects(infos[[infos indexOfObject:@"Last Rotation"] + 1], @"Never");
+}
+
+- (void)test_givenRTRActiveButNoTimestamp_whenGetDevSupportInfosInvoked_thenLastRotationIsNever {
+    [self createTestAppIdentity];
+    SFUserAccount *user = [self createUserAccount];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:user];
+    [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureRTR forUser:user];
+    // Deliberately NOT setting lastTokenRotationDate
+
+    NSArray<NSString *> *infos = [[SalesforceSDKManager sharedManager] getDevSupportInfos];
+
+    XCTAssertEqualObjects(infos[[infos indexOfObject:@"RTR Active"] + 1], @"YES");
+    XCTAssertEqualObjects(infos[[infos indexOfObject:@"Last Rotation"] + 1], @"Never");
+
+    [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureRTR forUser:user];
+    [[SFUserAccountManager sharedInstance] setCurrentUserInternal:nil];
+}
+
 @end


### PR DESCRIPTION
## Summary

- Adds `lastTokenRotationDate` to `OAuthCredentials`, persisted via NSSecureCoding and preserved on copy.
- `SFOAuthSessionRefresher` stamps the timestamp when a refresh returns a new refresh token (same site that already registers the per-user RTR feature flag).
- `SalesforceSDKManager.getDevSupportInfos` emits a new `section:RTR` block with two rows: RTR active (per-user `RTR` feature flag) and the ISO-8601 UTC timestamp of the last observed rotation.

## Behavior

- Section is emitted unconditionally, so devs can distinguish "RTR not enabled" from "RTR enabled but no rotation observed yet".
- `Last Rotation` renders as `Never` when the credential has no timestamp.
- When no current user is signed in, RTR active shows `N/A` and last rotation shows `Never`.
- Timestamps use `en_US_POSIX` / UTC / `yyyy-MM-dd'T'HH:mm:ss'Z'` for a stable, locale-independent format.
- Additive keychain field: older archives decode `lastTokenRotationDate` as `nil`; archive version is unchanged.


<img width="489" height="1008" alt="Screenshot 2026-07-29 at 3 37 17 PM" src="https://github.com/user-attachments/assets/72dd7c6b-dfbb-41de-b499-20e4b3a518d6" />


## Test plan

- [x] `SalesforceOAuthUnitTests -testCredentialsCoding` — NSSecureCoding round-trip (populated and nil cases).
- [x] `SalesforceOAuthUnitTests -testCredentialsCopying` — `copyWithZone:` preserves the new field.
- [x] `SFOAuthSessionRefresherTests` — timestamp stamped on rotation, preserved when refresh token is unchanged.
- [x] `SalesforceSDKManagerTests` — four new tests covering the four dev-info states (active+timestamp, active+no-timestamp, inactive, no current user).
- [x] Full `SalesforceSDKCoreTests` suite: 904/904 passing.