### PR TITLE
[iOS] SFUserAccountManager.m calls internal Swift method invisible to framework/CocoaPods consumers

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/BiometricAuthentication/BiometricAuthenticationManagerInternal.swift
@@ -73,7 +73,7 @@ public class BiometricAuthenticationManagerInternal: NSObject, BiometricAuthenti
     /// Consumes (clears) suppression for `sceneId`, returning whether it was armed. The gate calls
     /// this once per browser attempt so suppression is one-shot per scene and one scene's consume
     /// can't drain another's.
-    @objc internal func consumeBrowserAuthenticationSuppression(forSceneId sceneId: String) -> Bool {
+    @objc public func consumeBrowserAuthenticationSuppression(forSceneId sceneId: String) -> Bool {
         return suppressedBrowserAuthSceneIds.remove(sceneId) != nil
     }
 


### PR DESCRIPTION
## Summary

`SFUserAccountManager.m` calls `consumeBrowserAuthenticationSuppressionForSceneId:`, but the Swift method was `@objc internal`. Same-module CI builds don't notice — `internal` is visible within the module. Framework/CocoaPods consumers build `SalesforceSDKCore` as a separate module, so the generated header strips the method and the ObjC call site fails to compile.

Fix: `internal` → `public` on that one method. No behavior change. Sibling suppression methods stay `internal` — nothing outside the module calls them.

## Test plan

- [x] Same-module `SalesforceSDKCore` build (regression check)
- [x] CocoaPods-consumer build (React Native template via `use_frameworks!`) — original compile error gone
- [x] Independent end-to-end verification against a generated template app

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*