### PR TITLE
feat(security): remove RSA PKCS1 cipher mode fallback (W-19320491)

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFSDKPushNotificationDecryption.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/PushNotification/SFSDKPushNotificationDecryption.m
@@ -188,17 +188,15 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
     
     NSError *oaepDecryptionError;
     NSData *decryptedData = [SFSDKCryptoUtils decryptData:secretData key:privateKeyRef algorithm:kSecKeyAlgorithmRSAEncryptionOAEPSHA256 error:&oaepDecryptionError];
+    CFRelease(privateKeyRef);
     if (oaepDecryptionError) {
-        [SFSDKCoreLogger w:[self class] format:@"Decrypting secret with RSA OAEP failed, falling back to PKCS1: %@", oaepDecryptionError.localizedDescription];
-        
-        NSError *pkcs1DecryptionError;
-        decryptedData = [SFSDKCryptoUtils decryptData:secretData key:privateKeyRef algorithm:kSecKeyAlgorithmRSAEncryptionPKCS1 error:&pkcs1DecryptionError];
-        if (pkcs1DecryptionError) {
-            [SFSDKCoreLogger e:[self class] format:@"Decrypting secret with RSA PKCS1 failed: %@", pkcs1DecryptionError.localizedDescription];
+        [SFSDKCoreLogger e:[self class] format:@"Decrypting secret with RSA OAEP failed: %@", oaepDecryptionError.localizedDescription];
+        if (error) {
+            *error = oaepDecryptionError;
         }
+        return nil;
     }
 
-    CFRelease(privateKeyRef);
     if (decryptedData == nil || [decryptedData length] != 32) {
         if (error) {
             *error = [self pushErrorWithCode:SFSDKPushNotificationErrorSecretDecryptionFailed description:@"Failed to decrypt secret with RSA private key."];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/CryptoUtilsTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/CryptoUtilsTests.swift
@@ -44,15 +44,10 @@ class CryptoUtilsTests: XCTestCase {
     func testEncryptDecrypt() throws {
         let stringToEncrypt = "Test string"
         let data = try XCTUnwrap(stringToEncrypt.data(using: .utf8))
-        
-        // rsaEncryptionPKCS1
-        var encryptedData = try XCTUnwrap(SFSDKCryptoUtils.encrypt(data: data, key: publicKey, algorithm: SecKeyAlgorithm.rsaEncryptionPKCS1))
-        var decryptedData = try XCTUnwrap(SFSDKCryptoUtils.decrypt(data: encryptedData, key: privateKey, algorithm: SecKeyAlgorithm.rsaEncryptionPKCS1))
-        XCTAssertEqual(stringToEncrypt, String(bytes: decryptedData, encoding: .utf8))
-        
+
         // rsaEncryptionOAEPSHA256
-        encryptedData = try XCTUnwrap(SFSDKCryptoUtils.encrypt(data: data, key: publicKey, algorithm: SecKeyAlgorithm.rsaEncryptionOAEPSHA256))
-        decryptedData = try XCTUnwrap(SFSDKCryptoUtils.decrypt(data: encryptedData, key: privateKey, algorithm: SecKeyAlgorithm.rsaEncryptionOAEPSHA256))
+        let encryptedData = try XCTUnwrap(SFSDKCryptoUtils.encrypt(data: data, key: publicKey, algorithm: SecKeyAlgorithm.rsaEncryptionOAEPSHA256))
+        let decryptedData = try XCTUnwrap(SFSDKCryptoUtils.decrypt(data: encryptedData, key: privateKey, algorithm: SecKeyAlgorithm.rsaEncryptionOAEPSHA256))
         XCTAssertEqual(stringToEncrypt, String(bytes: decryptedData, encoding: .utf8))
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationDecryptionTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/PushNotificationDecryptionTests.swift
@@ -46,29 +46,26 @@ class PushNotificationDecryptionTests: XCTestCase {
         publicKey = try XCTUnwrap(SFSDKCryptoUtils.getRSAPublicKeyRef(withName: "com.salesforce.mobilesdk.notificationKey", keyLength: 2048)).takeUnretainedValue()
     }
     
-    func testPKCS1Secret() throws {
+    func testPKCS1EncryptedSecretReturnsError() throws {
         let notificationContent = baseNotificationContent()
-        
-        // Symmetric encryption for payload
+
+        // Symmetric encryption for payload (valid, but won't matter since secret decryption fails first)
         let key = SFSDKCryptoUtils.randomByteData(withLength: 16)
         let iv = SFSDKCryptoUtils.randomByteData(withLength: 16)
         let jsonContent = try JSONSerialization.data(withJSONObject: contentDictionary)
         let encryptedContent = try XCTUnwrap(SFSDKCryptoUtils.aes128EncryptData(jsonContent, withKey: key, iv: iv)).base64EncodedString()
-        
-        // RSA-PKCS1 encryption for secret
+
+        // RSA-PKCS1 encryption for secret — no longer accepted by the SDK
         let secret = key + iv
-        let encryptedSecret = try SFSDKCryptoUtils.encrypt(data: secret, key: publicKey, algorithm: SecKeyAlgorithm.rsaEncryptionPKCS1)
+        let encryptedSecret = try XCTUnwrap(SFSDKCryptoUtils.encrypt(data: secret, key: publicKey, algorithm: SecKeyAlgorithm.rsaEncryptionPKCS1))
         let secretString = encryptedSecret.base64EncodedString()
-        
+
         notificationContent.userInfo[kRemoteNotificationKeySecret] = secretString
         notificationContent.userInfo[kRemoteNotificationKeyContent] = encryptedContent
-        
-        // Decrypt
-        try SFSDKPushNotificationDecryption.decryptNotificationContent(notificationContent)
-        XCTAssertEqual("Matt D updated Jane Smith (CEO, Acme)", notificationContent.body)
-        XCTAssertEqual("Contact Updated", notificationContent.title)
+
+        XCTAssertThrowsError(try SFSDKPushNotificationDecryption.decryptNotificationContent(notificationContent))
     }
-    
+
     func testOAEPSecret() throws {
         let notificationContent = baseNotificationContent()
         

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKEncryptedPushNotificationTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKEncryptedPushNotificationTests.m
@@ -190,9 +190,7 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
     NSError *nonRSASecretError = nil;
     BOOL result = [SFSDKPushNotificationDecryption decryptNotificationContent:notifContent error:&nonRSASecretError];
     XCTAssertFalse(result);
-    // As of 17.4, decrypting a bad key with PKCS1 returns data instead of nil, so the secret decryption doesn't fail
-    // at the same point as before but using it later to decrypt the content still fails
-    XCTAssert(nonRSASecretError.code == SFSDKPushNotificationErrorContentDecryptionFailed || nonRSASecretError.code == SFSDKPushNotificationErrorSecretDecryptionFailed);
+    XCTAssertNotNil(nonRSASecretError);
 }
 
 - (void)testNotificationTransformMalformedContent {


### PR DESCRIPTION
## Summary
- Removes the PKCS1 decryption fallback from `SFSDKPushNotificationDecryption.getAESKeyFromSecret:error:` — OAEP-SHA256 is now the only accepted algorithm; OAEP failure propagates as an error immediately
- Bonus fix: `CFRelease(privateKeyRef)` is now called before any conditional returns, closing a latent resource leak in the original code
- Updates `PushNotificationDecryptionTests`: removes `testPKCS1Secret`; adds `testPKCS1EncryptedSecretReturnsError` which asserts that a PKCS1-encrypted secret now causes `decryptNotificationContent` to throw
- Updates `CryptoUtilsTests`: removes the `rsaEncryptionPKCS1` round-trip assertion from `testEncryptDecrypt` (wrapper itself is unchanged; PKCS1 is just no longer used in production)
- Updates `SFSDKEncryptedPushNotificationTests`: removes the iOS 17.4 PKCS1 behavior comment (now irrelevant); simplifies the error assertion to `XCTAssertNotNil`

Closes W-19320491. Part of ASA Program finding SA-02 cleanup (see W-14893584).

## Test plan
- [ ] `xcodebuild build -scheme SalesforceSDKCore -sdk iphonesimulator` — clean build
- [ ] `xcodebuild test -scheme SalesforceSDKCore -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16'` — all tests pass