### PR TITLE
fix(W-23622931): escape single quotes in SmartSQL json_extract path and FTS MATCH value

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
+++ b/libs/SmartStore/SmartStore/Classes/SFQuerySpec.m
@@ -331,7 +331,7 @@ NSString * const kQuerySpecParamSmartSql = @"smartSql";
                       @" WHERE ",
                       [self computeSoupFtsReference],
                       @" MATCH '",
-                      [SFQuerySpec qualifyMatchKey:self.matchKey field:field], // match clause -- statement arg binding doesn't seem to work so inlining matchKey
+                      [[SFQuerySpec qualifyMatchKey:self.matchKey field:field] stringByReplacingOccurrencesOfString:@"'" withString:@"''"], // match clause -- statement arg binding doesn't seem to work so inlining matchKey
                       @"') "
                       ]
                     componentsJoinedByString:@""];

--- a/libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartSqlHelper.m
@@ -157,7 +157,8 @@ static NSRegularExpression* soupPathRegexp;
                 BOOL indexed = [store hasIndexForPath:path inSoup:soupName withDb:db];
                 if (!indexed) {
                     // Thanks to the json1 extension we can query the data even if it is not indexed
-                    columnName = [NSString stringWithFormat:@"json_extract(soup, '$.%@')", path];
+                    NSString *escapedPath = [path stringByReplacingOccurrencesOfString:@"'" withString:@"''"];
+                    columnName = [NSString stringWithFormat:@"json_extract(soup, '$.%@')", escapedPath];
                 } else {
                     columnName = [store columnNameForPath:path inSoup:soupName withDb:db];
                     if (nil == columnName) {


### PR DESCRIPTION
## Summary
- **Sink 1 — `json_extract` path** (`SFSmartSqlHelper.m:160`): escapes `'` → `''` in the soup path before building `json_extract(soup, '$.path')`. A quote in the path broke out of the SQL string literal, allowing SmartSQL injection via a non-indexed query path (CWE-89).
- **Sink 2 — FTS MATCH value** (`SFQuerySpec.m:334`): escapes `'` → `''` in the qualified match key before inlining into `MATCH 'value'`. Statement arg binding doesn't work for FTS MATCH so inlining is unavoidable; escaping prevents breaking out of the surrounding string literal.
- Both sinks are reachable from the SmartStore Cordova bridge in hybrid apps (W-23622931).
- Note: the bug description only called out Android — the same sinks exist on iOS.

## Test plan
- [ ] Build SmartStore: `xcodebuild build -workspace SalesforceMobileSDK.xcworkspace -scheme SmartStore -sdk iphonesimulator` — confirmed passing
- [ ] Run SmartStore tests: `xcodebuild test -workspace SalesforceMobileSDK.xcworkspace -scheme SmartStore -destination 'platform=iOS Simulator,...'` — 176/177 passing; 1 pre-existing failure in `testGetGlobalStoreNames` (fails identically on unmodified `dev`)