### PR TITLE
fix(setVersion.sh): support pre-release version formats (e.g. 14.0.0-rc.0)

### DIFF
--- a/setversion.sh
+++ b/setversion.sh
@@ -54,8 +54,9 @@ update_salesforce_sdk_constants ()
     local file=$1
     local version=$2
     local isDev=$3
-    local defineNameForVersion="__SALESFORCE_SDK_${version//./_}"
-    local defineValueForVersion="${version//./0}" # XXX works y and z are < 10 in version x.y.z
+    local base_version="${version%%-*}"
+    local defineNameForVersion="__SALESFORCE_SDK_${base_version//./_}"
+    local defineValueForVersion="${base_version//./0}" # XXX works y and z are < 10 in version x.y.z
 
     local isProdBool="YES"
 


### PR DESCRIPTION
## Summary

Strip the pre-release suffix before computing the C preprocessor macro name and value in `update_salesforce_sdk_constants`. For `14.0.0-rc.0`, the old code produced `__SALESFORCE_SDK_14_0_0-rc_0` (invalid C identifier — hyphen is not allowed in macro names) and `14000-rc00` (not a valid integer). The fix derives both from `base_version=${version%%-*}` so the macro is always a valid C identifier.

GUS: W-23916129

## Test plan

- [ ] `./setVersion.sh -v 14.0.0-rc.0` completes without error; generated header contains valid `#define __SALESFORCE_SDK_14_0_0 140000`
- [ ] `./setVersion.sh -v 14.0.0` continues to work as before (no regression)