### PR TITLE
test(W-23836436): add non-DPoP pool server login test to ECALoginTests

### DIFF
--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ECALoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/ECALoginTests.swift
@@ -68,6 +68,18 @@ class ECALoginTests: BaseAuthFlowTester {
         launchLoginAndValidate(staticAppConfigName: .ecaJwt, staticScopeSelection: .all)
     }
     
+    // MARK: - Pool Server Login
+
+    /// Login via the pool server without DPoP and verify the session is valid.
+    func test_givenNoDPoP_whenLoginViaPoolServer_thenSessionIsValid() throws {
+        launchLoginAndValidate(
+            loginHost: .regularAuth,
+            user: .first,
+            staticAppConfigName: .ecaJwt,
+            useLoginPoolHost: true
+        )
+    }
+
     // MARK: - Negative testing
     
     /// Login with invalid client id in dynamic configuration

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -173,7 +173,7 @@ class BaseAuthFlowTester: XCTestCase {
             dynamicScopes: dynamicScopes,
             useWebServerFlow: useWebServerFlow,
             useHybridFlow: useHybridFlow,
-            forceAdvancedAuthentication: forceAdvancedAuthentication ?? false,
+            forceAdvancedAuthentication: forceAdvancedAuthentication,
             discoveryLoginHost: useWelcomeDiscovery ? hostConfig.urlNoProtocol : "",
             discoveryUsername: useWelcomeDiscovery ? userConfig.username : "",
             useDPoP: useDPoP

--- a/native/SampleApps/AuthFlowTester/README.md
+++ b/native/SampleApps/AuthFlowTester/README.md
@@ -48,7 +48,7 @@ All DPoP tests live here — basic login, RTR, multi-user, migration, restart, p
 | `test_givenTwoDPoPUsers_whenSwitchAndRefresh_thenTokensAndNoncesAreIsolated` | ECA JWT DPoP | — | Two users; unique tokens and nonces; independent revoke+refresh per user |
 | `test_givenDPoPUserWithSubsetScopes_whenMigrateToAllScopes_thenDPoPBindingPreserved` | ECA JWT DPoP | — | Scope upgrade; DPoP binding preserved |
 | `test_givenDPoPUser_whenMigrateToDPoPRtr_thenRefreshTokenRotationEnabled` | ECA JWT DPoP → ECA JWT DPoP RTR | — | Migrate from DPoP to DPoP+RTR |
-| `test_givenDPoPUser_whenAppRestart_thenSessionAndKeypairSurvive` | ECA JWT DPoP | — | DPoP EC key pair survives app restart (Keychain) |
+| `test_givenDPoPUser_whenAppRestart_thenSessionAndKeypairSurvive` | ECA JWT DPoP | — | `XCTSkip` (pending SDK fix — RestClient path lacks nonce-challenge retry; post-restart DPoP revoke fails because in-memory nonce cache is empty) |
 | `test_givenDPoP_whenLoginViaPoolServer_thenTokenTypeIsDPoP` | ECA JWT DPoP | — | `XCTSkip` (W-23864247 — pool login server rejects valid `dpop_jkt` token exchange) |
 | `test_givenDPoPECA_whenAdminLogin_thenDPoPBindingWorksThroughBrowser` | ECA JWT DPoP | — | Login for Admins hand-off to ASWebAuthenticationSession works with DPoP binding |
 


### PR DESCRIPTION
## Summary

- Adds `test_givenNoDPoP_whenLoginViaPoolServer_thenSessionIsValid` to `ECALoginTests` — verifies that a plain ECA JWT login through the pool server produces a valid session (non-DPoP path)
- Fixes an accidental `?? false` default on `forceAdvancedAuthentication` in `BaseAuthFlowTester.launchLoginAndValidate` that would suppress the flag when `nil` was intentionally passed

> **Note:** This commit should have been included in #4130. Opening as a separate PR to avoid rebasing the already-reviewed branch.

## Test plan

- [ ] AuthFlowTester: `test_givenNoDPoP_whenLoginViaPoolServer_thenSessionIsValid` passes against `login.test1.pc-rnd.salesforce.com`