### PR TITLE
fix(security/W-23622931): escape single quotes in json_extract paths and MATCH matchKey

### DIFF
--- a/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
+++ b/libs/SmartStore/SmartStore/Classes/SFSmartStore.m
@@ -1117,7 +1117,7 @@ NSUInteger CACHES_COUNT_LIMIT = 1024;
         // Column name or expression the db index is on
         NSString *columnName = [NSString stringWithFormat:@"%@_%lu",soupTableName,(unsigned long)i];
         if (kValueIndexedWithJSONExtract(indexSpec)) {
-            columnName = [NSString stringWithFormat:@"json_extract(soup, '$.%@')", indexSpec.path];
+            columnName = [NSString stringWithFormat:@"json_extract(soup, '$.%@')", [indexSpec.path stringByReplacingOccurrencesOfString:@"'" withString:@"''"]];
         }
         if (kValueExtractedToColumn(indexSpec)) {
             NSString * columnType = [indexSpec columnType];

--- a/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFQuerySpecTests.m
@@ -141,6 +141,13 @@
     XCTAssertEqualObjects(@"SELECT id FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees}_fts MATCH '{employees:lastName}:Bond') ORDER BY {employees:firstName} ASC ", querySpec.idsSmartSql, @"Wrong ids smart sql for match query spec");
 }
 
+- (void) testMatchQuerySmartSqlWithSingleQuoteInMatchKey
+{
+    // Single quotes in matchKey must be doubled so they don't break the surrounding MATCH '...' literal.
+    SFQuerySpec* querySpec = [SFQuerySpec newMatchQuerySpec:@"employees" withPath:@"lastName" withMatchKey:@"O'Brien" withOrderPath:@"firstName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];
+    XCTAssertEqualObjects(@"SELECT {employees:_soup} FROM {employees} WHERE {employees:_soupEntryId} IN (SELECT rowid FROM {employees}_fts WHERE {employees}_fts MATCH '{employees:lastName}:O''Brien') ORDER BY {employees:firstName} ASC ", querySpec.smartSql, @"Wrong smart sql for match query spec with single quote in matchKey");
+}
+
 - (void) testLikeQuerySmartSql
 {
     SFQuerySpec* querySpec = [SFQuerySpec newLikeQuerySpec:@"employees" withPath:@"lastName" withLikeKey:@"Bon%" withOrderPath:@"lastName" withOrder:kSFSoupQuerySortOrderAscending withPageSize:1];

--- a/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
+++ b/libs/SmartStore/SmartStoreTests/SFSmartSqlTests.m
@@ -218,6 +218,14 @@
     XCTAssertEqualObjects(@"select json_extract(soup, '$.education'), json_extract(soup, '$.address.zipcode') from TABLE_1 where json_extract(soup, '$.address.city') = 'San Francisco'", [self.store convertSmartSql:@"select {employees:education}, {employees:address.zipcode} from {employees} where {employees:address.city} = 'San Francisco'"], @"Bad conversion");
 }
 
+- (void) testConvertSmartSqlForNonIndexedColumnWithSingleQuoteInPath {
+    // Single quotes in non-indexed paths must be doubled so they don't break the surrounding json_extract(soup, '$.path') literal.
+    // The path with ' is in the WHERE clause so that the FROM {employees} token is resolved before any single-quote appears in beforeStr.
+    XCTAssertEqualObjects(@"select TABLE_1_3 from TABLE_1 where json_extract(soup, '$.user''s.address') = 'foo'",
+                          [self.store convertSmartSql:@"select {employees:employeeId} from {employees} where {employees:user's.address} = 'foo'"],
+                          @"Bad conversion");
+}
+
 - (void) testConvertSmartSqlWithQuotedCurlyBraces {
     XCTAssertEqualObjects(@"select json_extract(soup, '$.education') from TABLE_1 where json_extract(soup, '$.education') like 'Account(where: {Name: {eq: \"Jason\"}})'",
                         [self.store convertSmartSql:@"select {employees:education} from {employees} where {employees:education} like 'Account(where: {Name: {eq: \"Jason\"}})'"]);
@@ -509,6 +517,18 @@
     XCTAssertTrue([self timeRegexpInMs:newRegexp] * 500 < [self timeRegexpInMs:oldRegexp]);
     // No more than 25ms
     XCTAssertTrue([self timeRegexpInMs:newRegexp] <  25);
+}
+
+- (void) testRegisterSoupWithSingleQuoteInJSON1IndexPath {
+    // Single quotes in a JSON1 index path must be doubled so they don't break the json_extract(soup, '$.path') expression.
+    NSString *soupName = @"quotePathSoup";
+    [self.store registerSoup:soupName
+              withIndexSpecs:[SFSoupIndex asArraySoupIndexes:@[[self createJSON1IndexSpec:@"user's.name"]]]
+                       error:nil];
+    NSArray<SFSoupIndex*>* indices = [self.store indicesForSoup:soupName];
+    XCTAssertEqual(indices.count, 1U, @"Expected one index spec");
+    XCTAssertEqualObjects(indices[0].columnName, @"json_extract(soup, '$.user''s.name')", @"Single quote in JSON1 index path must be doubled");
+    [self.store removeSoup:soupName];
 }
 
 #pragma mark - helper methods


### PR DESCRIPTION
## Summary

iOS parity for the Android fix in forcedotcom/SalesforceMobileSDK-Android#2993.

Closes all three CWE-89 `json_extract` sink family members reachable from the hybrid bridge:

- **`SFSmartStore.m:1120`** — `indexSpec.path` in the index-registration path (`pgRegisterSoup` → `IndexSpec.fromJSON`), the sink called out in the Android PR review comment
- **`SFSmartSqlHelper.m:160`** — non-indexed path in `convertSmartSql` query-time resolution
- **`SFQuerySpec.m:334`** — `matchKey` inlined in the `MATCH '...'` FTS clause

All three apply `stringByReplacingOccurrencesOfString:@"'" withString:@"''"` to double any single quotes before embedding in a SQLite string literal.

## Tests added

- `SFSmartSqlTests.testConvertSmartSqlForNonIndexedColumnWithSingleQuoteInPath`
- `SFSmartSqlTests.testRegisterSoupWithSingleQuoteInJSON1IndexPath`
- `SFQuerySpecTests.testMatchQuerySmartSqlWithSingleQuoteInMatchKey`

## Test plan

- [x] All three new tests pass on iPhone 16 simulator (iOS 18.6)
- [x] Full SmartStore test suite passes (pre-existing `testGetGlobalStoreNames` failure confirmed unrelated to this change — fails on `dev` baseline too)