### PR TITLE
Support biometric authentication with advanced authentication

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		695E86BE29EF9312002BDEA6 /* SFSDKIDPAuthCodeLoginRequestHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 695E86BC29EF9312002BDEA6 /* SFSDKIDPAuthCodeLoginRequestHandler.m */; };
 		696D6C3E2DD7E0AD00138888 /* NewLoginHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696D6C3D2DD7E0AD00138888 /* NewLoginHostTests.swift */; };
 		696E91472AD0A14A00205884 /* BiometricAuthenticationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 696E91452AD0A14A00205884 /* BiometricAuthenticationManagerTests.swift */; };
+		C52760EBAE2A41A2B697ABF7 /* BiometricAdvancedAuthGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A9E801F34047C7A7E1A5BC /* BiometricAdvancedAuthGateTests.swift */; };
 		696E91482AD0A14A00205884 /* ScreenLockManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 696E91462AD0A14A00205884 /* ScreenLockManagerTests.m */; };
 		696E914A2AD0A68600205884 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 696E91492AD0A68600205884 /* PrivacyInfo.xcprivacy */; };
 		6975869F23296D7500574148 /* SFSDKURLCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 691D129F23296A93000D6D41 /* SFSDKURLCacheTests.m */; };
@@ -782,6 +783,7 @@
 		695E86BC29EF9312002BDEA6 /* SFSDKIDPAuthCodeLoginRequestHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SFSDKIDPAuthCodeLoginRequestHandler.m; sourceTree = "<group>"; };
 		696D6C3D2DD7E0AD00138888 /* NewLoginHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NewLoginHostTests.swift; path = SalesforceSDKCoreTests/NewLoginHostTests.swift; sourceTree = SOURCE_ROOT; };
 		696E91452AD0A14A00205884 /* BiometricAuthenticationManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BiometricAuthenticationManagerTests.swift; path = SalesforceSDKCoreTests/BiometricAuthenticationManagerTests.swift; sourceTree = SOURCE_ROOT; };
+		22A9E801F34047C7A7E1A5BC /* BiometricAdvancedAuthGateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BiometricAdvancedAuthGateTests.swift; path = SalesforceSDKCoreTests/BiometricAdvancedAuthGateTests.swift; sourceTree = SOURCE_ROOT; };
 		696E91462AD0A14A00205884 /* ScreenLockManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ScreenLockManagerTests.m; path = SalesforceSDKCoreTests/ScreenLockManagerTests.m; sourceTree = SOURCE_ROOT; };
 		696E91492AD0A68600205884 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		697A919E2363C3D800D2836F /* SFSDKPushNotificationDecryption.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SFSDKPushNotificationDecryption.h; sourceTree = "<group>"; };
@@ -1087,6 +1089,7 @@
 				23F200AB2E551C890091C5F5 /* ActionTypeTests.swift */,
 				4FAUTHFLOW112345678901ABC /* AuthFlowTypesViewTests.swift */,
 				696E91452AD0A14A00205884 /* BiometricAuthenticationManagerTests.swift */,
+				22A9E801F34047C7A7E1A5BC /* BiometricAdvancedAuthGateTests.swift */,
 				4FBOOTCP112345678901ABCD /* LoginOptionsViewControllerTests.swift */,
 				23F200AD2E551C890091C5F5 /* BootconfigTests.swift */,
 				4FDISCOV112345678901ABCD /* DiscoveryResultEditorTests.swift */,
@@ -2311,6 +2314,7 @@
 				009D77521CA4A92200D5183A /* SFPushNotificationManagerTests.m in Sources */,
 				699202FD2FEF11D70032ECD7 /* SFSDKTokenRefreshCoordinatorTests.m in Sources */,
 				696E91472AD0A14A00205884 /* BiometricAuthenticationManagerTests.swift in Sources */,
+				C52760EBAE2A41A2B697ABF7 /* BiometricAdvancedAuthGateTests.swift in Sources */,
 				692D36662F95F83A002FBFF3 /* AppAttestationTests.swift in Sources */,
 				2B7FB526B2A94663ABAA42F6 /* BrowserLoginTelemetryTests.swift in Sources */,
 				B7E8A2AF1E77062E007C0D92 /* SFUserAccountManagerPersisterTests.m in Sources */,

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -136,6 +136,10 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
     // is shown alongside the Add button (matching the in-app login screen). The 'Add Server'
     // button is shown only if the MDM policy allows it.
     NSMutableArray<UIBarButtonItem *> *rightItems = [NSMutableArray array];
+    UIBarButtonItem *retryBiometricButton = [self retryBiometricButton];
+    if (retryBiometricButton) {
+        [rightItems addObject:retryBiometricButton];
+    }
     UIBarButtonItem *settingsButton = [self loginOptionsButton];
     if (settingsButton) {
         [rightItems addObject:settingsButton];
@@ -299,6 +303,32 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
     settingsButton.accessibilityLabel = [SFSDKResourceUtils localizedString:@"LOGIN_SETTINGS_BUTTON"];
     settingsButton.accessibilityIdentifier = @"settings";
     return settingsButton;
+}
+
+/**
+ * Nav-bar button that re-presents the biometric unlock prompt. This is the picker-screen
+ * counterpart to SFLoginViewController's biometricButton for cases where auto-presentation
+ * didn't fire, was dismissed, or is disabled.  Only appears when biometric is actually locked,
+ * opted-in, and available.
+ */
+- (nullable UIBarButtonItem *)retryBiometricButton {
+    if (!self.presentedAsLoginScreen || ![[SFBiometricAuthenticationManagerInternal shared] showNativeLoginButton]) {
+        return nil;
+    }
+
+    UIBarButtonItem *retryButton = [[UIBarButtonItem alloc] initWithTitle:[SFSDKResourceUtils localizedString:@"biometricLoginButton"]
+                                                                     style:UIBarButtonItemStylePlain
+                                                                    target:self
+                                                                    action:@selector(presentBioAuthAction:)];
+    retryButton.accessibilityIdentifier = @"retryBiometric";
+    return retryButton;
+}
+
+/**
+ * Mirrors SFLoginViewController -presentBioAuthAction: verbatim.
+ */
+- (void)presentBioAuthAction:(id)sender {
+    [[SFBiometricAuthenticationManagerInternal shared] presentBiometricWithScene:self.view.window.windowScene];
 }
 
 #pragma mark - Delegate Wrapper Methods

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
@@ -53,6 +53,12 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
     internal var laContext = LAContext()
     private let kBioAuthPolicyIdentifier = "com.salesforce.security.bioauthpolicy"
     private let kBioAuthEnabledIdentifier = "com.salesforce.security.bioauth"
+
+    /// One-shot flag telling `willBeginBrowserAuthentication:` to suppress the browser launch that
+    /// `lock()`'s `login()` triggers, so it doesn't race the biometric prompt. The gate clears it
+    /// on its next check, so a later attempt (fallback picker, gear-menu retry) is not suppressed.
+    /// Read/written from SFUserAccountManager.m, hence `@objc`.
+    @objc internal var suppressInitialBrowserAuthentication = false
     
     private override init() {
         super.init()
@@ -66,7 +72,10 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
     
     /// Locks the screen if necessary
     @objc public func handleAppForeground() {
-        if shouldLock() {
+        // Skip if already locked: shouldLock() ignores `locked`, so a foreground while locked would
+        // call lock() again and re-arm suppressInitialBrowserAuthentication, wrongly suppressing a
+        // browser-auth attempt that already cleared it.
+        if !locked && shouldLock() {
             lock()
         }
     }
@@ -136,7 +145,11 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
     public func lock() {
         locked = true
         NotificationCenter.default.post(name: Notification.Name(rawValue: kSFBiometricAuthenticationFlowWillBegin), object: nil)
-        
+
+        // Suppress the browser launch from the login() below when biometric will be shown, so it
+        // doesn't race the prompt. The gate in SFUserAccountManager clears this on its next check.
+        suppressInitialBrowserAuthentication = showNativeLoginButton()
+
         // Open the Login Screen
         _ = UserAccountManager.shared.login { result in
             switch result {
@@ -249,12 +262,66 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
                         SFSDKWindowManager.shared().authWindow(scene).viewController?.dismiss(animated: false)
                     }
                 } catch {
-                    // This just means the user chose the fallback option instead of biometric
+                    // User declined biometric. Stay locked, but resume the browser (Advanced Auth)
+                    // attempt lock() suppressed rather than strand them on the picker. Resuming the
+                    // same suppressed session keeps its covering window up (no app exposure) and
+                    // preserves lock()'s completion. ASWebAuthenticationSession.start() only presents
+                    // from a .foregroundActive scene, so wait for the Face ID sheet's dismissal to
+                    // reactivate the scene first.
+                    await waitForSceneActive(scene)
+                    UserAccountManager.shared.resumeBrowserAuthentication(scene)
                 }
             }
         }
     }
     
+    /// Awaits the scene returning to `.foregroundActive`. Dismissing the Face ID sheet leaves the
+    /// scene `.foregroundInactive` for a beat, and `ASWebAuthenticationSession.start()` silently
+    /// fails from a non-active scene. Resolves immediately if already active, otherwise on this
+    /// scene's next `UIScene.didActivateNotification`, with a bounded fallback.
+    @MainActor
+    private func waitForSceneActive(_ scene: UIScene) async {
+        if scene.activationState == .foregroundActive {
+            return
+        }
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let center = NotificationCenter.default
+            var observer: NSObjectProtocol?
+            let resumeOnce = ResumeGuard()
+
+            let finish: () -> Void = {
+                guard resumeOnce.tryResume() else { return }
+                if let observer = observer {
+                    center.removeObserver(observer)
+                }
+                continuation.resume()
+            }
+
+            observer = center.addObserver(forName: UIScene.didActivateNotification, object: nil, queue: .main) { notification in
+                guard let activatedScene = notification.object as? UIScene, activatedScene === scene else {
+                    return
+                }
+                finish()
+            }
+
+            // Bounded fallback so a scene that never reactivates can't hang the flow.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                finish()
+            }
+        }
+    }
+
+    /// One-shot latch so the observer and the timeout fallback resume the continuation exactly once.
+    private final class ResumeGuard {
+        private var resumed = false
+        func tryResume() -> Bool {
+            if resumed { return false }
+            resumed = true
+            return true
+        }
+    }
+
     @objc public func unlockPostProcessing() {
         self.locked = false
         NotificationCenter.default.post(name: Notification.Name(rawValue: kSFBiometricAuthenticationFlowCompleted), object: nil)

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
@@ -262,29 +262,39 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
                         SFSDKWindowManager.shared().authWindow(scene).viewController?.dismiss(animated: false)
                     }
                 } catch {
-                    // User declined biometric. Stay locked, but resume the browser (Advanced Auth)
-                    // attempt lock() suppressed rather than strand them on the picker. Resuming the
-                    // same suppressed session keeps its covering window up (no app exposure) and
-                    // preserves lock()'s completion. ASWebAuthenticationSession.start() only presents
-                    // from a .foregroundActive scene, so wait for the Face ID sheet's dismissal to
-                    // reactivate the scene first.
-                    await waitForSceneActive(scene)
-                    UserAccountManager.shared.resumeBrowserAuthentication(scene)
+                    await handleBiometricCancellation(scene)
                 }
             }
         }
     }
