### PR TITLE
feat(W-23201582): surface App Attestation state in developer info screen

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -724,7 +724,7 @@ static NSString *SFSDKISO8601StringFromDate(NSDate *date) {
         }
         [devInfos addObjectsFromArray:@[
             @"Attestation Enabled", attestationEnabled ? @"YES" : @"NO",
-            @"Feature Flag (AA)", aaFeatureFlag
+            @"Used in Last Auth", aaFeatureFlag
         ]];
     }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -710,6 +710,24 @@ static NSString *SFSDKISO8601StringFromDate(NSDate *date) {
         ]];
     }
 
+    // section:App Attestation — app attestation observability
+    [devInfos addObject:@"section:App Attestation"];
+    {
+        SFUserAccount *aaUser = [SFUserAccountManager sharedInstance].currentUser;
+        BOOL attestationEnabled = [SFUserAccountManager sharedInstance].appAttestationEnabled;
+        NSString *aaFeatureFlag;
+        if (!aaUser) {
+            aaFeatureFlag = @"N/A";
+        } else {
+            NSSet<NSString *> *features = [SFSDKAppFeatureMarkers appFeaturesForUser:aaUser];
+            aaFeatureFlag = [features containsObject:kSFAppFeatureAppAttestation] ? @"YES" : @"NO";
+        }
+        [devInfos addObjectsFromArray:@[
+            @"Attestation Enabled", attestationEnabled ? @"YES" : @"NO",
+            @"Feature Flag (AA)", aaFeatureFlag
+        ]];
+    }
+
     return devInfos;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DevInfoViewControllerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DevInfoViewControllerTests.swift
@@ -519,6 +519,69 @@ class DevInfoViewControllerTests: XCTestCase {
     }
 }
 
