### PR TITLE
fix(dpop): gate proof attachment on per-credential state

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPKeyStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPKeyStore.swift
@@ -89,11 +89,17 @@ public final class DPoPKeyStore: NSObject {
     /// Returns `true` iff a private key is already present in the Keychain for `scope`.
     /// Side-effect-free — never generates a key on miss. Used to gate DPoP proof attachment
     /// on the presence of previously-minted key material for the credential.
-    func hasKeyPair(forScope scope: String) -> Bool {
+    public func hasKeyPair(forScope scope: String) -> Bool {
         guard !scope.isEmpty else { return false }
         let name = Self.keyName(for: scope)
+        // Non-barrier read: safe to run concurrently with other reads.
+        // All mutating methods in this class use .barrier for exclusive access.
         return queue.sync {
             guard let privateTag = try? KeyGenerator.keyTag(name: name, prefix: KeyGenerator.ecPrivateKeyTagPrefix) else {
+                // A throw here isn't necessarily "key absent" — it can be a Keychain access
+                // denied, entitlement, or device-locked error. Returning `false` means
+                // "proceed without a proof," so surface the failure for diagnostics.
+                SFSDKCoreLogger.w(Self.self, message: "DPoPKeyStore.hasKeyPair: Keychain lookup failed for scope \(scope)")
                 return false
             }
             return (try? KeyGenerator.ecKey(tag: privateTag)) != nil
@@ -101,7 +107,7 @@ public final class DPoPKeyStore: NSObject {
     }
 
     /// Convenience: presence check scoped on `credentials.identifier`.
-    func hasKeyPair(forCredentials credentials: OAuthCredentials) -> Bool {
+    public func hasKeyPair(forCredentials credentials: OAuthCredentials) -> Bool {
         return hasKeyPair(forScope: credentials.identifier)
     }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPKeyStore.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPKeyStore.swift
@@ -86,6 +86,25 @@ public final class DPoPKeyStore: NSObject {
         return try keyPair(forScope: credentials.identifier)
     }
 
+    /// Returns `true` iff a private key is already present in the Keychain for `scope`.
+    /// Side-effect-free — never generates a key on miss. Used to gate DPoP proof attachment
+    /// on the presence of previously-minted key material for the credential.
+    func hasKeyPair(forScope scope: String) -> Bool {
+        guard !scope.isEmpty else { return false }
+        let name = Self.keyName(for: scope)
+        return queue.sync {
+            guard let privateTag = try? KeyGenerator.keyTag(name: name, prefix: KeyGenerator.ecPrivateKeyTagPrefix) else {
+                return false
+            }
+            return (try? KeyGenerator.ecKey(tag: privateTag)) != nil
+        }
+    }
+
+    /// Convenience: presence check scoped on `credentials.identifier`.
+    func hasKeyPair(forCredentials credentials: OAuthCredentials) -> Bool {
+        return hasKeyPair(forScope: credentials.identifier)
+    }
+
     /// Removes any existing keypair for the scope. Idempotent.
     @objc(deleteForScope:)
     public func delete(forScope scope: String) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPRequestDecorator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPRequestDecorator.swift
@@ -37,14 +37,19 @@ public final class DPoPRequestDecorator: NSObject {
     /// `token_type: "DPoP"` (RFC 6749 §5.1 / RFC 9449 §6.1).
     @objc public static let dpopTokenType = "DPoP"
 
-    /// Belt-and-suspenders gate: attach a DPoP proof for `scope` when *either*
-    /// signal says the credential is DPoP-bound —
+    /// Gate deciding whether to attach a DPoP proof for `scope`.
     ///
-    /// 1. `tokenType == "DPoP"` (per RFC 6749 §5.1 / RFC 9449 §6.1), or
-    /// 2. a DPoP keypair for this scope is already persisted in the Keychain
-    ///    (covers the pre-tokenType window during initial auth-code exchange,
-    ///    and any refresh where the persisted `tokenType` hasn't yet been rehydrated
-    ///    onto the request struct).
+    /// An explicit `tokenType` is authoritative:
+    /// - `tokenType == "DPoP"` (case-insensitive, per RFC 6749 §5.1 / RFC 9449 §6.1) → attach.
+    /// - any other known type (e.g. `"Bearer"`) → do **not** attach, and short-circuit
+    ///   before any Keychain I/O. This is what protects the DPoP→Bearer migration /
+    ///   Bearer re-auth path: a Bearer credential that reuses a scope still holding stale
+    ///   DPoP key material must never get an unexpected proof.
+    ///
+    /// `tokenType == nil` is the transition window between `/authorize` and `/token`
+    /// (and any refresh where the persisted `tokenType` hasn't been rehydrated onto the
+    /// request struct yet). Only then do we fall back to the key-material signal: a DPoP
+    /// keypair already persisted for this scope in the Keychain.
     ///
     /// Empty scope always returns `false` — an empty `SFOAuthCredentials.identifier`
     /// would collide with unrelated accounts' key material.
@@ -57,7 +62,11 @@ public final class DPoPRequestDecorator: NSObject {
             SFSDKCoreLogger.i(Self.self, message: "DPoP decorator skipped: empty scope identifier")
             return false
         }
-        if tokenType == dpopTokenType { return true }
+        if let tokenType {
+            return tokenType.caseInsensitiveCompare(dpopTokenType) == .orderedSame
+        }
+        // tokenType is nil — transition window between /authorize and /token; fall back to
+        // the key-material signal.
         return DPoPKeyStore.shared.hasKeyPair(forScope: scope)
     }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPRequestDecorator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPRequestDecorator.swift
@@ -37,27 +37,66 @@ public final class DPoPRequestDecorator: NSObject {
     /// `token_type: "DPoP"` (RFC 6749 §5.1 / RFC 9449 §6.1).
     @objc public static let dpopTokenType = "DPoP"
 
-    /// No-op when `SalesforceSDKManager.shared.useDPoP == NO`. Otherwise builds a fresh
-    /// proof JWT (with cached nonce if any) and sets it on the `DPoP` header.
-    /// `scope` is typically `SFOAuthCredentials.identifier` so the keypair and nonce cache
-    /// are isolated per-account, even before an `SFUserAccount` exists.
+    /// Belt-and-suspenders gate: attach a DPoP proof for `scope` when *either*
+    /// signal says the credential is DPoP-bound —
+    ///
+    /// 1. `tokenType == "DPoP"` (per RFC 6749 §5.1 / RFC 9449 §6.1), or
+    /// 2. a DPoP keypair for this scope is already persisted in the Keychain
+    ///    (covers the pre-tokenType window during initial auth-code exchange,
+    ///    and any refresh where the persisted `tokenType` hasn't yet been rehydrated
+    ///    onto the request struct).
+    ///
+    /// Empty scope always returns `false` — an empty `SFOAuthCredentials.identifier`
+    /// would collide with unrelated accounts' key material.
+    ///
+    /// Note: this gate is deliberately independent of `SalesforceManager.shared.usesDPoP`.
+    /// The global flag governs *new* logins (whether to request DPoP-bound tokens); once a
+    /// credential is bound, every request for it carries a proof regardless of the flag.
+    static func shouldAttachDPoP(scope: String, tokenType: String?) -> Bool {
+        guard !scope.isEmpty else {
+            SFSDKCoreLogger.i(Self.self, message: "DPoP decorator skipped: empty scope identifier")
+            return false
+        }
+        if tokenType == dpopTokenType { return true }
+        return DPoPKeyStore.shared.hasKeyPair(forScope: scope)
+    }
+
+    /// No-op when the credential is not DPoP-bound (see `shouldAttachDPoP(scope:tokenType:)`).
+    /// Otherwise builds a fresh proof JWT (with cached nonce if any) and sets it on the
+    /// `DPoP` header. `scope` is typically `SFOAuthCredentials.identifier` so the keypair and
+    /// nonce cache are isolated per-account, even before an `SFUserAccount` exists.
+    ///
+    /// Preserved for backwards compatibility. Delegates with `tokenType: nil`, so the gate
+    /// falls back to the key-material signal — safe for the token-endpoint flow where the
+    /// tokenType isn't yet known.
     @objc(decorateRequest:scope:error:)
     public static func decorate(_ request: NSMutableURLRequest, scope: String) throws {
-        try decorate(request, scope: scope, accessToken: nil)
+        try decorate(request, scope: scope, tokenType: nil, accessToken: nil)
     }
 
     /// Same as `decorate(_:scope:)` but binds the proof to the given access token via the
     /// `ath` claim (RFC 9449 §4.2). Use at resource-server call sites where the SDK already
     /// holds a token; pass `nil` (or use the no-token overload) at the token endpoint.
+    ///
+    /// Preserved for backwards compatibility. Delegates to the 4-arg overload with
+    /// `tokenType: nil`.
     @objc(decorateRequest:scope:accessToken:error:)
     public static func decorate(_ request: NSMutableURLRequest,
                                 scope: String,
                                 accessToken: String?) throws {
-        guard SalesforceManager.shared.usesDPoP else { return }
-        guard !scope.isEmpty else {
-            SFSDKCoreLogger.i(self, message: "DPoP decorator skipped: empty scope identifier")
-            return
-        }
+        try decorate(request, scope: scope, tokenType: nil, accessToken: accessToken)
+    }
+
+    /// Full-signature entry point. Uses `shouldAttachDPoP(scope:tokenType:)` as the gate.
+    /// `tokenType` is the persisted `SFOAuthCredentials.tokenType` for the in-flight
+    /// account; pass `nil` when the caller doesn't have it (e.g. the token-endpoint
+    /// exchange itself), in which case the gate falls back to the key-material signal.
+    @objc(decorateRequest:scope:tokenType:accessToken:error:)
+    public static func decorate(_ request: NSMutableURLRequest,
+                                scope: String,
+                                tokenType: String?,
+                                accessToken: String?) throws {
+        guard Self.shouldAttachDPoP(scope: scope, tokenType: tokenType) else { return }
         guard let url = request.url else { return }
         let method = request.httpMethod
 
@@ -105,7 +144,7 @@ public final class DPoPRequestDecorator: NSObject {
         guard let accessToken, !accessToken.isEmpty else { return }
         if tokenType == dpopTokenType {
             request.setValue("DPoP \(accessToken)", forHTTPHeaderField: "Authorization")
-            try decorate(request, scope: scope, accessToken: accessToken)
+            try decorate(request, scope: scope, tokenType: tokenType, accessToken: accessToken)
         } else {
             request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -606,7 +606,11 @@
     NSString *scope = self.credentials.identifier;
     if (scope.length == 0) return;
     NSError *err = nil;
-    [SFSDKDPoPRequestDecorator decorateRequest:request scope:scope error:&err];
+    [SFSDKDPoPRequestDecorator decorateRequest:request
+                                         scope:scope
+                                     tokenType:self.credentials.tokenType
+                                   accessToken:nil
+                                         error:&err];
     if (err) {
         [SFSDKCoreLogger e:[self class] format:@"DPoP attach failed on JWT swap (code=%ld); proceeding without DPoP header.", (long)err.code];
     }
@@ -720,6 +724,7 @@
     request.redirectURI = self.credentials.redirectUri;
     request.serverURL = [self.credentials overrideDomainIfNeeded];
     request.credentialsIdentifier = self.credentials.identifier;
+    request.tokenType = self.credentials.tokenType;
     request.attestation = attestation;
 
     __weak typeof (self) weakSelf = self;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthSessionRefresher.m
@@ -101,6 +101,7 @@ SFSDK_USE_DEPRECATED_BEGIN
     request.redirectURI = self.credentials.redirectUri;
     request.serverURL = [self.credentials overrideDomainIfNeeded];
     request.credentialsIdentifier = self.credentials.identifier;
+    request.tokenType = self.credentials.tokenType;
     request.attestation = attestation;
 
     __weak typeof(self) weakSelf = self;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.h
@@ -111,6 +111,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// `SFOAuthCredentials.identifier` for the in-flight account. Used by the DPoP layer to
 /// scope the per-account keypair and nonce cache. Optional; when nil, DPoP is skipped.
 @property (nonatomic, copy, nullable) NSString *credentialsIdentifier;
+/// Carried through unchanged from `SFOAuthCredentials.tokenType`. Used by the DPoP
+/// layer so a DPoP-bound credential is honored even when the process-wide `usesDPoP`
+/// switch has been flipped off. On the fresh-login (auth code exchange) path this is
+/// typically nil since the token endpoint has not yet issued a tokenType; DPoP gating
+/// on that path falls back to the persisted-key-material signal.
+@property (nonatomic, copy, nullable) NSString *tokenType;
 @end
 
 @interface SFSDKOAuthTokenEndpointResponse : NSObject

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuth2.m
@@ -372,14 +372,14 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
     [request setHTTPMethod:kHttpMethodPost];
     [request setValue:kHttpPostContentType forHTTPHeaderField:kHttpHeaderContentType];
     [request setHTTPShouldHandleCookies:NO];
-    [self attachDPoPHeaderIfNeeded:request scope:endpointReq.credentialsIdentifier];
+    [self attachDPoPHeaderIfNeeded:request scope:endpointReq.credentialsIdentifier tokenType:endpointReq.tokenType];
     return request;
 }
 
-- (void)attachDPoPHeaderIfNeeded:(NSMutableURLRequest *)request scope:(NSString *)scope {
+- (void)attachDPoPHeaderIfNeeded:(NSMutableURLRequest *)request scope:(NSString *)scope tokenType:(nullable NSString *)tokenType {
     if (scope.length == 0) return;
     NSError *err = nil;
-    [SFSDKDPoPRequestDecorator decorateRequest:request scope:scope error:&err];
+    [SFSDKDPoPRequestDecorator decorateRequest:request scope:scope tokenType:tokenType accessToken:nil error:&err];
     if (err) {
         [SFSDKCoreLogger e:[self class] format:@"DPoP attach failed (code=%ld); proceeding without DPoP header.", (long)err.code];
     }
@@ -410,7 +410,7 @@ const NSTimeInterval kSFOAuthDefaultTimeout  = 120.0; // seconds
                 [SFSDKDPoPRequestDecorator isNonceChallengeWithStatusCode:statusCode body:data response:urlResponse]) {
                 [SFSDKCoreLogger i:[strongSelf class] format:@"DPoP nonce challenge received; retrying token-endpoint request once."];
                 [request setValue:nil forHTTPHeaderField:kHttpHeaderDPoP];
-                [strongSelf attachDPoPHeaderIfNeeded:request scope:endpointReq.credentialsIdentifier];
+                [strongSelf attachDPoPHeaderIfNeeded:request scope:endpointReq.credentialsIdentifier tokenType:endpointReq.tokenType];
                 [strongSelf sendTokenEndpointRequest:request
                                   forEndpointRequest:endpointReq
                                retryOnNonceChallenge:NO // already retried once; don't retry again.

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthSessionRefresherTests.m
@@ -40,11 +40,13 @@
 // Minimal SFSDKOAuthProtocol stub that immediately calls the completion block with a preset response.
 @interface SFSDKOAuthClientStub : NSObject <SFSDKOAuthProtocol>
 @property (nonatomic, strong) SFSDKOAuthTokenEndpointResponse *stubbedResponse;
+@property (nonatomic, strong, nullable) SFSDKOAuthTokenEndpointRequest *capturedRefreshRequest;
 @end
 
 @implementation SFSDKOAuthClientStub
 - (void)accessTokenForRefresh:(SFSDKOAuthTokenEndpointRequest *)endpointReq
                    completion:(void (^)(SFSDKOAuthTokenEndpointResponse *))completionBlock {
+    self.capturedRefreshRequest = endpointReq;
     completionBlock(self.stubbedResponse);
 }
 - (void)accessTokenForApprovalCode:(SFSDKOAuthTokenEndpointRequest *)endpointReq
@@ -197,6 +199,43 @@ SFSDK_USE_DEPRECATED_BEGIN
     [SFUserAccountManager sharedInstance].authClient = originalFactory;
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureRTR forUser:account];
     [[SFUserAccountManager sharedInstance] deleteAccountForUser:account error:nil];
+}
+
+- (void)test_givenDPoPBoundCredential_whenRefresh_thenEndpointRequestCarriesTokenTypeAndScope {
+    // Given: a DPoP-bound credential (tokenType = "DPoP") with a scope identifier
+    SFOAuthCredentials *creds = self.oauthSessionRefresher.credentials;
+    creds.tokenType = @"DPoP";
+    NSString *expectedScope = creds.identifier;
+
+    NSDictionary *responseDict = @{ kSFOAuthAccessToken: @"new_access_token",
+                                    kSFOAuthRefreshToken: creds.refreshToken };
+    SFSDKOAuthTokenEndpointResponse *response = [[SFSDKOAuthTokenEndpointResponse alloc]
+                                                  initWithDictionary:responseDict
+                                                  parseAdditionalFields:nil];
+    SFSDKOAuthClientStub *stub = [[SFSDKOAuthClientStub alloc] init];
+    stub.stubbedResponse = response;
+    SFAuthClientFactoryBlock originalFactory = [SFUserAccountManager sharedInstance].authClient;
+    [SFUserAccountManager sharedInstance].authClient = ^{ return stub; };
+
+    // When: refresh runs
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Refresh carries DPoP tokenType"];
+    [self.oauthSessionRefresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
+        [expectation fulfill];
+    } error:^(NSError *error) {
+        XCTFail(@"Refresh should not fail: %@", error);
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:2.0 handler:nil];
+
+    // Then: the outbound endpoint request carries both signals the DPoP layer needs
+    XCTAssertNotNil(stub.capturedRefreshRequest, @"Stub should have captured the refresh request");
+    XCTAssertEqualObjects(stub.capturedRefreshRequest.tokenType, @"DPoP",
+                          @"Refresher must forward credentials.tokenType so DPoP gating survives a global-flag flip");
+    XCTAssertEqualObjects(stub.capturedRefreshRequest.credentialsIdentifier, expectedScope,
+                          @"Refresher must forward credentials.identifier as the DPoP scope");
+
+    // Cleanup
+    [SFUserAccountManager sharedInstance].authClient = originalFactory;
 }
 
 - (void)test_givenUnchangedRefreshToken_whenRefreshSucceeds_thenRTFlagNotRegistered {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
@@ -270,10 +270,11 @@ class SFSDKDPoPTests: XCTestCase {
         // Token type "DPoP" alone (before key pair minted) short-circuits to true.
         XCTAssertTrue(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: "DPoP"))
 
-        // Mint the key pair. Now key material is enough on its own, even without tokenType.
+        // Mint the key pair. Key material is the fallback signal only when tokenType is nil.
         _ = try DPoPKeyStore.shared.keyPair(forScope: testScope)
         XCTAssertTrue(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: nil))
-        XCTAssertTrue(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: "Bearer"))
+        // An explicit "Bearer" tokenType takes priority — no proof, even with key material present.
+        XCTAssertFalse(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: "Bearer"))
         XCTAssertTrue(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: "DPoP"))
 
         // Removing the key pair collapses back to the tokenType-only signal.

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
@@ -259,6 +259,50 @@ class SFSDKDPoPTests: XCTestCase {
         }
     }
 
+    func test_givenPredicateSignals_whenShouldAttachDPoP_thenTokenTypeOrKeyMaterialTriggers() throws {
+        // Empty scope always false — never mistake a missing identifier for a DPoP credential.
+        XCTAssertFalse(DPoPRequestDecorator.shouldAttachDPoP(scope: "", tokenType: "DPoP"))
+
+        // No token type, no key pair on this scope: predicate false.
+        XCTAssertFalse(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: nil))
+        XCTAssertFalse(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: "Bearer"))
+
+        // Token type "DPoP" alone (before key pair minted) short-circuits to true.
+        XCTAssertTrue(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: "DPoP"))
+
+        // Mint the key pair. Now key material is enough on its own, even without tokenType.
+        _ = try DPoPKeyStore.shared.keyPair(forScope: testScope)
+        XCTAssertTrue(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: nil))
+        XCTAssertTrue(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: "Bearer"))
+        XCTAssertTrue(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: "DPoP"))
+
+        // Removing the key pair collapses back to the tokenType-only signal.
+        DPoPKeyStore.shared.delete(forScope: testScope)
+        XCTAssertFalse(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: nil))
+        XCTAssertFalse(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: "Bearer"))
+        XCTAssertTrue(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: "DPoP"))
+    }
+
+    func test_givenScope_whenHasKeyPairChecked_thenReflectsKeyMaterialPresenceOnly() throws {
+        // Fresh scope: no key material yet.
+        XCTAssertFalse(DPoPKeyStore.shared.hasKeyPair(forScope: testScope),
+                       "hasKeyPair should be false before keyPair(forScope:) is ever called")
+
+        // Minting the pair should flip the flag to true without side-effects on other scopes.
+        _ = try DPoPKeyStore.shared.keyPair(forScope: testScope)
+        XCTAssertTrue(DPoPKeyStore.shared.hasKeyPair(forScope: testScope),
+                      "hasKeyPair should be true after a keypair is minted for the scope")
+
+        // Deletion should flip it back to false.
+        DPoPKeyStore.shared.delete(forScope: testScope)
+        XCTAssertFalse(DPoPKeyStore.shared.hasKeyPair(forScope: testScope),
+                       "hasKeyPair should be false after the keypair is deleted")
+
+        // Empty scope must be rejected — never treat "" as a valid credential.
+        XCTAssertFalse(DPoPKeyStore.shared.hasKeyPair(forScope: ""),
+                       "hasKeyPair should be false for an empty scope")
+    }
+
     func test_givenScopedKey_whenDeleted_thenSubsequentLookupGeneratesFreshKey() throws {
         let pair1 = try DPoPKeyStore.shared.keyPair(forScope: testScope)
         let payload = "hello".data(using: .utf8)!
@@ -403,21 +447,36 @@ class SFSDKDPoPTests: XCTestCase {
 
     // MARK: - Decorator gating + nonce challenge detection
 
-    func test_givenUseDPoPDisabled_whenDecorate_thenNoHeaderAttached() throws {
-        SalesforceManager.shared.usesDPoP = false
+    func test_givenNoTokenTypeAndNoKeyMaterial_whenDecorate_thenNoHeaderAttached() throws {
+        // Fresh scope: no key material, no tokenType. Both predicate signals off → skip.
+        // Global usesDPoP is intentionally ignored — the gate is per-credential state now.
         let req = NSMutableURLRequest(url: tokenURL)
         req.httpMethod = "POST"
         try DPoPRequestDecorator.decorate(req, scope: testScope)
         XCTAssertNil(req.value(forHTTPHeaderField: "DPoP"))
     }
 
-    func test_givenUseDPoPEnabled_whenDecorate_thenDPoPHeaderAttached() throws {
-        let prior = SalesforceManager.shared.usesDPoP
-        SalesforceManager.shared.usesDPoP = true
-        defer { SalesforceManager.shared.usesDPoP = prior }
+    func test_givenKeyMaterialPresent_whenDecorate_thenDPoPHeaderAttached() throws {
+        // Simulates the fresh-login flow after `/authorize` (which mints the key pair via
+        // dpop_jkt) but before `/token` returns a tokenType. Presence of key material alone
+        // is sufficient to gate proof attachment.
+        _ = try DPoPKeyStore.shared.keyPair(forScope: testScope)
         let req = NSMutableURLRequest(url: tokenURL)
         req.httpMethod = "POST"
         try DPoPRequestDecorator.decorate(req, scope: testScope)
+        let header = try XCTUnwrap(req.value(forHTTPHeaderField: "DPoP"))
+        XCTAssertEqual(header.split(separator: ".").count, 3)
+    }
+
+    func test_givenTokenTypeDPoP_whenDecorate_thenDPoPHeaderAttachedRegardlessOfGlobalFlag() throws {
+        // Simulates the refresh flow after a DPoP-bound credential has been persisted.
+        // Global flag is off, but the credential's tokenType is "DPoP" → proof still attached.
+        let prior = SalesforceManager.shared.usesDPoP
+        SalesforceManager.shared.usesDPoP = false
+        defer { SalesforceManager.shared.usesDPoP = prior }
+        let req = NSMutableURLRequest(url: tokenURL)
+        req.httpMethod = "POST"
+        try DPoPRequestDecorator.decorate(req, scope: testScope, tokenType: "DPoP", accessToken: nil)
         let header = try XCTUnwrap(req.value(forHTTPHeaderField: "DPoP"))
         XCTAssertEqual(header.split(separator: ".").count, 3)
     }
@@ -557,7 +616,10 @@ class SFSDKDPoPTests: XCTestCase {
         XCTAssertEqual(ath, expected)
     }
 
-    func test_givenDPoPDisabledButTokenTypeDPoP_whenApplyAuthHeaders_thenDPoPSchemeButNoProof() throws {
+    func test_givenGlobalFlagOffButTokenTypeDPoP_whenApplyAuthHeaders_thenProofStillAttached() throws {
+        // With the credential-state gate in place, the proof follows the tokenType — a
+        // DPoP-bound credential always gets a proof, even if the process-wide usesDPoP
+        // switch was flipped off (e.g. after an app upgrade / config change).
         let prior = SalesforceManager.shared.usesDPoP
         SalesforceManager.shared.usesDPoP = false
         defer { SalesforceManager.shared.usesDPoP = prior }
@@ -568,10 +630,10 @@ class SFSDKDPoPTests: XCTestCase {
                                                   scope: testScope,
                                                   accessToken: "tok-abc",
                                                   tokenType: "DPoP")
-        // The Authorization scheme follows tokenType (server-driven). The DPoP proof
-        // header itself follows SalesforceManager.shared.usesDPoP (client opt-in).
         XCTAssertEqual(req.value(forHTTPHeaderField: "Authorization"), "DPoP tok-abc")
-        XCTAssertNil(req.value(forHTTPHeaderField: "DPoP"))
+        let proof = try XCTUnwrap(req.value(forHTTPHeaderField: "DPoP"))
+        XCTAssertEqual(proof.split(separator: ".").count, 3,
+                       "Proof must be attached whenever tokenType == DPoP, regardless of global flag")
     }
 
     // MARK: - SFRestRequest end-to-end
@@ -629,6 +691,69 @@ class SFSDKDPoPTests: XCTestCase {
                        "Bearer \(creds.accessToken!)")
         XCTAssertNil(urlRequest.value(forHTTPHeaderField: "DPoP"),
                      "Bearer credentials must not attach a DPoP header")
+    }
+
+    // A DPoP-bound credential MUST attach a proof on the outbound REST request even
+    // when the process-wide `usesDPoP` flag has been flipped OFF. Locks in the fix — the
+    // gate is per-credential state, not the global flag.
+    func test_givenGlobalFlagOffAndDPoPCredential_whenPrepareRestRequest_thenAuthorizationIsDPoPAndProofAttached() throws {
+        let prior = SalesforceManager.shared.usesDPoP
+        SalesforceManager.shared.usesDPoP = false
+        defer { SalesforceManager.shared.usesDPoP = prior }
+
+        let scope = "rest-dpop-flagoff-\(UUID().uuidString)"
+        let creds = OAuthCredentials(identifier: scope,
+                                     clientId: "CLIENT_ID",
+                                     encrypted: false)!
+        creds.accessToken = "00DXX0000000000!ARQ.dpop.access.token"
+        creds.tokenType = "DPoP"
+        creds.instanceUrl = URL(string: "https://example.salesforce.com")
+        creds.userId = "USERID"
+        creds.organizationId = "ORGID"
+        defer { DPoPKeyStore.shared.delete(forScope: scope) }
+
+        let account = UserAccount(credentials: creds)
+        let request = RestRequest(method: .GET,
+                                  path: "/services/data/v60.0/sobjects/Account",
+                                  queryParams: nil)
+        let urlRequest = try XCTUnwrap(request.prepare(forSend: account))
+
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Authorization"),
+                       "DPoP \(creds.accessToken!)",
+                       "Authorization scheme must follow credentials.tokenType even when the global usesDPoP flag is off")
+        let proof = try XCTUnwrap(urlRequest.value(forHTTPHeaderField: "DPoP"),
+                                  "DPoP proof header must be attached for a DPoP-bound credential even with global usesDPoP flag off")
+        XCTAssertEqual(proof.split(separator: ".").count, 3)
+    }
+
+    // A Bearer credential MUST NOT get a DPoP header regardless of the global flag.
+    func test_givenBearerCredential_whenPrepareRestRequest_thenNoDPoPHeaderRegardlessOfGlobalFlag() throws {
+        let prior = SalesforceManager.shared.usesDPoP
+        defer { SalesforceManager.shared.usesDPoP = prior }
+
+        for flag in [true, false] {
+            SalesforceManager.shared.usesDPoP = flag
+            let creds = OAuthCredentials(identifier: "rest-bearer-matrix-\(UUID().uuidString)",
+                                         clientId: "CLIENT_ID",
+                                         encrypted: false)!
+            creds.accessToken = "bearer-only-access-token"
+            // tokenType left nil, no keyPair seeded — Bearer baseline.
+            creds.instanceUrl = URL(string: "https://example.salesforce.com")
+            creds.userId = "USERID"
+            creds.organizationId = "ORGID"
+
+            let account = UserAccount(credentials: creds)
+            let request = RestRequest(method: .GET,
+                                      path: "/services/data/v60.0/sobjects/Account",
+                                      queryParams: nil)
+            let urlRequest = try XCTUnwrap(request.prepare(forSend: account), "flag=\(flag)")
+
+            XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Authorization"),
+                           "Bearer \(creds.accessToken!)",
+                           "Bearer credential must yield `Authorization: Bearer <token>` (flag=\(flag))")
+            XCTAssertNil(urlRequest.value(forHTTPHeaderField: "DPoP"),
+                         "Bearer credential must not attach a DPoP header (flag=\(flag))")
+        }
     }
 
     // MARK: - Log redaction

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester/Classes/AppDelegate.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester/Classes/AppDelegate.swift
@@ -44,6 +44,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if CommandLine.arguments.contains("--resetSDKForUITesting") {
             SalesforceManager.resetForUITesting()
         }
+        if CommandLine.arguments.contains("--disableDPoPAtStart") {
+            SalesforceManager.shared.usesDPoP = false
+        }
+        if CommandLine.arguments.contains("--invalidateCurrentUserAccessTokenAtStart") {
+            UserAccountManager.shared.currentUserAccount?.credentials.setValue("invalid-access-token", forKey: "accessToken")
+        }
         #endif
         SalesforceManager.shared.appDisplayName = "Auth Flow Tester"
         UserAccountManager.shared.navigationPolicyForAction = { webView, action in

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/MultiUserLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/MultiUserLoginTests.swift
@@ -671,6 +671,72 @@ class MultiUserLoginTests: BaseAuthFlowTester {
         validateUserAgent(userCredentials: getUserCredentials(), loginHost: .regularAuth, isMultiUser: false, expectedLMarker: kLoginServerMyDomain, expectedAMarker: kAuthTypeWebServerHybrid)
     }
 
+    // MARK: - DPoP + non-DPoP Multi-User (per-credential proof gating)
+
+    /// Mixed DPoP + non-DPoP users with the process-wide DPoP flag flipped off after both are
+    /// logged in. Each user's post-flip refresh + REST GET must use its own auth scheme
+    /// independently — DPoP for the DPoP-bound credential, Bearer for the non-DPoP one — gated
+    /// by per-credential state (tokenType or persisted key material), not the global flag.
+    ///
+    /// Simulates an app upgrade or config change that flips
+    /// `SalesforceManager.shared.usesDPoP = false` after both users are authenticated. The flag
+    /// flip is injected via the AuthFlowTester `--disableDPoPAtStart` launch argument (see
+    /// `AppDelegate.init`) on relaunch, since XCUITest runs out-of-process.
+    func test_dpopAndNonDPoPUsers_flagOff_maintainIndependentProofs() throws {
+        // User A: DPoP ECA (useDPoP=true so /authorize gets dpop_jkt and the credential is
+        // persisted with tokenType="DPoP" and a key pair in the Keychain).
+        launchLoginAndValidate(
+            loginHost: .regularAuth,
+            user: .fourth,
+            staticAppConfigName: .ecaJwtDpop,
+            useDPoP: true
+        )
+
+        // User B: non-DPoP ECA (Bearer) — no key material, no DPoP tokenType.
+        loginOtherUserAndValidate(
+            loginHost: .regularAuth,
+            user: .fifth,
+            staticAppConfigName: .ecaJwt
+        )
+
+        // Uses direct token invalidation rather than revokeAccessToken to avoid a known gap in the RestClient's use_dpop_nonce retry loop.
+
+        // Switch to user A so A is the current account across the next relaunch.
+        switchToUser(loginHost: .regularAuth, user: .fourth)
+        let userACredentialsBefore = getUserCredentials()
+        // Relaunch with the global DPoP flag flipped off AND user A's access token
+        // invalidated in place. --disableDPoPAtStart sets SalesforceManager.shared.usesDPoP = false;
+        // --invalidateCurrentUserAccessTokenAtStart corrupts the current user's access token so
+        // the next REST call 401s and triggers the natural refresh path.
+        restart(withLaunchArguments: ["--disableDPoPAtStart", "--invalidateCurrentUserAccessTokenAtStart"])
+        XCTAssertTrue(makeRestRequest(), "User A's REST request should succeed with DPoP proof after flag flip")
+        let userACredentialsAfter = getUserCredentials()
+        XCTAssertNotEqual(
+            userACredentialsBefore.accessToken,
+            userACredentialsAfter.accessToken,
+            "User A's access token should have refreshed"
+        )
+        XCTAssertEqual(userACredentialsAfter.dpopTokenType, "DPoP", "User A should remain DPoP-bound after global flag flipped off")
+        XCTAssertNotNil(userACredentialsAfter.dpopNonce, "User A DPoP nonce should be present after refresh")
+        XCTAssertFalse(userACredentialsAfter.dpopNonce?.isEmpty ?? true, "User A DPoP nonce should not be empty")
+
+        // Switch to user B (Bearer) and repeat with the same launch args. Refresh + REST must NOT be DPoP.
+        switchToUser(loginHost: .regularAuth, user: .fifth)
+        let userBCredentialsBefore = getUserCredentials()
+        restart(withLaunchArguments: ["--disableDPoPAtStart", "--invalidateCurrentUserAccessTokenAtStart"])
+        XCTAssertTrue(makeRestRequest(), "User B's REST request should succeed as Bearer after flag flip")
+        let userBCredentialsAfter = getUserCredentials()
+        XCTAssertNotEqual(
+            userBCredentialsBefore.accessToken,
+            userBCredentialsAfter.accessToken,
+            "User B's access token should have refreshed"
+        )
+        XCTAssertNotEqual(userBCredentialsAfter.dpopTokenType, "DPoP", "User B should remain Bearer after global flag flipped off")
+
+        // Logout current user
+        logout()
+    }
+
     /// Logout CA user and verify ECA user is unaffected.
     /// Tests that logging out one user automatically switches to the other user with different app types.
     func testDifferentAppTypes_LogoutCaUser_EcaUserUnaffected() throws {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -690,9 +690,18 @@ class BaseAuthFlowTester: XCTestCase {
     /// A fresh XCUIApplication is created without --resetSDKForUITesting so the
     /// existing user session is preserved across the restart.
     func restart() {
+        restart(withLaunchArguments: [])
+    }
+
+    /// Restarts the application with the given launch arguments.
+    ///
+    /// Session state persists (no `--resetSDKForUITesting`). Use for tests that need to relaunch
+    /// while injecting a test-only launch flag (e.g. `--disableDPoPAtStart`) recognized by the app.
+    func restart(withLaunchArguments launchArguments: [String]) {
         app.terminate()
         app = XCUIApplication()
         app.launchEnvironment["IS_UI_TESTING"] = "1"
+        app.launchArguments = launchArguments
         loginPage = LoginPageObject(testApp: app)
         mainPage = AuthFlowTesterMainPageObject(testApp: app)
         app.launch()


### PR DESCRIPTION
## Summary

DPoP proof attachment was gated by the process-wide `SalesforceManager.usesDPoP` flag. When the flag was flipped off while a DPoP-bound credential was still in use, subsequent refresh calls and REST/identity requests silently dropped the proof, producing a 401 loop.

Gate on `credentials.tokenType == "DPoP"` **or** `DPoPKeyStore.hasKeyPair(scope)` instead. The global flag continues to govern *new* logins only; once a credential is bound, every request for it carries a proof regardless of flag state (belt-and-suspenders).

## Changes

**SDK**
- `DPoPKeyStore` — new `hasKeyPair(forScope:)` / `hasKeyPair(forCredentials:)` side-effect-free presence check under a reader lock (never generates a key on miss).
- `DPoPRequestDecorator` — new `shouldAttachDPoP(scope:tokenType:)` predicate; new 4-arg `decorate` overload threads `tokenType` through; existing 3-arg overload preserved for backwards compatibility.
- `SFSDKOAuthTokenEndpointRequest` — new `tokenType` property, carried through unchanged from `credentials.tokenType`.
- `SFOAuthCoordinator` / `SFOAuthSessionRefresher` — populate `tokenType` at refresh construction so the predicate honors bound credentials even with the global flag off.

**Sample app / UI test hooks (AuthFlowTester)**
- New `--disableDPoPAtStart` and `--invalidateCurrentUserAccessTokenAtStart` launch args to drive the flag-flip + refresh scenario from XCUITest.

**Tests**
- `SFSDKDPoPTests` — added `hasKeyPair` presence-check test; belt-and-suspenders predicate matrix (empty scope, nil / Bearer / DPoP × key-present / key-absent); flag-off + tokenType=DPoP round-trip test; Bearer-credential never-attach test.
- `SFOAuthSessionRefresherTests` — refresh path attaches proof when `usesDPoP=false` but credential is DPoP-bound.
- `MultiUserLoginTests` — UI test locking in flag-off-then-refresh end-to-end.

## Backwards compatibility

- Public API additions only. Existing `SFSDKDPoPRequestDecorator.decorate(_:scope:)` / `decorate(_:scope:accessToken:)` are preserved and delegate to the new 4-arg overload.
- The global `SalesforceManager.usesDPoP` flag continues to work as before for new logins.

## Test plan

- [x] `SFSDKDPoPTests` — 44 tests pass (iPhone 16 Pro sim, iOS 18.6).
- [x] `SFOAuthSessionRefresherTests` — pass.
- [x] `SalesforceSDKCore` full suite — 194/195 pass; the one pre-existing failure (`testPublicApiCalls`) is unrelated.
- [x] `MultiUserLoginTests.testDPoPProofAttachedOnRefreshAfterFlagOff` — GREEN on iPhone 16 Pro sim.
- [ ] Full-suite CI regression on merge.