### PR TITLE
Default DPoP on for new logins in MSDK 14

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -267,10 +267,11 @@ NS_SWIFT_NAME(SalesforceManager)
 @property (nonatomic, assign) BOOL useHybridAuthentication;
 
 /** Whether DPoP (RFC 9449) proof JWTs should be attached to token-endpoint requests.
- *  Defaults to NO. Enable only when the Salesforce External Client App / Connected App
- *  is configured with `dpop_bound_access_tokens=true`. When enabled, the SDK lazily
- *  generates a per-user P-256 keypair (Secure Enclave when available) and signs a
- *  proof JWT for every request to `/services/oauth2/token`.
+ *  Defaults to `YES` as of Mobile SDK 14. When enabled, the SDK lazily generates a
+ *  per-user P-256 keypair (Secure Enclave when available) and signs a proof JWT for
+ *  every request to `/services/oauth2/token`. This flag governs new logins only:
+ *  existing DPoP-bound credentials keep their binding and existing Bearer credentials
+ *  are not upgraded to DPoP, regardless of this setting.
  */
 @property (nonatomic, assign) BOOL useDPoP NS_SWIFT_NAME(usesDPoP);
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -233,7 +233,7 @@ SFNativeLoginManagerInternal *nativeLogin;
     self.useEphemeralSessionForAdvancedAuth = YES;
     self.useWebServerAuthentication = YES;
     self.useHybridAuthentication = YES;
-    self.useDPoP = NO;
+    self.useDPoP = YES;
     self.sdk_forceAdvancedAuthentication = YES;
     self.blockSalesforceIntegrationUser = NO;
 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/LegacyLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/LegacyLoginTests.swift