-    
+
+    /// Handles the user declining/failing biometric. Stays locked, but resumes the browser (Advanced
+    /// Auth) attempt lock() suppressed rather than stranding them on the picker. Resuming the same
+    /// suppressed session keeps its covering window up (no app exposure) and preserves lock()'s
+    /// completion. ASWebAuthenticationSession.start() only presents from a .foregroundActive scene,
+    /// so wait for the Face ID sheet's dismissal to reactivate the scene first.
+    internal func handleBiometricCancellation(_ scene: UIScene) async {
+        await waitForSceneActive(scene)
+        UserAccountManager.shared.resumeBrowserAuthentication(scene)
+    }
+
     /// Awaits the scene returning to `.foregroundActive`. Dismissing the Face ID sheet leaves the
     /// scene `.foregroundInactive` for a beat, and `ASWebAuthenticationSession.start()` silently
     /// fails from a non-active scene. Resolves immediately if already active, otherwise on this
     /// scene's next `UIScene.didActivateNotification`, with a bounded fallback.
     @MainActor
-    private func waitForSceneActive(_ scene: UIScene) async {
+    internal func waitForSceneActive(_ scene: UIScene) async {
         if scene.activationState == .foregroundActive {
             return
         }
+        await awaitSceneActivation(scene)
+    }
 
+    /// Suspends until `scene` posts its next activation notification (or the bounded fallback fires).
+    /// Split out from `waitForSceneActive(_:)` so it can be exercised independently of the caller's
+    /// early-return-when-already-active guard.
+    @MainActor
+    internal func awaitSceneActivation(_ scene: UIScene) async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             let center = NotificationCenter.default
             var observer: NSObjectProtocol?
@@ -313,7 +323,7 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
     }
 
     /// One-shot latch so the observer and the timeout fallback resume the continuation exactly once.
