### PR TITLE
In-place upgrade to DPoP + per-call DPoP intent on token migration

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
@@ -52,6 +52,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, nullable) NSString *loginHint;
 
+/**
+ Per-call override for whether `/authorize` should request a DPoP-bound authorization
+ code (`dpop_jkt`). `nil` means "defer to the process-wide `SalesforceSDKManager.useDPoP`
+ flag" — this is the normal-login default and must not be set for that path. A non-nil
+ value (e.g. set by a refresh-token migration) takes precedence over the global flag,
+ letting a single call opt in or out of DPoP binding independent of the app's default
+ posture for brand-new logins.
+ */
+@property (nonatomic, strong, nullable) NSNumber *dpopOverride;
+
 - (instancetype)initWithAuthSession:(SFSDKAuthSession *)authSession;
 
 /** UpdateCredentials and record changes to instanceUrl,accessToken,communityId

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -1004,10 +1004,17 @@
 
 // Appends `&dpop_jkt=<base64url-sha256>` to the approval URL when DPoP is enabled
 // (RFC 9449 §10 authorization code binding). Soft-fails on key-material / crypto errors.
+//
+// DPoP intent is resolved per call: `self.dpopOverride`, when set, takes precedence
+// over the process-wide `SalesforceSDKManager.useDPoP` flag (e.g. a refresh-token
+// migration explicitly requesting DPoP binding regardless of the app's default login
+// posture). Normal login never sets `dpopOverride`, so it continues to follow the
+// global flag unchanged.
 - (void)appendDPoPJktIfNeededTo:(NSMutableString *)approvalUrlString
                          domain:(NSString *)domain
                     credentials:(SFOAuthCredentials *)credentials {
-    if (![[SalesforceSDKManager sharedManager] useDPoP]) {
+    BOOL dpopEnabled = self.dpopOverride ? self.dpopOverride.boolValue : [[SalesforceSDKManager sharedManager] useDPoP];
+    if (!dpopEnabled) {
         return;
     }
     if (domain == nil) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRequest.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthRequest.h
@@ -33,6 +33,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) BOOL useBrowserAuth;
 
+/// Per-call override for whether this authentication request should bind its
+/// authorization code to DPoP (`dpop_jkt` on `/authorize`), independent of the
+/// process-wide `SalesforceSDKManager.useDPoP` flag. `nil` (the default) means
+/// "defer to the global flag" — normal logins never set this. A non-nil value
+/// (e.g. set by a refresh-token migration) is threaded through to the
+/// coordinator's `dpopOverride`.
+@property (nonatomic, strong, nullable) NSNumber *useDPoP;
+
 /// Indicates that browser auth was initiated by the "Login for Admin" action.
 /// When YES, cancelling the browser session returns to the WebView login instead of showing the server picker.
 @property (nonatomic, assign) BOOL loginAsAdmin;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthSession.m
@@ -66,6 +66,7 @@ static NSString * const kSFSDKAuthSessionUnscopedSceneIdPrefix = @"com.salesforc
     self.oauthCoordinator.scopes = self.oauthRequest.scopes;
     self.oauthCoordinator.brandLoginPath = self.oauthRequest.brandLoginPath;
     self.oauthCoordinator.useBrowserAuth = self.oauthRequest.useBrowserAuth || self.oauthRequest.loginAsAdmin;
+    self.oauthCoordinator.dpopOverride = self.oauthRequest.useDPoP;
     if (_spAppCredentials && _spAppCredentials.domain) {
         self.oauthCoordinator.credentials.domain = _spAppCredentials.domain;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -601,6 +601,44 @@ Use this method to stop/clear any authentication which is has already been start
                     failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock NS_SWIFT_NAME(migrateRefreshToken(for:newAppConfig:success:failure:));
 
 /**
+ Migrates the refresh token for the specified user to a new app configuration, with explicit
+ control over whether the re-authentication requests a DPoP-bound authorization code.
+
+ This might cause the approve/deny screen to be presented to the user to authorize the
+ new app. If successful a new set of credentials (refresh token, access token) are obtained
+ and replace the existing credentials for the user.
+
+ @param user The user account whose refresh token should be migrated.
+ @param newAppConfig The new app configuration to migrate to.
+ @param useDPoP Per-call override for whether the re-authentication should bind its authorization
+ code to DPoP. `nil` defers to the process-wide `SalesforceSDKManager.useDPoP` flag, matching
+ `migrateRefreshToken:newAppConfig:success:failure:`.
+ @param completionBlock Called on successful migration with the updated user account and auth info.
+ @param failureBlock Called if the migration fails with an error and optional auth info.
+ */
+- (void)migrateRefreshToken:(SFUserAccount *)user
+               newAppConfig:(SFSDKAppConfig *)newAppConfig
+                    useDPoP:(nullable NSNumber *)useDPoP
+                    success:(SFUserAccountManagerSuccessCallbackBlock)completionBlock
+                    failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock NS_SWIFT_NAME(migrateRefreshToken(for:newAppConfig:useDPoP:success:failure:));
+
+/**
+ Upgrades the specified user's session to DPoP in place, without changing the connected app.
+
+ Re-authenticates using the user's current client id, redirect URI, and scopes, requesting a
+ DPoP-bound authorization code. This might cause the approve/deny screen to be presented to the
+ user. If successful, a new set of DPoP-bound credentials (refresh token, access token) are
+ obtained and replace the existing credentials for the user.
+
+ @param user The user account to upgrade to DPoP.
+ @param completionBlock Called on successful upgrade with the updated user account and auth info.
+ @param failureBlock Called if the upgrade fails with an error and optional auth info.
+ */
+- (void)upgradeToDPoP:(SFUserAccount *)user
+               success:(SFUserAccountManagerSuccessCallbackBlock)completionBlock
+               failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock NS_SWIFT_NAME(upgradeToDPoP(_:success:failure:));
+
+/**
  Handle an authentication response from the IDP application
  @param url The URL response returned to the app from the IDP application.
  @param options Dictionary of name-value pairs received from open URL

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -836,8 +836,10 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
                     success:(SFUserAccountManagerSuccessCallbackBlock)completionBlock
                     failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
 
-    // Store current user credentials to revoke them once migration completes
-    SFOAuthCredentials *preMigrationCredentials = self.currentUser.credentials;
+    // Store the migrated user's credentials to revoke them once migration completes. Snapshot the
+    // passed-in `user`, not `self.currentUser`: the two differ when upgrading a background account,
+    // and revoking currentUser's token here would sign out the wrong user.
+    SFOAuthCredentials *preMigrationCredentials = user.credentials;
 
     // Creating a SFSDKAuthRequest and SFSDKAuthSession
     SFSDKAuthRequest *request = [self migrateRefreshAuthRequest:newAppConfig];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -827,12 +827,21 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
                newAppConfig:(SFSDKAppConfig *)newAppConfig
                     success:(SFUserAccountManagerSuccessCallbackBlock)completionBlock
                     failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
-    
+    [self migrateRefreshToken:user newAppConfig:newAppConfig useDPoP:nil success:completionBlock failure:failureBlock];
+}
+
+- (void)migrateRefreshToken:(SFUserAccount *)user
+               newAppConfig:(SFSDKAppConfig *)newAppConfig
+                    useDPoP:(nullable NSNumber *)useDPoP
+                    success:(SFUserAccountManagerSuccessCallbackBlock)completionBlock
+                    failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
+
     // Store current user credentials to revoke them once migration completes
     SFOAuthCredentials *preMigrationCredentials = self.currentUser.credentials;
 
     // Creating a SFSDKAuthRequest and SFSDKAuthSession
     SFSDKAuthRequest *request = [self migrateRefreshAuthRequest:newAppConfig];
+    request.useDPoP = useDPoP;
     SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] initWith:request credentials:nil];
     authSession.isAuthenticating = YES;
     authSession.authSuccessCallback = ^(SFOAuthInfo *authInfo, SFUserAccount *newUserAccount) {
@@ -859,6 +868,18 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             [authSession.oauthCoordinator migrateRefreshToken:user];
         }];
     });
+}
+
+- (void)upgradeToDPoP:(SFUserAccount *)user
+               success:(SFUserAccountManagerSuccessCallbackBlock)completionBlock
+               failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
+    SFOAuthCredentials *credentials = user.credentials;
+    SFSDKAppConfig *sameAppConfig = [[SFSDKAppConfig alloc] initWithDict:@{
+        @"remoteAccessConsumerKey": credentials.clientId ?: @"",
+        @"oauthRedirectURI": credentials.redirectUri ?: @"",
+        @"oauthScopes": credentials.scopes ?: @[]
+    }];
+    [self migrateRefreshToken:user newAppConfig:sameAppConfig useDPoP:@YES success:completionBlock failure:failureBlock];
 }
 
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
@@ -271,19 +271,21 @@ class SFOAuthCoordinatorTests: XCTestCase {
 
     /// The `migrateRefreshToken:` flow constructs its single-access
     /// request path from `generateApprovalUrlString()`. Under the same gate
-    /// (DPoP enabled + my-domain + identifier set), the URL it feeds to
-    /// `requestForSingleAccess` therefore includes `dpop_jkt`. Because the
-    /// downstream `SFRestAPI sendRequest:` invocation makes a real network
-    /// call, this test verifies the URL produced by the same coordinator
-    /// method that migrateRefreshToken invokes — no REST mocking needed.
+    /// (a per-call `dpopOverride=@YES` + my-domain + identifier set), the URL it
+    /// feeds to `requestForSingleAccess` therefore includes `dpop_jkt`, regardless
+    /// of the process-wide `usesDPoP` flag. Because the downstream
+    /// `SFRestAPI sendRequest:` invocation makes a real network call, this test
+    /// verifies the URL produced by the same coordinator method that
+    /// migrateRefreshToken invokes — no REST mocking needed.
     func test_givenDPoPEnabledMigrateRefreshTokenSetup_whenGenerateApprovalUrlString_thenUrlContainsDPoPJkt() throws {
-        SalesforceManager.shared.usesDPoP = true
+        SalesforceManager.shared.usesDPoP = false
 
         let scope = trackedScope("sc7-migrate-refresh")
         let credentials = try makeCredentials(identifier: scope, domain: "acme.my.salesforce.com")
         credentials.refreshToken = "test-refresh-token"
         let coordinator = SFOAuthCoordinator()
         coordinator.credentials = credentials
+        coordinator.dpopOverride = NSNumber(value: true)
 
         // migrateRefreshToken: internally does:
         //   NSURL *approvalUrl = [NSURL URLWithString:[self generateApprovalUrlString]];
@@ -291,9 +293,69 @@ class SFOAuthCoordinatorTests: XCTestCase {
         // this string. The dpop_jkt binding therefore propagates end-to-end.
         let url = coordinator.generateApprovalUrlString()
         let jktValue = try XCTUnwrap(queryValue(name: "dpop_jkt", in: url),
-                                     "migrateRefreshToken path must produce a URL with dpop_jkt under DPoP + my-domain gate")
+                                     "migrateRefreshToken path must produce a URL with dpop_jkt under a per-call dpopOverride, independent of the global flag")
         XCTAssertEqual(jktValue.count, 43,
                        "dpop_jkt on migrateRefreshToken path must be a 43-char base64url string")
+    }
+
+    // MARK: - dpopOverride per-call gate (independent of the global usesDPoP flag)
+
+    /// Global flag OFF + a per-call `dpopOverride=@YES` (e.g. an in-place DPoP
+    /// upgrade migration) still attaches `dpop_jkt`. This is the crux of the
+    /// per-call gate: the override takes precedence over the global flag.
+    func test_givenGlobalFlagOffAndDpopOverrideYes_whenGenerateApprovalUrlString_thenUrlContainsDPoPJkt() throws {
+        SalesforceManager.shared.usesDPoP = false
+
+        let scope = trackedScope("override-flag-off-override-yes")
+        let credentials = try makeCredentials(identifier: scope, domain: "acme.my.salesforce.com")
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+        coordinator.dpopOverride = NSNumber(value: true)
+
+        let url = coordinator.generateApprovalUrlString()
+        XCTAssertNotNil(queryValue(name: "dpop_jkt", in: url),
+                        "dpop_jkt must be present when dpopOverride=YES, even with the global flag off")
+    }
+
+    /// Global flag ON + a per-call `dpopOverride=@NO` (e.g. an explicit
+    /// downgrade migration) omits `dpop_jkt`. The override can turn DPoP off
+    /// per call just as it can turn it on.
+    func test_givenGlobalFlagOnAndDpopOverrideNo_whenGenerateApprovalUrlString_thenUrlHasNoDPoPJkt() throws {
+        SalesforceManager.shared.usesDPoP = true
+
+        let scope = trackedScope("override-flag-on-override-no")
+        let credentials = try makeCredentials(identifier: scope, domain: "acme.my.salesforce.com")
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+        coordinator.dpopOverride = NSNumber(value: false)
+
+        let url = coordinator.generateApprovalUrlString()
+        XCTAssertNil(queryValue(name: "dpop_jkt", in: url),
+                     "dpop_jkt must be absent when dpopOverride=NO, even with the global flag on")
+    }
+
+    /// A nil `dpopOverride` (the normal-login default — never set outside a
+    /// per-call migration) must defer to the global flag exactly as before:
+    /// flag on ⇒ dpop_jkt present, flag off ⇒ absent.
+    func test_givenDpopOverrideNil_whenGenerateApprovalUrlString_thenUrlFollowsGlobalFlag() throws {
+        let scopeOn = trackedScope("override-nil-flag-on")
+        SalesforceManager.shared.usesDPoP = true
+        let credentialsOn = try makeCredentials(identifier: scopeOn, domain: "acme.my.salesforce.com")
+        let coordinatorOn = SFOAuthCoordinator()
+        coordinatorOn.credentials = credentialsOn
+        XCTAssertNil(coordinatorOn.dpopOverride, "normal login must never set dpopOverride")
+        let urlOn = coordinatorOn.generateApprovalUrlString()
+        XCTAssertNotNil(queryValue(name: "dpop_jkt", in: urlOn),
+                        "with dpopOverride nil and the global flag on, dpop_jkt must be present")
+
+        let scopeOff = trackedScope("override-nil-flag-off")
+        SalesforceManager.shared.usesDPoP = false
+        let credentialsOff = try makeCredentials(identifier: scopeOff, domain: "acme.my.salesforce.com")
+        let coordinatorOff = SFOAuthCoordinator()
+        coordinatorOff.credentials = credentialsOff
+        let urlOff = coordinatorOff.generateApprovalUrlString()
+        XCTAssertNil(queryValue(name: "dpop_jkt", in: urlOff),
+                     "with dpopOverride nil and the global flag off, dpop_jkt must be absent")
     }
 
     /// Entry-point coverage — user-agent flow (webServerFlow resolves to `NO`

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -91,6 +91,28 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 
 @end
 
+/** Auth client stub that captures the credentials passed to revokeRefreshToken:, so tests can
+ assert which user's refresh token gets revoked. */
+@interface SFSDKRevokeCapturingOAuthClient : NSObject <SFSDKOAuthProtocol>
+
+@property (nonatomic, strong, nullable) SFOAuthCredentials *revokedCredentials;
+@property (nonatomic, assign) NSUInteger revokeCallCount;
+
+@end
+
+@implementation SFSDKRevokeCapturingOAuthClient
+
+- (void)accessTokenForApprovalCode:(SFSDKOAuthTokenEndpointRequest *)endpointReq completion:(void (^)(SFSDKOAuthTokenEndpointResponse *))completionBlock {}
+- (void)accessTokenForRefresh:(SFSDKOAuthTokenEndpointRequest *)endpointReq completion:(void (^)(SFSDKOAuthTokenEndpointResponse *))completionBlock {}
+- (void)openIDTokenForRefresh:(SFSDKOAuthTokenEndpointRequest *)endpointReq completion:(void (^)(NSString *))completionBlock {}
+
+- (void)revokeRefreshToken:(SFOAuthCredentials *)credentials reason:(SFLogoutReason)reason {
+    self.revokedCredentials = credentials;
+    self.revokeCallCount += 1;
+}
+
+@end
+
 /** Unit tests for the SFUserAccountManager
  */
 @interface SFUserAccountManagerTests : XCTestCase