+    // MARK: - App Attestation section tests
+
+    func testAppAttestationSection_DisabledNoUser() {
+        let infoData = [
+            "section:App Attestation",
+            "Attestation Enabled", "NO",
+            "Feature Flag (AA)", "N/A"
+        ]
+        let sections = DevInfoView.testExtractSections(from: infoData)
+
+        XCTAssertEqual(sections.count, 1)
+        let rows = sections[0].rows
+        XCTAssertEqual(sections[0].title, "App Attestation")
+        XCTAssertEqual(rows.first(where: { $0.headline == "Attestation Enabled" })?.text, "NO")
+        XCTAssertEqual(rows.first(where: { $0.headline == "Feature Flag (AA)" })?.text, "N/A")
+    }
+
+    func testAppAttestationSection_DisabledWithUser_NoFlag() {
+        let infoData = [
+            "section:App Attestation",
+            "Attestation Enabled", "NO",
+            "Feature Flag (AA)", "NO"
+        ]
+        let sections = DevInfoView.testExtractSections(from: infoData)
+
+        XCTAssertEqual(sections.count, 1)
+        let rows = sections[0].rows
+        XCTAssertEqual(rows.first(where: { $0.headline == "Attestation Enabled" })?.text, "NO")
+        XCTAssertEqual(rows.first(where: { $0.headline == "Feature Flag (AA)" })?.text, "NO")
+    }
+
+    func testAppAttestationSection_EnabledWithFeatureFlag() {
+        let infoData = [
+            "section:App Attestation",
+            "Attestation Enabled", "YES",
+            "Feature Flag (AA)", "YES"
+        ]
+        let sections = DevInfoView.testExtractSections(from: infoData)
+
+        XCTAssertEqual(sections.count, 1)
+        let rows = sections[0].rows
+        XCTAssertEqual(rows.first(where: { $0.headline == "Attestation Enabled" })?.text, "YES")
+        XCTAssertEqual(rows.first(where: { $0.headline == "Feature Flag (AA)" })?.text, "YES")
+    }
+
+    func testAppAttestationSection_AppearsAfterRtrSection() {
+        let infoData = [
+            "section:RTR",
+            "RTR Active", "NO",
+            "Last Rotation", "Never",
+            "section:App Attestation",
+            "Attestation Enabled", "NO",
+            "Feature Flag (AA)", "N/A"
+        ]
+        let sections = DevInfoView.testExtractSections(from: infoData)
+
+        XCTAssertEqual(sections.count, 2)
+        XCTAssertEqual(sections[0].title, "RTR")
+        XCTAssertEqual(sections[1].title, "App Attestation")
+        XCTAssertEqual(sections[1].rows.count, 2)
+    }
+}
+
 // MARK: - Test Helper Extension
 
 extension DevInfoView {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DevInfoViewControllerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DevInfoViewControllerTests.swift
@@ -517,7 +517,6 @@ class DevInfoViewControllerTests: XCTestCase {
         XCTAssertEqual(view.sections[2].rows[2].headline, "Scopes")
         XCTAssertEqual(view.sections[2].rows[2].text, "api web refresh_token")
     }
-}
 
     // MARK: - App Attestation section tests
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DevInfoViewControllerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/DevInfoViewControllerTests.swift
@@ -524,7 +524,7 @@ class DevInfoViewControllerTests: XCTestCase {
         let infoData = [
             "section:App Attestation",
             "Attestation Enabled", "NO",
-            "Feature Flag (AA)", "N/A"
+            "Used in Last Auth", "N/A"
         ]
         let sections = DevInfoView.testExtractSections(from: infoData)
 
@@ -532,35 +532,35 @@ class DevInfoViewControllerTests: XCTestCase {
         let rows = sections[0].rows
         XCTAssertEqual(sections[0].title, "App Attestation")
         XCTAssertEqual(rows.first(where: { $0.headline == "Attestation Enabled" })?.text, "NO")
-        XCTAssertEqual(rows.first(where: { $0.headline == "Feature Flag (AA)" })?.text, "N/A")
+        XCTAssertEqual(rows.first(where: { $0.headline == "Used in Last Auth" })?.text, "N/A")
     }
 
     func testAppAttestationSection_DisabledWithUser_NoFlag() {
         let infoData = [
             "section:App Attestation",
             "Attestation Enabled", "NO",
-            "Feature Flag (AA)", "NO"
+            "Used in Last Auth", "NO"
         ]
         let sections = DevInfoView.testExtractSections(from: infoData)
 
         XCTAssertEqual(sections.count, 1)
         let rows = sections[0].rows
         XCTAssertEqual(rows.first(where: { $0.headline == "Attestation Enabled" })?.text, "NO")
-        XCTAssertEqual(rows.first(where: { $0.headline == "Feature Flag (AA)" })?.text, "NO")
+        XCTAssertEqual(rows.first(where: { $0.headline == "Used in Last Auth" })?.text, "NO")
     }
 
     func testAppAttestationSection_EnabledWithFeatureFlag() {
         let infoData = [
             "section:App Attestation",
             "Attestation Enabled", "YES",
-            "Feature Flag (AA)", "YES"
+            "Used in Last Auth", "YES"
         ]
         let sections = DevInfoView.testExtractSections(from: infoData)
 
         XCTAssertEqual(sections.count, 1)
         let rows = sections[0].rows
         XCTAssertEqual(rows.first(where: { $0.headline == "Attestation Enabled" })?.text, "YES")
-        XCTAssertEqual(rows.first(where: { $0.headline == "Feature Flag (AA)" })?.text, "YES")
+        XCTAssertEqual(rows.first(where: { $0.headline == "Used in Last Auth" })?.text, "YES")
     }
 
     func testAppAttestationSection_AppearsAfterRtrSection() {
@@ -570,7 +570,7 @@ class DevInfoViewControllerTests: XCTestCase {
             "Last Rotation", "Never",
             "section:App Attestation",
             "Attestation Enabled", "NO",
-            "Feature Flag (AA)", "N/A"
+            "Used in Last Auth", "N/A"
         ]
         let sections = DevInfoView.testExtractSections(from: infoData)
 


### PR DESCRIPTION
## Summary

- Appends an **"App Attestation"** collapsible section to `getDevSupportInfos()` in `SalesforceSDKManager.m`, placed after the existing RTR section
- **Attestation Enabled** — YES/NO from `[SFUserAccountManager sharedInstance].appAttestationEnabled`
- **Feature Flag (AA)** — YES/NO from `kSFAppFeatureAppAttestation` per-user feature flag; N/A if no user is logged in

## Tests

Added 4 unit tests in `DevInfoViewControllerTests.swift` via the existing `testExtractSections` helper:
- `testAppAttestationSection_DisabledNoUser` — Attestation Enabled: NO, Feature Flag: N/A
- `testAppAttestationSection_DisabledWithUser_NoFlag` — Attestation Enabled: NO, Feature Flag: NO
- `testAppAttestationSection_EnabledWithFeatureFlag` — Attestation Enabled: YES, Feature Flag: YES
- `testAppAttestationSection_AppearsAfterRtrSection` — verifies section order (RTR then App Attestation)

## Related
- W-23201582
- Companion Android PR: forcedotcom/SalesforceMobileSDK-Android (W-23201584)