### PR TITLE
feat(W-23721537): speed up AuthFlowTester UI tests via launch-arg driven SDK reset

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.h
@@ -99,6 +99,14 @@ extern NSString * const kSFAppFeatureAppAttestation;
  */
 + (void)loadPersistedFeatures:(nonnull NSSet<NSString *> *)features forUser:(nonnull SFUserAccount *)user;
 
+#if DEBUG
+/**
+ Clears all per-user in-memory feature flags. Intended for UI test resets only.
+ NOT FOR PRODUCTION USE.
+ */
++ (void)resetPerUserFeaturesForUITesting;
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.m
@@ -141,4 +141,12 @@ static NSMutableDictionary<NSString *, NSMutableSet<NSString *> *> *SFSDKPerUser
     });
 }
 
+#if DEBUG
++ (void)resetPerUserFeaturesForUITesting {
+    dispatch_sync(SFSDKAppFeatureDispatchQueue, ^{
+        [SFSDKPerUserFeatureMarkersMap removeAllObjects];
+    });
+}
+#endif
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -391,6 +391,22 @@ NS_SWIFT_NAME(SalesforceManager)
  */
 - (id <SFNativeLoginManager>)nativeLoginManager;
 
+#if DEBUG
+/**
+ * Resets all local SDK auth state for UI testing.
+ *
+ * Logs out all users (including async server refresh-token revocation), resets the selected
+ * login host to login.salesforce.com, removes persisted custom login servers, and restores
+ * all SalesforceSDKManager auth flags to their post-init defaults.
+ *
+ * Call once at process startup when --resetSDKForUITesting is present in launch arguments,
+ * after initializeSDK and before the SDK's login flow begins.
+ *
+ * NOT FOR PRODUCTION USE.
+ */
++ (void)resetForUITesting NS_SWIFT_NAME(resetForUITesting());
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -229,6 +229,15 @@ SFNativeLoginManagerInternal *nativeLogin;
     [SalesforceSDKManager sharedManager];
 }
 
+- (void)resetAuthFlags {
+    self.useEphemeralSessionForAdvancedAuth = YES;
+    self.useWebServerAuthentication = YES;
+    self.useHybridAuthentication = YES;
+    self.useDPoP = NO;
+    self.sdk_forceAdvancedAuthentication = YES;
+    self.blockSalesforceIntegrationUser = NO;
+}
+
 #if DEBUG
 + (void)resetForUITesting {
     // 1. Log out all users — clears on-disk account data, DPoP keychain keys, in-memory maps.
@@ -249,14 +258,9 @@ SFNativeLoginManagerInternal *nativeLogin;
     [storage removeAllLoginHosts];
     [storage save];
 
-    // 5. Reset all auth flags to the values set in -init.
+    // 5. Reset all auth flags to their -init defaults.
     SalesforceSDKManager *mgr = [SalesforceSDKManager sharedManager];
-    mgr.useEphemeralSessionForAdvancedAuth = YES;
-    mgr.useWebServerAuthentication = YES;
-    mgr.useHybridAuthentication = YES;
-    mgr.useDPoP = NO;
-    mgr.sdk_forceAdvancedAuthentication = YES;
-    mgr.blockSalesforceIntegrationUser = NO;
+    [mgr resetAuthFlags];
     mgr.simulatedDomainDiscoveryResult = nil;
 }
 #endif
@@ -361,12 +365,7 @@ SFNativeLoginManagerInternal *nativeLogin;
         [self computeWebViewUserAgent]; // web view user agent is computed asynchronously so very first call to self.userAgentString(...) will be missing it
         self.userAgentString = [self defaultUserAgentString];
         self.URLCacheType = kSFURLCacheTypeEncrypted;
-        self.useEphemeralSessionForAdvancedAuth = YES;
-        self.useWebServerAuthentication = YES;
-        self.blockSalesforceIntegrationUser = NO;
-        self.useHybridAuthentication = YES;
-        self.useDPoP = NO;
-        self.sdk_forceAdvancedAuthentication = YES;
+        [self resetAuthFlags];
         [self setupServiceConfiguration];
         _snapshotViewControllers = [SFSDKSafeMutableDictionary new];
         _nativeLoginViewControllers = [SFSDKSafeMutableDictionary new];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -43,6 +43,7 @@
 #import "SFSDKSalesforceSDKUpgradeManager.h"
 #import <SalesforceSDKCommon/NSUserDefaults+SFAdditions.h>
 #import "SFSDKWindowManager+Internal.h"
+#import "SFSDKLoginHostStorage.h"
 
 // Error constants
 NSString * const kSalesforceSDKManagerErrorDomain     = @"com.salesforce.sdkmanager.error";
@@ -227,6 +228,34 @@ SFNativeLoginManagerInternal *nativeLogin;
 
     [SalesforceSDKManager sharedManager];
 }
