### PR TITLE
Add auth_trigger and sdkInfo params to native browser authorize URL

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -44,4 +44,9 @@ API_UNAVAILABLE(visionos)
 - (nonnull NSArray<SFSDKDevAction *> *)getDevActions:(nonnull UIViewController *)presentedViewController;
 - (void)hydratePerUserFeatureFlags;
 
+/** The SDK's own user agent string (SDK version, device/app info, app type, ftr_ markers),
+ without the WebView user agent that -userAgentString:forUser: appends as a trailing component.
+ */
+- (nonnull NSString *)sdkUserAgentString:(nonnull NSString *)qualifier forUser:(nullable SFUserAccount *)user;
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -1008,6 +1008,16 @@ static NSString *SFSDKISO8601StringFromDate(NSDate *date) {
 }
 
 - (NSString *)userAgentString:(NSString *)qualifier forUser:(SFUserAccount *)user {
+    return [NSString stringWithFormat:@"%@ %@",
+            [self sdkUserAgentString:qualifier forUser:user],
+            self.webViewUserAgent == nil ? @"" : self.webViewUserAgent];
+}
+
+// The SDK's own user agent string — SDK version, device/app info, app type, and ftr_ markers —
+// without the WebView user agent that -userAgentString:forUser: appends as a trailing component.
+// Used where the WebView UA is not wanted, e.g. the `sdkInfo` OAuth authorize param, which is only
+// meant to identify the SDK itself (the native browser's own UA is captured separately server-side).
+- (NSString *)sdkUserAgentString:(NSString *)qualifier forUser:(SFUserAccount *)user {
     SFUserAccount *resolvedUser = user ?: [SFUserAccountManager sharedInstance].currentUser;
     UIDevice *curDevice = [UIDevice currentDevice];
     NSString *appName = [SalesforceSDKManager appName];
@@ -1019,7 +1029,7 @@ static NSString *SFSDKISO8601StringFromDate(NSDate *date) {
                       sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)]
                      componentsJoinedByString:@"."];
     return [NSString stringWithFormat:
-            @"SalesforceMobileSDK/%@ %@/%@ (%@) %@/%@ %@%@ uid_%@ ftr_%@ %@",
+            @"SalesforceMobileSDK/%@ %@/%@ (%@) %@/%@ %@%@ uid_%@ ftr_%@",
             SALESFORCE_SDK_VERSION,
             [curDevice systemName],
             [curDevice systemVersion],
@@ -1029,8 +1039,7 @@ static NSString *SFSDKISO8601StringFromDate(NSDate *date) {
             appTypeStr,
             (qualifier != nil ? qualifier : @""),
             uid,
-            ftr,
-            self.webViewUserAgent == nil ? @"" : self.webViewUserAgent];
+            ftr];
 }
 
 - (SFSDKUserAgentCreationBlock)defaultUserAgentString {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
@@ -75,6 +75,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSString *)generateApprovalUrlString;
 
+/**
+ * Used for testing only.
+ * @return The authorize url for the native browser (advanced auth) path, including
+ *         `state`/`prompt`/`auth_trigger`/`sdkInfo` params.
+ */
+- (NSString *)nativeBrowserApprovalUrlWithSharedBrowserSessionEnabled:(BOOL)shareBrowserSession;
+
 - (void)beginWebViewFlow;
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -457,13 +457,30 @@
     }
 }
 