@@ -51,34 +51,34 @@ class LegacyLoginTests: BaseAuthFlowTester {
 
     /// Login with CA opaque using default scopes and web server flow.
     func testCAOpaque_DefaultScopes_WebServerFlow() throws {
-        launchLoginAndValidate(staticAppConfigName: .caOpaque, useHybridFlow: useHybridFlow())
+        launchLoginAndValidate(staticAppConfigName: .caOpaque, useHybridFlow: useHybridFlow(), useDPoP: false)
     }
 
     /// Login with CA opaque using subset of scopes and web server flow.
     func testCAOpaque_SubsetScopes_WebServerFlow() throws {
-        launchLoginAndValidate(staticAppConfigName: .caOpaque, staticScopeSelection: .subset, useHybridFlow: useHybridFlow())
+        launchLoginAndValidate(staticAppConfigName: .caOpaque, staticScopeSelection: .subset, useHybridFlow: useHybridFlow(), useDPoP: false)
     }
 
     /// Login with CA opaque using all scopes and web server flow.
     func testCAOpaque_AllScopes_WebServerFlow() throws {
-        launchLoginAndValidate(staticAppConfigName: .caOpaque, staticScopeSelection: .all, useHybridFlow: useHybridFlow())
+        launchLoginAndValidate(staticAppConfigName: .caOpaque, staticScopeSelection: .all, useHybridFlow: useHybridFlow(), useDPoP: false)
     }
 
     // MARK: - CA Web Server Flow Tests (In-App WebView)
 
     /// Login with CA opaque using default scopes, web server flow, and in-app WebView (advanced auth disabled).
     func testCAOpaque_DefaultScopes_WebServerFlow_InAppWebView() throws {
-        launchLoginAndValidate(staticAppConfigName: .caOpaque, useHybridFlow: useHybridFlow(), forceAdvancedAuthentication: false)
+        launchLoginAndValidate(staticAppConfigName: .caOpaque, useHybridFlow: useHybridFlow(), forceAdvancedAuthentication: false, useDPoP: false)
     }
 
     /// Login with CA opaque using subset of scopes, web server flow, and in-app WebView (advanced auth disabled).
     func testCAOpaque_SubsetScopes_WebServerFlow_InAppWebView() throws {
-        launchLoginAndValidate(staticAppConfigName: .caOpaque, staticScopeSelection: .subset, useHybridFlow: useHybridFlow(), forceAdvancedAuthentication: false)
+        launchLoginAndValidate(staticAppConfigName: .caOpaque, staticScopeSelection: .subset, useHybridFlow: useHybridFlow(), forceAdvancedAuthentication: false, useDPoP: false)
     }
 
     /// Login with CA opaque using all scopes, web server flow, and in-app WebView (advanced auth disabled).
     func testCAOpaque_AllScopes_WebServerFlow_InAppWebView() throws {
-        launchLoginAndValidate(staticAppConfigName: .caOpaque, staticScopeSelection: .all, useHybridFlow: useHybridFlow(), forceAdvancedAuthentication: false)
+        launchLoginAndValidate(staticAppConfigName: .caOpaque, staticScopeSelection: .all, useHybridFlow: useHybridFlow(), forceAdvancedAuthentication: false, useDPoP: false)
     }
 
     // MARK: - CA User Agent Flow Tests
@@ -91,7 +91,7 @@ class LegacyLoginTests: BaseAuthFlowTester {
     /// agent flow test retained: scope-variation coverage lives on the web server flow (advanced
     /// auth on) tests above, which is the default path for the vast majority of apps.
     func testCAOpaque_DefaultScopes_UserAgentFlow() throws {
-        launchLoginAndValidate(staticAppConfigName: .caOpaque, useWebServerFlow: false, useHybridFlow: useHybridFlow(), forceAdvancedAuthentication: false)
+        launchLoginAndValidate(staticAppConfigName: .caOpaque, useWebServerFlow: false, useHybridFlow: useHybridFlow(), forceAdvancedAuthentication: false, useDPoP: false)
     }
 }
 

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/overview.md
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/overview.md
@@ -29,6 +29,8 @@ This document provides an overview of all UI tests in the AuthFlowTester test su
 
 Tests for Connected App (CA) configurations with default, subset, and all scopes using hybrid authentication flow. Tests web server flow with both the external browser (default) and in-app WebView (`forceAdvancedAuthentication: false`), plus the user agent flow (also in-app WebView).
 
+> **DPoP default note:** Mobile SDK 14 defaults DPoP **on** for new logins (`SalesforceSDKManager.useDPoP` defaults to `true`). Every case in this suite explicitly passes `useDPoP: false`, so it is the dedicated **Bearer (non-DPoP) compatibility suite** — the legacy CA flows continue to be exercised as they behaved before 14, independent of the new default. DPoP-bound coverage lives in `DPoPLoginTests`.
+
 | Test Name | App Config | Scopes | Flow | Auth Surface |
 |-----------|------------|--------|------|--------------|
 | `testCAOpaque_DefaultScopes_WebServerFlow` | CA Opaque | Default | Web Server | Browser (default) |

--- a/native/SampleApps/AuthFlowTester/README.md
+++ b/native/SampleApps/AuthFlowTester/README.md
@@ -11,6 +11,8 @@ Tests are run via GitHub Actions using the `AuthFlowTester` Xcode scheme and `xc
 #### LegacyLoginTests
 Legacy login tests using the default Connected App (CA) opaque configuration from the app's boot config.
 
+> **DPoP default note:** Mobile SDK 14 defaults DPoP **on** for new logins (`SalesforceSDKManager.useDPoP` defaults to `true`). This suite deliberately passes `useDPoP: false` on every case so it remains the dedicated **Bearer (non-DPoP) compatibility suite**, exercising the legacy CA flows exactly as pre-14 apps did. DPoP-bound coverage lives in `DPoPLoginTests`.
+
 | Test | App Config | Scopes | Auth Surface |
 |------|-----------|--------|--------------|
 | `testCAOpaque_DefaultScopes_WebServerFlow` | CA Opaque | Default | ASWebAuthenticationSession |


### PR DESCRIPTION
## What

Flips `SalesforceSDKManager.usesDPoP` from `NO` to `YES`. DPoP (RFC 9449) is now validated by the server, so new apps and new logins request DPoP-bound tokens by default.

The change governs **new logins only** — the per-credential attachment gate keeps existing Bearer credentials Bearer and existing DPoP credentials bound. Updates the property doc to reflect the new default and drops the old opt-in advisory.

## Changes

- `SalesforceSDKManager.h/.m` — default flipped to `YES`; doc updated.
- `LegacyLoginTests` — now passes `useDPoP: false` explicitly on all its login calls so it stays a dedicated Bearer class under the new default; `LegacyLoginTestsNotHybrid` inherits the override.

## Rebase note

This is a small, self-contained flip that overlaps the DPoP upgrade/migration work in #4133 (both touch DPoP defaults and the AuthFlowTester test classes). Whichever of the two merges first, the other will need a rebase. No preference on order.

## Testing

Tested and passing.