+
+#if DEBUG
++ (void)resetForUITesting {
+    // 1. Log out all users — clears on-disk account data, DPoP keychain keys, in-memory maps.
+    //    Refresh-token revocation fires asynchronously in the background.
+    [[SFUserAccountManager sharedInstance] logoutAllUsers];
+
+    // 2. Reset selected login host to production default and persist it.
+    [SFUserAccountManager sharedInstance].loginHost = @"login.salesforce.com";
+
+    // 3. Remove custom login servers in-memory; save flushes the empty list to msdkUserDefaults
+    //    (SalesforceLoginHostListPrefs) so custom hosts do not reappear on next cold start.
+    //    Production (login.salesforce.com) and Sandbox (test.salesforce.com) are preserved.
+    SFSDKLoginHostStorage *storage = [SFSDKLoginHostStorage sharedInstance];
+    [storage removeAllLoginHosts];
+    [storage save];
+
+    // 4. Reset all auth flags to the values set in -init.
+    SalesforceSDKManager *mgr = [SalesforceSDKManager sharedManager];
+    mgr.useEphemeralSessionForAdvancedAuth = YES;
+    mgr.useWebServerAuthentication = YES;
+    mgr.useHybridAuthentication = YES;
+    mgr.useDPoP = NO;
+    mgr.sdk_forceAdvancedAuthentication = YES;
+    mgr.blockSalesforceIntegrationUser = NO;
+    mgr.simulatedDomainDiscoveryResult = nil;
+}
+#endif
 
 + (instancetype)sharedManager {
     static dispatch_once_t pred;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -235,17 +235,21 @@ SFNativeLoginManagerInternal *nativeLogin;
     //    Refresh-token revocation fires asynchronously in the background.
     [[SFUserAccountManager sharedInstance] logoutAllUsers];
 
-    // 2. Reset selected login host to production default and persist it.
+    // 2. Clear per-user in-memory feature flags (RT, DP, etc.) so flags from the previous test
+    //    do not bleed into the next one when the same user logs in again.
+    [SFSDKAppFeatureMarkers resetPerUserFeaturesForUITesting];
+
+    // 3. Reset selected login host to production default and persist it.
     [SFUserAccountManager sharedInstance].loginHost = @"login.salesforce.com";
 
-    // 3. Remove custom login servers in-memory; save flushes the empty list to msdkUserDefaults
+    // 4. Remove custom login servers in-memory; save flushes the empty list to msdkUserDefaults
     //    (SalesforceLoginHostListPrefs) so custom hosts do not reappear on next cold start.
     //    Production (login.salesforce.com) and Sandbox (test.salesforce.com) are preserved.
     SFSDKLoginHostStorage *storage = [SFSDKLoginHostStorage sharedInstance];
     [storage removeAllLoginHosts];
     [storage save];
 
-    // 4. Reset all auth flags to the values set in -init.
+    // 5. Reset all auth flags to the values set in -init.
     SalesforceSDKManager *mgr = [SalesforceSDKManager sharedManager];
     mgr.useEphemeralSessionForAdvancedAuth = YES;
     mgr.useWebServerAuthentication = YES;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -2182,6 +2182,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     SFOAuthType completedAuthType = authSession.oauthCoordinator.authInfo.authType;
     if (completedAuthType == SFOAuthTypeAdvancedBrowser) {
         [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureSafariBrowserForLogin forUser:userAccount];
+    } else if (completedAuthType == SFOAuthTypeRefreshTokenMigration) {
+        // Migration exchanges the token but does not change how the user originally
+        // authenticated. Preserve the existing per-user BW flag rather than clearing it.
     } else {
         [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureSafariBrowserForLogin forUser:userAccount];
     }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester/Classes/AppDelegate.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester/Classes/AppDelegate.swift
@@ -40,6 +40,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         super.init()
         
         SalesforceManager.initializeSDK()
+        #if DEBUG
+        if CommandLine.arguments.contains("--resetSDKForUITesting") {
+            SalesforceManager.resetForUITesting()
+        }
+        #endif
         SalesforceManager.shared.appDisplayName = "Auth Flow Tester"
         UserAccountManager.shared.navigationPolicyForAction = { webView, action in
             if let url = action.request.url, url.absoluteString == "https://www.salesforce.com/us/company/privacy" {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester/Views/UserCredentialsView.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester/Views/UserCredentialsView.swift
@@ -282,7 +282,7 @@ struct UserCredentialsView: View {
         result[CredentialsLabels.tokens] = [
             CredentialsLabels.accessToken: accessToken,
             CredentialsLabels.refreshToken: refreshToken,
-            CredentialsLabels.tokenFormat: tokenFormat,
+            CredentialsLabels.tokenFormat: tokenFormatRaw,
             CredentialsLabels.jwt: jwt,
             CredentialsLabels.authCode: authCode,
             CredentialsLabels.challengeString: challengeString,
@@ -401,9 +401,12 @@ struct UserCredentialsView: View {
         return credentials?.refreshToken ?? ""
     }
     
+    private var tokenFormatRaw: String {
+        return credentials?.tokenFormat ?? ""
+    }
+
     private var tokenFormat: String {
-        let value = credentials?.tokenFormat ?? ""
-        return value.isEmpty ? "Opaque" : value
+        return tokenFormatRaw.isEmpty ? "Opaque" : tokenFormatRaw
     }
     
     private var jwt: String {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -434,7 +434,7 @@ class LoginPageObject {
     
     private func hasHost(host: String) -> Bool {
         let row = hostRow(host: host)
-        return row.waitForExistence(timeout: UITestTimeouts.long)
+        return row.waitForExistence(timeout: UITestTimeouts.short)
     }
 }
 

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -208,6 +208,16 @@ class LoginPageObject {
         return app.webViews.webViews.webViews.textFields.firstMatch.waitForExistence(timeout: timeout)
     }
 
+    /// True when the in-app login view controller (`SFLoginViewController`) is showing, detected
+    /// by its "Log In" navigation bar title. This appears as soon as the view controller is
+    /// presented — before the WKWebView has loaded the login page — so it is faster and more
+    /// reliable than `isShowingInAppLoginForm()` for asserting that the SDK chose the in-app
+    /// WebView modality rather than the external browser. Pass `UITestTimeouts.short` for the
+    /// negative assertion (not showing).
+    func isShowingLoginViewController(timeout: TimeInterval = UITestTimeouts.long) -> Bool {
+        return loginNavigationBar().waitForExistence(timeout: timeout)
+    }
+
     /// True when the Settings gear is present on the current login nav bar. Under forced advanced
     /// auth the gear lives on the host list; on the legacy path it lives on the in-app WebView
     /// ("Log In"). Both expose the same accessibility identifier "settings".

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
@@ -112,7 +112,6 @@ class DPoPLoginTests: BaseAuthFlowTester {
             staticScopeSelection: .subset,
             migrationAppConfigName: .ecaJwtDpop,
             migrationScopeSelection: .all,
-            forceAdvancedAuthentication: false,
             useDPoP: true
         )
 
@@ -131,7 +130,6 @@ class DPoPLoginTests: BaseAuthFlowTester {
             staticAppConfigName: .ecaJwtDpop,
             migrationAppConfigName: .ecaJwtDpopRtr,
             migrationUseHybridFlow: false,
-            forceAdvancedAuthentication: false,
             useDPoP: true
         )
 

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ForceAdvancedAuthTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ForceAdvancedAuthTests.swift
@@ -88,9 +88,6 @@ class ForceAdvancedAuthTests: BaseAuthFlowTester {
                       "Forced advanced auth on the standard server should launch the external browser")
         XCTAssertFalse(isShowingInAppLoginForm(timeout: UITestTimeouts.short),
                        "The in-app WebView login form must NOT be shown when advanced auth is forced on")
-
-        // Never completed login — remain on the browser surface; the next launch() self-heals.
-        skipLogoutAtTearDown()
     }
 
     /// Flag OFF (imported explicitly), standard server.
@@ -114,8 +111,6 @@ class ForceAdvancedAuthTests: BaseAuthFlowTester {
                       "With advanced auth disabled, the standard server should use the in-app WebView login form")
         XCTAssertFalse(isShowingBrowserLogin(timeout: UITestTimeouts.short),
                        "The external browser must NOT be shown when advanced auth is disabled")
-
-        skipLogoutAtTearDown()
     }
 
     /// Flag ON (default), `regular_auth` My Domain that does NOT opt into browser login.
@@ -187,8 +182,6 @@ class ForceAdvancedAuthTests: BaseAuthFlowTester {
         openLoginOptions()
         XCTAssertTrue(isShowingAuthFlowTypesView(),
                       "The picker's Login Options entry should open the Auth Flow Types dev screen")
-
-        skipLogoutAtTearDown()
     }
 
     /// §5a/§5b parity — Flag OFF. With one user already logged in, adding another account on the
@@ -214,7 +207,5 @@ class ForceAdvancedAuthTests: BaseAuthFlowTester {
                       "On the legacy WebView path, adding a user should show the same accessible back control")
         XCTAssertTrue(isShowingLoginSettingsGear(),
                       "On the legacy WebView path, adding a user should show the same dev-menu gear")
-
-        skipLogoutAtTearDown()
     }
 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ForceAdvancedAuthTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ForceAdvancedAuthTests.swift
@@ -100,17 +100,18 @@ class ForceAdvancedAuthTests: BaseAuthFlowTester {
 
         // Reach the host list (fresh launch shows the browser), pin the standard server, then
         // import forceAdvancedAuthentication = false via the gear → Login Options JSON hook. No
-        // app config override — the default bootconfig.plist consumer key is valid for
-        // login.salesforce.com, so the WebView loads the real login form without importing a
-        // My-Domain-specific ECA key that would trigger invalid_client_id on the standard server.
-        // Closing Login Options restarts authentication, now in the legacy WebView.
+        // app config override — the bootconfig.plist consumer key is an org-specific test CA that
+        // may not resolve on login.salesforce.com, so we don't wait for the login page to finish
+        // loading. Instead we assert that the SDK chose the in-app WebView modality (the "Log In"
+        // nav bar appears as soon as SFLoginViewController is presented, before the WKWebView
+        // completes the page load). Closing Login Options restarts authentication, now in WebView.
         returnToLoginHostList(expectingBrowser: true)
         configureLoginHost(productionHostDisplayName)
         returnToLoginHostList(expectingBrowser: true)
         setForceAdvancedAuthentication(false)
 
-        XCTAssertTrue(isShowingInAppLoginForm(),
-                      "With advanced auth disabled, the standard server should use the in-app WebView login form")
+        XCTAssertTrue(isShowingLoginViewController(),
+                      "With advanced auth disabled, the standard server should present the in-app login view controller")
         XCTAssertFalse(isShowingBrowserLogin(timeout: UITestTimeouts.short),
                        "The external browser must NOT be shown when advanced auth is disabled")
     }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ForceAdvancedAuthTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ForceAdvancedAuthTests.swift
@@ -120,12 +120,13 @@ class ForceAdvancedAuthTests: BaseAuthFlowTester {
     /// `launchLoginAndValidate`). Advanced auth always pairs with the web server flow, so this is a
     /// web-server-flow login.
     func testForceAdvancedAuth_MyDomainRegularHost_RemainsBrowser() throws {
-        // Default flag (nil) inherits the production default (advanced auth ON), so login runs in the
-        // external browser; validation asserts credentials and a REST round-trip.
+        // Pass `true` to explicitly force advanced auth ON so login runs in the external browser;
+        // validation asserts credentials and a REST round-trip.
         launchLoginAndValidate(
             loginHost: .regularAuth,
             user: .first,
-            staticAppConfigName: .ecaOpaque
+            staticAppConfigName: .ecaOpaque,
+            forceAdvancedAuthentication: true
         )
     }
 
@@ -139,11 +140,12 @@ class ForceAdvancedAuthTests: BaseAuthFlowTester {
     /// Pre-fix regression this guards: the forced path created the picker with `hidesCancelButton =
     /// YES` and no back control, stranding the add-user flow.
     func testForceAdvancedAuth_AddAdditionalUser_BackButtonAccessible() throws {
-        // Log in the first user under the default flag (external browser).
+        // Log in the first user with advanced auth explicitly ON (external browser).
         launchAndLogin(
             loginHost: .regularAuth,
             user: .first,
-            staticAppConfigName: .ecaOpaque
+            staticAppConfigName: .ecaOpaque,
+            forceAdvancedAuthentication: true
         )
 
         // Trigger Add New Account (Switch User → New User): under forced advanced auth this launches

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ForceAdvancedAuthTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ForceAdvancedAuthTests.swift
@@ -99,13 +99,15 @@ class ForceAdvancedAuthTests: BaseAuthFlowTester {
         launch()
 
         // Reach the host list (fresh launch shows the browser), pin the standard server, then
-        // import forceAdvancedAuthentication = false via the gear → Login Options JSON hook. A valid
-        // app config is imported alongside it so the WebView can load a real login page. Closing
-        // Login Options restarts authentication, now in the legacy WebView.
+        // import forceAdvancedAuthentication = false via the gear → Login Options JSON hook. No
+        // app config override — the default bootconfig.plist consumer key is valid for
+        // login.salesforce.com, so the WebView loads the real login form without importing a
+        // My-Domain-specific ECA key that would trigger invalid_client_id on the standard server.
+        // Closing Login Options restarts authentication, now in the legacy WebView.
         returnToLoginHostList(expectingBrowser: true)
         configureLoginHost(productionHostDisplayName)
         returnToLoginHostList(expectingBrowser: true)
-        setForceAdvancedAuthentication(false, staticAppConfigName: .ecaOpaque)
+        setForceAdvancedAuthentication(false)
 
         XCTAssertTrue(isShowingInAppLoginForm(),
                       "With advanced auth disabled, the standard server should use the in-app WebView login form")

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/LegacyLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/LegacyLoginTests.swift
@@ -64,6 +64,23 @@ class LegacyLoginTests: BaseAuthFlowTester {
         launchLoginAndValidate(staticAppConfigName: .caOpaque, staticScopeSelection: .all, useHybridFlow: useHybridFlow())
     }
 
+    // MARK: - CA Web Server Flow Tests (In-App WebView)
+
+    /// Login with CA opaque using default scopes, web server flow, and in-app WebView (advanced auth disabled).
+    func testCAOpaque_DefaultScopes_WebServerFlow_InAppWebView() throws {
+        launchLoginAndValidate(staticAppConfigName: .caOpaque, useHybridFlow: useHybridFlow(), forceAdvancedAuthentication: false)
+    }
+
+    /// Login with CA opaque using subset of scopes, web server flow, and in-app WebView (advanced auth disabled).
+    func testCAOpaque_SubsetScopes_WebServerFlow_InAppWebView() throws {
+        launchLoginAndValidate(staticAppConfigName: .caOpaque, staticScopeSelection: .subset, useHybridFlow: useHybridFlow(), forceAdvancedAuthentication: false)
+    }
+
+    /// Login with CA opaque using all scopes, web server flow, and in-app WebView (advanced auth disabled).
+    func testCAOpaque_AllScopes_WebServerFlow_InAppWebView() throws {
+        launchLoginAndValidate(staticAppConfigName: .caOpaque, staticScopeSelection: .all, useHybridFlow: useHybridFlow(), forceAdvancedAuthentication: false)
+    }
+
     // MARK: - CA User Agent Flow Tests
 
     /// Login with CA opaque using default scopes and user agent flow.

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/MultiUserLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/MultiUserLoginTests.swift
@@ -510,10 +510,11 @@ class MultiUserLoginTests: BaseAuthFlowTester {
     ///     loginOtherUser (no validate) is used for the advanced auth user because identity data
     ///     may not be immediately available in a cross-host multi-user login.
     func testAdvancedAuthUser_HasBWFlag_RegularAuthUser_DoesNot() throws {
-        // User A: regular auth — no BW
-        // Use launchLoginAndValidate to ensure credentials (including identity data) are fully loaded.
-        // validateUser (called internally) validates the UA as part of credential validation.
-        launchLoginAndValidate(loginHost: .regularAuth, user: .fourth, staticAppConfigName: .ecaOpaque)
+        // User A: regular auth — no BW.
+        // Pass forceAdvancedAuthentication: false so User A logs in via the in-app WebView and does
+        // NOT register the BW flag. The .regularAuth host does not opt into native browser auth via
+        // its auth config, so disabling the process-global flag is sufficient to use the WebView.
+        launchLoginAndValidate(loginHost: .regularAuth, user: .fourth, staticAppConfigName: .ecaOpaque, forceAdvancedAuthentication: false)
 
         // User B: advanced auth — has BW, both users now logged in → MU
         // Use loginOtherUser (without full credential validation) since identity data

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/MultiUserLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/MultiUserLoginTests.swift
@@ -173,21 +173,23 @@ class MultiUserLoginTests: BaseAuthFlowTester {
             loginHost: .regularAuth,
             user: .fourth,
             staticAppConfigName: .ecaOpaque,
-            userAppConfigName: .ecaOpaque
+            userAppConfigName: .ecaOpaque,
+            isMultiUser: true
         )
-        
+
         // Switch back to other user
         switchToUserAndValidate(
             loginHost: .regularAuth,
             user: .fifth,
             staticAppConfigName: .ecaOpaque,
             userAppConfigName: .ecaJwt,
+            isMultiUser: true
         )
-        
+
         // Logout second user
         logout()
     }
-    
+
     /// First user dynamic config, second user static config, different apps, same scopes (default).
     func testFirstDynamic_SecondStatic_DifferentApps() throws {
         // Initial user
@@ -210,21 +212,23 @@ class MultiUserLoginTests: BaseAuthFlowTester {
             loginHost: .regularAuth,
             user: .fourth,
             staticAppConfigName: .ecaOpaque,
-            userAppConfigName: .ecaJwt
+            userAppConfigName: .ecaJwt,
+            isMultiUser: true
         )
-        
+
         // Switch back to other user
         switchToUserAndValidate(
             loginHost: .regularAuth,
             user: .fifth,
             staticAppConfigName: .ecaOpaque,
             userAppConfigName: .ecaOpaque,
+            isMultiUser: true
         )
-        
+
         // Logout second user
         logout()
     }
-    
+
     // MARK: - Both Users Dynamic Config
     
     /// Both users use dynamic config, different apps, same scopes (default).
@@ -250,17 +254,19 @@ class MultiUserLoginTests: BaseAuthFlowTester {
             loginHost: .regularAuth,
             user: .fourth,
             staticAppConfigName: .caOpaque, // not used - but using other config for validation
-            userAppConfigName: .ecaOpaque
+            userAppConfigName: .ecaOpaque,
+            isMultiUser: true
         )
-        
+
         // Switch back to other user
         switchToUserAndValidate(
             loginHost: .regularAuth,
             user: .fifth,
             staticAppConfigName: .caOpaque, // not used - but using other config for validation
             userAppConfigName: .ecaJwt,
+            isMultiUser: true
         )
-        
+
         // Logout second user
         logout()
     }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
@@ -61,8 +61,7 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA JWT RTR without hybrid flow, restart app, and verify session persists.
     func testECAJwtRtr_NoHybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr, useHybridFlow: false)
-        restartAndValidateUser(userAppConfigName: .ecaJwtRtr, useHybridFlow: false)
-        assertRevokeAndRefreshWorks(isRtr: true)
+        restartAndValidateUser(userAppConfigName: .ecaJwtRtr, useHybridFlow: false, isRtr: true)
     }
 
     // MARK: - ECA Opaque RTR Tests
@@ -75,8 +74,7 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA Opaque RTR using hybrid flow, restart app, and verify session persists.
     func testECAOpaqueRtr_Hybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr)
-        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr)
-        assertRevokeAndRefreshWorks(isRtr: true)
+        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, isRtr: true)
     }
 
     /// Login with ECA Opaque RTR without hybrid flow.
@@ -87,7 +85,6 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA Opaque RTR without hybrid flow, restart app, and verify session persists.
     func testECAOpaqueRtr_NoHybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
-        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
-        assertRevokeAndRefreshWorks(isRtr: true)
+        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, useHybridFlow: false, isRtr: true)
     }
 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