-    private final class ResumeGuard {
+    internal final class ResumeGuard {
         private var resumed = false
         func tryResume() -> Bool {
             if resumed { return false }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
@@ -54,12 +54,46 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
     private let kBioAuthPolicyIdentifier = "com.salesforce.security.bioauthpolicy"
     private let kBioAuthEnabledIdentifier = "com.salesforce.security.bioauth"
 
-    /// One-shot flag telling `willBeginBrowserAuthentication:` to suppress the browser launch that
-    /// `lock()`'s `login()` triggers, so it doesn't race the biometric prompt. The gate clears it
-    /// on its next check, so a later attempt (fallback picker, gear-menu retry) is not suppressed.
-    /// Read/written from SFUserAccountManager.m, hence `@objc`.
-    @objc internal var suppressInitialBrowserAuthentication = false
-    
+    /// Scene identifiers whose initial browser launch — the one `lock()`'s `login()` triggers for
+    /// that scene — must be suppressed so it doesn't race the biometric prompt. Scoped **per scene**
+    /// because `login()` fans out to every connected scene and each reaches
+    /// `willBeginBrowserAuthentication:` independently: a single global flag would be consumed by
+    /// the first scene and let the rest launch `ASWebAuthenticationSession` while still locked. The
+    /// gate consumes (removes) a scene's id on its next check, so a later attempt on that scene
+    /// (fallback picker, gear-menu retry) is not suppressed. Mutated from SFUserAccountManager.m
+    /// via the `@objc` arm/consume/disarm methods below.
+    private var suppressedBrowserAuthSceneIds = Set<String>()
+
+    /// Arms initial-browser-launch suppression for `sceneId`. Called by `lock()` for each connected
+    /// scene before it triggers `login()`.
+    @objc internal func armBrowserAuthenticationSuppression(forSceneId sceneId: String) {
+        suppressedBrowserAuthSceneIds.insert(sceneId)
+    }
+
+    /// Consumes (clears) suppression for `sceneId`, returning whether it was armed. The gate calls
+    /// this once per browser attempt so suppression is one-shot per scene and one scene's consume
+    /// can't drain another's.
+    @objc internal func consumeBrowserAuthenticationSuppression(forSceneId sceneId: String) -> Bool {
+        return suppressedBrowserAuthSceneIds.remove(sceneId) != nil
+    }
+
+    /// Clears suppression for `sceneId` without the consume return value — used when
+    /// `presentBiometric(scene:)` finds biometric unavailable and must let the browser gate proceed.
+    @objc internal func disarmBrowserAuthenticationSuppression(forSceneId sceneId: String) {
+        suppressedBrowserAuthSceneIds.remove(sceneId)
+    }
+
+    /// Whether `sceneId`'s initial browser launch is currently armed for suppression. Test/read-only
+    /// accessor; does not consume.
+    @objc internal func isBrowserAuthenticationSuppressed(forSceneId sceneId: String) -> Bool {
+        return suppressedBrowserAuthSceneIds.contains(sceneId)
+    }
+
+    /// Clears all armed scene suppression. Used to reset state between tests.
+    @objc internal func clearAllBrowserAuthenticationSuppression() {
+        suppressedBrowserAuthSceneIds.removeAll()
+    }
+
     private override init() {
         super.init()
         NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) { [weak self] _ in
@@ -73,8 +107,8 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
     /// Locks the screen if necessary
     @objc public func handleAppForeground() {
         // Skip if already locked: shouldLock() ignores `locked`, so a foreground while locked would
-        // call lock() again and re-arm suppressInitialBrowserAuthentication, wrongly suppressing a
-        // browser-auth attempt that already cleared it.
+        // call lock() again and re-arm scene suppression, wrongly suppressing a browser-auth
+        // attempt that already cleared it.
         if !locked && shouldLock() {
             lock()
         }
@@ -146,9 +180,15 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
         locked = true
         NotificationCenter.default.post(name: Notification.Name(rawValue: kSFBiometricAuthenticationFlowWillBegin), object: nil)
 
-        // Suppress the browser launch from the login() below when biometric will be shown, so it
-        // doesn't race the prompt. The gate in SFUserAccountManager clears this on its next check.
-        suppressInitialBrowserAuthentication = showNativeLoginButton()
+        // Suppress the initial browser launch from the login() below when biometric will be shown,
+        // so it doesn't race the prompt. login() fans out to every connected scene, so arm
+        // suppression per scene — each scene reaches the gate in SFUserAccountManager independently
+        // and consumes only its own scene's flag on its next check.
+        if showNativeLoginButton() {
+            SFApplicationHelper.sharedApplication()?.connectedScenes.forEach() { scene in
+                armBrowserAuthenticationSuppression(forSceneId: scene.session.persistentIdentifier)
+            }
+        }
 
         // Open the Login Screen
         _ = UserAccountManager.shared.login { result in
@@ -245,10 +285,10 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
     @objc public func presentBiometric(scene: UIScene) {
         guard biometricAvailable() else {
             // Biometric is unavailable (e.g. hardware busy or enrollment removed since lock()
-            // checked). Disarm suppression so the browser-auth gate lets Advanced Auth /
-            // username-password proceed normally instead of stranding the user behind a
+            // checked). Disarm suppression for this scene so the browser-auth gate lets Advanced
+            // Auth / username-password proceed normally instead of stranding the user behind a
             // suppressed browser with no prompt.
-            suppressInitialBrowserAuthentication = false
+            disarmBrowserAuthenticationSuppression(forSceneId: scene.session.persistentIdentifier)
             return
         }
         let laContext = LAContext()

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
@@ -201,11 +201,10 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
     }
     
     @objc public func showNativeLoginButton() -> Bool {
-        var error: NSError?
-        if (!laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)) {
+        if (!biometricAvailable()) {
             return false
         }
-        
+
         if let policy = readBioAuhPolicy() {
             if (policy.hasPolicy && locked && hasBiometricOptedIn()) {
                 // true if not specified
@@ -233,37 +232,51 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
         
         return false
     }
-    
+
+    /// Whether biometric authentication can currently be evaluated on this device. Both the
+    /// suppress-the-browser decision (`showNativeLoginButton()` via `lock()`) and the actual prompt
+    /// (`presentBiometric(scene:)`) consult this so they can't disagree: if biometric is unavailable
+    /// the browser is never suppressed and Advanced Auth / username-password proceeds normally.
+    @objc internal func biometricAvailable() -> Bool {
+        var error: NSError?
+        return laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+    }
+
     @objc public func presentBiometric(scene: UIScene) {
+        guard biometricAvailable() else {
+            // Biometric is unavailable (e.g. hardware busy or enrollment removed since lock()
+            // checked). Disarm suppression so the browser-auth gate lets Advanced Auth /
+            // username-password proceed normally instead of stranding the user behind a
+            // suppressed browser with no prompt.
+            suppressInitialBrowserAuthentication = false
+            return
+        }
         let laContext = LAContext()
         laContext.localizedCancelTitle = SFSDKResourceUtils.localizedString("usePassword")
-        var error: NSError?
-        if (laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)) {
-            Task {
-                do {
-                    try await laContext.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: SFSDKResourceUtils.localizedString("biometricReason"))
-                    
-                    // Refresh token and unlock
-                    let accountManager = UserAccountManager.shared
-                    if let currentAccount = accountManager.currentUserAccount {
-                        _ = accountManager.refresh(credentials: currentAccount.credentials, { (result) in
-                            switch(result) {
-                            case .success((_, _)):
-                                SFSDKCoreLogger.d(BiometricAuthenticationManagerInternal.self, message: "Refresh credentials succeeded")
-                            case .failure(let error):
-                                SFSDKCoreLogger.d(BiometricAuthenticationManagerInternal.self, message: "Refresh credentials failed: \(error)")
-                            }
-                        })
-                    }
-                    
-                    unlockPostProcessing()
-                    await accountManager.stopCurrentAuthentication()
-                    await MainActor.run {
-                        SFSDKWindowManager.shared().authWindow(scene).viewController?.dismiss(animated: false)
-                    }
-                } catch {
-                    await handleBiometricCancellation(scene)
+        Task {
+            do {
+                try await laContext.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, localizedReason: SFSDKResourceUtils.localizedString("biometricReason"))
+
+                // Refresh token and unlock
+                let accountManager = UserAccountManager.shared
+                if let currentAccount = accountManager.currentUserAccount {
+                    _ = accountManager.refresh(credentials: currentAccount.credentials, { (result) in
+                        switch(result) {
+                        case .success((_, _)):
+                            SFSDKCoreLogger.d(BiometricAuthenticationManagerInternal.self, message: "Refresh credentials succeeded")
+                        case .failure(let error):
+                            SFSDKCoreLogger.d(BiometricAuthenticationManagerInternal.self, message: "Refresh credentials failed: \(error)")
+                        }
+                    })
                 }
+
+                unlockPostProcessing()
+                await accountManager.stopCurrentAuthentication()
+                await MainActor.run {
+                    SFSDKWindowManager.shared().authWindow(scene).viewController?.dismiss(animated: false)
+                }
+            } catch {
+                await handleBiometricCancellation(scene)
             }
         }
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -549,6 +549,13 @@ Use this method to stop/clear any authentication which is has already been start
 - (void)stopCurrentAuthentication:(nullable void (^)(BOOL))completionBlock;
 
 /**
+ SDK-internal. Resumes the browser (Advanced Auth) attempt that was suppressed while the biometric
+ prompt was shown, used when the user declines biometric. Not intended for SDK consumers.
+ @param scene The scene whose suppressed browser-auth attempt should be resumed.
+ */
+- (void)resumeBrowserAuthentication:(UIScene *)scene;
+
+/**
  Forces a logout from the current account, redirecting the user to the login process.
  This throws out the OAuth refresh token.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -454,6 +454,26 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     return YES;
 }
 
+// Fires the held browser-launch callback of the attempt that willBeginBrowserAuthentication:
+// suppressed for the biometric prompt, resuming Advanced Auth on the same session without tearing
+// down the covering auth window. Falls back to a fresh login if the callback is gone.
+- (void)resumeBrowserAuthentication:(UIScene *)scene {
+    if (![NSThread isMainThread]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self resumeBrowserAuthentication:scene];
+        });
+        return;
+    }
+    SFSDKAuthSession *authSession = self.authSessions[scene.session.persistentIdentifier];
+    void (^browserBlock)(BOOL) = authSession.authCoordinatorBrowserBlock;
+    if (browserBlock) {
+        browserBlock(YES);
+    } else {
+        [self stopCurrentAuthentication:nil];
+        [self loginWithCompletion:^(SFOAuthInfo *authInfo, SFUserAccount *user) { } failure:^(SFOAuthInfo *authInfo, NSError *error) { }];
+    }
+}
+
 - (void)stopCurrentAuthentication:(void (^)(BOOL))completionBlock {
     if (![NSThread isMainThread]) {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -900,7 +920,39 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator willBeginBrowserAuthentication:(SFOAuthBrowserFlowCallbackBlock)callbackBlock {
     coordinator.authSession.authCoordinatorBrowserBlock = callbackBlock;
-    callbackBlock(YES);
+    SFBiometricAuthenticationManagerInternal *bioAuthManager = [SFBiometricAuthenticationManagerInternal shared];
+    // One-shot flag armed by -lock: for the browser attempt it triggers. Consume it unconditionally
+    // so being locked never suppresses a later attempt (fallback picker, gear-menu retry).
+    BOOL suppress = bioAuthManager.suppressInitialBrowserAuthentication;
+    bioAuthManager.suppressInitialBrowserAuthentication = NO;
+    if (suppress) {
+        // Biometric is locked: suppress the browser and show the picker as the fallback landing
+        // screen behind the biometric prompt -lock: already presented.
+        callbackBlock(NO);
+        [self presentLoginHostListViewControllerForBiometricFallback:coordinator.authSession];
+    } else {
+        callbackBlock(YES);
+    }
+}
+
+// Presents the login-host picker as the fallback landing screen when Advanced Auth is suppressed
+// for a biometric-locked user, mirroring oauthCoordinatorDidCancelBrowserAuthentication:'s picker
+// presentation. Driven explicitly since callbackBlock(NO) triggers no cancel delegate.
+- (void)presentLoginHostListViewControllerForBiometricFallback:(SFSDKAuthSession *)authSession {
+    if (self.authCancelledByUserHandlerBlock) {
+        self.authCancelledByUserHandlerBlock();
+        return;
+    }
+    SFSDKLoginHostListViewController *hostListViewController = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
+    hostListViewController.delegate = self;
+    SFSDKNavigationController *controller = [[SFSDKNavigationController alloc] initWithRootViewController:hostListViewController];
+    hostListViewController.hidesCancelButton = YES;
+    hostListViewController.presentedAsLoginScreen = YES;
+    controller.modalPresentationStyle = UIModalPresentationFullScreen;
+    UIScene *scene = authSession.oauthRequest.scene;
+    [[[SFSDKWindowManager sharedManager] authWindow:scene] presentWindowAnimated:NO withCompletion:^{
+        [[[SFSDKWindowManager sharedManager] authWindow:scene].viewController presentViewController:controller animated:NO completion:nil];
+    }];
 }
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator displayAlertMessage:(NSString*)message completion:(dispatch_block_t)completion {
@@ -2647,10 +2699,17 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
  }
 
 - (BOOL)isAlreadyPresentingLoginController:(UIViewController*)presentedViewController {
-    return (presentedViewController
-            && !presentedViewController.beingDismissed
-            && [presentedViewController isKindOfClass:[SFSDKNavigationController class]]
-            && [((SFSDKNavigationController*) presentedViewController).topViewController isKindOfClass:[SFLoginViewController class]]);
+    if (!presentedViewController
+        || presentedViewController.beingDismissed
+        || ![presentedViewController isKindOfClass:[SFSDKNavigationController class]]) {
+        return NO;
+    }
+    UIViewController *topViewController = ((SFSDKNavigationController*) presentedViewController).topViewController;
+    // Also match the login-host picker shown as the biometric fallback: when the user declines
+    // Face ID, the Advanced Auth retry must dismiss it before presenting the browser, else the
+    // browser never becomes visible and the user is stranded on the picker.
+    return ([topViewController isKindOfClass:[SFLoginViewController class]]
+            || [topViewController isKindOfClass:[SFSDKLoginHostListViewController class]]);
 }
 
 - (SFLoginViewController *)createLoginViewControllerInstance:(SFOAuthCoordinator *)coordinator {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -921,10 +921,11 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator willBeginBrowserAuthentication:(SFOAuthBrowserFlowCallbackBlock)callbackBlock {
     coordinator.authSession.authCoordinatorBrowserBlock = callbackBlock;
     SFBiometricAuthenticationManagerInternal *bioAuthManager = [SFBiometricAuthenticationManagerInternal shared];
-    // One-shot flag armed by -lock: for the browser attempt it triggers. Consume it unconditionally
-    // so being locked never suppresses a later attempt (fallback picker, gear-menu retry).
-    BOOL suppress = bioAuthManager.suppressInitialBrowserAuthentication;
-    bioAuthManager.suppressInitialBrowserAuthentication = NO;
+    // Per-scene one-shot suppression armed by -lock: for the browser attempt it triggers on this
+    // scene. Consume only this scene's flag so being locked never suppresses a later attempt
+    // (fallback picker, gear-menu retry) and one scene's consume can't drain another's — login()
+    // fans out to every connected scene and each reaches this gate independently.
+    BOOL suppress = [bioAuthManager consumeBrowserAuthenticationSuppressionForSceneId:coordinator.authSession.sceneId];
     if (suppress) {
         // Biometric is locked: suppress the browser and show the picker as the fallback landing
         // screen behind the biometric prompt -lock: already presented.

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BiometricAdvancedAuthGateTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BiometricAdvancedAuthGateTests.swift
@@ -1,0 +1,251 @@
+/*
+ Copyright (c) 2026-present, salesforce.com, inc. All rights reserved.
+
+ Redistribution and use of this software in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions
+ and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of
+ conditions and the following disclaimer in the documentation and/or other materials provided
+ with the distribution.
+ * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+ endorse or promote products derived from this software without specific prior written
+ permission of salesforce.com, inc.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+ IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import XCTest
+import LocalAuthentication
+@testable import SalesforceSDKCore
+
+// MARK: - Biometric + Advanced Auth Gate Tests
+//
+// Covers SFUserAccountManager's `oauthCoordinator:willBeginBrowserAuthentication:` gate together
+// with BiometricAuthenticationManagerInternal.suppressInitialBrowserAuthentication, the one-shot
+// flag `lock()` arms right before it triggers the very browser-auth attempt that would otherwise
+// race the biometric prompt `lock()` also presents. The gate consumes (clears) that flag on its
+// very next check, win or lose -- being locked must never again suppress a later attempt (e.g. a
+// server picked from the fallback picker, or a retry from the login-options gear menu). This
+// intentionally does NOT re-derive the decision from `locked`/`showNativeLoginButton()` on every
+// call, unlike the superseded implementation this file used to pin.
+
+class BiometricAdvancedAuthGateTests: XCTestCase {
+
+    let bioAuthManager = BiometricAuthenticationManagerInternal.shared
+    private var originalAuthCancelledByUserHandlerBlock: (() -> Void)?
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        _ = KeychainHelper.removeAll()
+        bioAuthManager.locked = false
+        bioAuthManager.automaticPresentation = true
+        bioAuthManager.suppressInitialBrowserAuthentication = false
+        originalAuthCancelledByUserHandlerBlock = UserAccountManager.shared.authCancelledByUserHandlerBlock
+        // The gate's biometric-fallback branch presents a host-list screen unless a handler
+        // block is installed; force the nil/default path so the fallback UI is deterministic.
+        UserAccountManager.shared.authCancelledByUserHandlerBlock = nil
+    }
+
+    override func tearDownWithError() throws {
+        bioAuthManager.locked = false
+        bioAuthManager.automaticPresentation = true
+        bioAuthManager.suppressInitialBrowserAuthentication = false
+        UserAccountManager.shared.authCancelledByUserHandlerBlock = originalAuthCancelledByUserHandlerBlock
+        _ = KeychainHelper.removeAll()
+        UserAccountManager.shared.clearAllAccountState()
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Tests
+
+    func test_willBeginBrowserAuth_whenSuppressionArmed_returnsNoAndPresentsBiometric() throws {
+        let uam = UserAccountManager.shared
+        let user = createUser(index: 0)
+        bioAuthManager.storePolicy(userAccount: user, hasMobilePolicy: true, sessionTimeout: 15)
+        bioAuthManager.biometricOptIn(optIn: true)
+        bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
+        bioAuthManager.locked = true
+        // Mirrors what lock() does: capture the suppression decision once, ahead of the browser
+        // launch it's about to trigger, rather than the gate re-deriving it from `locked`.
+        bioAuthManager.suppressInitialBrowserAuthentication = true
+
+        let session = makeAuthSession(uam: uam)
+        var capturedProceed: Bool?
+        let expectation = expectation(description: "willBeginBrowserAuthentication callback invoked")
+
+        uam.oauthCoordinator(session.oauthCoordinator, willBeginBrowserAuthentication: { proceed in
+            capturedProceed = proceed
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 2.0)
+        XCTAssertEqual(capturedProceed, false, "Callback must be invoked with NO to suppress the native browser launch when the one-shot flag is armed")
+        XCTAssertNil(session.oauthCoordinator.asWebAuthenticationSession, "No ASWebAuthenticationSession should be allocated when the browser launch is suppressed")
+        XCTAssertFalse(bioAuthManager.suppressInitialBrowserAuthentication, "The gate must consume (clear) the one-shot flag on this check, regardless of outcome")
+
+        // Clean up the host-list fallback screen the gate presents on the auth window.
+        dismissPresentedAuthWindow(uam: uam)
+        removeSession(session, from: uam)
+    }
+
+    func test_willBeginBrowserAuth_whenSuppressionNotArmed_returnsYesEvenWhileLocked() throws {
+        // This is the regression case: a picker-driven re-selection (or any
+        // browser-auth attempt other than the one lock() itself triggered) must launch Advanced
+        // Auth normally while still locked -- `locked` alone must never suppress it again.
+        let uam = UserAccountManager.shared
+        let user = createUser(index: 0)
+        bioAuthManager.storePolicy(userAccount: user, hasMobilePolicy: true, sessionTimeout: 15)
+        bioAuthManager.biometricOptIn(optIn: true)
+        bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
+        bioAuthManager.locked = true
+        XCTAssertTrue(bioAuthManager.showNativeLoginButton(), "Test precondition: this scenario is exercising the case where showNativeLoginButton() would be true, yet the gate must still proceed because the one-shot flag was already consumed")
+        bioAuthManager.suppressInitialBrowserAuthentication = false
+
+        let session = makeAuthSession(uam: uam)
+        var capturedProceed: Bool?
+        let expectation = expectation(description: "willBeginBrowserAuthentication callback invoked")
+
+        uam.oauthCoordinator(session.oauthCoordinator, willBeginBrowserAuthentication: { proceed in
+            capturedProceed = proceed
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 2.0)
+        XCTAssertEqual(capturedProceed, true, "Callback must be invoked with YES once the one-shot flag has already been consumed, even while still locked")
+
+        removeSession(session, from: uam)
+    }
+
+    func test_willBeginBrowserAuth_whenNotLocked_returnsYes() throws {
+        let uam = UserAccountManager.shared
+        let user = createUser(index: 0)
+        bioAuthManager.storePolicy(userAccount: user, hasMobilePolicy: true, sessionTimeout: 15)
+        bioAuthManager.biometricOptIn(optIn: true)
+        bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
+        bioAuthManager.locked = false
+        bioAuthManager.suppressInitialBrowserAuthentication = false
+
+        let session = makeAuthSession(uam: uam)
+        var capturedProceed: Bool?
+        let expectation = expectation(description: "willBeginBrowserAuthentication callback invoked")
+
+        uam.oauthCoordinator(session.oauthCoordinator, willBeginBrowserAuthentication: { proceed in
+            capturedProceed = proceed
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 2.0)
+        XCTAssertEqual(capturedProceed, true, "Callback must be invoked with YES for the regression (unlocked) case")
+
+        removeSession(session, from: uam)
+    }
+
+    func test_lock_armsSuppressionFlagFromShowNativeLoginButtonAtCallTime() throws {
+        // lock() must capture the suppression decision once, at the moment it's about to trigger
+        // login() -- not leave it to be re-derived later from the (by-then-stale) `locked` state.
+        let user = createUser(index: 0)
+        bioAuthManager.storePolicy(userAccount: user, hasMobilePolicy: true, sessionTimeout: 15)
+        bioAuthManager.biometricOptIn(optIn: true)
+        bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
+        bioAuthManager.automaticPresentation = false
+        bioAuthManager.locked = false
+
+        bioAuthManager.lock()
+
+        XCTAssertTrue(bioAuthManager.locked, "lock() must set locked = true")
+        XCTAssertTrue(bioAuthManager.suppressInitialBrowserAuthentication, "lock() must arm the one-shot suppression flag when showNativeLoginButton() was true at call time")
+
+        UserAccountManager.shared.stopCurrentAuthentication(nil)
+    }
+
+    func test_handleAppForeground_whenAlreadyLocked_doesNotRearmSuppressionFlag() throws {
+        // Mirrors the guard already added to Android's AppLockManager.onAppForegrounded() for this
+        // same bug: shouldLock() derives purely from a timeout elapsed since
+        // backgroundTimestamp, without consulting `locked` -- so any foreground notification while
+        // already locked (the OS backgrounding the app behind the Face ID sheet, or momentarily
+        // losing/regaining foreground during presentBiometric's catch-block retry) calls lock()
+        // again. That second lock() re-arms suppressInitialBrowserAuthentication, wrongly
+        // suppressing the very retry that just cleared it -- reproducing the reported symptom
+        // where cancelling Face ID or tapping "Use Password" lands on the fallback picker instead
+        // of launching Advanced Auth.
+        let user = createUser(index: 0)
+        bioAuthManager.storePolicy(userAccount: user, hasMobilePolicy: true, sessionTimeout: 15)
+        bioAuthManager.biometricOptIn(optIn: true)
+        bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
+        bioAuthManager.automaticPresentation = false
+        bioAuthManager.locked = true
+        bioAuthManager.suppressInitialBrowserAuthentication = false
+
+        bioAuthManager.handleAppForeground()
+
+        XCTAssertFalse(bioAuthManager.suppressInitialBrowserAuthentication, "handleAppForeground() must not call lock() again while already locked, which would re-arm the one-shot suppression flag and strand a subsequent browser-auth attempt")
+
+        UserAccountManager.shared.stopCurrentAuthentication(nil)
+    }
+
+    // MARK: - Helpers
+
+    private func createUser(index: Int) -> UserAccount {
+        let credentials = OAuthCredentials(identifier: "gate-identifier-\(index)", clientId: "fakeClientIdForTesting", encrypted: true)!
+        let user = UserAccount(credentials: credentials)
+        user.idData = IdentityData(jsonDict: ["user_id": "\(index)"])
+        UserAccountManager.shared.currentUserAccount = user
+        return user
+    }
+
+    private func makeAuthRequest() -> SFSDKAuthRequest {
+        let request = SFSDKAuthRequest()
+        request.oauthClientId = "testClientId"
+        request.oauthCompletionUrl = "test://callback"
+        request.loginHost = "test.salesforce.com"
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            request.scene = windowScene
+        }
+        return request
+    }
+
+    /// Builds an SFSDKAuthSession with its coordinator delegate set to UserAccountManager.shared
+    /// and registered in `authSessions`, mirroring LoginForAdminTests' pattern for directly
+    /// invoking SFOAuthCoordinatorDelegate methods without running the full authenticate() flow.
+    private func makeAuthSession(uam: UserAccountManager) -> SFSDKAuthSession {
+        let request = makeAuthRequest()
+        let session = SFSDKAuthSession(request, credentials: nil)
+        session.oauthCoordinator.delegate = uam
+        uam.authSessions[session.sceneId as NSString] = session
+        return session
+    }
+
+    private func removeSession(_ session: SFSDKAuthSession, from uam: UserAccountManager) {
+        uam.authSessions.removeObject(session.sceneId as NSString)
+    }
+
+    /// The gate's biometric-fallback branch presents a host-list screen on the auth window
+    /// (mirroring oauthCoordinatorDidCancelBrowserAuthentication:'s existing fallback UI); tear
+    /// it down so it doesn't leak into subsequent tests.
+    private func dismissPresentedAuthWindow(uam: UserAccountManager) {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+        let authWindow = SFSDKWindowManager.shared().authWindow(windowScene)
+        authWindow.viewController?.dismiss(animated: false, completion: nil)
+        authWindow.dismissWindow()
+    }
+
+    private class StubbedLAContext: LAContext {
+        let canEvaluate: Bool
+
+        init(canEvaluate: Bool) {
+            self.canEvaluate = canEvaluate
+        }
+
+        override func canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool {
+            return canEvaluate
+        }
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BiometricAdvancedAuthGateTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BiometricAdvancedAuthGateTests.swift
@@ -335,6 +335,38 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         XCTAssertFalse(guardLatch.tryResume(), "Subsequent tryResume() calls must keep failing")
     }
 
+    // MARK: - Capability-availability tests
+    //
+    // showNativeLoginButton() (which lock() uses to arm suppression) and presentBiometric(scene:)
+    // (which shows the prompt) must consult the same capability signal so they can't disagree. If
+    // biometric became unavailable between the two, presentBiometric must disarm suppression so the
+    // browser-auth gate falls back to Advanced Auth / username-password instead of stranding the
+    // user behind a suppressed browser with no prompt.
+
+    func test_biometricAvailable_reflectsLAContextCapability() throws {
+        bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
+        XCTAssertTrue(bioAuthManager.biometricAvailable(), "biometricAvailable() must be true when the LAContext can evaluate the policy")
+
+        bioAuthManager.laContext = StubbedLAContext(canEvaluate: false)
+        XCTAssertFalse(bioAuthManager.biometricAvailable(), "biometricAvailable() must be false when the LAContext cannot evaluate the policy")
+    }
+
+    func test_presentBiometric_whenBiometricUnavailable_disarmsSuppressionForBrowserFallback() throws {
+        guard let scene = activeWindowScene() else {
+            throw XCTSkip("No active UIWindowScene in the test host")
+        }
+        // Simulate the capability race: lock() armed suppression, but biometric is no longer
+        // available by the time presentBiometric runs.
+        bioAuthManager.locked = true
+        bioAuthManager.suppressInitialBrowserAuthentication = true
+        bioAuthManager.laContext = StubbedLAContext(canEvaluate: false)
+
+        bioAuthManager.presentBiometric(scene: scene)
+
+        XCTAssertFalse(bioAuthManager.suppressInitialBrowserAuthentication,
+                       "presentBiometric must disarm suppression when biometric is unavailable so the browser-auth gate proceeds normally")
+    }
+
     // MARK: - Helpers
 
     private func activeWindowScene() -> UIWindowScene? {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BiometricAdvancedAuthGateTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BiometricAdvancedAuthGateTests.swift
@@ -29,13 +29,16 @@ import LocalAuthentication
 // MARK: - Biometric + Advanced Auth Gate Tests
 //
 // Covers SFUserAccountManager's `oauthCoordinator:willBeginBrowserAuthentication:` gate together
-// with BiometricAuthenticationManagerInternal.suppressInitialBrowserAuthentication, the one-shot
-// flag `lock()` arms right before it triggers the very browser-auth attempt that would otherwise
-// race the biometric prompt `lock()` also presents. The gate consumes (clears) that flag on its
-// very next check, win or lose -- being locked must never again suppress a later attempt (e.g. a
-// server picked from the fallback picker, or a retry from the login-options gear menu). This
-// intentionally does NOT re-derive the decision from `locked`/`showNativeLoginButton()` on every
-// call, unlike the superseded implementation this file used to pin.
+// with BiometricAuthenticationManagerInternal's per-scene suppression set, armed by `lock()` right
+// before it triggers the very browser-auth attempt (per connected scene) that would otherwise race
+// the biometric prompt `lock()` also presents. Suppression is scoped **per scene** because
+// `login()` fans out to every connected scene and each reaches the gate independently: a single
+// global flag would be consumed by the first scene and let the rest launch a browser while still
+// locked. The gate consumes (clears) only that scene's id on its next check, win or lose -- being
+// locked must never again suppress a later attempt (e.g. a server picked from the fallback picker,
+// or a retry from the login-options gear menu), and one scene's consume must not drain another's.
+// This intentionally does NOT re-derive the decision from `locked`/`showNativeLoginButton()` on
+// every call, unlike the superseded implementation this file used to pin.
 
 class BiometricAdvancedAuthGateTests: XCTestCase {
 
@@ -47,7 +50,7 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         _ = KeychainHelper.removeAll()
         bioAuthManager.locked = false
         bioAuthManager.automaticPresentation = true
-        bioAuthManager.suppressInitialBrowserAuthentication = false
+        bioAuthManager.clearAllBrowserAuthenticationSuppression()
         originalAuthCancelledByUserHandlerBlock = UserAccountManager.shared.authCancelledByUserHandlerBlock
         // The gate's biometric-fallback branch presents a host-list screen unless a handler
         // block is installed; force the nil/default path so the fallback UI is deterministic.
@@ -57,7 +60,7 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
     override func tearDownWithError() throws {
         bioAuthManager.locked = false
         bioAuthManager.automaticPresentation = true
-        bioAuthManager.suppressInitialBrowserAuthentication = false
+        bioAuthManager.clearAllBrowserAuthenticationSuppression()
         UserAccountManager.shared.authCancelledByUserHandlerBlock = originalAuthCancelledByUserHandlerBlock
         _ = KeychainHelper.removeAll()
         UserAccountManager.shared.clearAllAccountState()
@@ -73,11 +76,11 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         bioAuthManager.biometricOptIn(optIn: true)
         bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
         bioAuthManager.locked = true
-        // Mirrors what lock() does: capture the suppression decision once, ahead of the browser
-        // launch it's about to trigger, rather than the gate re-deriving it from `locked`.
-        bioAuthManager.suppressInitialBrowserAuthentication = true
 
         let session = makeAuthSession(uam: uam)
+        // Mirrors what lock() does: arm suppression for this scene once, ahead of the browser
+        // launch it's about to trigger, rather than the gate re-deriving it from `locked`.
+        bioAuthManager.armBrowserAuthenticationSuppression(forSceneId: session.sceneId)
         var capturedProceed: Bool?
         let expectation = expectation(description: "willBeginBrowserAuthentication callback invoked")
 
@@ -87,9 +90,9 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         })
 
         wait(for: [expectation], timeout: 2.0)
-        XCTAssertEqual(capturedProceed, false, "Callback must be invoked with NO to suppress the native browser launch when the one-shot flag is armed")
+        XCTAssertEqual(capturedProceed, false, "Callback must be invoked with NO to suppress the native browser launch when this scene's suppression is armed")
         XCTAssertNil(session.oauthCoordinator.asWebAuthenticationSession, "No ASWebAuthenticationSession should be allocated when the browser launch is suppressed")
-        XCTAssertFalse(bioAuthManager.suppressInitialBrowserAuthentication, "The gate must consume (clear) the one-shot flag on this check, regardless of outcome")
+        XCTAssertFalse(bioAuthManager.isBrowserAuthenticationSuppressed(forSceneId: session.sceneId), "The gate must consume (clear) this scene's suppression on this check, regardless of outcome")
 
         // Clean up the host-list fallback screen the gate presents on the auth window.
         dismissPresentedAuthWindow(uam: uam)
@@ -106,10 +109,10 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         bioAuthManager.biometricOptIn(optIn: true)
         bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
         bioAuthManager.locked = true
-        XCTAssertTrue(bioAuthManager.showNativeLoginButton(), "Test precondition: this scenario is exercising the case where showNativeLoginButton() would be true, yet the gate must still proceed because the one-shot flag was already consumed")
-        bioAuthManager.suppressInitialBrowserAuthentication = false
+        XCTAssertTrue(bioAuthManager.showNativeLoginButton(), "Test precondition: this scenario is exercising the case where showNativeLoginButton() would be true, yet the gate must still proceed because this scene's suppression was already consumed")
 
         let session = makeAuthSession(uam: uam)
+        // This scene's suppression is intentionally not armed (setUp cleared all).
         var capturedProceed: Bool?
         let expectation = expectation(description: "willBeginBrowserAuthentication callback invoked")
 
@@ -119,7 +122,7 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         })
 
         wait(for: [expectation], timeout: 2.0)
-        XCTAssertEqual(capturedProceed, true, "Callback must be invoked with YES once the one-shot flag has already been consumed, even while still locked")
+        XCTAssertEqual(capturedProceed, true, "Callback must be invoked with YES once this scene's suppression has already been consumed, even while still locked")
 
         removeSession(session, from: uam)
     }
@@ -131,7 +134,6 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         bioAuthManager.biometricOptIn(optIn: true)
         bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
         bioAuthManager.locked = false
-        bioAuthManager.suppressInitialBrowserAuthentication = false
 
         let session = makeAuthSession(uam: uam)
         var capturedProceed: Bool?
@@ -148,9 +150,74 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         removeSession(session, from: uam)
     }
 
-    func test_lock_armsSuppressionFlagFromShowNativeLoginButtonAtCallTime() throws {
+    func test_willBeginBrowserAuth_twoScenes_eachSuppressedIndependently() throws {
+        // Regression for the multi-scene race: login() fans out to every connected scene, so each
+        // scene reaches this gate independently. With per-scene suppression, arming both scenes
+        // must suppress the browser on BOTH -- a single global one-shot would be consumed by the
+        // first scene and let the second launch ASWebAuthenticationSession while still locked.
+        let uam = UserAccountManager.shared
+        let user = createUser(index: 0)
+        bioAuthManager.storePolicy(userAccount: user, hasMobilePolicy: true, sessionTimeout: 15)
+        bioAuthManager.biometricOptIn(optIn: true)
+        bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
+        bioAuthManager.locked = true
+
+        let sessionA = makeUnscopedAuthSession(uam: uam)
+        let sessionB = makeUnscopedAuthSession(uam: uam)
+        XCTAssertNotEqual(sessionA.sceneId, sessionB.sceneId, "Test precondition: the two sessions must model distinct scenes")
+        bioAuthManager.armBrowserAuthenticationSuppression(forSceneId: sessionA.sceneId)
+        bioAuthManager.armBrowserAuthenticationSuppression(forSceneId: sessionB.sceneId)
+
+        var proceedA: Bool?
+        let gateA = expectation(description: "scene A gate callback invoked")
+        uam.oauthCoordinator(sessionA.oauthCoordinator, willBeginBrowserAuthentication: { proceed in
+            proceedA = proceed
+            gateA.fulfill()
+        })
+        wait(for: [gateA], timeout: 2.0)
+
+        var proceedB: Bool?
+        let gateB = expectation(description: "scene B gate callback invoked")
+        uam.oauthCoordinator(sessionB.oauthCoordinator, willBeginBrowserAuthentication: { proceed in
+            proceedB = proceed
+            gateB.fulfill()
+        })
+        wait(for: [gateB], timeout: 2.0)
+
+        XCTAssertEqual(proceedA, false, "Scene A's browser launch must be suppressed")
+        XCTAssertEqual(proceedB, false, "Scene B's browser launch must ALSO be suppressed -- scene A consuming its own flag must not drain scene B's")
+        XCTAssertNil(sessionA.oauthCoordinator.asWebAuthenticationSession, "No ASWebAuthenticationSession should be allocated for scene A")
+        XCTAssertNil(sessionB.oauthCoordinator.asWebAuthenticationSession, "No ASWebAuthenticationSession should be allocated for scene B")
+
+        // Both scenes' fallback pickers were presented on the auth window; tear them down.
+        dismissPresentedAuthWindow(uam: uam)
+        removeSession(sessionA, from: uam)
+        removeSession(sessionB, from: uam)
+    }
+
+    func test_consumeSuppression_isScopedPerScene() throws {
+        // Unit-level invariant behind the two-scene gate test: consuming one scene's suppression
+        // must not affect another scene's, and consume is one-shot per scene.
+        bioAuthManager.clearAllBrowserAuthenticationSuppression()
+        bioAuthManager.armBrowserAuthenticationSuppression(forSceneId: "sceneA")
+        bioAuthManager.armBrowserAuthenticationSuppression(forSceneId: "sceneB")
+
+        XCTAssertTrue(bioAuthManager.consumeBrowserAuthenticationSuppression(forSceneId: "sceneA"), "sceneA's armed suppression must be consumed as true")
+        XCTAssertFalse(bioAuthManager.isBrowserAuthenticationSuppressed(forSceneId: "sceneA"), "sceneA must be cleared after consume")
+        XCTAssertTrue(bioAuthManager.isBrowserAuthenticationSuppressed(forSceneId: "sceneB"), "sceneB must remain armed -- consuming sceneA must not drain it")
+
+        XCTAssertFalse(bioAuthManager.consumeBrowserAuthenticationSuppression(forSceneId: "sceneA"), "A second consume of sceneA must return false -- suppression is one-shot per scene")
+        XCTAssertTrue(bioAuthManager.consumeBrowserAuthenticationSuppression(forSceneId: "sceneB"), "sceneB must still consume as true independently")
+    }
+
+    func test_lock_armsSuppressionForConnectedScenesFromShowNativeLoginButtonAtCallTime() throws {
         // lock() must capture the suppression decision once, at the moment it's about to trigger
         // login() -- not leave it to be re-derived later from the (by-then-stale) `locked` state.
+        // It arms suppression per connected scene, since login() fans out over all of them.
+        guard let scene = activeWindowScene() else {
+            throw XCTSkip("No active UIWindowScene in the test host")
+        }
+        let sceneId = scene.session.persistentIdentifier
         let user = createUser(index: 0)
         bioAuthManager.storePolicy(userAccount: user, hasMobilePolicy: true, sessionTimeout: 15)
         bioAuthManager.biometricOptIn(optIn: true)
@@ -161,7 +228,7 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         bioAuthManager.lock()
 
         XCTAssertTrue(bioAuthManager.locked, "lock() must set locked = true")
-        XCTAssertTrue(bioAuthManager.suppressInitialBrowserAuthentication, "lock() must arm the one-shot suppression flag when showNativeLoginButton() was true at call time")
+        XCTAssertTrue(bioAuthManager.isBrowserAuthenticationSuppressed(forSceneId: sceneId), "lock() must arm suppression for the connected scene when showNativeLoginButton() was true at call time")
 
         UserAccountManager.shared.stopCurrentAuthentication(nil)
     }
@@ -172,21 +239,24 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         // backgroundTimestamp, without consulting `locked` -- so any foreground notification while
         // already locked (the OS backgrounding the app behind the Face ID sheet, or momentarily
         // losing/regaining foreground during presentBiometric's catch-block retry) calls lock()
-        // again. That second lock() re-arms suppressInitialBrowserAuthentication, wrongly
-        // suppressing the very retry that just cleared it -- reproducing the reported symptom
-        // where cancelling Face ID or tapping "Use Password" lands on the fallback picker instead
-        // of launching Advanced Auth.
+        // again. That second lock() re-arms scene suppression, wrongly suppressing the very retry
+        // that just cleared it -- reproducing the reported symptom where cancelling Face ID or
+        // tapping "Use Password" lands on the fallback picker instead of launching Advanced Auth.
+        guard let scene = activeWindowScene() else {
+            throw XCTSkip("No active UIWindowScene in the test host")
+        }
+        let sceneId = scene.session.persistentIdentifier
         let user = createUser(index: 0)
         bioAuthManager.storePolicy(userAccount: user, hasMobilePolicy: true, sessionTimeout: 15)
         bioAuthManager.biometricOptIn(optIn: true)
         bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
         bioAuthManager.automaticPresentation = false
         bioAuthManager.locked = true
-        bioAuthManager.suppressInitialBrowserAuthentication = false
+        bioAuthManager.clearAllBrowserAuthenticationSuppression()
 
         bioAuthManager.handleAppForeground()
 
-        XCTAssertFalse(bioAuthManager.suppressInitialBrowserAuthentication, "handleAppForeground() must not call lock() again while already locked, which would re-arm the one-shot suppression flag and strand a subsequent browser-auth attempt")
+        XCTAssertFalse(bioAuthManager.isBrowserAuthenticationSuppressed(forSceneId: sceneId), "handleAppForeground() must not call lock() again while already locked, which would re-arm scene suppression and strand a subsequent browser-auth attempt")
 
         UserAccountManager.shared.stopCurrentAuthentication(nil)
     }
@@ -202,12 +272,12 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         bioAuthManager.biometricOptIn(optIn: true)
         bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
         bioAuthManager.locked = true
-        bioAuthManager.suppressInitialBrowserAuthentication = true
 
         let handlerCalled = expectation(description: "authCancelledByUserHandlerBlock invoked")
         uam.authCancelledByUserHandlerBlock = { handlerCalled.fulfill() }
 
         let session = makeAuthSession(uam: uam)
+        bioAuthManager.armBrowserAuthenticationSuppression(forSceneId: session.sceneId)
         let gateReturned = expectation(description: "willBeginBrowserAuthentication callback invoked")
         var capturedProceed: Bool?
         uam.oauthCoordinator(session.oauthCoordinator, willBeginBrowserAuthentication: { proceed in
@@ -355,16 +425,17 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         guard let scene = activeWindowScene() else {
             throw XCTSkip("No active UIWindowScene in the test host")
         }
-        // Simulate the capability race: lock() armed suppression, but biometric is no longer
-        // available by the time presentBiometric runs.
+        // Simulate the capability race: lock() armed suppression for this scene, but biometric is
+        // no longer available by the time presentBiometric runs.
+        let sceneId = scene.session.persistentIdentifier
         bioAuthManager.locked = true
-        bioAuthManager.suppressInitialBrowserAuthentication = true
+        bioAuthManager.armBrowserAuthenticationSuppression(forSceneId: sceneId)
         bioAuthManager.laContext = StubbedLAContext(canEvaluate: false)
 
         bioAuthManager.presentBiometric(scene: scene)
 
-        XCTAssertFalse(bioAuthManager.suppressInitialBrowserAuthentication,
-                       "presentBiometric must disarm suppression when biometric is unavailable so the browser-auth gate proceeds normally")
+        XCTAssertFalse(bioAuthManager.isBrowserAuthenticationSuppressed(forSceneId: sceneId),
+                       "presentBiometric must disarm this scene's suppression when biometric is unavailable so the browser-auth gate proceeds normally")
     }
 
     // MARK: - Helpers
@@ -390,6 +461,20 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
             request.scene = windowScene
         }
         return request
+    }
+
+    /// Builds a session with no attached UIScene, so `SFSDKAuthSession` synthesizes a unique
+    /// per-session `sceneId`. Two such sessions model two independent connected scenes, letting the
+    /// multi-scene gate behavior be exercised without spinning up real additional UIScenes.
+    private func makeUnscopedAuthSession(uam: UserAccountManager) -> SFSDKAuthSession {
+        let request = SFSDKAuthRequest()
+        request.oauthClientId = "testClientId"
+        request.oauthCompletionUrl = "test://callback"
+        request.loginHost = "test.salesforce.com"
+        let session = SFSDKAuthSession(request, credentials: nil)
+        session.oauthCoordinator.delegate = uam
+        uam.authSessions[session.sceneId as NSString] = session
+        return session
     }
 
     /// Builds an SFSDKAuthSession with its coordinator delegate set to UserAccountManager.shared

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BiometricAdvancedAuthGateTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/BiometricAdvancedAuthGateTests.swift
@@ -191,7 +191,155 @@ class BiometricAdvancedAuthGateTests: XCTestCase {
         UserAccountManager.shared.stopCurrentAuthentication(nil)
     }
 
+    func test_willBeginBrowserAuth_whenSuppressedAndCancelHandlerSet_invokesHandlerInsteadOfPicker() throws {
+        // presentLoginHostListViewControllerForBiometricFallback: short-circuits to the app-provided
+        // authCancelledByUserHandlerBlock when one is installed, instead of presenting the built-in
+        // host-list picker. This is the handler-block branch (the nil-handler picker branch is
+        // covered by test_willBeginBrowserAuth_whenSuppressionArmed_...).
+        let uam = UserAccountManager.shared
+        let user = createUser(index: 0)
+        bioAuthManager.storePolicy(userAccount: user, hasMobilePolicy: true, sessionTimeout: 15)
+        bioAuthManager.biometricOptIn(optIn: true)
+        bioAuthManager.laContext = StubbedLAContext(canEvaluate: true)
+        bioAuthManager.locked = true
+        bioAuthManager.suppressInitialBrowserAuthentication = true
+
+        let handlerCalled = expectation(description: "authCancelledByUserHandlerBlock invoked")
+        uam.authCancelledByUserHandlerBlock = { handlerCalled.fulfill() }
+
+        let session = makeAuthSession(uam: uam)
+        let gateReturned = expectation(description: "willBeginBrowserAuthentication callback invoked")
+        var capturedProceed: Bool?
+        uam.oauthCoordinator(session.oauthCoordinator, willBeginBrowserAuthentication: { proceed in
+            capturedProceed = proceed
+            gateReturned.fulfill()
+        })
+
+        wait(for: [gateReturned, handlerCalled], timeout: 2.0)
+        XCTAssertEqual(capturedProceed, false, "Browser launch must still be suppressed when a cancel handler is installed")
+
+        removeSession(session, from: uam)
+    }
+
+    // MARK: - resumeBrowserAuthentication:
+
+    func test_resumeBrowserAuthentication_whenBrowserBlockHeld_firesItWithYes() throws {
+        // The no-teardown resume path: the suppressed attempt's held browser-launch callback is
+        // fired with YES to continue Advanced Auth on the SAME session, leaving its covering window
+        // in place.
+        guard let scene = activeWindowScene() else {
+            throw XCTSkip("No active UIWindowScene in the test host")
+        }
+        let uam = UserAccountManager.shared
+        let session = makeAuthSession(uam: uam)
+
+        let blockFired = expectation(description: "held browser block fired")
+        var capturedProceed: Bool?
+        session.authCoordinatorBrowserBlock = { proceed in
+            capturedProceed = proceed
+            blockFired.fulfill()
+        }
+
+        uam.resumeBrowserAuthentication(scene)
+
+        wait(for: [blockFired], timeout: 2.0)
+        XCTAssertEqual(capturedProceed, true, "resumeBrowserAuthentication: must fire the held callback with YES to resume the browser")
+
+        removeSession(session, from: uam)
+    }
+
+    func test_resumeBrowserAuthentication_whenNoBrowserBlock_tearsDownSuppressedSession() throws {
+        // Fallback path: with no held callback (e.g. the session was already torn down), the method
+        // stops the current authentication and restarts login rather than doing nothing. Verify the
+        // suppressed session is torn down via stopCurrentAuthentication.
+        guard let scene = activeWindowScene() else {
+            throw XCTSkip("No active UIWindowScene in the test host")
+        }
+        let uam = UserAccountManager.shared
+        let session = makeAuthSession(uam: uam)
+        session.isAuthenticating = true
+        session.authCoordinatorBrowserBlock = nil
+        let sceneId = session.sceneId as NSString
+
+        uam.resumeBrowserAuthentication(scene)
+
+        let stillSameSession = (uam.authSessions[sceneId] as AnyObject?) === session
+        XCTAssertFalse(stillSameSession, "The suppressed session must be torn down by stopCurrentAuthentication before login is restarted")
+
+        // login() may have started a fresh attempt / presented UI -- tear it all down.
+        uam.stopCurrentAuthentication(nil)
+        dismissPresentedAuthWindow(uam: uam)
+        removeSession(session, from: uam)
+    }
+
+    // MARK: - Biometric cancellation resume (Swift)
+
+    func test_handleBiometricCancellation_resumesHeldBrowserSession() throws {
+        // handleBiometricCancellation(_:) is the extracted body of presentBiometric's catch block
+        // (unreachable in CI because presentBiometric builds a real LAContext). It waits for the
+        // scene to reactivate, then resumes the suppressed browser session.
+        guard let scene = activeWindowScene() else {
+            throw XCTSkip("No active UIWindowScene in the test host")
+        }
+        let uam = UserAccountManager.shared
+        let session = makeAuthSession(uam: uam)
+
+        let blockFired = expectation(description: "held browser block fired via cancellation handler")
+        session.authCoordinatorBrowserBlock = { _ in blockFired.fulfill() }
+
+        Task { await bioAuthManager.handleBiometricCancellation(scene) }
+        // Unblock waitForSceneActive in case the test scene is not already active.
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: UIScene.didActivateNotification, object: scene)
+        }
+
+        wait(for: [blockFired], timeout: 5.0)
+        removeSession(session, from: uam)
+    }
+
+    func test_waitForSceneActive_returnsImmediatelyWhenAlreadyActive() throws {
+        guard let scene = activeWindowScene() else {
+            throw XCTSkip("No active UIWindowScene in the test host")
+        }
+        // The test host's scene is .foregroundActive, so this exercises the early-return guard.
+        XCTAssertEqual(scene.activationState, .foregroundActive, "Test precondition: host scene must be active")
+        let resolved = expectation(description: "waitForSceneActive resolved via early return")
+        Task { @MainActor in
+            await bioAuthManager.waitForSceneActive(scene)
+            resolved.fulfill()
+        }
+        wait(for: [resolved], timeout: 5.0)
+    }
+
+    func test_awaitSceneActivation_resolvesOnActivationNotification() throws {
+        guard let scene = activeWindowScene() else {
+            throw XCTSkip("No active UIWindowScene in the test host")
+        }
+        // Exercises the continuation/observer path directly (the caller's early-return guard would
+        // otherwise skip it, since the host scene is already active).
+        let resolved = expectation(description: "awaitSceneActivation resolved on activation")
+        Task { @MainActor in
+            await bioAuthManager.awaitSceneActivation(scene)
+            resolved.fulfill()
+        }
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: UIScene.didActivateNotification, object: scene)
+        }
+        wait(for: [resolved], timeout: 5.0)
+    }
+
+    func test_resumeGuard_permitsResumeExactlyOnce() throws {
+        let guardLatch = BiometricAuthenticationManagerInternal.ResumeGuard()
+        XCTAssertTrue(guardLatch.tryResume(), "First tryResume() must succeed")
+        XCTAssertFalse(guardLatch.tryResume(), "Second tryResume() must fail -- the latch is one-shot")
+        XCTAssertFalse(guardLatch.tryResume(), "Subsequent tryResume() calls must keep failing")
+    }
+
     // MARK: - Helpers
+
+    private func activeWindowScene() -> UIWindowScene? {
+        return UIApplication.shared.connectedScenes.first as? UIWindowScene
+    }
 
     private func createUser(index: Int) -> UserAccount {
         let credentials = OAuthCredentials(identifier: "gate-identifier-\(index)", clientId: "fakeClientIdForTesting", encrypted: true)!

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLoginHostTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLoginHostTests.m
@@ -27,6 +27,7 @@
  */
 
 #import <XCTest/XCTest.h>
+#import <objc/runtime.h>
 #import "SFLoginViewController.h"
 #import "SFSDKLoginHostListViewController.h"
 #import "SFSDKLoginHostStorage.h"
@@ -49,6 +50,8 @@
 - (void)backToPreviousHost:(id)sender;
 - (nullable UIBarButtonItem *)loginOptionsButton;
 - (void)delegateDidChangeLoginOptions;
+- (nullable UIBarButtonItem *)retryBiometricButton;
+- (void)presentBioAuthAction:(id)sender;
 @end
 
 // Spy delegate to observe the change-login-options callback.
@@ -61,6 +64,11 @@
     self.didChangeLoginOptionsCalled = YES;
 }
 @end
+
+// File-statics backing the swizzled replacements below (which run as if on
+// SFBiometricAuthenticationManagerInternal, not on the test case). Reset in setUp.
+static BOOL gShowNativeLoginButtonStubValue = NO;
+static NSUInteger gPresentBiometricWithSceneCallCount = 0;
 
 @interface SFSDKLoginHostTests : XCTestCase
 
@@ -80,9 +88,20 @@
 @property (nonatomic, copy, nullable) NSString *originalIdpAppURIScheme;
 @property (nonatomic, strong, nullable) SFUserAccount *originalCurrentUser;
 
+// Stand-in implementations swapped into SFBiometricAuthenticationManagerInternal for the
+// lifetime of an individual retry-button test. Mirrors the SFSDKLogoutBlocker /
+// SFUserAccountManagerLoginHostRecoveryTests swizzling pattern (see those files) so the retry
+// button and its action can be exercised deterministically without a mocking framework (this
+// test target has no OCMock or similar dependency).
+- (BOOL)dummy_showNativeLoginButton;
+- (void)dummy_presentBiometricWithScene:(UIScene *)scene;
+
 @end
 
-@implementation SFSDKLoginHostTests
+@implementation SFSDKLoginHostTests {
+    BOOL _showNativeLoginButtonSwapped;
+    BOOL _presentBiometricWithSceneSwapped;
+}
 
 - (void)setUp {
     [super setUp];
@@ -111,7 +130,47 @@
     [SFUserAccountManager sharedInstance].idpAppURIScheme = self.originalIdpAppURIScheme;
     [[SFUserAccountManager sharedInstance] setCurrentUserInternal:self.originalCurrentUser];
     [[SFUserAccountManager sharedInstance] stopCurrentAuthentication:nil];
+
+    // Guard against a test failing/throwing between swap-in and swap-back, which would otherwise
+    // leave the swizzle applied and corrupt every subsequent test in the suite.
+    if (_showNativeLoginButtonSwapped) {
+        [self swapShowNativeLoginButton];
+    }
+    if (_presentBiometricWithSceneSwapped) {
+        [self swapPresentBiometricWithScene];
+    }
+
     [super tearDown];
+}
+
+#pragma mark - Biometric Swizzle Helpers
+// This test target has no mocking framework (no OCMock or similar dependency), so the retry
+// button tests below drive SFBiometricAuthenticationManagerInternal's showNativeLoginButton and
+// presentBiometricWithScene: through the same method-swizzling pattern already used in this test
+// target (see SFSDKLogoutBlocker.m and SFUserAccountManagerLoginHostRecoveryTests.m).
+// method_exchangeImplementations is symmetric, so calling the same swap method a second time
+// restores the original implementation — each test that swaps must swap back before returning.
+
+- (void)swapShowNativeLoginButton {
+    Method original = class_getInstanceMethod([SFBiometricAuthenticationManagerInternal class], @selector(showNativeLoginButton));
+    Method replacement = class_getInstanceMethod([self class], @selector(dummy_showNativeLoginButton));
+    method_exchangeImplementations(original, replacement);
+    _showNativeLoginButtonSwapped = !_showNativeLoginButtonSwapped;
+}
+
+- (BOOL)dummy_showNativeLoginButton {
+    return gShowNativeLoginButtonStubValue;
+}
+
+- (void)swapPresentBiometricWithScene {
+    Method original = class_getInstanceMethod([SFBiometricAuthenticationManagerInternal class], @selector(presentBiometricWithScene:));
+    Method replacement = class_getInstanceMethod([self class], @selector(dummy_presentBiometricWithScene:));
+    method_exchangeImplementations(original, replacement);
+    _presentBiometricWithSceneSwapped = !_presentBiometricWithSceneSwapped;
+}
+
+- (void)dummy_presentBiometricWithScene:(UIScene *)scene {
+    gPresentBiometricWithSceneCallCount++;
 }
 
 #pragma clang diagnostic push
@@ -412,6 +471,90 @@
     vc.delegate = nil;
 
     XCTAssertNoThrow([vc delegateDidChangeLoginOptions], @"Should not throw when no delegate is set");
+}
+
+#pragma mark - Retry Biometric Button
+
+// retryBiometricButton is present when the host list is the standalone login screen and the app
+// is biometric-locked, opted-in, and biometric hardware is available (showNativeLoginButton()).
+- (void)test_givenPresentedAsLoginScreenAndShowNativeLoginButton_whenRetryBiometricButton_thenPresent {
+    gShowNativeLoginButtonStubValue = YES;
+    [self swapShowNativeLoginButton];
+
+    SFSDKLoginHostListViewController *vc = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
+    vc.presentedAsLoginScreen = YES;
+
+    UIBarButtonItem *retryButton = [vc retryBiometricButton];
+
+    XCTAssertNotNil(retryButton, @"Retry biometric button should be present when presented as the login screen and showNativeLoginButton() is true");
+    XCTAssertEqualObjects(retryButton.accessibilityIdentifier, @"retryBiometric", @"Retry biometric button should carry the 'retryBiometric' accessibility identifier");
+    XCTAssertEqual(retryButton.action, @selector(presentBioAuthAction:), @"Retry biometric button should target presentBioAuthAction:");
+
+    [self swapShowNativeLoginButton];
+}
+
+// retryBiometricButton is absent when the host list is not the standalone login screen, even if
+// showNativeLoginButton() would otherwise allow it (e.g. the transient "Choose Connection" sheet).
+- (void)test_givenNotPresentedAsLoginScreen_whenRetryBiometricButton_thenNil {
+    gShowNativeLoginButtonStubValue = YES;
+    [self swapShowNativeLoginButton];
+
+    SFSDKLoginHostListViewController *vc = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
+    vc.presentedAsLoginScreen = NO;
+
+    XCTAssertNil([vc retryBiometricButton], @"Retry biometric button should be nil when not presented as the login screen");
+
+    [self swapShowNativeLoginButton];
+}
+
+// retryBiometricButton is absent when showNativeLoginButton() is false (not locked / not opted-in
+// / biometric unavailable), even when presented as the standalone login screen.
+- (void)test_givenPresentedAsLoginScreenButNotShowNativeLoginButton_whenRetryBiometricButton_thenNil {
+    gShowNativeLoginButtonStubValue = NO;
+    [self swapShowNativeLoginButton];
+
+    SFSDKLoginHostListViewController *vc = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
+    vc.presentedAsLoginScreen = YES;
+
+    XCTAssertNil([vc retryBiometricButton], @"Retry biometric button should be nil when showNativeLoginButton() is false");
+
+    [self swapShowNativeLoginButton];
+}
+
+// viewDidLoad installs the retry biometric button into the right bar items when eligible.
+- (void)test_givenPresentedAsLoginScreenAndShowNativeLoginButton_whenViewLoads_thenRetryBiometricButtonInRightItems {
+    gShowNativeLoginButtonStubValue = YES;
+    [self swapShowNativeLoginButton];
+
+    SFSDKLoginHostListViewController *vc = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
+    vc.presentedAsLoginScreen = YES;
+
+    [vc loadViewIfNeeded];
+
+    BOOL retryButtonInRightItems = NO;
+    for (UIBarButtonItem *item in vc.navigationItem.rightBarButtonItems) {
+        if ([item.accessibilityIdentifier isEqualToString:@"retryBiometric"]) {
+            retryButtonInRightItems = YES;
+        }
+    }
+    XCTAssertTrue(retryButtonInRightItems, @"Right bar items should include the retry biometric button when eligible");
+
+    [self swapShowNativeLoginButton];
+}
+
+// presentBioAuthAction: invokes presentBiometricWithScene: on the shared biometric manager.
+- (void)test_whenPresentBioAuthAction_thenPresentBiometricWithSceneInvoked {
+    gPresentBiometricWithSceneCallCount = 0;
+    [self swapPresentBiometricWithScene];
+
+    SFSDKLoginHostListViewController *vc = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
+    [vc loadViewIfNeeded];
+
+    [vc presentBioAuthAction:nil];
+
+    XCTAssertEqual(gPresentBiometricWithSceneCallCount, 1, @"presentBioAuthAction: should invoke presentBiometricWithScene: exactly once");
+
+    [self swapPresentBiometricWithScene];
 }
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -35,12 +35,19 @@
 #import "SFSDKAuthRequest.h"
 #import "SFUserAccountConstants.h"
 #import "SFOAuthCoordinator+Internal.h"
+#import "SFSDKLoginHostListViewController.h"
+#import "SFSDKNavigationController.h"
+#import "SFLoginViewController.h"
 static NSString * const kUserIdFormatString = @"005R0000000Dsl%lu";
 static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 
 @interface SFUserAccountManager ()
 
 - (void)notifyLoginCompletion:(SFUserAccount *)userAccount authInfo:(SFOAuthInfo *)authInfo;
+
+// Private helper exercised directly below. -presentLoginView: consults this to decide whether a
+// login screen is already on the auth window and must be dismissed before presenting new login UI.
+- (BOOL)isAlreadyPresentingLoginController:(UIViewController *)presentedViewController;
 
 @end
 
@@ -431,8 +438,43 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     [coordinator beginWebViewFlow];
 
     [self waitForExpectations:@[expectation] timeout:20];
-    
+
     [SFUserAccountManager sharedInstance].authViewHandler = origAuthViewHandler;
+}
+
+// -presentLoginView: consults -isAlreadyPresentingLoginController: to decide whether an existing
+// login screen must be dismissed before presenting new login UI. When a biometric-locked user
+// cancels/fails Face ID during an Advanced Auth flow, the retry re-enters -presentLoginView:. The
+// screen already on the auth window at that point is the biometric fallback picker -- an
+// SFSDKLoginHostListViewController wrapped in an SFSDKNavigationController (see
+// -presentLoginHostListViewControllerForBiometricFallback:). If -isAlreadyPresentingLoginController:
+// fails to recognize it, the picker is never dismissed: the advanced-auth branch swaps the auth
+// window's root view controller and starts the ASWebAuthenticationSession while the picker is still
+// presented on top, so the browser login never becomes visible and the user is stranded on the
+// picker. The host-list picker must be recognized just like SFLoginViewController.
+- (void)test_givenLoginHostListPickerPresented_whenCheckingIsAlreadyPresentingLoginController_thenReturnsYES {
+    SFUserAccountManager *manager = [SFUserAccountManager sharedInstance];
+
+    // Regression guard: the standard login controller must still be recognized.
+    SFLoginViewController *loginController = [[SFLoginViewController alloc] init];
+    SFSDKNavigationController *loginNav = [[SFSDKNavigationController alloc] initWithRootViewController:loginController];
+    XCTAssertTrue([manager isAlreadyPresentingLoginController:loginNav],
+                  @"A presented SFLoginViewController should be recognized as already presenting login UI.");
+
+    // The defect: the biometric fallback picker must also be recognized so it gets dismissed
+    // before the Advanced Auth retry presents the ASWebAuthenticationSession.
+    SFSDKLoginHostListViewController *hostListViewController = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
+    SFSDKNavigationController *hostListNav = [[SFSDKNavigationController alloc] initWithRootViewController:hostListViewController];
+    XCTAssertTrue([manager isAlreadyPresentingLoginController:hostListNav],
+                  @"A presented biometric-fallback login-host picker should be recognized as already "
+                  @"presenting login UI so it is dismissed before the Advanced Auth session starts.");
+
+    // Negative guard: an unrelated view controller must not be treated as a login screen.
+    UIViewController *unrelated = [[UIViewController alloc] init];
+    XCTAssertFalse([manager isAlreadyPresentingLoginController:unrelated],
+                   @"A non-login view controller should not be treated as an already-presented login screen.");
+    XCTAssertFalse([manager isAlreadyPresentingLoginController:nil],
+                   @"A nil presented view controller should not be treated as an already-presented login screen.");
 }
 
 - (void)testLoginViewControllerCustomizations {


### PR DESCRIPTION
## Summary

Suppress Advanced Authentication (`ASWebAuthenticationSession`)  to show OS Biometric Prompt if locked.  When a biometric-locked user declines or fails the Face ID / Touch ID prompt (e.g. taps "Use Password" or cancels), the login screen is automatically launched. 

## What changed

- **`BiometricAuthenticationManagerInternal.swift`**
  - Added `suppressInitialBrowserAuthentication`, a one-shot flag armed by `lock()` so the browser attempt it triggers doesn't race the biometric prompt. Consumed (cleared) by the gate on its next check.
  - On biometric cancel/failure, wait for the scene to return to `.foregroundActive` (dismissing the system biometric sheet briefly leaves it inactive, and `ASWebAuthenticationSession.start()` silently no-ops from a non-active scene), then resume the suppressed browser session in place — keeping its covering window up so the app is never exposed.
  - Guard `handleAppForeground()` against re-locking (and re-arming the flag) while already locked.
- **`SFUserAccountManager` (`.h`/`.m`)**
  - `willBeginBrowserAuthentication:` gate honors the suppression flag: suppresses the browser and presents the login-host picker as a fallback landing screen when biometric is locked; otherwise proceeds normally.
  - Added `resumeBrowserAuthentication:` to resume the suppressed session's held browser-launch callback (falls back to a fresh login if the callback is gone).
  - `isAlreadyPresentingLoginController:` now also recognizes the host-list picker so the Advanced Auth retry dismisses it before presenting the browser.
- **`SFSDKLoginHostListViewController.m`** — adds a "retry biometric" nav-bar button (picker-screen counterpart to `SFLoginViewController`'s existing biometric button), shown only when biometric is locked, opted-in, and available. Reuses the existing `biometricLoginButton` localized string — no new strings.

## Tests

- New `BiometricAdvancedAuthGateTests.swift` covering the gate / suppression-flag behavior.
- Extended `SFUserAccountManagerTests.m` and `SFSDKLoginHostTests.m`.
- `SalesforceSDKCore` builds clean; new + affected suites pass on the simulator. Also device-tested on a physical iPhone for the Face ID cancel → browser flow.