### PR TITLE
Add downgradeFromDPoP for in-place DPoP→Bearer migration

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPRequestDecorator.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/DPoP/DPoPRequestDecorator.swift
@@ -37,6 +37,23 @@ public final class DPoPRequestDecorator: NSObject {
     /// `token_type: "DPoP"` (RFC 6749 §5.1 / RFC 9449 §6.1).
     @objc public static let dpopTokenType = "DPoP"
 
+    /// Single source of truth for "does this `tokenType` denote a DPoP-bound session?".
+    ///
+    /// Compares case-insensitively against `dpopTokenType` (RFC 6749 §5.1 / RFC 9449 §6.1 both
+    /// define `token_type` as case-insensitive). Every DPoP-vs-Bearer decision — the `/authorize`
+    /// binding gate in `SFOAuthCoordinator`, the proof-attach gate below, and the migration guards
+    /// in `SFUserAccountManager` — routes through this so they can never disagree on a server
+    /// casing variant. `nil`/empty → `false`.
+    ///
+    /// Public (not internal) so it stays visible to the Objective-C callers across framework, SPM,
+    /// and CocoaPods builds — an internal `@objc` member is invisible to in-module Objective-C in a
+    /// framework build.
+    @objc(isDPoPTokenType:)
+    public static func isDPoPTokenType(_ tokenType: String?) -> Bool {
+        guard let tokenType, !tokenType.isEmpty else { return false }
+        return tokenType.caseInsensitiveCompare(dpopTokenType) == .orderedSame
+    }
+
     /// Gate deciding whether to attach a DPoP proof for `scope`.
     ///
     /// An explicit `tokenType` is authoritative:
@@ -64,7 +81,7 @@ public final class DPoPRequestDecorator: NSObject {
             return false
         }
         if let tokenType {
-            return tokenType.caseInsensitiveCompare(dpopTokenType) == .orderedSame
+            return isDPoPTokenType(tokenType)
         }
         // tokenType is nil — transition window between /authorize and /token; fall back to
         // the key-material signal.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -1005,15 +1005,29 @@
 // Appends `&dpop_jkt=<base64url-sha256>` to the approval URL when DPoP is enabled
 // (RFC 9449 §10 authorization code binding). Soft-fails on key-material / crypto errors.
 //
-// DPoP intent is resolved per call: `self.dpopOverride`, when set, takes precedence
-// over the process-wide `SalesforceSDKManager.useDPoP` flag (e.g. a refresh-token
-// migration explicitly requesting DPoP binding regardless of the app's default login
-// posture). Normal login never sets `dpopOverride`, so it continues to follow the
-// global flag unchanged.
+// DPoP intent is resolved per call, in precedence order:
+//   1. `self.dpopOverride`, when set, wins (e.g. a refresh-token migration explicitly
+//      requesting or declining DPoP binding regardless of the app's default posture).
+//   2. Otherwise, if the credential already carries a token type (an interactive
+//      re-authentication of an existing account), honor the per-user
+//      `credentials.tokenType`: a Bearer session (e.g. one that was downgraded from
+//      DPoP) must not silently re-bind to DPoP on re-login, and a DPoP session stays
+//      DPoP — both independent of the process-wide flag. This mirrors the proof-attach
+//      gate in `SFSDKDPoPRequestDecorator`, so the /authorize binding decision and the
+//      outbound-request decoration agree on the same per-credential source of truth.
+//   3. Otherwise (a brand-new login with no per-user binding yet), the process-wide
+//      `SalesforceSDKManager.useDPoP` default governs.
 - (void)appendDPoPJktIfNeededTo:(NSMutableString *)approvalUrlString
                          domain:(NSString *)domain
                     credentials:(SFOAuthCredentials *)credentials {
-    BOOL dpopEnabled = self.dpopOverride ? self.dpopOverride.boolValue : [[SalesforceSDKManager sharedManager] useDPoP];
+    BOOL dpopEnabled;
+    if (self.dpopOverride) {
+        dpopEnabled = self.dpopOverride.boolValue;
+    } else if (credentials.tokenType.length > 0) {
+        dpopEnabled = [credentials.tokenType caseInsensitiveCompare:[SFSDKDPoPRequestDecorator dpopTokenType]] == NSOrderedSame;
+    } else {
+        dpopEnabled = [[SalesforceSDKManager sharedManager] useDPoP];
+    }
     if (!dpopEnabled) {
         return;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -1024,7 +1024,7 @@
     if (self.dpopOverride) {
         dpopEnabled = self.dpopOverride.boolValue;
     } else if (credentials.tokenType.length > 0) {
-        dpopEnabled = [credentials.tokenType caseInsensitiveCompare:[SFSDKDPoPRequestDecorator dpopTokenType]] == NSOrderedSame;
+        dpopEnabled = [SFSDKDPoPRequestDecorator isDPoPTokenType:credentials.tokenType];
     } else {
         dpopEnabled = [[SalesforceSDKManager sharedManager] useDPoP];
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -637,6 +637,9 @@ Use this method to stop/clear any authentication which is has already been start
  user. If successful, a new set of DPoP-bound credentials (refresh token, access token) are
  obtained and replace the existing credentials for the user.
 
+ If the user's session is already DPoP-bound, this is a no-op: `completionBlock` is invoked
+ immediately with the unchanged user account and no re-authentication is attempted.
+
  @param user The user account to upgrade to DPoP.
  @param completionBlock Called on successful upgrade with the updated user account and auth info.
  @param failureBlock Called if the upgrade fails with an error and optional auth info.
@@ -644,6 +647,31 @@ Use this method to stop/clear any authentication which is has already been start
 - (void)upgradeToDPoP:(SFUserAccount *)user
                success:(SFUserAccountManagerSuccessCallbackBlock)completionBlock
                failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock NS_SWIFT_NAME(upgradeToDPoP(_:success:failure:));
+
+/**
+ Downgrades the specified user's session from DPoP to Bearer in place, without changing the
+ connected app.
+
+ Re-authenticates using the user's current client id, redirect URI, and scopes, requesting an
+ unbound (Bearer) authorization code even if the process-wide DPoP flag is on. This might cause
+ the approve/deny screen to be presented to the user. If successful, a new set of Bearer
+ credentials (refresh token, access token) are obtained and replace the existing credentials for
+ the user, and the now-obsolete DPoP key pair, nonce-cache entries, and per-user DPoP marker are
+ reclaimed.
+
+ Note: the connected app must accept Bearer tokens for the downgrade to succeed; a DPoP-enforcing
+ connected app will reject the resulting Bearer session.
+
+ If the user's session is already unbound (Bearer), this is a no-op: `completionBlock` is invoked
+ immediately with the unchanged user account and no re-authentication is attempted.
+
+ @param user The user account to downgrade from DPoP.
+ @param completionBlock Called on successful downgrade with the updated user account and auth info.
+ @param failureBlock Called if the downgrade fails with an error and optional auth info.
+ */
+- (void)downgradeFromDPoP:(SFUserAccount *)user
+               success:(SFUserAccountManagerSuccessCallbackBlock)completionBlock
+               failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock NS_SWIFT_NAME(downgradeFromDPoP(_:success:failure:));
 
 /**
  Handle an authentication response from the IDP application

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -866,11 +866,27 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     request.useDPoP = useDPoP;
     SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] initWith:request credentials:nil];
     authSession.isAuthenticating = YES;
+    // Snapshot DPoP-ness before the revoke block below can mutate `preMigrationCredentials`:
+    // `revokeRefreshToken:` synchronously clears `tokenType` (and other fields) on the credentials
+    // object it's handed, so reading `tokenType` after that call would always see it as non-DPoP.
+    BOOL preMigrationWasDPoP = [preMigrationCredentials.tokenType isEqualToString:@"DPoP"];
     authSession.authSuccessCallback = ^(SFOAuthInfo *authInfo, SFUserAccount *newUserAccount) {
         if (preMigrationCredentials != nil && ![preMigrationCredentials.refreshToken isEqualToString:newUserAccount.credentials.refreshToken]) {
-            
+
             id<SFSDKOAuthProtocol> authClient = self.authClient();
             [authClient revokeRefreshToken:preMigrationCredentials reason:SFLogoutReasonRefreshTokenRotated];
+        }
+
+        // Downgrade cleanup: if this migration moved the user off a DPoP-bound identifier onto a
+        // non-DPoP one, the pre-migration DPoP key pair and nonce-cache entries are now obsolete
+        // and would otherwise leak until logout. Only reclaim them once the migration has actually
+        // succeeded with a non-DPoP result — a failed/cancelled migration (authFailureCallback)
+        // leaves the original DPoP session untouched and fully functional.
+        if (preMigrationWasDPoP
+            && ![newUserAccount.credentials.tokenType isEqualToString:@"DPoP"]
+            && preMigrationCredentials.identifier.length > 0) {
+            [SFSDKDPoPKeyStore.shared deleteForCredentials:preMigrationCredentials];
+            [SFSDKDPoPNonceCache.shared clearForScope:preMigrationCredentials.identifier];
         }
 
         if (completionBlock) {
@@ -895,6 +911,14 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 - (void)upgradeToDPoP:(SFUserAccount *)user
                success:(SFUserAccountManagerSuccessCallbackBlock)completionBlock
                failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
+    // No-op if the session is already DPoP-bound: there's nothing to migrate, so return the
+    // user unchanged rather than kicking off a needless re-authentication.
+    if ([user.credentials.tokenType isEqualToString:@"DPoP"]) {
+        if (completionBlock) {
+            completionBlock(nil, user);
+        }
+        return;
+    }
     SFOAuthCredentials *credentials = user.credentials;
     SFSDKAppConfig *sameAppConfig = [[SFSDKAppConfig alloc] initWithDict:@{
         @"remoteAccessConsumerKey": credentials.clientId ?: @"",
@@ -902,6 +926,26 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         @"oauthScopes": credentials.scopes ?: @[]
     }];
     [self migrateRefreshToken:user newAppConfig:sameAppConfig useDPoP:@YES success:completionBlock failure:failureBlock];
+}
+
+- (void)downgradeFromDPoP:(SFUserAccount *)user
+               success:(SFUserAccountManagerSuccessCallbackBlock)completionBlock
+               failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
+    // No-op if the session is already unbound (Bearer): there's nothing to migrate, so return
+    // the user unchanged rather than kicking off a needless re-authentication.
+    if (![user.credentials.tokenType isEqualToString:@"DPoP"]) {
+        if (completionBlock) {
+            completionBlock(nil, user);
+        }
+        return;
+    }
+    SFOAuthCredentials *credentials = user.credentials;
+    SFSDKAppConfig *sameAppConfig = [[SFSDKAppConfig alloc] initWithDict:@{
+        @"remoteAccessConsumerKey": credentials.clientId ?: @"",
+        @"oauthRedirectURI": credentials.redirectUri ?: @"",
+        @"oauthScopes": credentials.scopes ?: @[]
+    }];
+    [self migrateRefreshToken:user newAppConfig:sameAppConfig useDPoP:@NO success:completionBlock failure:failureBlock];
 }
 
 
@@ -2410,8 +2454,14 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 
     // DPoP: register unconditionally on every completed session where the server issued
     // a DPoP-bound token (initial login OR refresh) — token_type is a per-session property.
+    // The else branch is a deliberate broadening beyond the original register-only logic: any
+    // completed session that comes back non-DPoP (e.g. a downgradeFromDPoP migration) must clear
+    // the marker too, or a session that has rolled back to Bearer would keep reporting DP. This is
+    // idempotent and applies to any non-DPoP completion, not just downgrade.
     if ([userAccount.credentials.tokenType isEqualToString:@"DPoP"]) {
         [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureDPoP forUser:userAccount];
+    } else {
+        [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureDPoP forUser:userAccount];
     }
 
     // JT/OT: token format — written on every completed session (credentials may change on migration)

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -869,7 +869,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     // Snapshot DPoP-ness before the revoke block below can mutate `preMigrationCredentials`:
     // `revokeRefreshToken:` synchronously clears `tokenType` (and other fields) on the credentials
     // object it's handed, so reading `tokenType` after that call would always see it as non-DPoP.
-    BOOL preMigrationWasDPoP = [preMigrationCredentials.tokenType isEqualToString:@"DPoP"];
+    BOOL preMigrationWasDPoP = [SFSDKDPoPRequestDecorator isDPoPTokenType:preMigrationCredentials.tokenType];
     authSession.authSuccessCallback = ^(SFOAuthInfo *authInfo, SFUserAccount *newUserAccount) {
         if (preMigrationCredentials != nil && ![preMigrationCredentials.refreshToken isEqualToString:newUserAccount.credentials.refreshToken]) {
 
@@ -883,7 +883,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         // succeeded with a non-DPoP result — a failed/cancelled migration (authFailureCallback)
         // leaves the original DPoP session untouched and fully functional.
         if (preMigrationWasDPoP
-            && ![newUserAccount.credentials.tokenType isEqualToString:@"DPoP"]
+            && ![SFSDKDPoPRequestDecorator isDPoPTokenType:newUserAccount.credentials.tokenType]
             && preMigrationCredentials.identifier.length > 0) {
             [SFSDKDPoPKeyStore.shared deleteForCredentials:preMigrationCredentials];
             [SFSDKDPoPNonceCache.shared clearForScope:preMigrationCredentials.identifier];
@@ -913,7 +913,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
                failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
     // No-op if the session is already DPoP-bound: there's nothing to migrate, so return the
     // user unchanged rather than kicking off a needless re-authentication.
-    if ([user.credentials.tokenType isEqualToString:@"DPoP"]) {
+    if ([SFSDKDPoPRequestDecorator isDPoPTokenType:user.credentials.tokenType]) {
         if (completionBlock) {
             completionBlock(nil, user);
         }
@@ -933,7 +933,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
                failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
     // No-op if the session is already unbound (Bearer): there's nothing to migrate, so return
     // the user unchanged rather than kicking off a needless re-authentication.
-    if (![user.credentials.tokenType isEqualToString:@"DPoP"]) {
+    if (![SFSDKDPoPRequestDecorator isDPoPTokenType:user.credentials.tokenType]) {
         if (completionBlock) {
             completionBlock(nil, user);
         }
@@ -2458,7 +2458,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     // completed session that comes back non-DPoP (e.g. a downgradeFromDPoP migration) must clear
     // the marker too, or a session that has rolled back to Bearer would keep reporting DP. This is
     // idempotent and applies to any non-DPoP completion, not just downgrade.
-    if ([userAccount.credentials.tokenType isEqualToString:@"DPoP"]) {
+    if ([SFSDKDPoPRequestDecorator isDPoPTokenType:userAccount.credentials.tokenType]) {
         [SFSDKAppFeatureMarkers registerAppFeature:kSFAppFeatureDPoP forUser:userAccount];
     } else {
         [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureDPoP forUser:userAccount];
@@ -2542,7 +2542,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         [network sendRequest:request  dataResponseBlock:^(NSData *data, NSURLResponse *response, NSError *error){
             // Gate harvest on DPoP credentials only — Bearer logins must not write to the
             // DPoP nonce cache even if the photo origin returns a stray DPoP-Nonce header.
-            if ([account.credentials.tokenType isEqualToString:[SFSDKDPoPRequestDecorator dpopTokenType]]
+            if ([SFSDKDPoPRequestDecorator isDPoPTokenType:account.credentials.tokenType]
                 && [[SalesforceSDKManager sharedManager] useDPoP]) {
                 [SFSDKDPoPRequestDecorator harvestNonceFromResponse:response
                                                          requestURL:request.URL

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
@@ -358,6 +358,46 @@ class SFOAuthCoordinatorTests: XCTestCase {
                      "with dpopOverride nil and the global flag off, dpop_jkt must be absent")
     }
 
+    // MARK: - Per-user credential binding on re-auth (independent of the global flag)
+
+    /// Interactive re-authentication of an already-Bearer credential (e.g. a
+    /// session that was downgraded from DPoP) must NOT re-bind to DPoP, even
+    /// with the global `usesDPoP` flag on and no per-call override. Before the
+    /// fix this fell through to the global flag and silently re-bound on the
+    /// stale-session re-login that follows a revoke+refresh. The per-user
+    /// `credentials.tokenType` is now the source of truth for re-auth.
+    func test_givenDpopOverrideNilAndBearerCredential_whenGenerateApprovalUrlString_thenUrlHasNoDPoPJktEvenWithGlobalFlagOn() throws {
+        SalesforceManager.shared.usesDPoP = true
+
+        let scope = trackedScope("reauth-bearer-credential")
+        let credentials = try makeCredentials(identifier: scope, domain: "acme.my.salesforce.com")
+        credentials.testTokenType = "Bearer"
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+        XCTAssertNil(coordinator.dpopOverride, "interactive re-auth must never set dpopOverride")
+
+        let url = coordinator.generateApprovalUrlString()
+        XCTAssertNil(queryValue(name: "dpop_jkt", in: url),
+                     "a Bearer (downgraded) credential must not re-bind to DPoP on re-login, even with the global flag on")
+    }
+
+    /// Interactive re-authentication of a DPoP-bound credential must stay
+    /// DPoP-bound, even with the global `usesDPoP` flag off and no per-call
+    /// override — the per-user binding is honored in both directions.
+    func test_givenDpopOverrideNilAndDPoPCredential_whenGenerateApprovalUrlString_thenUrlHasDPoPJktEvenWithGlobalFlagOff() throws {
+        SalesforceManager.shared.usesDPoP = false
+
+        let scope = trackedScope("reauth-dpop-credential")
+        let credentials = try makeCredentials(identifier: scope, domain: "acme.my.salesforce.com")
+        credentials.testTokenType = DPoPRequestDecorator.dpopTokenType
+        let coordinator = SFOAuthCoordinator()
+        coordinator.credentials = credentials
+
+        let url = coordinator.generateApprovalUrlString()
+        XCTAssertNotNil(queryValue(name: "dpop_jkt", in: url),
+                        "a DPoP-bound credential must stay DPoP on re-login, even with the global flag off")
+    }
+
     /// Entry-point coverage — user-agent flow (webServerFlow resolves to `NO`
     /// when `useBrowserAuth=NO` and web-server auth is off). The URL builder
     /// emits `response_type=token` (or `hybrid_token` when hybrid mode is on),
@@ -460,6 +500,11 @@ extension OAuthCredentials {
     var testRedirectURI: String? {
         get { return self.redirectUri }
         set { self.setValue(newValue, forKey: "redirectUri") }
+    }
+
+    var testTokenType: String? {
+        get { return self.tokenType }
+        set { self.setValue(newValue, forKey: "tokenType") }
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKDPoPTests.swift
@@ -284,6 +284,23 @@ class SFSDKDPoPTests: XCTestCase {
         XCTAssertTrue(DPoPRequestDecorator.shouldAttachDPoP(scope: testScope, tokenType: "DPoP"))
     }
 
+    func test_givenTokenTypeVariants_whenIsDPoPTokenType_thenMatchesCaseInsensitivelyAndRejectsNilEmptyBearer() {
+        // Canonical and casing variants all resolve to DPoP — token_type is case-insensitive per
+        // RFC 6749 §5.1 / RFC 9449 §6.1, so the /authorize gate and the migration guards agree
+        // no matter how the server cases the value.
+        XCTAssertTrue(DPoPRequestDecorator.isDPoPTokenType("DPoP"))
+        XCTAssertTrue(DPoPRequestDecorator.isDPoPTokenType("dpop"))
+        XCTAssertTrue(DPoPRequestDecorator.isDPoPTokenType("DPOP"))
+
+        // nil / empty / Bearer are not DPoP. nil and empty especially matter: the predicate must
+        // preserve the `isEqualToString:` semantics it replaced (a bare `caseInsensitiveCompare:`
+        // on a nil receiver would return NSOrderedSame and wrongly read as DPoP).
+        XCTAssertFalse(DPoPRequestDecorator.isDPoPTokenType(nil))
+        XCTAssertFalse(DPoPRequestDecorator.isDPoPTokenType(""))
+        XCTAssertFalse(DPoPRequestDecorator.isDPoPTokenType("Bearer"))
+        XCTAssertFalse(DPoPRequestDecorator.isDPoPTokenType("bearer"))
+    }
+
     func test_givenScope_whenHasKeyPairChecked_thenReflectsKeyMaterialPresenceOnly() throws {
         // Fresh scope: no key material yet.
         XCTAssertFalse(DPoPKeyStore.shared.hasKeyPair(forScope: testScope),

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -38,6 +38,7 @@
 #import "SFSDKLoginHostListViewController.h"
 #import "SFSDKNavigationController.h"
 #import "SFLoginViewController.h"
+#import <Security/Security.h>
 static NSString * const kUserIdFormatString = @"005R0000000Dsl%lu";
 static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 
@@ -99,11 +100,16 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 @end
 
 /** Auth client stub that captures the credentials passed to revokeRefreshToken:, so tests can
- assert which user's refresh token gets revoked. */
+ assert which user's refresh token gets revoked. By default it only captures -- it does NOT
+ clear any fields on the credentials, unlike the real SFSDKOAuth2 implementation. Set
+ `mimicsProductionRevokeSideEffect` to YES to also call `-[SFOAuthCredentials revoke]`, matching
+ what the real auth client does synchronously (clears refreshToken, tokenType, etc.) -- needed by
+ tests that must exercise that side effect rather than be shielded from it. */
 @interface SFSDKRevokeCapturingOAuthClient : NSObject <SFSDKOAuthProtocol>
 
 @property (nonatomic, strong, nullable) SFOAuthCredentials *revokedCredentials;
 @property (nonatomic, assign) NSUInteger revokeCallCount;
+@property (nonatomic, assign) BOOL mimicsProductionRevokeSideEffect;
 
 @end
 
@@ -116,6 +122,9 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
 - (void)revokeRefreshToken:(SFOAuthCredentials *)credentials reason:(SFLogoutReason)reason {
     self.revokedCredentials = credentials;
     self.revokeCallCount += 1;
+    if (self.mimicsProductionRevokeSideEffect) {
+        [credentials revoke];
+    }
 }
 
 @end
@@ -944,6 +953,235 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     // Cleanup
     self.uam.authClient = originalFactory;
     [self.uam.authSessions removeObject:sceneId];
+}
+
+#pragma mark - upgradeToDPoP
+
+- (void)testUpgradeToDPoP_alreadyDPoP_isNoOpAndUserUnchanged {
+    // Given: a user whose session is already DPoP-bound.
+    SFUserAccount *testUser = [self createNewUserWithIndex:0];
+    testUser.credentials.tokenType = @"DPoP";
+    testUser.credentials.refreshToken = @"alreadyDPoPRefreshToken";
+
+    // Capture whichever credentials get revoked, so we can confirm no revoke -- and therefore no
+    // migration -- ever happens.
+    SFSDKRevokeCapturingOAuthClient *revokeClient = [[SFSDKRevokeCapturingOAuthClient alloc] init];
+    SFAuthClientFactoryBlock originalFactory = self.uam.authClient;
+    self.uam.authClient = ^{ return revokeClient; };
+
+    __block BOOL successCallbackInvoked = NO;
+    __block BOOL failureCallbackInvoked = NO;
+    __block SFUserAccount *capturedUserAccount = nil;
+
+    // When: upgrading a session that's already DPoP-bound.
+    [self.uam upgradeToDPoP:testUser
+                     success:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
+                         successCallbackInvoked = YES;
+                         capturedUserAccount = userAccount;
+                     }
+                     failure:^(SFOAuthInfo *authInfo, NSError *error) {
+                         failureCallbackInvoked = YES;
+                     }];
+
+    // Then: the success block fires immediately with the same user, and no migration/auth
+    // session was ever created -- proof that migrateRefreshToken was never invoked.
+    XCTAssertTrue(successCallbackInvoked, @"Success callback should be invoked for a no-op upgrade");
+    XCTAssertFalse(failureCallbackInvoked, @"Failure callback should not be invoked for a no-op upgrade");
+    XCTAssertEqual(capturedUserAccount, testUser, @"The unchanged user account should be passed back");
+    XCTAssertEqual(self.uam.authSessions.allKeys.count, 0, @"No auth session should be created for a no-op upgrade");
+    XCTAssertEqual(revokeClient.revokeCallCount, 0, @"No refresh token should be revoked for a no-op upgrade");
+    XCTAssertEqualObjects(testUser.credentials.refreshToken, @"alreadyDPoPRefreshToken",
+                          @"The refresh token must be untouched by a no-op upgrade");
+    XCTAssertEqualObjects(testUser.credentials.tokenType, @"DPoP",
+                          @"The token type must be untouched by a no-op upgrade");
+
+    // Cleanup
+    self.uam.authClient = originalFactory;
+}
+
+#pragma mark - downgradeFromDPoP
+
+/** Reads the raw public key bytes for a DPoP key pair so tests can tell a retained key apart
+ from a freshly-minted replacement (DPoPKeyStore's lookup is get-or-create, so a non-nil result
+ alone doesn't prove whether the original key survived). */
+- (NSData *)publicKeyDataForKeyPair:(SFSDKDPoPKeyPair *)keyPair {
+    CFErrorRef copyError = NULL;
+    NSData *data = (NSData *)CFBridgingRelease(SecKeyCopyExternalRepresentation(keyPair.publicKey, &copyError));
+    XCTAssertNotNil(data, @"Should be able to read the public key's raw representation");
+    return data;
+}
+
+- (void)testDowngradeFromDPoP_delegatesWithSameAppConfigAndUseDPoPNo {
+    // Given: a DPoP-bound user with a specific client id / redirect URI / scopes.
+    SFUserAccount *testUser = [self createNewUserWithIndex:0];
+    testUser.credentials.tokenType = @"DPoP";
+    testUser.credentials.clientId = @"existingClientId";
+    testUser.credentials.redirectUri = @"existingapp://oauth/callback";
+    testUser.credentials.scopes = @[@"api", @"refresh_token"];
+
+    // When: downgrading from DPoP.
+    [self.uam downgradeFromDPoP:testUser
+                         success:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {}
+                         failure:^(SFOAuthInfo *authInfo, NSError *error) {}];
+
+    // Then: the migration is set up against the SAME connected app, with useDPoP forced to NO --
+    // beating the process-wide DPoP flag, whatever it's set to.
+    NSString *sceneId = self.uam.authSessions.allKeys.firstObject;
+    XCTAssertNotNil(sceneId, @"Auth session should have been created");
+    SFSDKAuthSession *authSession = self.uam.authSessions[sceneId];
+
+    XCTAssertEqualObjects(authSession.oauthRequest.oauthClientId, testUser.credentials.clientId,
+                          @"Downgrade should reuse the user's existing client id");
+    XCTAssertEqualObjects(authSession.oauthRequest.oauthCompletionUrl, testUser.credentials.redirectUri,
+                          @"Downgrade should reuse the user's existing redirect URI");
+    XCTAssertEqualObjects(authSession.oauthRequest.useDPoP, @NO,
+                          @"Downgrade must force useDPoP:NO regardless of the global flag");
+
+    // Clean up
+    [self.uam.authSessions removeObject:sceneId];
+}
+
+- (void)testDowngradeFromDPoP_alreadyBearer_isNoOpAndUserUnchanged {
+    // Given: a user whose session is already unbound (Bearer).
+    SFUserAccount *testUser = [self createNewUserWithIndex:0];
+    testUser.credentials.tokenType = @"Bearer";
+    testUser.credentials.refreshToken = @"alreadyBearerRefreshToken";
+
+    // Capture whichever credentials get revoked, so we can confirm no revoke -- and therefore no
+    // migration -- ever happens.
+    SFSDKRevokeCapturingOAuthClient *revokeClient = [[SFSDKRevokeCapturingOAuthClient alloc] init];
+    SFAuthClientFactoryBlock originalFactory = self.uam.authClient;
+    self.uam.authClient = ^{ return revokeClient; };
+
+    __block BOOL successCallbackInvoked = NO;
+    __block BOOL failureCallbackInvoked = NO;
+    __block SFUserAccount *capturedUserAccount = nil;
+
+    // When: downgrading a session that's already Bearer.
+    [self.uam downgradeFromDPoP:testUser
+                         success:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {
+                             successCallbackInvoked = YES;
+                             capturedUserAccount = userAccount;
+                         }
+                         failure:^(SFOAuthInfo *authInfo, NSError *error) {
+                             failureCallbackInvoked = YES;
+                         }];
+
+    // Then: the success block fires immediately with the same user, and no migration/auth
+    // session was ever created -- proof that migrateRefreshToken was never invoked.
+    XCTAssertTrue(successCallbackInvoked, @"Success callback should be invoked for a no-op downgrade");
+    XCTAssertFalse(failureCallbackInvoked, @"Failure callback should not be invoked for a no-op downgrade");
+    XCTAssertEqual(capturedUserAccount, testUser, @"The unchanged user account should be passed back");
+    XCTAssertEqual(self.uam.authSessions.allKeys.count, 0, @"No auth session should be created for a no-op downgrade");
+    XCTAssertEqual(revokeClient.revokeCallCount, 0, @"No refresh token should be revoked for a no-op downgrade");
+    XCTAssertEqualObjects(testUser.credentials.refreshToken, @"alreadyBearerRefreshToken",
+                          @"The refresh token must be untouched by a no-op downgrade");
+    XCTAssertEqualObjects(testUser.credentials.tokenType, @"Bearer",
+                          @"The token type must be untouched by a no-op downgrade");
+
+    // Cleanup
+    self.uam.authClient = originalFactory;
+}
+
+- (void)testDowngradeFromDPoP_successCleansUpObsoleteDPoPKeyAndNonce {
+    // Given: a DPoP-bound user with real key material and a cached nonce. Stub the auth client so
+    // the refresh-token-rotated revoke is captured instead of going over the network -- but set
+    // `mimicsProductionRevokeSideEffect` so the stub still reproduces the real auth client's
+    // synchronous side effect of clearing preMigrationCredentials' tokenType (among other fields)
+    // via `-[SFOAuthCredentials revoke]`. Cleanup must still fire after that happens: the
+    // production code must snapshot the DPoP-ness of preMigrationCredentials before the revoke
+    // block runs, not read it afterward.
+    SFSDKRevokeCapturingOAuthClient *revokeClient = [[SFSDKRevokeCapturingOAuthClient alloc] init];
+    revokeClient.mimicsProductionRevokeSideEffect = YES;
+    SFAuthClientFactoryBlock originalFactory = self.uam.authClient;
+    self.uam.authClient = ^{ return revokeClient; };
+
+    SFUserAccount *testUser = [self createNewUserWithIndex:0];
+    testUser.credentials.tokenType = @"DPoP";
+
+    NSURL *tokenURL = [NSURL URLWithString:@"https://login.salesforce.com/services/oauth2/token"];
+    [SFSDKDPoPNonceCache.shared setNonce:@"pre-downgrade-nonce" htu:tokenURL scope:testUser.credentials.identifier];
+
+    NSError *keyError = nil;
+    SFSDKDPoPKeyPair *originalKeyPair = [SFSDKDPoPKeyStore.shared keyPairForCredentials:testUser.credentials error:&keyError];
+    XCTAssertNil(keyError, @"Seeding the pre-downgrade key pair should succeed");
+    NSData *originalPublicKeyData = [self publicKeyDataForKeyPair:originalKeyPair];
+
+    [self.uam downgradeFromDPoP:testUser
+                         success:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {}
+                         failure:^(SFOAuthInfo *authInfo, NSError *error) {}];
+
+    NSString *sceneId = self.uam.authSessions.allKeys.firstObject;
+    SFSDKAuthSession *authSession = self.uam.authSessions[sceneId];
+
+    // When: the downgrade succeeds with a Bearer result.
+    SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefreshTokenMigration];
+    SFUserAccount *bearerUserAccount = [self createNewUserWithIndex:1];
+    bearerUserAccount.credentials.tokenType = @"Bearer";
+    bearerUserAccount.credentials.refreshToken = @"newBearerRefreshToken";
+    authSession.authSuccessCallback(authInfo, bearerUserAccount);
+
+    // Then: the pre-downgrade DPoP nonce is gone.
+    XCTAssertNil([SFSDKDPoPNonceCache.shared latestForScope:testUser.credentials.identifier],
+                @"Obsolete DPoP nonce should be cleared after a successful downgrade");
+
+    // And: the pre-downgrade DPoP key pair is gone -- a fresh lookup for the same identifier mints
+    // a brand-new key rather than returning the seeded one.
+    NSError *newKeyError = nil;
+    SFSDKDPoPKeyPair *regeneratedKeyPair = [SFSDKDPoPKeyStore.shared keyPairForCredentials:testUser.credentials error:&newKeyError];
+    XCTAssertNil(newKeyError);
+    NSData *regeneratedPublicKeyData = [self publicKeyDataForKeyPair:regeneratedKeyPair];
+    XCTAssertNotEqualObjects(originalPublicKeyData, regeneratedPublicKeyData,
+                            @"Obsolete DPoP key pair should have been deleted, forcing a fresh key on next lookup");
+
+    // Clean up
+    [self.uam.authSessions removeObject:sceneId];
+    [SFSDKDPoPNonceCache.shared clearForScope:testUser.credentials.identifier];
+    [SFSDKDPoPKeyStore.shared deleteForCredentials:testUser.credentials];
+    self.uam.authClient = originalFactory;
+}
+
+- (void)testDowngradeFromDPoP_failureRetainsDPoPKeyAndNonce {
+    // Given: a DPoP-bound user with real key material and a cached nonce.
+    SFUserAccount *testUser = [self createNewUserWithIndex:0];
+    testUser.credentials.tokenType = @"DPoP";
+
+    NSURL *tokenURL = [NSURL URLWithString:@"https://login.salesforce.com/services/oauth2/token"];
+    [SFSDKDPoPNonceCache.shared setNonce:@"still-working-nonce" htu:tokenURL scope:testUser.credentials.identifier];
+
+    NSError *keyError = nil;
+    SFSDKDPoPKeyPair *originalKeyPair = [SFSDKDPoPKeyStore.shared keyPairForCredentials:testUser.credentials error:&keyError];
+    XCTAssertNil(keyError);
+    NSData *originalPublicKeyData = [self publicKeyDataForKeyPair:originalKeyPair];
+
+    [self.uam downgradeFromDPoP:testUser
+                         success:^(SFOAuthInfo *authInfo, SFUserAccount *userAccount) {}
+                         failure:^(SFOAuthInfo *authInfo, NSError *error) {}];
+
+    NSString *sceneId = self.uam.authSessions.allKeys.firstObject;
+    SFSDKAuthSession *authSession = self.uam.authSessions[sceneId];
+
+    // When: the downgrade fails (e.g. the user cancels the re-auth).
+    SFOAuthInfo *authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeRefreshTokenMigration];
+    NSError *testError = [NSError errorWithDomain:@"TestErrorDomain" code:1 userInfo:nil];
+    authSession.authFailureCallback(authInfo, testError);
+
+    // Then: the still-working DPoP session's nonce and key pair are untouched.
+    XCTAssertEqualObjects([SFSDKDPoPNonceCache.shared latestForScope:testUser.credentials.identifier],
+                         @"still-working-nonce",
+                         @"A failed downgrade must retain the original DPoP nonce");
+
+    NSError *lookupError = nil;
+    SFSDKDPoPKeyPair *keyPairAfterFailure = [SFSDKDPoPKeyStore.shared keyPairForCredentials:testUser.credentials error:&lookupError];
+    XCTAssertNil(lookupError);
+    NSData *publicKeyDataAfterFailure = [self publicKeyDataForKeyPair:keyPairAfterFailure];
+    XCTAssertEqualObjects(originalPublicKeyData, publicKeyDataAfterFailure,
+                         @"A failed downgrade must retain the original DPoP key pair, not mint a new one");
+
+    // Clean up
+    [self.uam.authSessions removeObject:sceneId];
+    [SFSDKDPoPNonceCache.shared clearForScope:testUser.credentials.identifier];
+    [SFSDKDPoPKeyStore.shared deleteForCredentials:testUser.credentials];
 }
 
 - (void)testNotifyLoginCompletion_PostsMigrateRefreshTokenNotification {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester/ViewControllers/SessionDetailViewController.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester/ViewControllers/SessionDetailViewController.swift
@@ -41,6 +41,7 @@ struct SessionDetailView: View {
     @State private var migrateScopes = ""
     @State private var isMigrating = false
     @State private var isUpgradingToDPoP = false
+    @State private var isDowngradingFromDPoP = false
     @State private var migrationError: String?
     @State private var showMigrationError = false
     
@@ -156,6 +157,32 @@ struct SessionDetailView: View {
                             }
                             .disabled(isCurrentSessionDPoP || isUpgradingToDPoP)
                             .accessibilityIdentifier("upgradeToDPoPButton")
+                        }
+                        .padding()
+
+                        // Downgrade from DPoP Section
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Downgrade from DPoP")
+                                .font(.headline)
+                                .foregroundColor(.primary)
+
+                            Text("Re-authenticates the current user with the same connected app, requesting an unbound (Bearer) authorization code.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+
+                            Button(action: {
+                                handleDowngradeFromDPoP()
+                            }) {
+                                Text("Downgrade from DPoP")
+                                    .font(.headline)
+                                    .foregroundColor(.white)
+                                    .frame(maxWidth: .infinity)
+                                    .frame(height: 44)
+                                    .background(isCurrentSessionDPoP ? Color.green : Color.gray)
+                                    .cornerRadius(8)
+                            }
+                            .disabled(!isCurrentSessionDPoP || isDowngradingFromDPoP)
+                            .accessibilityIdentifier("downgradeFromDPoPButton")
                         }
                         .padding()
 
@@ -329,6 +356,34 @@ struct SessionDetailView: View {
             failure: { [self] _, error in
                 DispatchQueue.main.async {
                     isUpgradingToDPoP = false
+                    migrationError = error.localizedDescription
+                    showMigrationError = true
+                }
+            }
+        )
+    }
+
+    private func handleDowngradeFromDPoP() {
+        guard let user = UserAccountManager.shared.currentUserAccount else {
+            migrationError = "No current user found"
+            showMigrationError = true
+            return
+        }
+
+        isDowngradingFromDPoP = true
+
+        UserAccountManager.shared.downgradeFromDPoP(
+            user,
+            success: { [self] _, _ in
+                DispatchQueue.main.async {
+                    isDowngradingFromDPoP = false
+                    showMigrateRefreshToken = false
+                    refreshTrigger = UUID()
+                }
+            },
+            failure: { [self] _, error in
+                DispatchQueue.main.async {
+                    isDowngradingFromDPoP = false
                     migrationError = error.localizedDescription
                     showMigrationError = true
                 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTesterMainPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTesterMainPageObject.swift
@@ -363,6 +363,31 @@ class AuthFlowTesterMainPageObject {
         return true
     }
 
+    /// Opens the "Change Key" sheet and taps "Downgrade from DPoP", handling the approve/deny
+    /// screen if it appears. Mirrors `upgradeToDPoP`'s error-surfacing.
+    func downgradeFromDPoP() -> Bool {
+        // Tap Change Key button to open the sheet
+        tap(bottomBarChangeKeyButton())
+
+        // Tap the "Downgrade from DPoP" button
+        tap(downgradeFromDPoPButton())
+
+        // Tap the allow button if it appears
+        tapIfPresent(allowButton())
+
+        let alert = app.alerts["Migration Error"]
+        if (alert.waitForExistence(timeout: UITestTimeouts.long)) {
+            let message = alert.staticTexts.allElementsBoundByIndex
+                .map { $0.label }
+                .filter { $0 != "Migration Error" && !$0.isEmpty }
+                .joined(separator: " ")
+            XCTFail("Migration Error alert: \(message.isEmpty ? "<no message>" : message)")
+            alert.buttons["OK"].tap()
+            return false
+        }
+        return true
+    }
+
     // MARK: - Config Import Helpers
     
     private func buildConfigJSON(consumerKey: String, redirectUri: String, scopes: String) -> String {
@@ -480,6 +505,10 @@ class AuthFlowTesterMainPageObject {
 
     private func upgradeToDPoPButton() -> XCUIElement {
         return app.buttons["upgradeToDPoPButton"]
+    }
+
+    private func downgradeFromDPoPButton() -> XCUIElement {
+        return app.buttons["downgradeFromDPoPButton"]
     }
 
     private func allowButton() -> XCUIElement {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
@@ -159,6 +159,23 @@ class DPoPLoginTests: BaseAuthFlowTester {
         upgradeToDPoPAndValidate()
     }
 
+    // MARK: - Downgrade
+
+    /// Login with a DPoP-bound session, then use `UserAccountManager.downgradeFromDPoP` to
+    /// re-authenticate the same connected app in place and verify the session becomes an unbound
+    /// Bearer session without changing the consumer key.
+    ///
+    /// Uses the DPoP-optional `.ecaJwt` ECA rather than the DPoP-enforced `.ecaJwtDpop`: an
+    /// enforced ECA rejects the downgrade's unbound `/authorize` request outright, so downgrading
+    /// only makes sense starting from an ECA that accepts DPoP without requiring it.
+    func test_givenDPoPSession_whenDowngradeFromDPoP_thenBearerUnbound() throws {
+        // Login with a DPoP-bound session against a DPoP-optional ECA.
+        launchLoginAndValidate(staticAppConfigName: .ecaJwt, useDPoP: true)
+
+        // Downgrade the current session from DPoP in place and validate the result.
+        downgradeFromDPoPAndValidate()
+    }
+
     // MARK: - Restart
 
     /// Restart app after DPoP login and verify session and keypair persist.

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -744,6 +744,47 @@ class BaseAuthFlowTester: XCTestCase {
         assertRevokeAndRefreshWorks(isRtr: false, isDPoP: true, wasMigrated: true, isJwt: isJwt)
     }
 
+    /// Downgrades the current DPoP-bound session back to Bearer in place (same connected app, via
+    /// `UserAccountManager.downgradeFromDPoP`) and validates the result: Bearer credentials, an
+    /// unchanged consumer key, and a working revoke/refresh cycle.
+    ///
+    /// Mirrors `upgradeToDPoPAndValidate` in the opposite direction — it re-authenticates against
+    /// the same client id/redirect URI/scopes with `useDPoP: false`, so the consumer key is
+    /// expected to stay the same while the refresh token is rotated and the session unbinds from
+    /// DPoP.
+    ///
+    /// - Parameter isJwt: Whether the connected app issues JWT-format access tokens (drives the
+    ///   "JT"/"OT" UA marker assertion). Defaults to `true` since the downgrade test uses `.ecaJwt`.
+    func downgradeFromDPoPAndValidate(isJwt: Bool = true) {
+        let originalUserCredentials = getUserCredentials()
+
+        XCTAssert(mainPage.downgradeFromDPoP(), "Failed to downgrade from DPoP")
+
+        let downgradedUserCredentials = getUserCredentials()
+
+        // The downgrade re-authenticates with the same connected app: consumer key is unchanged.
+        XCTAssertEqual(
+            originalUserCredentials.clientId,
+            downgradedUserCredentials.clientId,
+            "Consumer key should be unchanged after downgrading from DPoP"
+        )
+
+        XCTAssertNotEqual(downgradedUserCredentials.dpopTokenType, "DPoP", "Token type should no longer be DPoP after downgrade")
+
+        // Making sure the refresh token changed
+        XCTAssertNotEqual(
+            originalUserCredentials.refreshToken,
+            downgradedUserCredentials.refreshToken,
+            "Refresh token should have been rotated by the DPoP downgrade"
+        )
+
+        // `downgradeFromDPoP` delegates to the refresh-token migration path, so the "TM"
+        // (token-migration) UA feature flag is legitimately registered — the marker tracks the
+        // migration mechanism, not whether the connected app changed. Assert its presence, and
+        // that "DP" is absent now that the session is Bearer-bound.
+        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: false, wasMigrated: true, isJwt: isJwt)
+    }
+
     /// Launches the app and attempts a login expected to fail before any credentials are entered.
     ///
     /// Replays the same host-list / login-options / login-host prefix as `login()` (selecting the

--- a/native/SampleApps/AuthFlowTester/README.md
+++ b/native/SampleApps/AuthFlowTester/README.md
@@ -51,6 +51,7 @@ All DPoP tests live here — basic login, RTR, multi-user, migration, server enf
 | `test_givenDPoPUser_whenMigrateToDPoPRtr_thenRefreshTokenRotationEnabled` | ECA JWT DPoP → ECA JWT DPoP RTR | — | Migrate from DPoP to DPoP+RTR |
 | `testLogin_DPoP_ECA_Without_DPoP_Fails` | ECA JWT DPoP | — | Server enforcement: DPoP-enforced ECA rejects login without DPoP (`useDPoP: false`); no account created |
 | `test_givenBearerSession_whenUpgradeToDPoP_thenDPoPBound` | ECA JWT → ECA JWT DPoP | — | Bearer → DPoP in-place upgrade via `UserAccountManager.upgradeToDPoP`; consumer key unchanged, `token_type: "DPoP"` post-upgrade |
+| `test_givenDPoPSession_whenDowngradeFromDPoP_thenBearerUnbound` | ECA JWT | — | DPoP → Bearer in-place downgrade via `UserAccountManager.downgradeFromDPoP`; consumer key unchanged, `token_type` no longer `"DPoP"` post-downgrade. Runs on the DPoP-*optional* ECA JWT app (a DPoP-*enforced* app would reject the downgrade's unbound `/authorize` request) |
 | `test_givenDPoPUser_whenAppRestart_thenSessionAndKeypairSurvive` | ECA JWT DPoP | — | `XCTSkip` (pending SDK fix — RestClient path lacks nonce-challenge retry; post-restart DPoP revoke fails because in-memory nonce cache is empty) |
 | `test_givenDPoP_whenLoginViaPoolServer_thenTokenTypeIsDPoP` | ECA JWT DPoP | — | `XCTSkip` (W-23864247 — pool login server rejects valid `dpop_jkt` token exchange) |
 | `test_givenDPoPECA_whenAdminLogin_thenDPoPBindingWorksThroughBrowser` | ECA JWT DPoP | — | Login for Admins hand-off to ASWebAuthenticationSession works with DPoP binding |


### PR DESCRIPTION
## What

Adds `SFUserAccountManager.downgradeFromDPoP(_:success:failure:)`, the inverse of the existing `upgradeToDPoP`. It rolls a DPoP-bound session back to unbound Bearer **in place** — same connected app, redirect URI, and scopes — independent of the global `usesDPoP` flag. It is a **no-op** (success callback, unchanged account) when the session is already Bearer.

## Why

Completes the in-place DPoP migration pair so apps can move a user off DPoP without a full logout/login, mirroring `upgradeToDPoP`.

## Changes

- **`SFUserAccountManager`** — new `downgradeFromDPoP:` wrapper delegating to `migrateRefreshToken` with `useDPoP:@NO`; no-op guard when already Bearer. On success it deletes the obsolete DPoP key pair + nonce-cache entry keyed to the pre-migration credentials, and unregisters the `DP` user-agent feature marker for the now-Bearer completion.
- **`SFOAuthCoordinator` (`/authorize` binding)** — decides whether to append `dpop_jkt` by precedence: explicit per-call override → per-user `credentials.tokenType` → global flag. Previously an interactive re-login of a downgraded account fell through to the global flag (default on in 14.0) and silently re-bound the session to DPoP. **This is an OAuth2 `/authorize` behavior change and needs maintainer review.**
- **AuthFlowTester** — "Downgrade from DPoP" action (enabled only for a DPoP-bound session) + downgrade UI test.
- **Tests** — coordinator precedence unit tests (17/17 pass) + downgrade delegation / no-op-guard unit tests.

## Review notes

- Touches the OAuth2 credential path, a public API, and the `/authorize` binding decision — requesting maintainer (Wolf) review before merge; kept as **draft**.
- Device re-run of the downgrade UI test's post-downgrade revoke→refresh leg is the remaining verification.