-- (void)continueNativeBrowserFlowWithSharedBrowserSessionEnabled:(BOOL)shareBrowserSession {
-    if (![NSThread isMainThread]) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self continueNativeBrowserFlowWithSharedBrowserSessionEnabled:shareBrowserSession];
-        });
-        return;
+// Returns the single auth_trigger value that best describes why native browser login is being
+// used. Mirrors the priority logic (and underlying signals) of computeBMarkerForAuthSession:
+// completedAuthType: in SFUserAccountManager.m — login_for_admin > mdm > force_advanced_auth >
+// org_config. Computed lazily from state that is fixed for the duration of a single
+// authentication attempt, so no threading through the modality-decision call sites is needed.
+- (NSString *)computeAuthTrigger {
+    if (self.authSession.oauthRequest.loginAsAdmin) {
+        return kSFOAuthAuthTriggerLoginForAdmin;     // B3 — highest priority
     }
+    if (self.useBrowserAuth) {
+        return kSFOAuthAuthTriggerMDM;               // B2
+    }
+    if ([SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication) {
+        return kSFOAuthAuthTriggerForceAdvancedAuth; // B4
+    }
+    return kSFOAuthAuthTriggerOrgConfig;             // B1 — fallback
+}
+
+// Builds the authorize URL for the native browser (advanced auth) path, including the
+// `state`/`prompt` params already appended for that path plus the additive `auth_trigger` and
+// `sdkInfo` params. Broken out from continueNativeBrowserFlowWithSharedBrowserSessionEnabled: so
+// it can be exercised directly in tests — ASWebAuthenticationSession itself cannot be driven in
+// the unit test target and does not expose the URL it was created with.
+- (NSString *)nativeBrowserApprovalUrlWithSharedBrowserSessionEnabled:(BOOL)shareBrowserSession {
     NSString *approvalUrl = [self approvalURLForEndpoint:[self brandedAuthorizeURL]
                                              credentials:self.credentials
                                            webServerFlow:YES
@@ -471,11 +488,29 @@
                                                   domain:nil
                                            codeChallenge:nil];
     approvalUrl = [NSString stringWithFormat:@"%@&state=%@", approvalUrl, self.credentials.identifier];
-    
+
     if (!shareBrowserSession) {
         approvalUrl = [NSString stringWithFormat:@"%@&prompt=login", approvalUrl];
     }
-    
+
+    NSString *sdkInfoValue = [[SalesforceSDKManager sharedManager] userAgentString:@"" forUser:nil];
+    approvalUrl = [NSString stringWithFormat:@"%@&%@=%@&%@=%@",
+                   approvalUrl,
+                   kSFOAuthSdkInfoParamName, [sdkInfoValue sfsdk_stringByURLEncoding],
+                   kSFOAuthAuthTriggerParamName, [self computeAuthTrigger]];
+
+    return approvalUrl;
+}
+
+- (void)continueNativeBrowserFlowWithSharedBrowserSessionEnabled:(BOOL)shareBrowserSession {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self continueNativeBrowserFlowWithSharedBrowserSessionEnabled:shareBrowserSession];
+        });
+        return;
+    }
+    NSString *approvalUrl = [self nativeBrowserApprovalUrlWithSharedBrowserSessionEnabled:shareBrowserSession];
+
     // Launch the native browser.
     [SFSDKCoreLogger d:[self class] format:@"%@: Initiating native browser flow with URL %@", NSStringFromSelector(_cmd), approvalUrl];
     NSURL *nativeBrowserUrl = [NSURL URLWithString:approvalUrl];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -493,7 +493,7 @@
         approvalUrl = [NSString stringWithFormat:@"%@&prompt=login", approvalUrl];
     }
 
-    NSString *sdkInfoValue = [[SalesforceSDKManager sharedManager] userAgentString:@"" forUser:nil];
+    NSString *sdkInfoValue = [[SalesforceSDKManager sharedManager] sdkUserAgentString:@"" forUser:nil];
     approvalUrl = [NSString stringWithFormat:@"%@&%@=%@&%@=%@",
                    approvalUrl,
                    kSFOAuthSdkInfoParamName, [sdkInfoValue sfsdk_stringByURLEncoding],

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -39,6 +39,19 @@ static NSUInteger const kSFOAuthCodeVerifierByteLength          = 128;
 static NSString * const kSFOAuthCodeVerifierParamName           = @"code_verifier";
 static NSString * const kSFOAuthCodeChallengeParamName          = @"code_challenge";
 static NSString * const kSFOAuthDPoPJktParamName                = @"dpop_jkt";
+
+// Native browser (advanced auth) authorize URL params: tell the server why the SDK is using
+// native browser login, and carry the SDK user agent string as a query param (the system
+// browser's own outbound requests use its own User-Agent header, not the SDK's).
+static NSString * const kSFOAuthAuthTriggerParamName             = @"auth_trigger";
+static NSString * const kSFOAuthSdkInfoParamName                 = @"sdkInfo";
+
+// auth_trigger values. Priority when more than one applies: LoginForAdmin > MDM > ForceAdvancedAuth > OrgConfig
+// (mirrors the B1-B4 app feature marker priority in SFUserAccountManager's computeBMarkerForAuthSession:).
+static NSString * const kSFOAuthAuthTriggerOrgConfig             = @"org_config";
+static NSString * const kSFOAuthAuthTriggerMDM                   = @"mdm";
+static NSString * const kSFOAuthAuthTriggerForceAdvancedAuth     = @"force_advanced_auth";
+static NSString * const kSFOAuthAuthTriggerLoginForAdmin         = @"login_for_admin";
 static NSString * const kSFOAuthResponseTypeCode                = @"code";
 static NSString * const kSFOAuthAccessToken                     = @"access_token";
 static NSString * const kSFOAuthClientId                        = @"client_id";

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.m
@@ -31,8 +31,14 @@
 #import "SFSDKAuthRequest.h"
 #import "SFOAuthTestFlowCoordinatorDelegate.h"
 #import "SFSDKAppFeatureMarkers.h"
+#import "SalesforceSDKManager+Internal.h"
 
 @interface SFOAuthCoordinatorTests : XCTestCase
+
+// SFOAuthCoordinator.authSession is weak; production code keeps it alive via
+// SFUserAccountManager's authSessions store, so tests must retain it here for as long as
+// the coordinator under test needs to read authSession.oauthRequest (e.g. computeAuthTrigger).
+@property (nonatomic, strong) SFSDKAuthSession *retainedAuthSession;
 
 @end
 
@@ -151,6 +157,108 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
     authRequest.loginHost = @"login.salesforce.com";
     SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] initWith:authRequest credentials:nil];
     return [[SFOAuthCoordinator alloc] initWithAuthSession:authSession];