@@ -832,6 +854,53 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     XCTAssertFalse(successCallbackInvoked, @"Success callback should not be invoked");
     
     // Clean up
+    [self.uam.authSessions removeObject:sceneId];
+}
+
+- (void)testMigrateRefreshToken_whenUserIsNotCurrentUser_revokesMigratedUsersToken {
+    // Given: user B is the current user, and user A (a different, background account) is the one
+    // being migrated. Their refresh tokens are distinct.
+    SFUserAccount *userA = [self createNewUserWithIndex:0];
+    userA.credentials.refreshToken = @"userA_oldRefreshToken";
+    SFUserAccount *userB = [self createNewUserWithIndex:1];
+    userB.credentials.refreshToken = @"userB_refreshToken";
+    [self.uam setCurrentUserInternal:userB];
+
+    // Capture whichever credentials get revoked.
+    SFSDKRevokeCapturingOAuthClient *revokeClient = [[SFSDKRevokeCapturingOAuthClient alloc] init];
+    SFAuthClientFactoryBlock originalFactory = self.uam.authClient;
+    self.uam.authClient = ^{ return revokeClient; };
+
+    NSDictionary *configDict = @{
+        @"remoteAccessConsumerKey": @"NewConsumerKey456",
+        @"oauthRedirectURI": @"newapp://oauth/callback",
+        @"oauthScopes": @[@"api", @"refresh_token"]
+    };
+    SFSDKAppConfig *appConfig = [[SFSDKAppConfig alloc] initWithDict:configDict];
+
+    // When: migrate the non-current user A, and the migration succeeds with a rotated token.
+    [self.uam migrateRefreshToken:userA
+                     newAppConfig:appConfig
+                          success:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {}
+                          failure:^(SFOAuthInfo *authInfo, NSError *error) {}];
+
+    NSString *sceneId = self.uam.authSessions.allKeys.firstObject;
+    SFSDKAuthSession *authSession = self.uam.authSessions[sceneId];
+
+    SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefresh];
+    SFUserAccount *migratedAccount = [self createNewUserWithIndex:2];
+    migratedAccount.credentials.refreshToken = @"userA_newRefreshToken"; // rotated -> triggers revoke
+    authSession.authSuccessCallback(authInfo, migratedAccount);
+
+    // Then: the migrated user A's old token is revoked -- NOT the current user B's token.
+    XCTAssertEqual(revokeClient.revokeCallCount, 1, @"Exactly one refresh token should be revoked");
+    XCTAssertEqualObjects(revokeClient.revokedCredentials.refreshToken, @"userA_oldRefreshToken",
+                          @"Should revoke the migrated (passed-in) user's token, not the current user's");
+    XCTAssertNotEqualObjects(revokeClient.revokedCredentials.refreshToken, @"userB_refreshToken",
+                             @"Must not revoke the current user's token when migrating a background account");
+
+    // Cleanup
+    self.uam.authClient = originalFactory;
     [self.uam.authSessions removeObject:sceneId];
 }
 

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester/ViewControllers/SessionDetailViewController.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester/ViewControllers/SessionDetailViewController.swift
@@ -40,6 +40,7 @@ struct SessionDetailView: View {
     @State private var migrateCallbackUrl = ""
     @State private var migrateScopes = ""
     @State private var isMigrating = false
+    @State private var isUpgradingToDPoP = false
     @State private var migrationError: String?
     @State private var showMigrationError = false
     
@@ -127,27 +128,62 @@ struct SessionDetailView: View {
         }
         .sheet(isPresented: $showMigrateRefreshToken) {
             NavigationView {
-                VStack(spacing: 20) {
-                    AuthFlowTypesView()
-                        .padding(.top)
+                ScrollView {
+                    VStack(spacing: 20) {
+                        AuthFlowTypesView()
+                            .padding(.top)
 
-                    BootConfigEditor(
-                        title: "New App Configuration",
-                        buttonLabel: "Migrate refresh token",
-                        buttonColor: .blue,
-                        consumerKey: $migrateConsumerKey,
-                        callbackUrl: $migrateCallbackUrl,
-                        scopes: $migrateScopes,
-                        isLoading: false,
-                        onConfigChanged: {
-                            handleMigrateRefreshToken()
-                        },
-                        initiallyExpanded: true
-                    )
-                    .padding()
-                    Spacer()
+                        // Upgrade to DPoP Section
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Upgrade to DPoP")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+
+                            Text("Re-authenticates the current user with the same connected app, requesting a DPoP-bound authorization code.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+
+                            Button(action: {
+                                handleUpgradeToDPoP()
+                            }) {
+                                Text("Upgrade to DPoP")
+                                    .font(.headline)
+                                    .foregroundColor(.white)
+                                    .frame(maxWidth: .infinity)
+                                    .frame(height: 44)
+                                    .background(isCurrentSessionDPoP ? Color.gray : Color.green)
+                                    .cornerRadius(8)
+                            }
+                            .disabled(isCurrentSessionDPoP || isUpgradingToDPoP)
+                            .accessibilityIdentifier("upgradeToDPoPButton")
+                        }
+                        .padding()
+
+                        // Change Connected App Section
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Change Connected App")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+
+                            BootConfigEditor(
+                                title: "New App Configuration",
+                                buttonLabel: "Migrate refresh token",
+                                buttonColor: .blue,
+                                consumerKey: $migrateConsumerKey,
+                                callbackUrl: $migrateCallbackUrl,
+                                scopes: $migrateScopes,
+                                isLoading: false,
+                                onConfigChanged: {
+                                    handleMigrateRefreshToken()
+                                },
+                                initiallyExpanded: true
+                            )
+                        }
+                        .padding()
+                        Spacer()
+                    }
                 }
-                .navigationTitle("Migrate to New App")
+                .navigationTitle("Migrate Refresh Token")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
@@ -180,6 +216,10 @@ struct SessionDetailView: View {
         }
     }
     
+    private var isCurrentSessionDPoP: Bool {
+        UserAccountManager.shared.currentUserAccount?.credentials.tokenType == "DPoP"
+    }
+
     private func loadCurrentCredentials() {
         guard let credentials = UserAccountManager.shared.currentUserAccount?.credentials else {
             return
@@ -261,6 +301,34 @@ struct SessionDetailView: View {
             failure: { [self] _, error in
                 DispatchQueue.main.async {
                     isMigrating = false
+                    migrationError = error.localizedDescription
+                    showMigrationError = true
+                }
+            }
+        )
+    }
+
+    private func handleUpgradeToDPoP() {
+        guard let user = UserAccountManager.shared.currentUserAccount else {
+            migrationError = "No current user found"
+            showMigrationError = true
+            return
+        }
+
+        isUpgradingToDPoP = true
+
+        UserAccountManager.shared.upgradeToDPoP(
+            user,
+            success: { [self] _, _ in
+                DispatchQueue.main.async {
+                    isUpgradingToDPoP = false
+                    showMigrateRefreshToken = false
+                    refreshTrigger = UUID()
+                }
+            },
+            failure: { [self] _, error in
+                DispatchQueue.main.async {
+                    isUpgradingToDPoP = false
                     migrationError = error.localizedDescription
                     showMigrationError = true
                 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTesterMainPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTesterMainPageObject.swift
@@ -314,8 +314,9 @@ class AuthFlowTesterMainPageObject {
         let configJSON = buildConfigJSON(consumerKey: appConfig.consumerKey, redirectUri: appConfig.redirectUri, scopes: scopesToRequest)
         importConfig(configJSON)
 
-        // Tap the migrate button
-        tap(migrateRefreshTokenButton())
+        // Tap the migrate button (now below the "Upgrade to DPoP" section in a ScrollView —
+        // scroll it into a hittable region first).
+        tapScrollingIntoView(migrateRefreshTokenButton())
 
         // Tap the allow button if it appears
         tapIfPresent(allowButton())
@@ -336,6 +337,32 @@ class AuthFlowTesterMainPageObject {
         return true
     }
     
+    /// Opens the "Change Key" sheet and taps "Upgrade to DPoP", handling the approve/deny
+    /// screen if it appears. Mirrors `changeAppConfig`'s error-surfacing: the sheet reuses the
+    /// same "Migration Error" alert for both flows.
+    func upgradeToDPoP() -> Bool {
+        // Tap Change Key button to open the sheet
+        tap(bottomBarChangeKeyButton())
+
+        // Tap the "Upgrade to DPoP" button
+        tap(upgradeToDPoPButton())
+
+        // Tap the allow button if it appears
+        tapIfPresent(allowButton())
+
+        let alert = app.alerts["Migration Error"]
+        if (alert.waitForExistence(timeout: UITestTimeouts.long)) {
+            let message = alert.staticTexts.allElementsBoundByIndex
+                .map { $0.label }
+                .filter { $0 != "Migration Error" && !$0.isEmpty }
+                .joined(separator: " ")
+            XCTFail("Migration Error alert: \(message.isEmpty ? "<no message>" : message)")
+            alert.buttons["OK"].tap()
+            return false
+        }
+        return true
+    }
+
     // MARK: - Config Import Helpers
     
     private func buildConfigJSON(consumerKey: String, redirectUri: String, scopes: String) -> String {
@@ -450,7 +477,11 @@ class AuthFlowTesterMainPageObject {
     private func migrateRefreshTokenButton() -> XCUIElement {
         return app.buttons["Migrate refresh token"]
     }
-    
+
+    private func upgradeToDPoPButton() -> XCUIElement {
+        return app.buttons["upgradeToDPoPButton"]
+    }
+
     private func allowButton() -> XCUIElement {
         let buttons = app.webViews.webViews.webViews.buttons
         let predicate = NSPredicate(format: "label CONTAINS[c] 'Allow'")
@@ -496,6 +527,22 @@ class AuthFlowTesterMainPageObject {
         let exists = element.waitForExistence(timeout: timeout)
         XCTAssertTrue(exists, "Element \(element.debugDescription) did not appear within \(timeout)s", file: file, line: line)
         element.tap()
+    }
+
+    /// Taps a custom-styled SwiftUI `Button` (Text + background + cornerRadius) that exists and is
+    /// on-screen but whose hit-test returns `{-1, -1}`, so a plain `.tap()` fails with "Not hittable".
+    /// This happens for the "Migrate refresh token" button once it's pushed down by the "Upgrade to
+    /// DPoP" section (frame near the bottom of the sheet). The content fits, so there is nothing to
+    /// scroll — swiping is a no-op (or scrolls the sheet away). The reliable fix is a coordinate tap
+    /// on the element's frame center, which bypasses the hittability heuristic.
+    private func tapScrollingIntoView(_ element: XCUIElement, timeout: TimeInterval = UITestTimeouts.long, file: StaticString = #file, line: UInt = #line) {
+        let exists = element.waitForExistence(timeout: timeout)
+        XCTAssertTrue(exists, "Element \(element.debugDescription) did not appear within \(timeout)s", file: file, line: line)
+        if element.isHittable {
+            element.tap()
+        } else {
+            element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+        }
     }
 
     private func tapIfPresent(_ element: XCUIElement, timeout: TimeInterval = UITestTimeouts.long) {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
@@ -137,6 +137,28 @@ class DPoPLoginTests: BaseAuthFlowTester {
         assertRevokeAndRefreshWorks(isRtr: true, isDPoP: true, expectAdvancedAuth: true, useHybridFlow: false, wasMigrated: true, isJwt: true)
     }
 
+    // MARK: - Enforcement
+
+    /// Attempt to log in against a DPoP-enforced ECA with the "Use DPoP" toggle off and verify the
+    /// login is rejected: the enforced ECA requires a dpop_jkt on /authorize to bind the
+    /// authorization code, so an unbound login never reaches the post-login credentials view.
+    func testLogin_DPoP_ECA_Without_DPoP_Fails() throws {
+        launchAndAttemptLoginExpectingFailure(loginHost: .regularAuth, staticAppConfigName: .ecaJwtDpop, useDPoP: false)
+    }
+
+    // MARK: - Upgrade
+
+    /// Login with a Bearer (non-DPoP) session against the global "Use DPoP" flag off, then use
+    /// `UserAccountManager.upgradeToDPoP` to re-authenticate the same connected app in place and
+    /// verify the session becomes DPoP-bound without changing the consumer key.
+    func test_givenBearerSession_whenUpgradeToDPoP_thenDPoPBound() throws {
+        // Login with a plain Bearer (non-DPoP) ECA, global "Use DPoP" flag off.
+        launchLoginAndValidate(staticAppConfigName: .ecaJwt, useDPoP: false)
+
+        // Upgrade the current session to DPoP in place and validate the result.
+        upgradeToDPoPAndValidate()
+    }
+
     // MARK: - Restart
 
     /// Restart app after DPoP login and verify session and keypair persist.

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -704,7 +704,103 @@ class BaseAuthFlowTester: XCTestCase {
             "Refresh token should have been migrated"
         )
     }
-    
+
+    /// Upgrades the current session to DPoP in place (same connected app, via
+    /// `UserAccountManager.upgradeToDPoP`) and validates the result: DPoP-bound credentials,
+    /// an unchanged consumer key, and a working revoke/refresh cycle.
+    ///
+    /// Unlike `migrateAndValidate`, this does not change the connected app — it re-authenticates
+    /// against the same client id/redirect URI/scopes, so the consumer key is expected to stay
+    /// the same while the refresh token is rotated.
+    ///
+    /// - Parameter isJwt: Whether the connected app issues JWT-format access tokens (drives the
+    ///   "JT"/"OT" UA marker assertion). Defaults to `true` since the upgrade test uses `.ecaJwt`.
+    func upgradeToDPoPAndValidate(isJwt: Bool = true) {
+        let originalUserCredentials = getUserCredentials()
+
+        XCTAssert(mainPage.upgradeToDPoP(), "Failed to upgrade to DPoP")
+
+        let upgradedUserCredentials = getUserCredentials()
+
+        // The upgrade re-authenticates with the same connected app: consumer key is unchanged.
+        XCTAssertEqual(
+            originalUserCredentials.clientId,
+            upgradedUserCredentials.clientId,
+            "Consumer key should be unchanged after upgrading to DPoP"
+        )
+
+        assertDPoPCredentials(upgradedUserCredentials, context: "after upgrade")
+
+        // Making sure the refresh token changed
+        XCTAssertNotEqual(
+            originalUserCredentials.refreshToken,
+            upgradedUserCredentials.refreshToken,
+            "Refresh token should have been rotated by the DPoP upgrade"
+        )
+
+        // `upgradeToDPoP` delegates to the refresh-token migration path, so the "TM"
+        // (token-migration) UA feature flag is legitimately registered — the marker tracks the
+        // migration mechanism, not whether the connected app changed. Assert its presence.
+        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: true, wasMigrated: true, isJwt: isJwt)
+    }
+
+    /// Launches the app and attempts a login expected to fail before any credentials are entered.
+    ///
+    /// Replays the same host-list / login-options / login-host prefix as `login()` (selecting the
+    /// login host is what triggers `/authorize`), then stops — it never calls `performLogin`.
+    /// Use this for enforced-server rejections that fire at `/authorize` before a login form ever
+    /// renders (e.g. a DPoP-enforced ECA rejecting an unbound login with `useDPoP: false`); calling
+    /// `performLogin` in that case would hang waiting on form fields that never appear.
+    ///
+    /// - Parameters:
+    ///   - loginHost: The login host configuration to use.
+    ///   - staticAppConfigName: The static app configuration name.
+    ///   - staticScopeSelection: The scope selection for static configuration. Defaults to `.empty`.
+    ///   - forceAdvancedAuthentication: Whether to use the external browser for login. Defaults to `true`.
+    ///   - useDPoP: Whether to enable the "Use DPoP" login option. Defaults to `false`.
+    func launchAndAttemptLoginExpectingFailure(
+        loginHost: KnownLoginHostConfig,
+        staticAppConfigName: KnownAppConfig,
+        staticScopeSelection: ScopeSelection = .empty,
+        forceAdvancedAuthentication: Bool = true,
+        useDPoP: Bool = false
+    ) {
+        launch()
+
+        let hostConfig = getLoginHost(loginHost: loginHost)
+        let staticAppConfig = getAppConfig(named: staticAppConfigName)
+        let staticScopes = testConfig.getScopesToRequest(for: staticAppConfig, staticScopeSelection)
+
+        let advancedAuthEnabled = forceAdvancedAuthentication
+
+        // A fresh login surface always starts under the process default (advanced auth on), so the
+        // external browser is showing. Cancel it to reach the host list, where login options and
+        // the login host are configured. (Mirrors login()'s own prefix.)
+        loginPage.returnToHostList(expectingBrowser: true)
+
+        loginPage.configureLoginOptions(
+            staticAppConfig: staticAppConfig,
+            staticScopes: staticScopes,
+            dynamicAppConfig: nil,
+            dynamicScopes: "",
+            useWebServerFlow: true,
+            useHybridFlow: true,
+            forceAdvancedAuthentication: forceAdvancedAuthentication,
+            discoveryLoginHost: "",
+            discoveryUsername: "",
+            useDPoP: useDPoP
+        )
+
+        loginPage.returnToHostList(expectingBrowser: advancedAuthEnabled)
+
+        // Selecting the login host triggers /authorize. For an enforced ECA with useDPoP: false,
+        // the server rejects before any login form renders, so there is nothing further to drive —
+        // assert on the outcome instead of attempting performLogin.
+        loginPage.configureLoginHost(host: hostConfig.urlNoProtocol)
+
+        assertMainPageNotLoaded()
+    }
+
     // MARK: - Protected Helpers for Subclasses
 
     /// Restarts the application.
@@ -1205,7 +1301,16 @@ class BaseAuthFlowTester: XCTestCase {
     func assertMainPageLoaded() {
         XCTAssert(mainPage.isShowing(), "AuthFlowTester is not loaded")
     }
-    
+
+    /// Asserts that the main page never loads, i.e. the app never reaches the post-login
+    /// credentials view. Use this after a login attempt expected to be rejected before any
+    /// authenticated user is added (e.g. an enforced-server `/authorize` rejection). Waits out
+    /// `mainPage.isShowing()`'s own network timeout to give a rejected login enough time to settle
+    /// back on the host picker before asserting absence.
+    func assertMainPageNotLoaded() {
+        XCTAssertFalse(mainPage.isShowing(), "AuthFlowTester should not have loaded")
+    }
+
     private func checkUserCredentials(username: String, userConsumerKey: String, userRedirectUri: String, grantedScopes: String, issuesJwt: Bool) -> UserCredentialsData {
         let userCredentials = mainPage.getUserCredentials()
         XCTAssertEqual(userCredentials.username, username, "Username in credentials should match expected username")

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -798,6 +798,15 @@ class BaseAuthFlowTester: XCTestCase {
         // assert on the outcome instead of attempting performLogin.
         loginPage.configureLoginHost(host: hostConfig.urlNoProtocol)
 
+        // We assert on absence-of-main-page rather than on error text because there is no error
+        // surface to read here. This path uses advanced auth (ASWebAuthenticationSession), and the
+        // enforced ECA rejects the unbound /authorize with a short non-HTML body. The system browser
+        // can't render it and falls back to a QuickLook document preview (a generic file icon
+        // labeled "authorize" / "data - N bytes" / "Open in…") — there is no error= / error_description
+        // string on screen. This differs from the in-app WebView negative tests (invalid client id,
+        // invalid scope), which render an HTML error page whose text is assertable. The only elements
+        // available here are iOS's file-preview chrome, which is not a stable SDK/server contract, so
+        // "the app never reaches the authenticated view" is the strongest reliable signal.
         assertMainPageNotLoaded()
     }
 


### PR DESCRIPTION
## What

Adds a public **`UserAccountManager.upgradeToDPoP(_:success:failure:)`** API that binds an existing Bearer (non-DPoP) session's refresh token to DPoP **in place** — re-authenticating with the user's own client id, redirect URI, and scopes, so no connected-app change is involved. This is the production path for migrating users to DPoP proactively, while the server still accepts the Bearer session, ahead of an ECA flipping to DPoP-enforced.

Supporting changes:

- **`migrateRefreshToken(for:newAppConfig:useDPoP:success:failure:)` overload** — a per-call `useDPoP: NSNumber?` (`@YES` binds the migration to DPoP, `@NO` migrates unbound, `nil` defers to the global flag). The existing `migrateRefreshToken(for:newAppConfig:success:failure:)` now delegates with `nil`, preserving its behavior exactly.
- The per-call intent is threaded **`SFSDKAuthRequest.useDPoP` → `SFSDKAuthSession` → `SFOAuthCoordinator.dpopOverride`**, and `appendDPoPJktIfNeededTo:` now resolves DPoP from `dpopOverride` when set, falling back to `SalesforceSDKManager.useDPoP` otherwise. **Normal login never sets `dpopOverride`, so its `/authorize` gating is unchanged.**
- **AuthFlowTester sample app**: "Upgrade to DPoP" affordance in the migration sheet; new UITest coverage; `SFOAuthCoordinatorTests` cover the per-call gate.

The global `SalesforceSDKManager.useDPoP` flag remains the default DPoP posture for **new logins** only; the migration API is an explicit action on an existing session and is deliberately flag-independent.

## Cross-platform note

This is the iOS half of a cross-platform pair; the **Android sibling is a separate PR in the Android repo** (parallel work). The two are behavior-matched: same per-call `useDPoP` (both directions), same flag-independent migration, same "global flag governs only new logins" split, same DPoP-bound post-upgrade assertions.

## Changes beyond the original spec/plan (added to make on-device tests pass)

On-device UITest runs surfaced two test-only issues that required changes not in the initial spec/plan; recording them here for review (all test-infra, no product code):

1. **`upgradeToDPoP` legitimately registers the `TM` (token-migration) user-agent flag.** The upgrade validation helper initially asserted `TM` *absent* (on the assumption that same-app re-auth isn't a "migration"). On device the UA was `ftr_A2.B4.BW.DP.JT.L4.TM.UA` — `TM` tracks the migration *mechanism*, not "migrated to a different app," so an in-place upgrade correctly sets it. Fixed the helper to assert `TM` present (`wasMigrated: true`) and to pass `isJwt: true` for the `.ecaJwt` token.

2. **SwiftUI custom-`Button` hittability after the sheet reorg.** Adding the "Upgrade to DPoP" section above the existing config editor wrapped the sheet body in a `ScrollView`, after which the pre-existing "Migrate refresh token" button reported a `{-1,-1}` hit point ("Not hittable") though fully visible. Fixed in the page object with a coordinate-based tap (`coordinate(withNormalizedOffset:).tap()`) when `!isHittable`; the spec-required layout is unchanged (no product/UI revert).

## Review flags

- Touches the OAuth `/authorize` DPoP gate, a new public `UserAccountManager` API, and login-UI-adjacent sample-app code — requires maintainer sign-off. The `migrateRefreshToken` overload and the internal `dpopOverride`/`useDPoP` properties are additive/backward-compatible; the existing migration entry point is unchanged.

## Testing

- `SalesforceSDKCore` + AuthFlowTester UITest targets `build-for-testing` succeed (`** TEST BUILD SUCCEEDED **`).
- `SFOAuthCoordinatorTests` cover the per-call gate (override on with global flag off ⇒ `dpop_jkt` present; normal login still gated on the flag).
- On-device: `test_givenBearerSession_whenUpgradeToDPoP_thenDPoPBound` and `testLogin_DPoP_ECA_Without_DPoP_Fails` pass, and the pre-existing migration tests remain green.