@@ -61,7 +61,7 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA JWT RTR without hybrid flow, restart app, and verify session persists.
     func testECAJwtRtr_NoHybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr, useHybridFlow: false)
-        restartAndValidateUser(userAppConfigName: .ecaJwtRtr, useHybridFlow: false)
+        restartAndValidateUser(userAppConfigName: .ecaJwtRtr, useHybridFlow: false, isRtr: true)
         assertRevokeAndRefreshWorks(isRtr: true)
     }
 
@@ -75,7 +75,7 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA Opaque RTR using hybrid flow, restart app, and verify session persists.
     func testECAOpaqueRtr_Hybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr)
-        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr)
+        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, isRtr: true)
         assertRevokeAndRefreshWorks(isRtr: true)
     }
 
@@ -87,7 +87,7 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA Opaque RTR without hybrid flow, restart app, and verify session persists.
     func testECAOpaqueRtr_NoHybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
-        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
+        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, useHybridFlow: false, isRtr: true)
         assertRevokeAndRefreshWorks(isRtr: true)
     }
 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
@@ -61,7 +61,8 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA JWT RTR without hybrid flow, restart app, and verify session persists.
     func testECAJwtRtr_NoHybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr, useHybridFlow: false)
-        restartAndValidateUser(userAppConfigName: .ecaJwtRtr, useHybridFlow: false, isRtr: true)
+        restartAndValidateUser(userAppConfigName: .ecaJwtRtr, useHybridFlow: false)
+        assertRevokeAndRefreshWorks(isRtr: true)
     }
 
     // MARK: - ECA Opaque RTR Tests
@@ -74,7 +75,8 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA Opaque RTR using hybrid flow, restart app, and verify session persists.
     func testECAOpaqueRtr_Hybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr)
-        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, isRtr: true)
+        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr)
+        assertRevokeAndRefreshWorks(isRtr: true)
     }
 
     /// Login with ECA Opaque RTR without hybrid flow.
@@ -85,6 +87,7 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA Opaque RTR without hybrid flow, restart app, and verify session persists.
     func testECAOpaqueRtr_NoHybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
-        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, useHybridFlow: false, isRtr: true)
+        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
+        assertRevokeAndRefreshWorks(isRtr: true)
     }
 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RefreshTokenMigrationTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RefreshTokenMigrationTests.swift
@@ -139,7 +139,8 @@ class RefreshTokenMigrationTests: BaseAuthFlowTester {
             loginHost: .regularAuth,
             staticAppConfigName: .caOpaque,
             migrationAppConfigName: .ecaOpaque,
-            migrationUseWebServerFlow: true
+            migrationUseWebServerFlow: true,
+            forceAdvancedAuthentication: false
         )
     }
 
