### PR TITLE
fix(W-23695429): escape single quotes in SmartSQL IN-clause record IDs

### DIFF
--- a/libs/MobileSync/MobileSync/Classes/SyncTarget.swift
+++ b/libs/MobileSync/MobileSync/Classes/SyncTarget.swift
@@ -47,7 +47,8 @@ extension SyncDownTarget {
 
     func deleteRecordsFromLocalStore(syncManager: SyncManager, soupName: String, ids: [String], idField: String) throws {
         if !ids.isEmpty {
-            let smartSql = "SELECT {\(soupName):\(SmartStore.soupEntryId)} FROM {\(soupName)} WHERE {\(soupName):\(idField)} IN ('\(ids.joined(separator: "','"))')"
+            let escapedIds = ids.map { $0.replacingOccurrences(of: "'", with: "''") }
+            let smartSql = "SELECT {\(soupName):\(SmartStore.soupEntryId)} FROM {\(soupName)} WHERE {\(soupName):\(idField)} IN ('\(escapedIds.joined(separator: "','"))')"
             if let spec = QuerySpec.buildSmartQuerySpec(smartSql: smartSql, pageSize: UInt(ids.count)) {
                 try syncManager.store.removeEntries(usingQuerySpec: spec, forSoupNamed: soupName)
             }

--- a/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
+++ b/libs/MobileSync/MobileSync/Classes/Target/SFSyncTarget.m
@@ -86,9 +86,13 @@ NSString * const kSyncTargetLastError = @"__last_error__";
 
 - (void) deleteRecordsFromLocalStore:(SFMobileSyncSyncManager*)syncManager soupName:(NSString*)soupName ids:(NSArray*)ids idField:(NSString*)idField {
     if (ids.count > 0) {
+        NSMutableArray *escapedIds = [NSMutableArray arrayWithCapacity:ids.count];
+        for (NSString *anId in ids) {
+            [escapedIds addObject:[anId stringByReplacingOccurrencesOfString:@"'" withString:@"''"]];
+        }
         NSString *smartSql = [NSString stringWithFormat:@"SELECT {%@:%@} FROM {%@} WHERE {%@:%@} IN ('%@')",
                                                         soupName, SOUP_ENTRY_ID, soupName, soupName, idField,
-                                                        [ids componentsJoinedByString:@"','"]];
+                                                        [escapedIds componentsJoinedByString:@"','"]];
 
         SFQuerySpec *querySpec = [SFQuerySpec newSmartQuerySpec:smartSql withPageSize:ids.count];
         [syncManager.store removeEntriesByQuery:querySpec fromSoup:soupName];


### PR DESCRIPTION
## Summary
- Escapes single quotes in the ID lists passed to `deleteRecordsFromLocalStore` in `SFSyncTarget.m` and `SyncTarget.swift`
- The IDs are joined into a SmartSQL `IN ('id1','id2',...)` clause; without escaping a single quote in an ID could break the query
- Salesforce record IDs are 15/18-char alphanumeric so actual risk is zero, but this satisfies scanner rule BUG-03 (SQL injection, P3) filed as W-23695429

## Test plan
- [ ] Build MobileSync scheme: `xcodebuild build -workspace SalesforceMobileSDK.xcworkspace -scheme MobileSync -sdk iphonesimulator` — confirmed passing
- [ ] Run MobileSync test suite: `xcodebuild test -workspace SalesforceMobileSDK.xcworkspace -scheme MobileSync -sdk iphonesimulator`
- [ ] Verify sync-down + clean-ghosts still work end-to-end in MobileSyncExplorerSwift sample app