+}
+
+// Helper to build a coordinator backed by an auth session whose oauthRequest flags
+// (loginAsAdmin, useBrowserAuth) can be set before asserting on the native browser approval URL.
+// Returns authSession.oauthCoordinator (not a freshly-initWithAuthSession: instance): SFSDKAuthSession
+// already builds and configures its own coordinator in -initCoordinator, including setting
+// useBrowserAuth from oauthRequest.useBrowserAuth/loginAsAdmin — a second coordinator built directly
+// via initWithAuthSession: would skip that configuration. authSession is retained on self for the
+// test's duration since SFOAuthCoordinator.authSession is weak (production keeps it alive via
+// SFUserAccountManager's authSessions store).
+- (SFOAuthCoordinator *)browserFlowCoordinatorWithLoginAsAdmin:(BOOL)loginAsAdmin useBrowserAuth:(BOOL)useBrowserAuth {
+    SFSDKAuthRequest *authRequest = [[SFSDKAuthRequest alloc] init];
+    authRequest.oauthClientId = @"testClientId";
+    authRequest.oauthCompletionUrl = @"testapp://callback";
+    authRequest.loginHost = @"login.salesforce.com";
+    authRequest.loginAsAdmin = loginAsAdmin;
+    authRequest.useBrowserAuth = useBrowserAuth;
+    self.retainedAuthSession = [[SFSDKAuthSession alloc] initWith:authRequest credentials:nil];
+    return self.retainedAuthSession.oauthCoordinator;
+}
+
+#pragma mark - auth_trigger / sdkInfo Tests
+
+- (void)test_givenForceAdvancedAuthentication_whenBuildingNativeBrowserApprovalUrl_thenContainsForceAdvancedAuthTriggerAndSdkInfo {
+    BOOL original = [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication;
+    [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication = YES;
+
+    SFOAuthCoordinator *coordinator = [self browserFlowCoordinatorWithLoginAsAdmin:NO useBrowserAuth:NO];
+
+    NSString *approvalUrl = [coordinator nativeBrowserApprovalUrlWithSharedBrowserSessionEnabled:YES];
+
+    XCTAssertTrue([approvalUrl containsString:@"auth_trigger=force_advanced_auth"], @"Expected force_advanced_auth trigger, got: %@", approvalUrl);
+    NSString *expectedSdkInfo = [[[SalesforceSDKManager sharedManager] userAgentString:@"" forUser:nil] sfsdk_stringByURLEncoding];
+    NSString *expectedSdkInfoParam = [NSString stringWithFormat:@"sdkInfo=%@", expectedSdkInfo];
+    XCTAssertTrue([approvalUrl containsString:expectedSdkInfoParam], @"Expected encoded sdkInfo, got: %@", approvalUrl);
+
+    [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication = original;
+}
+
+- (void)test_givenNoTriggerSignalsSet_whenBuildingNativeBrowserApprovalUrl_thenContainsOrgConfigTrigger {
+    BOOL original = [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication;
+    [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication = NO;
+
+    SFOAuthCoordinator *coordinator = [self browserFlowCoordinatorWithLoginAsAdmin:NO useBrowserAuth:NO];
+
+    NSString *approvalUrl = [coordinator nativeBrowserApprovalUrlWithSharedBrowserSessionEnabled:YES];
+
+    XCTAssertTrue([approvalUrl containsString:@"auth_trigger=org_config"], @"Expected org_config trigger, got: %@", approvalUrl);
+
+    [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication = original;
+}
+
+- (void)test_givenLoginAsAdmin_whenBuildingNativeBrowserApprovalUrl_thenContainsLoginForAdminTrigger {
+    BOOL original = [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication;
+    [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication = YES; // lower priority than loginAsAdmin
+
+    SFOAuthCoordinator *coordinator = [self browserFlowCoordinatorWithLoginAsAdmin:YES useBrowserAuth:NO];
+
+    NSString *approvalUrl = [coordinator nativeBrowserApprovalUrlWithSharedBrowserSessionEnabled:YES];
+
+    XCTAssertTrue([approvalUrl containsString:@"auth_trigger=login_for_admin"], @"Expected login_for_admin trigger to take priority, got: %@", approvalUrl);
+
+    [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication = original;
+}
+
+- (void)test_givenMdmUseBrowserAuth_whenBuildingNativeBrowserApprovalUrl_thenContainsMdmTrigger {
+    BOOL original = [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication;
+    [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication = YES; // lower priority than MDM
+
+    SFOAuthCoordinator *coordinator = [self browserFlowCoordinatorWithLoginAsAdmin:NO useBrowserAuth:YES];
+
+    NSString *approvalUrl = [coordinator nativeBrowserApprovalUrlWithSharedBrowserSessionEnabled:YES];
+
+    XCTAssertTrue([approvalUrl containsString:@"auth_trigger=mdm"], @"Expected mdm trigger to take priority over force_advanced_auth, got: %@", approvalUrl);
+
+    [SalesforceSDKManager sharedManager].sdk_forceAdvancedAuthentication = original;
+}
+
+- (void)test_givenWebViewFlow_whenGeneratingApprovalUrl_thenDoesNotContainAuthTriggerOrSdkInfo {
+    SFOAuthCoordinator *coordinator = [self browserFlowCoordinator];
+    coordinator.useBrowserAuth = NO;
+
+    NSString *approvalUrl = [coordinator generateApprovalUrlString];
+
+    XCTAssertFalse([approvalUrl containsString:@"auth_trigger="], @"WebView-path approval URL must not contain auth_trigger, got: %@", approvalUrl);
+    XCTAssertFalse([approvalUrl containsString:@"sdkInfo="], @"WebView-path approval URL must not contain sdkInfo, got: %@", approvalUrl);
+}
+
+- (void)test_givenNativeBrowserFlow_whenBuildingApprovalUrl_thenSdkInfoIsProperlyPercentEncoded {
+    SFOAuthCoordinator *coordinator = [self browserFlowCoordinatorWithLoginAsAdmin:NO useBrowserAuth:NO];
+
+    NSString *approvalUrl = [coordinator nativeBrowserApprovalUrlWithSharedBrowserSessionEnabled:YES];
+
+    NSString *rawUserAgent = [[SalesforceSDKManager sharedManager] userAgentString:@"" forUser:nil];
+    NSString *encodedUserAgent = [rawUserAgent sfsdk_stringByURLEncoding];
+    NSString *encodedSdkInfoParam = [NSString stringWithFormat:@"sdkInfo=%@", encodedUserAgent];
+    XCTAssertTrue([approvalUrl containsString:encodedSdkInfoParam], @"sdkInfo value should be percent-encoded exactly once, got: %@", approvalUrl);
+    // The SDK user agent always contains spaces (e.g. "SalesforceMobileSDK/..."); assert those are
+    // encoded away rather than appearing raw in the query string.
+    XCTAssertTrue([rawUserAgent containsString:@" "], @"Precondition: user agent string should contain spaces to make this a meaningful encoding check");
+    NSString *rawSdkInfoParam = [NSString stringWithFormat:@"sdkInfo=%@", rawUserAgent];
+    XCTAssertFalse([approvalUrl containsString:rawSdkInfoParam], @"sdkInfo value must not appear unencoded in the approval URL");
 }
 
 // When a scene is connected, the advanced-auth browser callback must key its options dictionary by

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.m
@@ -189,7 +189,7 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
     NSString *approvalUrl = [coordinator nativeBrowserApprovalUrlWithSharedBrowserSessionEnabled:YES];
 
     XCTAssertTrue([approvalUrl containsString:@"auth_trigger=force_advanced_auth"], @"Expected force_advanced_auth trigger, got: %@", approvalUrl);
-    NSString *expectedSdkInfo = [[[SalesforceSDKManager sharedManager] userAgentString:@"" forUser:nil] sfsdk_stringByURLEncoding];
+    NSString *expectedSdkInfo = [[[SalesforceSDKManager sharedManager] sdkUserAgentString:@"" forUser:nil] sfsdk_stringByURLEncoding];
     NSString *expectedSdkInfoParam = [NSString stringWithFormat:@"sdkInfo=%@", expectedSdkInfo];
     XCTAssertTrue([approvalUrl containsString:expectedSdkInfoParam], @"Expected encoded sdkInfo, got: %@", approvalUrl);
 
@@ -250,7 +250,7 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
 
     NSString *approvalUrl = [coordinator nativeBrowserApprovalUrlWithSharedBrowserSessionEnabled:YES];
 
-    NSString *rawUserAgent = [[SalesforceSDKManager sharedManager] userAgentString:@"" forUser:nil];
+    NSString *rawUserAgent = [[SalesforceSDKManager sharedManager] sdkUserAgentString:@"" forUser:nil];
     NSString *encodedUserAgent = [rawUserAgent sfsdk_stringByURLEncoding];
     NSString *encodedSdkInfoParam = [NSString stringWithFormat:@"sdkInfo=%@", encodedUserAgent];
     XCTAssertTrue([approvalUrl containsString:encodedSdkInfoParam], @"sdkInfo value should be percent-encoded exactly once, got: %@", approvalUrl);
@@ -259,6 +259,21 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
     XCTAssertTrue([rawUserAgent containsString:@" "], @"Precondition: user agent string should contain spaces to make this a meaningful encoding check");
     NSString *rawSdkInfoParam = [NSString stringWithFormat:@"sdkInfo=%@", rawUserAgent];
     XCTAssertFalse([approvalUrl containsString:rawSdkInfoParam], @"sdkInfo value must not appear unencoded in the approval URL");
+}
+
+- (void)test_givenNativeBrowserFlow_whenBuildingApprovalUrl_thenSdkInfoExcludesWebViewUserAgent {
+    SFOAuthCoordinator *coordinator = [self browserFlowCoordinatorWithLoginAsAdmin:NO useBrowserAuth:NO];
+
+    NSString *approvalUrl = [coordinator nativeBrowserApprovalUrlWithSharedBrowserSessionEnabled:YES];
+
+    NSString *fullUserAgent = [[SalesforceSDKManager sharedManager] userAgentString:@"" forUser:nil];
+    NSString *sdkOnlyUserAgent = [[SalesforceSDKManager sharedManager] sdkUserAgentString:@"" forUser:nil];
+    XCTAssertNotEqualObjects(fullUserAgent, sdkOnlyUserAgent,
+                              @"Precondition: userAgentString:forUser: should append a trailing WebView UA that sdkUserAgentString:forUser: omits");
+
+    NSString *fullUserAgentEncodedParam = [NSString stringWithFormat:@"sdkInfo=%@", [fullUserAgent sfsdk_stringByURLEncoding]];
+    XCTAssertFalse([approvalUrl containsString:fullUserAgentEncodedParam],
+                    @"sdkInfo must not include the WebView user agent — the native browser's own UA is captured server-side, got: %@", approvalUrl);
 }
 
 // When a scene is connected, the advanced-auth browser callback must key its options dictionary by


### PR DESCRIPTION
## Summary
- Appends `sdkInfo` (SDK user-agent string) and `auth_trigger` (why native browser login was chosen) query params to the OAuth authorize URL, native browser (ASWebAuthenticationSession) path only
- WebView path is unchanged — it already sends the real User-Agent header
- `auth_trigger` priority: `login_for_admin` > `mdm` > `force_advanced_auth` > `org_config`

## Test plan
- [ ] `SFOAuthCoordinatorTests` passes
- [ ] Manual login via native browser confirms both params present in the authorize request

GUS: W-23789310