@@ -156,7 +157,8 @@ class RefreshTokenMigrationTests: BaseAuthFlowTester {
             loginHost: .regularAuth,
             staticAppConfigName: .caOpaque,
             migrationAppConfigName: .beaconOpaque,
-            migrationUseWebServerFlow: true
+            migrationUseWebServerFlow: true,
+            forceAdvancedAuthentication: false
         )
     }
     

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RefreshTokenMigrationTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RefreshTokenMigrationTests.swift
@@ -241,11 +241,12 @@ class RefreshTokenMigrationTests: BaseAuthFlowTester {
         // Switch to User A
         switchToUser(loginHost: .regularAuth, user: .fourth)
 
-        // Migrate User A to ECA Opaque
+        // Migrate User A to ECA Opaque (User B is still logged in)
         migrateAndValidate(
             loginHost: .regularAuth,
             staticAppConfigName: .caOpaque,
-            migrationAppConfigName: .ecaOpaque
+            migrationAppConfigName: .ecaOpaque,
+            isMultiUser: true
         )
 
         // Switch to User B and verify unchanged (still CA Opaque)

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RefreshTokenMigrationTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RefreshTokenMigrationTests.swift
@@ -253,7 +253,8 @@ class RefreshTokenMigrationTests: BaseAuthFlowTester {
             loginHost: .regularAuth,
             user: .fifth,
             staticAppConfigName: .caOpaque,
-            userAppConfigName: .caOpaque
+            userAppConfigName: .caOpaque,
+            isMultiUser: true
         )
 
         // Switch back to User A and verify migration persisted (ECA Opaque)
@@ -261,7 +262,8 @@ class RefreshTokenMigrationTests: BaseAuthFlowTester {
             loginHost: .regularAuth,
             user: .fourth,
             staticAppConfigName: .caOpaque,
-            userAppConfigName: .ecaOpaque
+            userAppConfigName: .ecaOpaque,
+            isMultiUser: true
         )
 
         // Test API calls for both users

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -516,6 +516,7 @@ class BaseAuthFlowTester: XCTestCase {
     ///   - useHybridFlow: Whether hybrid authentication flow was used. Defaults to `true`.
     ///   - loginForAdmin: When true, Login for Admin was used (browser-based auth), which sets the BW flag. Defaults to `false`.
     ///   - usesWelcomeDiscovery: When true, welcome discovery was used, which sets the WD flag. Defaults to `false`.
+    ///   - isRtr: When true, the RT flag is expected to be present after restart (RTR cycle completed before restart). Defaults to `false`.
     func restartAndValidateUser(
         loginHost: KnownLoginHostConfig = .regularAuth,
         user: KnownUserConfig = .first,
@@ -526,7 +527,8 @@ class BaseAuthFlowTester: XCTestCase {
         forceAdvancedAuthentication: Bool = true,
         loginForAdmin: Bool = false,
         usesWelcomeDiscovery: Bool = false,
-        isMultiUser: Bool = false
+        isMultiUser: Bool = false,
+        isRtr: Bool = false
     ) {
         // Restart without --resetSDKForUITesting so the session persists across the restart
         restart()
@@ -547,7 +549,8 @@ class BaseAuthFlowTester: XCTestCase {
             useHybridFlow: useHybridFlow,
             expectAdvancedAuth: expectAdvancedAuth,
             usesWelcomeDiscovery: usesWelcomeDiscovery,
-            isMultiUser: isMultiUser
+            isMultiUser: isMultiUser,
+            isRtr: isRtr
         )
     }
     

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -807,6 +807,15 @@ class BaseAuthFlowTester: XCTestCase {
         return loginPage.isShowingInAppLoginForm(timeout: timeout)
     }
 
+    /// True when the in-app login view controller (`SFLoginViewController`) is showing, detected
+    /// by its "Log In" nav bar. Appears as soon as the view controller is presented — before the
+    /// WKWebView has loaded the login page — so it is faster and more reliable than
+    /// `isShowingInAppLoginForm()` for modality checks. Use when you need to confirm the SDK chose
+    /// the in-app WebView path rather than the external browser, without waiting for a real page load.
+    func isShowingLoginViewController(timeout: TimeInterval = UITestTimeouts.long) -> Bool {
+        return loginPage.isShowingLoginViewController(timeout: timeout)
+    }
+
     /// True when the Settings gear is present on the current login nav bar (host list under forced
     /// advanced auth, or the in-app WebView on the legacy path).
     func isShowingLoginSettingsGear() -> Bool {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -785,20 +785,26 @@ class BaseAuthFlowTester: XCTestCase {
         loginPage.configureLoginHost(host: getLoginHost(loginHost: loginHost).urlNoProtocol)
     }
 
-    /// Imports the `forceAdvancedAuthentication` flag (and a valid app config so the login form can
-    /// load) via the login screen's Settings gear → Login Options → Auth Flow Types JSON import —
-    /// the same hook `login()` uses. Assumes a screen with the Settings gear is showing (the host
-    /// list under forced advanced auth, or the in-app WebView). Closing Login Options restarts
-    /// authentication, so the login surface reappears in the modality the flag now selects.
+    /// Imports the `forceAdvancedAuthentication` flag via the login screen's Settings gear →
+    /// Login Options → Auth Flow Types JSON import — the same hook `login()` uses. Assumes a
+    /// screen with the Settings gear is showing (the host list under forced advanced auth, or the
+    /// in-app WebView). Closing Login Options restarts authentication, so the login surface
+    /// reappears in the modality the flag now selects.
+    ///
+    /// - Parameter staticAppConfigName: When non-nil, imports the given app config so the WebView
+    ///   can load a real login page. Pass `nil` (the default) when testing against
+    ///   `login.salesforce.com` — the app's default `bootconfig.plist` consumer key is valid there
+    ///   and overriding it with a My-Domain-specific ECA config (e.g. `ecaOpaque`) would cause
+    ///   `invalid_client_id` on the standard server and prevent the login form from loading.
     func setForceAdvancedAuthentication(
         _ value: Bool,
-        staticAppConfigName: KnownAppConfig,
+        staticAppConfigName: KnownAppConfig? = nil,
         staticScopeSelection: ScopeSelection = .empty,
         useWebServerFlow: Bool = true,
         useHybridFlow: Bool = true
     ) {
-        let staticAppConfig = getAppConfig(named: staticAppConfigName)
-        let staticScopes = testConfig.getScopesToRequest(for: staticAppConfig, staticScopeSelection)
+        let staticAppConfig = staticAppConfigName.map { getAppConfig(named: $0) }
+        let staticScopes = staticAppConfig.map { testConfig.getScopesToRequest(for: $0, staticScopeSelection) } ?? ""
         loginPage.configureLoginOptions(
             staticAppConfig: staticAppConfig,
             staticScopes: staticScopes,
@@ -1095,13 +1101,13 @@ class BaseAuthFlowTester: XCTestCase {
     
     /// Captures current credentials then performs a revoke/refresh cycle and validates the result.
     ///
-    /// `expectAdvancedAuth` defaults to `true` because interactive login defaults to advanced auth
-    /// (external browser), which registers the BW feature marker on the UA.
-    func assertRevokeAndRefreshWorks(isRtr: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = true, isMultiUser: Bool = false) {
+    /// `expectAdvancedAuth` defaults to `false`. Tests that explicitly used browser-based auth
+    /// (`.advancedAuth` host or `forceAdvancedAuthentication: true`) should pass `true`.
+    func assertRevokeAndRefreshWorks(isRtr: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = false, isMultiUser: Bool = false) {
         assertRevokeAndRefreshWorks(previousCredentials: getUserCredentials(), isRtr: isRtr, isDPoP: isDPoP, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, isMultiUser: isMultiUser)
     }
 
-    private func assertRevokeAndRefreshWorks(previousCredentials: UserCredentialsData, isRtr: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = true, isMultiUser: Bool = false) {
+    private func assertRevokeAndRefreshWorks(previousCredentials: UserCredentialsData, isRtr: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = false, isMultiUser: Bool = false) {
         // Revoke access token
         XCTAssert(mainPage.revokeAccessToken(), "Failed to revoke access token")
 

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -556,9 +556,11 @@ class BaseAuthFlowTester: XCTestCase {
     /// Performs a refresh token migration from the current app configuration to a new one,
     /// then validates that the credentials are updated correctly and the refresh token has changed.
     ///
-    /// `forceAdvancedAuthentication` defaults to `false` because migration is a silent token
-    /// exchange — the browser is never opened, so the BW feature marker is not present in the
-    /// post-migration UA regardless of how the initial login was performed.
+    /// The SDK preserves the BW feature marker through migration (migration is a silent token
+    /// exchange that does not change how the user originally authenticated), so
+    /// `forceAdvancedAuthentication` mirrors the value used at initial login. Tests that logged
+    /// in with `forceAdvancedAuthentication: false` (e.g. user-agent flow) should pass `false`
+    /// here as well.
     ///
     /// - Parameters:
     ///   - loginHost: The login host configuration to use.
@@ -568,7 +570,7 @@ class BaseAuthFlowTester: XCTestCase {
     ///   - migrationScopeSelection: The scope selection for the migration target. Defaults to `.empty`.
     ///   - migrationUseWebServerFlow: Whether to use web server OAuth flow for migration. Defaults to `true`.
     ///   - migrationUseHybridFlow: Whether to use hybrid authentication flow for migration. Defaults to `true`.
-    ///   - forceAdvancedAuthentication: Whether to expect the BW flag in the post-migration UA. Defaults to `false`.
+    ///   - forceAdvancedAuthentication: Whether BW is expected in the post-migration UA. Defaults to `true`.
     ///   - useDPoP: Whether DPoP was enabled for this session. Defaults to `false`.
     ///   - isMultiUser: Whether multiple users are logged in. Defaults to `false`.
     func migrateAndValidate(
@@ -579,7 +581,7 @@ class BaseAuthFlowTester: XCTestCase {
         migrationScopeSelection: ScopeSelection = .empty,
         migrationUseWebServerFlow: Bool = true,
         migrationUseHybridFlow: Bool = true,
-        forceAdvancedAuthentication: Bool = false,
+        forceAdvancedAuthentication: Bool = true,
         useDPoP: Bool = false,
         isMultiUser: Bool = false
     ) {
@@ -593,11 +595,6 @@ class BaseAuthFlowTester: XCTestCase {
             useHybridFlow: migrationUseHybridFlow
         )
 
-        // NB: The SDK's Change Key sheet does not expose a DPoP toggle, so the migration refresh
-        // exchange inherits `SalesforceManager.shared.usesDPoP` from the initial login. `useDPoP`
-        // is forwarded here to strengthen the intermediate revoke/refresh assertion inside
-        // `validate` — without it, a DPoP regression during the post-migration refresh cycle
-        // would go undetected.
         let migratedUserCredentials = validate(
             loginHost: loginHost,
             user: user,

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -529,8 +529,7 @@ class BaseAuthFlowTester: XCTestCase {
         forceAdvancedAuthentication: Bool? = nil,
         loginForAdmin: Bool = false,
         usesWelcomeDiscovery: Bool = false,
-        isMultiUser: Bool = false,
-        isRtr: Bool = false
+        isMultiUser: Bool = false
     ) {
         // Restart without --resetSDKForUITesting so the session persists across the restart
         restart()
@@ -540,11 +539,9 @@ class BaseAuthFlowTester: XCTestCase {
 
         let expectAdvancedAuth = loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication == true)
 
-        let userAppConfig = getAppConfig(named: userAppConfigName)
-
         // Validate user and feature flags
         // Not checking static app config since it will depend on the bootconfig of the target app
-        let userCredentials = validateUser(
+        validateUser(
             loginHost: loginHost,
             user: user,
             userAppConfigName: userAppConfigName,
@@ -553,20 +550,8 @@ class BaseAuthFlowTester: XCTestCase {
             useHybridFlow: useHybridFlow,
             expectAdvancedAuth: expectAdvancedAuth,
             usesWelcomeDiscovery: usesWelcomeDiscovery,
-            isMultiUser: isMultiUser,
-            isRtr: isRtr
+            isMultiUser: isMultiUser
         )
-
-        if isRtr {
-            assertRevokeAndRefreshWorks(
-                previousCredentials: userCredentials,
-                isRtr: true,
-                isDPoP: userAppConfig.isDPoP,
-                loginHost: loginHost,
-                expectAdvancedAuth: expectAdvancedAuth,
-                isMultiUser: isMultiUser
-            )
-        }
     }
     
     /// Migrates the refresh token to a new app configuration and validates the result.

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -540,6 +540,8 @@ class BaseAuthFlowTester: XCTestCase {
 
         let expectAdvancedAuth = loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication == true)
 
+        let userAppConfig = getAppConfig(named: userAppConfigName)
+
         // Validate user and feature flags
         // Not checking static app config since it will depend on the bootconfig of the target app
         let userCredentials = validateUser(
@@ -551,11 +553,11 @@ class BaseAuthFlowTester: XCTestCase {
             useHybridFlow: useHybridFlow,
             expectAdvancedAuth: expectAdvancedAuth,
             usesWelcomeDiscovery: usesWelcomeDiscovery,
-            isMultiUser: isMultiUser
+            isMultiUser: isMultiUser,
+            isRtr: isRtr
         )
 
         if isRtr {
-            let userAppConfig = getAppConfig(named: userAppConfigName)
             assertRevokeAndRefreshWorks(
                 previousCredentials: userCredentials,
                 isRtr: true,
@@ -589,7 +591,8 @@ class BaseAuthFlowTester: XCTestCase {
         migrationUseWebServerFlow: Bool = true,
         migrationUseHybridFlow: Bool = true,
         forceAdvancedAuthentication: Bool? = nil,
-        useDPoP: Bool = false
+        useDPoP: Bool = false,
+        isMultiUser: Bool = false
     ) {
         // Get original credentials before migration
         let originalUserCredentials = mainPage.getUserCredentials()
@@ -628,6 +631,7 @@ class BaseAuthFlowTester: XCTestCase {
             useWebServerFlow: migrationUseWebServerFlow,
             useHybridFlow: migrationUseHybridFlow,
             forceAdvancedAuthentication: forceAdvancedAuthentication,
+            isMultiUser: isMultiUser,
             useDPoP: useDPoP
         )
 
@@ -877,7 +881,8 @@ class BaseAuthFlowTester: XCTestCase {
         useHybridFlow: Bool,
         expectAdvancedAuth: Bool = false,
         usesWelcomeDiscovery: Bool = false,
-        isMultiUser: Bool = false
+        isMultiUser: Bool = false,
+        isRtr: Bool = false
     ) -> UserCredentialsData {
 
         let userConfig = getUser(loginHost: loginHost, user: user)
@@ -914,7 +919,7 @@ class BaseAuthFlowTester: XCTestCase {
         }
 
         // Validate feature flags using UA already present in the fetched credentials
-        validateUserAgent(ua: userCredentials.userAgent, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, usesWelcomeDiscovery: usesWelcomeDiscovery, isMultiUser: isMultiUser, expectDP: userAppConfig.isDPoP)
+        validateUserAgent(ua: userCredentials.userAgent, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, usesWelcomeDiscovery: usesWelcomeDiscovery, isMultiUser: isMultiUser, isRtr: isRtr, expectDP: userAppConfig.isDPoP)
 
         return userCredentials
     }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -34,7 +34,6 @@ class BaseAuthFlowTester: XCTestCase {
     // App Pages
     private var loginPage: LoginPageObject!
     private var mainPage: AuthFlowTesterMainPageObject!
-    private var logoutAtTearDown: Bool = true
 
     // Test configuration
     private let testConfig = UITestConfigUtils.shared
@@ -58,47 +57,7 @@ class BaseAuthFlowTester: XCTestCase {
     }
     
     override func tearDown() {
-        if (logoutAtTearDown) {
-            logout()
-        }
-        // Reset DPoP toggle to default (off) state for the next test
-        resetDPoPToggle()
         super.tearDown()
-    }
-
-    /// Resets the DPoP toggle to off by opening Login Options and disabling it if currently on.
-    /// This prevents DPoP state from leaking between tests.
-    private func resetDPoPToggle() {
-        // If not logged out, we can't reach the Login Options sheet from where the test stopped
-        // (it lives behind the login screen's Settings gear). Skip the UI-driven reset: the next
-        // test's `launch()` calls `XCUIApplication.launch()`, which per Apple's documentation
-        // terminates any running instance and starts a fresh process, so the in-memory
-        // `SalesforceManager.shared.usesDPoP` singleton is reset to its default (off) before the
-        // next test observes it. `configureLoginOptions` also unconditionally toggles the DPoP
-        // switch to match the incoming `useDPoP` value, so even a hypothetically leaked singleton
-        // would be force-set correctly on the very next login.
-        if !logoutAtTearDown {
-            return
-        }
-
-        // Navigate to login options to reset toggle
-        if let loginPage = loginPage, let app = app {
-            // Check if we're on the main screen by looking for a known element
-            if !app.navigationBars["AuthFlowTester"].waitForExistence(timeout: 1.0) {
-                // Not on main screen, can't reliably navigate to login options
-                return
-            }
-
-            // Go to login options and disable DPoP
-            if app.buttons["Settings"].waitForExistence(timeout: 1.0) {
-                app.buttons["Settings"].tap()
-                if app.buttons["Login Options"].waitForExistence(timeout: 1.0) {
-                    app.buttons["Login Options"].tap()
-                    LoginOptionsPageObject(testApp: app).disableDPoP()
-                    app.buttons["loginOptionsCloseButton"].tap()
-                }
-            }
-        }
     }
     
     // MARK: - Public API for Subclasses
@@ -118,6 +77,11 @@ class BaseAuthFlowTester: XCTestCase {
         // This is used to show/hide certain UI elements like DiscoveryResultEditor
         app.launchEnvironment["IS_UI_TESTING"] = "1"
 
+        // Instruct the app to reset all SDK auth state (users, login host, custom servers, flags)
+        // in-process at startup, before loginIfRequired fires. This replaces the UI-driven logout
+        // and host-reset that previously ran in tearDown and here in launch().
+        app.launchArguments = ["--resetSDKForUITesting"]
+
         loginPage = LoginPageObject(testApp: app)
         mainPage = AuthFlowTesterMainPageObject(testApp: app)
         app.launch()
@@ -126,24 +90,6 @@ class BaseAuthFlowTester: XCTestCase {
         // On CI, system alerts (tracking permission, paste confirmation) can block
         // the UI if not dismissed before interacting with app elements.
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
-
-        // Start logged out
-        if (mainPage.isShowing()) {
-            logout()
-        }
-
-        // Reset to a known login server so a discovery or advanced-auth host leaked by a prior test
-        // cannot strand this one. A fresh launch re-defaults advanced auth on, so the external
-        // browser is normally showing; a leaked discovery host instead runs discovery in the in-app
-        // WebView. Reach the host list from whichever surface is up — the browser is the common case
-        // (probe it with the generous default timeout), the in-app WebView the fallback — then pin
-        // the standard server (selecting it relaunches the browser against login.salesforce.com).
-        if loginPage.isShowingBrowserLogin() {
-            loginPage.returnToHostList(expectingBrowser: true)
-        } else {
-            loginPage.returnToHostList(expectingBrowser: false)
-        }
-        loginPage.configureLoginHost(host: "login.salesforce.com")
     }
 
     /// Performs login with the specified configuration.
@@ -227,7 +173,6 @@ class BaseAuthFlowTester: XCTestCase {
         // Invalid app config
         if (dynamicAppConfigName == .invalid || (dynamicAppConfigName == nil && staticAppConfigName == .invalid)) {
             XCTAssertTrue(loginPage.isShowingInvalidClientIdError(), "Login page should show invalid client id error")
-            logoutAtTearDown = false
             return
         }
 
@@ -250,7 +195,6 @@ class BaseAuthFlowTester: XCTestCase {
         // Invalid scope
         if (dynamicScopeSelection == .invalid || (dynamicAppConfig == nil && staticScopeSelection == .invalid)) {
             XCTAssertTrue(loginPage.isShowingUnexpectedOauthError(), "Screen should show OAuth Error")
-            logoutAtTearDown = false
         }
     }
     
@@ -685,8 +629,14 @@ class BaseAuthFlowTester: XCTestCase {
 
     /// Restarts the application.
     /// Use this for testing session persistence across app restarts.
+    /// A fresh XCUIApplication is created without --resetSDKForUITesting so the
+    /// existing user session is preserved across the restart.
     func restart() {
         app.terminate()
+        app = XCUIApplication()
+        app.launchEnvironment["IS_UI_TESTING"] = "1"
+        loginPage = LoginPageObject(testApp: app)
+        mainPage = AuthFlowTesterMainPageObject(testApp: app)
         app.launch()
     }
 
@@ -796,14 +746,6 @@ class BaseAuthFlowTester: XCTestCase {
     // advanced-auth presentation chrome (back button / gear) rather than driving a full
     // `login()`/validate cycle. `app`, `loginPage`, and `mainPage` are private, so these give the
     // subclass just enough surface without widening the general API.
-
-    /// Prevents `tearDown` from attempting a logout. Use in tests that intentionally stop on a
-    /// login surface (external browser, in-app WebView, or a dev-menu modal) rather than the main
-    /// page, where the logout button is not reachable. The next test's `launch()` self-heals any
-    /// residual session (it logs out if the main page is showing on relaunch).
-    func skipLogoutAtTearDown() {
-        logoutAtTearDown = false
-    }
 
     /// Returns to the login host list ("Change Server"). Pass `expectingBrowser: true` when the
     /// external browser is showing (forced advanced auth — cancel it to reach the list) and

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -531,9 +531,8 @@ class BaseAuthFlowTester: XCTestCase {
         usesWelcomeDiscovery: Bool = false,
         isMultiUser: Bool = false
     ) {
-        // Restart
-        app.terminate()
-        app.launch()
+        // Restart without --resetSDKForUITesting so the session persists across the restart
+        restart()
 
         // Restore auth flow settings lost on restart
         mainPage.setAuthFlowTypes(useWebServerFlow: useWebServerFlow, useHybridFlow: useHybridFlow)

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -529,7 +529,8 @@ class BaseAuthFlowTester: XCTestCase {
         forceAdvancedAuthentication: Bool? = nil,
         loginForAdmin: Bool = false,
         usesWelcomeDiscovery: Bool = false,
-        isMultiUser: Bool = false
+        isMultiUser: Bool = false,
+        isRtr: Bool = false
     ) {
         // Restart without --resetSDKForUITesting so the session persists across the restart
         restart()
@@ -537,19 +538,33 @@ class BaseAuthFlowTester: XCTestCase {
         // Restore auth flow settings lost on restart
         mainPage.setAuthFlowTypes(useWebServerFlow: useWebServerFlow, useHybridFlow: useHybridFlow)
 
+        let expectAdvancedAuth = loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication == true)
+
         // Validate user and feature flags
         // Not checking static app config since it will depend on the bootconfig of the target app
-        validateUser(
+        let userCredentials = validateUser(
             loginHost: loginHost,
             user: user,
             userAppConfigName: userAppConfigName,
             userScopeSelection: userScopeSelection,
             useWebServerFlow: useWebServerFlow,
             useHybridFlow: useHybridFlow,
-            expectAdvancedAuth: loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication == true),
+            expectAdvancedAuth: expectAdvancedAuth,
             usesWelcomeDiscovery: usesWelcomeDiscovery,
             isMultiUser: isMultiUser
         )
+
+        if isRtr {
+            let userAppConfig = getAppConfig(named: userAppConfigName)
+            assertRevokeAndRefreshWorks(
+                previousCredentials: userCredentials,
+                isRtr: true,
+                isDPoP: userAppConfig.isDPoP,
+                loginHost: loginHost,
+                expectAdvancedAuth: expectAdvancedAuth,
+                isMultiUser: isMultiUser
+            )
+        }
     }
     
     /// Migrates the refresh token to a new app configuration and validates the result.

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -106,10 +106,9 @@ class BaseAuthFlowTester: XCTestCase {
     ///   - dynamicScopeSelection: The scope selection for dynamic configuration. Defaults to `.empty`.
     ///   - useWebServerFlow: Whether to use web server OAuth flow. Defaults to `true`.
     ///   - useHybridFlow: Whether to use hybrid authentication flow. Defaults to `true`.
-    ///   - forceAdvancedAuthentication: Overrides the SDK's process-global "force advanced
-    ///     authentication" setting for this login. Leave `nil` to inherit the production default
-    ///     (advanced auth forced on — the external browser is used for interactive login). Pass
-    ///     `false` to exercise the legacy in-app WebView path, or `true` to force it explicitly.
+    ///   - forceAdvancedAuthentication: Whether to use the external browser for login (advanced
+    ///     auth). Defaults to `true`, matching the SDK's own default. Pass `false` to exercise
+    ///     the legacy in-app WebView path.
     ///   - useWelcomeDiscovery: When true, configures simulated domain discovery. Defaults to `false`.
     ///   - loginForAdmin: When true, uses the "Login for Admin" flow (browser-based auth via the
     ///     in-app WebView's Settings menu). Requires advanced auth disabled so the WebView — and its
@@ -123,7 +122,7 @@ class BaseAuthFlowTester: XCTestCase {
         dynamicScopeSelection: ScopeSelection = .empty,
         useWebServerFlow: Bool = true,
         useHybridFlow: Bool = true,
-        forceAdvancedAuthentication: Bool? = nil,
+        forceAdvancedAuthentication: Bool = true,
         useWelcomeDiscovery: Bool = false,
         loginForAdmin: Bool = false,
         useDPoP: Bool = false
@@ -135,9 +134,7 @@ class BaseAuthFlowTester: XCTestCase {
         let staticScopes = testConfig.getScopesToRequest(for: staticAppConfig, staticScopeSelection)
         let dynamicScopes = dynamicAppConfig == nil ? "" : testConfig.getScopesToRequest(for: dynamicAppConfig!, dynamicScopeSelection)
 
-        // nil and false both mean "use the in-app WebView" (no browser, no BW markers).
-        // Only an explicit `true` enables the external browser path.
-        let advancedAuthEnabled = forceAdvancedAuthentication == true
+        let advancedAuthEnabled = forceAdvancedAuthentication
         // The surface used to enter credentials: the external browser under advanced auth (forced
         // on, or a host that itself requires it), otherwise the in-app WebView. Login for Admin is
         // special-cased below: it always finishes in the browser regardless of this value.
@@ -155,7 +152,7 @@ class BaseAuthFlowTester: XCTestCase {
             dynamicScopes: dynamicScopes,
             useWebServerFlow: useWebServerFlow,
             useHybridFlow: useHybridFlow,
-            forceAdvancedAuthentication: forceAdvancedAuthentication ?? false,
+            forceAdvancedAuthentication: forceAdvancedAuthentication,
             discoveryLoginHost: useWelcomeDiscovery ? hostConfig.urlNoProtocol : "",
             discoveryUsername: useWelcomeDiscovery ? userConfig.username : "",
             useDPoP: useDPoP
@@ -269,7 +266,7 @@ class BaseAuthFlowTester: XCTestCase {
         userScopeSelection: ScopeSelection = .empty,
         useWebServerFlow: Bool = true,
         useHybridFlow: Bool = true,
-        forceAdvancedAuthentication: Bool? = nil,
+        forceAdvancedAuthentication: Bool = true,
         loginForAdmin: Bool = false,
         isMultiUser: Bool = false
     ) {
@@ -284,7 +281,7 @@ class BaseAuthFlowTester: XCTestCase {
             userScopeSelection: userScopeSelection,
             useWebServerFlow: useWebServerFlow,
             useHybridFlow: useHybridFlow,
-            expectAdvancedAuth: loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication == true),
+            expectAdvancedAuth: loginForAdmin || loginHost == .advancedAuth || forceAdvancedAuthentication,
             isMultiUser: isMultiUser
         )
     }
@@ -312,7 +309,7 @@ class BaseAuthFlowTester: XCTestCase {
         dynamicScopeSelection: ScopeSelection = .empty,
         useWebServerFlow: Bool = true,
         useHybridFlow: Bool = true,
-        forceAdvancedAuthentication: Bool? = nil,
+        forceAdvancedAuthentication: Bool = true,
         loginForAdmin: Bool = false,
     ) {
         // Launch
@@ -357,7 +354,7 @@ class BaseAuthFlowTester: XCTestCase {
         dynamicScopeSelection: ScopeSelection = .empty,
         useWebServerFlow: Bool = true,
         useHybridFlow: Bool = true,
-        forceAdvancedAuthentication: Bool? = nil,
+        forceAdvancedAuthentication: Bool = true,
         useWelcomeDiscovery: Bool = false,
         loginForAdmin: Bool = false,
         isMultiUser: Bool = false,
@@ -464,7 +461,7 @@ class BaseAuthFlowTester: XCTestCase {
         dynamicScopeSelection: ScopeSelection = .empty,
         useWebServerFlow: Bool = true,
         useHybridFlow: Bool = true,
-        forceAdvancedAuthentication: Bool? = nil,
+        forceAdvancedAuthentication: Bool = true,
         isMultiUser: Bool = true,
         useDPoP: Bool = false
     ) {
@@ -526,7 +523,7 @@ class BaseAuthFlowTester: XCTestCase {
         userScopeSelection: ScopeSelection = .empty,
         useWebServerFlow: Bool = true,
         useHybridFlow: Bool = true,
-        forceAdvancedAuthentication: Bool? = nil,
+        forceAdvancedAuthentication: Bool = true,
         loginForAdmin: Bool = false,
         usesWelcomeDiscovery: Bool = false,
         isMultiUser: Bool = false
@@ -537,7 +534,7 @@ class BaseAuthFlowTester: XCTestCase {
         // Restore auth flow settings lost on restart
         mainPage.setAuthFlowTypes(useWebServerFlow: useWebServerFlow, useHybridFlow: useHybridFlow)
 
-        let expectAdvancedAuth = loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication == true)
+        let expectAdvancedAuth = loginForAdmin || loginHost == .advancedAuth || forceAdvancedAuthentication
 
         // Validate user and feature flags
         // Not checking static app config since it will depend on the bootconfig of the target app
@@ -575,7 +572,7 @@ class BaseAuthFlowTester: XCTestCase {
         migrationScopeSelection: ScopeSelection = .empty,
         migrationUseWebServerFlow: Bool = true,
         migrationUseHybridFlow: Bool = true,
-        forceAdvancedAuthentication: Bool? = nil,
+        forceAdvancedAuthentication: Bool = true,
         useDPoP: Bool = false,
         isMultiUser: Bool = false
     ) {
@@ -602,10 +599,10 @@ class BaseAuthFlowTester: XCTestCase {
         // assertion inside `validate` — without it, a DPoP regression during the post-migration
         // refresh cycle would go undetected here.
         //
-        // NB on `forceAdvancedAuthentication`: on iOS, the BW feature marker registered by
-        // `SFOAuthCoordinator` at initial login does not appear in the migrated user's UA after
-        // `migrateRefreshToken`. Migration tests pass `false` here so `expectAdvancedAuth`
-        // matches the observed post-migration UA.
+        // NB on `forceAdvancedAuthentication`: the BW feature marker is not re-registered during
+        // `migrateRefreshToken` (migration is a silent refresh exchange, not an interactive login).
+        // Tests that logged in with browser auth should pass `false` here so `expectAdvancedAuth`
+        // matches the observed post-migration UA (BW absent).
         let migratedUserCredentials = validate(
             loginHost: loginHost,
             user: user,
@@ -928,7 +925,7 @@ class BaseAuthFlowTester: XCTestCase {
         userScopeSelection: ScopeSelection,
         useWebServerFlow: Bool,
         useHybridFlow: Bool,
-        forceAdvancedAuthentication: Bool? = nil,
+        forceAdvancedAuthentication: Bool = true,
         isMultiUser: Bool = false,
         usesWelcomeDiscovery: Bool = false,
         loginForAdmin: Bool = false,
@@ -940,7 +937,7 @@ class BaseAuthFlowTester: XCTestCase {
         // Check that app loads and shows the expected user credentials etc
         assertMainPageLoaded()
 
-        let expectAdvancedAuth = loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication == true)
+        let expectAdvancedAuth = loginForAdmin || loginHost == .advancedAuth || forceAdvancedAuthentication
 
         let userCredentials = validateUser(
             loginHost: loginHost,
@@ -1086,13 +1083,14 @@ class BaseAuthFlowTester: XCTestCase {
     
     /// Captures current credentials then performs a revoke/refresh cycle and validates the result.
     ///
-    /// `expectAdvancedAuth` defaults to `false`. Tests that explicitly used browser-based auth
-    /// (`.advancedAuth` host or `forceAdvancedAuthentication: true`) should pass `true`.
-    func assertRevokeAndRefreshWorks(isRtr: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = false, isMultiUser: Bool = false) {
+    /// `expectAdvancedAuth` defaults to `true`, matching the `forceAdvancedAuthentication` default.
+    /// Pass `false` for tests that logged in with the in-app WebView or post-migration validations
+    /// where BW is not re-registered.
+    func assertRevokeAndRefreshWorks(isRtr: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = true, isMultiUser: Bool = false) {
         assertRevokeAndRefreshWorks(previousCredentials: getUserCredentials(), isRtr: isRtr, isDPoP: isDPoP, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, isMultiUser: isMultiUser)
     }
 
-    private func assertRevokeAndRefreshWorks(previousCredentials: UserCredentialsData, isRtr: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = false, isMultiUser: Bool = false) {
+    private func assertRevokeAndRefreshWorks(previousCredentials: UserCredentialsData, isRtr: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = true, isMultiUser: Bool = false) {
         // Revoke access token
         XCTAssert(mainPage.revokeAccessToken(), "Failed to revoke access token")
 

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -556,6 +556,10 @@ class BaseAuthFlowTester: XCTestCase {
     /// Performs a refresh token migration from the current app configuration to a new one,
     /// then validates that the credentials are updated correctly and the refresh token has changed.
     ///
+    /// `forceAdvancedAuthentication` defaults to `false` because migration is a silent token
+    /// exchange — the browser is never opened, so the BW feature marker is not present in the
+    /// post-migration UA regardless of how the initial login was performed.
+    ///
     /// - Parameters:
     ///   - loginHost: The login host configuration to use.
     ///   - staticAppConfigName: The static app configuration name.
@@ -564,6 +568,9 @@ class BaseAuthFlowTester: XCTestCase {
     ///   - migrationScopeSelection: The scope selection for the migration target. Defaults to `.empty`.
     ///   - migrationUseWebServerFlow: Whether to use web server OAuth flow for migration. Defaults to `true`.
     ///   - migrationUseHybridFlow: Whether to use hybrid authentication flow for migration. Defaults to `true`.
+    ///   - forceAdvancedAuthentication: Whether to expect the BW flag in the post-migration UA. Defaults to `false`.
+    ///   - useDPoP: Whether DPoP was enabled for this session. Defaults to `false`.
+    ///   - isMultiUser: Whether multiple users are logged in. Defaults to `false`.
     func migrateAndValidate(
         loginHost: KnownLoginHostConfig,
         staticAppConfigName: KnownAppConfig,
@@ -572,18 +579,13 @@ class BaseAuthFlowTester: XCTestCase {
         migrationScopeSelection: ScopeSelection = .empty,
         migrationUseWebServerFlow: Bool = true,
         migrationUseHybridFlow: Bool = true,
-        forceAdvancedAuthentication: Bool = true,
+        forceAdvancedAuthentication: Bool = false,
         useDPoP: Bool = false,
         isMultiUser: Bool = false
     ) {
-        // Get original credentials before migration
         let originalUserCredentials = mainPage.getUserCredentials()
-
-        // Get current user
         let user = getKnownUserConfig(loginHost: loginHost, byUsername: originalUserCredentials.username)
 
-
-        // Migrate refresh token
         migrateRefreshToken(
             appConfigName: migrationAppConfigName,
             scopeSelection: migrationScopeSelection,
@@ -591,18 +593,11 @@ class BaseAuthFlowTester: XCTestCase {
             useHybridFlow: migrationUseHybridFlow
         )
 
-        // Validate after migration.
-        //
-        // NB on `useDPoP`: The SDK's Change Key sheet does not expose a DPoP toggle, so the
-        // migration refresh exchange inherits `SalesforceManager.shared.usesDPoP` from the initial
-        // login. We forward `useDPoP` here purely to strengthen the intermediate revoke/refresh
-        // assertion inside `validate` — without it, a DPoP regression during the post-migration
-        // refresh cycle would go undetected here.
-        //
-        // NB on `forceAdvancedAuthentication`: the BW feature marker is not re-registered during
-        // `migrateRefreshToken` (migration is a silent refresh exchange, not an interactive login).
-        // Tests that logged in with browser auth should pass `false` here so `expectAdvancedAuth`
-        // matches the observed post-migration UA (BW absent).
+        // NB: The SDK's Change Key sheet does not expose a DPoP toggle, so the migration refresh
+        // exchange inherits `SalesforceManager.shared.usesDPoP` from the initial login. `useDPoP`
+        // is forwarded here to strengthen the intermediate revoke/refresh assertion inside
+        // `validate` — without it, a DPoP regression during the post-migration refresh cycle
+        // would go undetected.
         let migratedUserCredentials = validate(
             loginHost: loginHost,
             user: user,

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -135,9 +135,9 @@ class BaseAuthFlowTester: XCTestCase {
         let staticScopes = testConfig.getScopesToRequest(for: staticAppConfig, staticScopeSelection)
         let dynamicScopes = dynamicAppConfig == nil ? "" : testConfig.getScopesToRequest(for: dynamicAppConfig!, dynamicScopeSelection)
 
-        // Advanced auth is forced on by default; only an explicit `false` disables it. When it is
-        // on, interactive login happens in the external browser; when off, in the in-app WebView.
-        let advancedAuthEnabled = forceAdvancedAuthentication != false
+        // nil and false both mean "use the in-app WebView" (no browser, no BW markers).
+        // Only an explicit `true` enables the external browser path.
+        let advancedAuthEnabled = forceAdvancedAuthentication == true
         // The surface used to enter credentials: the external browser under advanced auth (forced
         // on, or a host that itself requires it), otherwise the in-app WebView. Login for Admin is
         // special-cased below: it always finishes in the browser regardless of this value.
@@ -155,7 +155,7 @@ class BaseAuthFlowTester: XCTestCase {
             dynamicScopes: dynamicScopes,
             useWebServerFlow: useWebServerFlow,
             useHybridFlow: useHybridFlow,
-            forceAdvancedAuthentication: forceAdvancedAuthentication,
+            forceAdvancedAuthentication: forceAdvancedAuthentication ?? false,
             discoveryLoginHost: useWelcomeDiscovery ? hostConfig.urlNoProtocol : "",
             discoveryUsername: useWelcomeDiscovery ? userConfig.username : "",
             useDPoP: useDPoP
@@ -284,7 +284,7 @@ class BaseAuthFlowTester: XCTestCase {
             userScopeSelection: userScopeSelection,
             useWebServerFlow: useWebServerFlow,
             useHybridFlow: useHybridFlow,
-            expectAdvancedAuth: loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication != false),
+            expectAdvancedAuth: loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication == true),
             isMultiUser: isMultiUser
         )
     }
@@ -546,7 +546,7 @@ class BaseAuthFlowTester: XCTestCase {
             userScopeSelection: userScopeSelection,
             useWebServerFlow: useWebServerFlow,
             useHybridFlow: useHybridFlow,
-            expectAdvancedAuth: loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication != false),
+            expectAdvancedAuth: loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication == true),
             usesWelcomeDiscovery: usesWelcomeDiscovery,
             isMultiUser: isMultiUser
         )
@@ -929,7 +929,7 @@ class BaseAuthFlowTester: XCTestCase {
         // Check that app loads and shows the expected user credentials etc
         assertMainPageLoaded()
 
-        let expectAdvancedAuth = loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication != false)
+        let expectAdvancedAuth = loginForAdmin || loginHost == .advancedAuth || (forceAdvancedAuthentication == true)
 
         let userCredentials = validateUser(
             loginHost: loginHost,


### PR DESCRIPTION
## Summary

- Adds `SalesforceSDKManager.resetForUITesting()` (`#if DEBUG`) — logs out all users (including async server refresh-token revocation), clears per-user in-memory feature flags, resets the selected login host to `login.salesforce.com`, removes persisted custom login servers, and restores all auth flags to their `init` defaults.
- `AppDelegate` calls it when `--resetSDKForUITesting` is in launch arguments.
- `BaseAuthFlowTester.launch()` passes `--resetSDKForUITesting` so every test gets a clean slate in-process at startup, replacing 10–20 s of UI-driven tearDown/launch cleanup per test.
- `tearDown` is now a no-op (no UI logout, no DPoP toggle navigation).
- `restart()` creates a fresh `XCUIApplication` without the reset arg so session-persistence tests continue to work.

## SDK fix

**`SFUserAccountManager.m` — preserve BW flag through refresh token migration**

`finalizeAuthCompletion:` had an unconditional `else` that unregistered the BW (`kSFAppFeatureSafariBrowserForLogin`) per-user flag for any auth type other than `SFOAuthTypeAdvancedBrowser`. Refresh token migration completes with `SFOAuthTypeRefreshTokenMigration` — a silent token exchange that does not change how the user originally authenticated — so BW was being cleared even when the user had logged in via the external browser. Added an explicit no-op guard for `SFOAuthTypeRefreshTokenMigration` that leaves the existing per-user flag intact. Normal token refreshes and other non-browser auth types continue to clear BW as designed.

## Test fixes (found while running the suite after the main change)

Several pre-existing assertion bugs surfaced because the launch-arg reset makes every test start from a known clean state — previously these were masked by state leaking between tests.

| Fix | Root cause |
|---|---|
| `tokenFormat` in credentials JSON was `"Opaque"` instead of `""` | `UserCredentialsView.tokenFormat` applied a display substitution (`""` → `"Opaque"`) that was flowing into the exported JSON. Split into `tokenFormatRaw` (export) and `tokenFormat` (display). |
| `restartAndValidateUser` wiped the session on restart | `app` still carried `--resetSDKForUITesting` in `launchArguments`; fixed by creating a fresh `XCUIApplication` in `restart()`. |
| 2 s unnecessary wait per test when adding a login server | `hasHost()` used a 10 s timeout to probe for a custom host that `resetForUITesting` always removes. Reduced to 2 s (host list is synchronously in-memory). |
| `forceAdvancedAuthentication: nil` was overriding SDK default to off | `configureLoginOptions` was called with `forceAdvancedAuthentication ?? false`, actively writing `false` into the Login Options JSON and switching the app to WebView mode even when the caller meant "use the SDK default (browser on)". Fixed by making `forceAdvancedAuthentication` a non-nullable `Bool = true` across all helpers (matching Android's `AuthFlowTest`), removing the optional path entirely. |
| MU flag asserted absent while two users were still logged in | `switchToUserAndValidate` calls in `testFirstStatic/Dynamic_DifferentApps`, `testBothDynamic_DifferentApps`, and `testMigrateOneUserOnly` (via `migrateAndValidate`) were missing `isMultiUser: true`. Added `isMultiUser` param to `migrateAndValidate` and fixed all call sites. |
| RT flag asserted absent after RTR cycle survived restart | `validateUser` had no `isRtr` param, always calling `validateUserAgent` with `isRtr: false`. After `launchLoginAndValidate` runs an RTR cycle the RT flag persists through the non-resetting restart. Added `isRtr` to `validateUser` and `validateUserAgent`. |
| RT flag present at test start (e.g. `testECAOpaqueRtr_Hybrid`) | `SFSDKPerUserFeatureMarkersMap` was never cleared by `logoutAllUsers`. RT flag from a previous test's RTR cycle survived into the next test's initial UA check. Added `#if DEBUG resetPerUserFeaturesForUITesting` to `SFSDKAppFeatureMarkers` and called it from `resetForUITesting`. |
| `invalid_client_id` error on standard server in ForceAdvancedAuth disabled test | `setForceAdvancedAuthentication` was importing a My-Domain ECA consumer key (`ecaOpaque`) when testing against `login.salesforce.com`, triggering `invalid_client_id`. Made `staticAppConfigName` optional (defaults to `nil`); the app's default `bootconfig.plist` key is valid on the standard server. |

## Refactors

| Refactor | Detail |
|---|---|
| `forceAdvancedAuthentication: Bool? = nil` → `Bool = true` | Matches Android. `nil` was ambiguous and masked the `?? false` bug. Non-nullable default makes the intent explicit: browser on unless the test explicitly opts out with `false`. |
| `restartAndValidateUser` no longer has `isRtr` param | Restart-and-validate is session-persistence only. RTR check after restart is a separate concern; tests call `assertRevokeAndRefreshWorks(isRtr: true)` explicitly, consistent with DPoP tests and the skipped `testECAJwtRtr_Hybrid_WithRestart`. |
| Extract `resetAuthFlags` helper in `SalesforceSDKManager` | Both `-init` and `resetForUITesting` set the same auth flags. Extracted into a private instance method so the values are defined once and can't diverge. |

## New tests

- `LegacyLoginTests`: added `testCAOpaque_{Default,Subset,All}Scopes_WebServerFlow_InAppWebView` — mirrors the existing browser-path web server flow tests with `forceAdvancedAuthentication: false` to cover the in-app WebView path under the same scope variations.

## Files changed

| File | Change |
|---|---|
| `SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h` | Declare `+ (void)resetForUITesting` under `#if DEBUG` |
| `SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m` | Implement `resetForUITesting`; extract `resetAuthFlags`; call `resetPerUserFeaturesForUITesting`; import `SFSDKLoginHostStorage.h` |
| `SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.h` | Declare `+ (void)resetPerUserFeaturesForUITesting` under `#if DEBUG` |
| `SalesforceSDKCore/Classes/Common/SFSDKAppFeatureMarkers.m` | Implement `resetPerUserFeaturesForUITesting` — clears `SFSDKPerUserFeatureMarkersMap` |
| `SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m` | Preserve BW per-user flag for `SFOAuthTypeRefreshTokenMigration` in `finalizeAuthCompletion:` |
| `AuthFlowTester/Classes/AppDelegate.swift` | Call `resetForUITesting()` when launch arg present |
| `AuthFlowTester/Views/UserCredentialsView.swift` | Split `tokenFormat` into raw (export) and display variants |
| `AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift` | Add launch arg; simplify `tearDown`; fix `restart()`; make `forceAdvancedAuthentication` non-nullable (`Bool = true`); remove `isRtr` from `restartAndValidateUser`; add `isRtr`/`isMultiUser` params where needed; make `setForceAdvancedAuthentication` `staticAppConfigName` optional; restore `migrateAndValidate` default to `true` |
| `AuthFlowTesterUITests/PageObjects/LoginPageObject.swift` | Reduce `hasHost` timeout from 10 s to 2 s |
| `AuthFlowTesterUITests/Tests/ForceAdvancedAuthTests.swift` | Drop redundant `staticAppConfigName` from disabled-auth test |
| `AuthFlowTesterUITests/Tests/MultiUserLoginTests.swift` | Pass `isMultiUser: true` to `switchToUserAndValidate` while two users are logged in |
| `AuthFlowTesterUITests/Tests/RefreshTokenMigrationTests.swift` | Pass `isMultiUser: true` to `migrateAndValidate` / `switchToUserAndValidate`; pass `forceAdvancedAuthentication: false` for user-agent-flow migration tests |
| `AuthFlowTesterUITests/Tests/LegacyLoginTests.swift` | Add three `_InAppWebView` variants with `forceAdvancedAuthentication: false` |