### PR TITLE
feat(W-23815423): add applyAuthHeaders(_:credentials:) convenience API

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPRequestDecorator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPRequestDecorator.swift
@@ -57,7 +57,8 @@ public final class DPoPRequestDecorator: NSObject {
     /// Note: this gate is deliberately independent of `SalesforceManager.shared.usesDPoP`.
     /// The global flag governs *new* logins (whether to request DPoP-bound tokens); once a
     /// credential is bound, every request for it carries a proof regardless of the flag.
-    static func shouldAttachDPoP(scope: String, tokenType: String?) -> Bool {
+    @objc(shouldAttachDPoPForScope:tokenType:)
+    public static func shouldAttachDPoP(scope: String, tokenType: String?) -> Bool {
         guard !scope.isEmpty else {
             SFSDKCoreLogger.i(Self.self, message: "DPoP decorator skipped: empty scope identifier")
             return false
@@ -152,6 +153,35 @@ public final class DPoPRequestDecorator: NSObject {
                                         tokenType: String?) throws {
         guard let accessToken, !accessToken.isEmpty else { return }
         if tokenType == dpopTokenType {
+            request.setValue("DPoP \(accessToken)", forHTTPHeaderField: "Authorization")
+            try decorate(request, scope: scope, tokenType: tokenType, accessToken: accessToken)
+        } else {
+            request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        }
+    }
+
+    /// Convenience overload for app-built requests. Extracts `scope`, `accessToken`,
+    /// and `tokenType` from `credentials`, then stamps the same headers as
+    /// `applyAuthHeaders(_:scope:accessToken:tokenType:)`.
+    ///
+    /// Use this when you hold an `OAuthCredentials` object and want to stamp the
+    /// correct `Authorization` (and, if the credential is DPoP-bound, `DPoP` proof)
+    /// headers on an `NSMutableURLRequest` you constructed yourself — outside the
+    /// SDK's `RestClient`.
+    ///
+    /// Unlike the four-argument overload (which keys the scheme off `tokenType ==
+    /// "DPoP"`), this gates via `shouldAttachDPoP(scope:tokenType:)`, so a credential
+    /// still in the `/authorize`→`/token` transition window (nil `tokenType` but with
+    /// persisted key material) also gets a proof. Gating is per-credential, not the
+    /// global `SalesforceManager.shared.usesDPoP` flag: a DPoP-bound credential carries
+    /// proofs regardless of that flag.
+    @objc(applyAuthHeaders:credentials:error:)
+    public static func applyAuthHeaders(_ request: NSMutableURLRequest,
+                                        credentials: OAuthCredentials) throws {
+        guard let accessToken = credentials.accessToken, !accessToken.isEmpty else { return }
+        let scope = credentials.identifier
+        let tokenType = credentials.tokenType
+        if shouldAttachDPoP(scope: scope, tokenType: tokenType) {
             request.setValue("DPoP \(accessToken)", forHTTPHeaderField: "Authorization")
             try decorate(request, scope: scope, tokenType: tokenType, accessToken: accessToken)
         } else {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
@@ -583,6 +583,92 @@ class SFSDKDPoPTests: XCTestCase {
         XCTAssertNil(req.value(forHTTPHeaderField: "DPoP"))
     }
 
+    // MARK: - applyAuthHeaders(_:credentials:)
+
+    func test_givenDPoPCredentials_whenApplyAuthHeadersWithCredentials_thenBothHeadersSet() throws {
+        let scope = "creds-dpop-\(UUID().uuidString)"
+        defer { DPoPKeyStore.shared.delete(forScope: scope) }
+        let creds = OAuthCredentials(identifier: scope, clientId: "CLIENT_ID", encrypted: false)!
+        creds.accessToken = "00DXX0000000000!ARQ.dpop.access.token"
+        creds.tokenType = "DPoP"
+        _ = try DPoPKeyStore.shared.keyPair(forScope: scope)
+
+        let req = NSMutableURLRequest(url: URL(string: "https://example.salesforce.com/services/data/v60.0/sobjects/Account")!)
+        req.httpMethod = "GET"
+        try DPoPRequestDecorator.applyAuthHeaders(req, credentials: creds)
+
+        let auth = try XCTUnwrap(req.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertTrue(auth.hasPrefix("DPoP "))
+        let proof = try XCTUnwrap(req.value(forHTTPHeaderField: "DPoP"))
+        XCTAssertEqual(proof.split(separator: ".").count, 3)
+    }
+
+    func test_givenBearerCredentials_whenApplyAuthHeadersWithCredentials_thenOnlyAuthorizationHeader() throws {
+        let scope = "creds-bearer-\(UUID().uuidString)"
+        defer { DPoPKeyStore.shared.delete(forScope: scope) }
+        let creds = OAuthCredentials(identifier: scope, clientId: "CLIENT_ID", encrypted: false)!
+        creds.accessToken = "bearer-only-access-token"
+        creds.tokenType = "Bearer"
+
+        let req = NSMutableURLRequest(url: tokenURL)
+        req.httpMethod = "GET"
+        try DPoPRequestDecorator.applyAuthHeaders(req, credentials: creds)
+
+        let auth = try XCTUnwrap(req.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertTrue(auth.hasPrefix("Bearer "))
+        XCTAssertNil(req.value(forHTTPHeaderField: "DPoP"))
+    }
+
+    func test_givenDPoPCredentials_usesDPoPFalse_whenApplyAuthHeadersWithCredentials_thenProofStillAttached() throws {
+        let prior = SalesforceManager.shared.usesDPoP
+        SalesforceManager.shared.usesDPoP = false
+        defer { SalesforceManager.shared.usesDPoP = prior }
+
+        let scope = "creds-dpop-flagoff-\(UUID().uuidString)"
+        defer { DPoPKeyStore.shared.delete(forScope: scope) }
+        let creds = OAuthCredentials(identifier: scope, clientId: "CLIENT_ID", encrypted: false)!
+        creds.accessToken = "00DXX0000000000!ARQ.dpop.access.token"
+        creds.tokenType = "DPoP"
+        _ = try DPoPKeyStore.shared.keyPair(forScope: scope)
+
+        let req = NSMutableURLRequest(url: tokenURL)
+        req.httpMethod = "GET"
+        try DPoPRequestDecorator.applyAuthHeaders(req, credentials: creds)
+
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "DPoP"),
+                        "Proof gating is per-credential, not the global usesDPoP flag")
+    }
+
+    func test_givenNilTokenType_withKeypair_whenApplyAuthHeadersWithCredentials_thenProofAttached() throws {
+        let scope = "creds-niltype-keypair-\(UUID().uuidString)"
+        defer { DPoPKeyStore.shared.delete(forScope: scope) }
+        let creds = OAuthCredentials(identifier: scope, clientId: "CLIENT_ID", encrypted: false)!
+        creds.accessToken = "00DXX0000000000!ARQ.dpop.access.token"
+        // tokenType left nil.
+        _ = try DPoPKeyStore.shared.keyPair(forScope: scope)
+
+        let req = NSMutableURLRequest(url: tokenURL)
+        req.httpMethod = "GET"
+        try DPoPRequestDecorator.applyAuthHeaders(req, credentials: creds)
+
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "DPoP"))
+    }
+
+    func test_givenNilTokenType_noKeypair_whenApplyAuthHeadersWithCredentials_thenBearerOnly() throws {
+        let scope = "creds-niltype-nokeypair-\(UUID().uuidString)"
+        let creds = OAuthCredentials(identifier: scope, clientId: "CLIENT_ID", encrypted: false)!
+        creds.accessToken = "bearer-only-access-token"
+        // tokenType left nil, no keypair seeded.
+
+        let req = NSMutableURLRequest(url: tokenURL)
+        req.httpMethod = "GET"
+        try DPoPRequestDecorator.applyAuthHeaders(req, credentials: creds)
+
+        let auth = try XCTUnwrap(req.value(forHTTPHeaderField: "Authorization"))
+        XCTAssertTrue(auth.hasPrefix("Bearer "))
+        XCTAssertNil(req.value(forHTTPHeaderField: "DPoP"))
+    }
+
     // MARK: - Identity service loop-prevention
 
     /// Loop regression: under DPoP-bound credentials, an identity request must go out


### PR DESCRIPTION
## Summary

Two changes to `DPoPRequestDecorator` to expose a public convenience API for app-built requests:

1. **`shouldAttachDPoP(scope:tokenType:)` is now public** (`@objc(shouldAttachDPoPForScope:tokenType:)`). Body unchanged — only visibility and the ObjC name annotation. This is the per-credential DPoP gate (explicit `tokenType == "DPoP"` → attach; `nil` tokenType → fall back to persisted key-material signal; `"Bearer"`/empty scope → no proof).

2. **New `applyAuthHeaders(_:credentials:)` overload** (`@objc(applyAuthHeaders:credentials:error:)`). Extracts `scope`/`accessToken`/`tokenType` from an `OAuthCredentials` and stamps the correct `Authorization` (and, if DPoP-bound, `DPoP` proof) headers on a caller-built `NSMutableURLRequest` — for use outside the SDK's `RestClient`.

Unlike the existing four-argument `applyAuthHeaders(_:scope:accessToken:tokenType:)` (which keys the scheme strictly off `tokenType == "DPoP"`), the new overload gates via `shouldAttachDPoP(scope:tokenType:)`. This means a credential still in the `/authorize`→`/token` transition window (nil `tokenType` but with persisted key material) correctly gets a proof. The four-argument overload is untouched; its existing tests are unchanged.

Gating is per-credential, independent of the global `SalesforceManager.shared.usesDPoP` flag — a DPoP-bound credential carries proofs regardless of that flag.

## GUS

W-23815423

## Test plan

New unit tests added in `SFSDKDPoPTests.swift` under a `// MARK: - applyAuthHeaders(_:credentials:)` section:

- `test_givenDPoPCredentials_whenApplyAuthHeadersWithCredentials_thenBothHeadersSet` — DPoP tokenType + seeded keypair → `Authorization: DPoP …` and a 3-segment `DPoP` proof.
- `test_givenBearerCredentials_whenApplyAuthHeadersWithCredentials_thenOnlyAuthorizationHeader` — Bearer tokenType → `Authorization: Bearer …`, no `DPoP` header.
- `test_givenDPoPCredentials_usesDPoPFalse_whenApplyAuthHeadersWithCredentials_thenProofStillAttached` — global `usesDPoP = false` → proof still attached (per-credential gating).
- `test_givenNilTokenType_withKeypair_whenApplyAuthHeadersWithCredentials_thenProofAttached` — nil tokenType + seeded keypair → proof attached (transition-window fallback).
- `test_givenNilTokenType_noKeypair_whenApplyAuthHeadersWithCredentials_thenBearerOnly` — nil tokenType, no keypair → Bearer only, no `DPoP` header.

`SFSDKDPoPTests` suite: 49 tests, 0 failures. Remaining `SalesforceSDKCore` suite failures (`SalesforceRestAPITests`, `RestClientTests`, etc.) are pre-existing and environmental ("config credentials are missing!" — they require a live test org) and reproduce identically on the clean `dev` baseline; they are unrelated to this change.

## Notes for reviewers

This touches OAuth `Authorization`-header construction / credential handling and adds public API surface — flagged per CLAUDE.md for human review.