### PR TITLE
fix(auth): guard migrateRefreshToken dispatch_async against stale sessions (W-23992574)

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -902,7 +902,13 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     __weak typeof(self) weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
+        // Guard: if the session was removed before this block ran (e.g. the caller
+        // manually invoked the success/failure callback in a test, or another code
+        // path cancelled the session), skip the OAuth kick-off so no stale
+        // coordinator attempts to fire a network request for a dead session.
+        if (!strongSelf || !strongSelf.authSessions[authSession.sceneId]) { return; }
         [strongSelf dismissAuthViewControllerIfPresentForScene:authSession.oauthRequest.scene completion:^{
+            if (!strongSelf.authSessions[authSession.sceneId]) { return; }
             [authSession.oauthCoordinator migrateRefreshToken:user];
         }];
     });

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -429,8 +429,10 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
          [refreshExpectation fulfill];
          user = userAccount;
      } failure:^(SFOAuthInfo *authInfo, NSError *error) {
+         XCTFail(@"refreshCredentials failed: %@", error.localizedDescription);
+         [refreshExpectation fulfill];
      }];
-   
+
     [self waitForExpectations:@[refreshExpectation] timeout:20];
     
 }


### PR DESCRIPTION
## Summary

- `testDowngradeFromDPoP_*` tests queue a `dispatch_async(dispatch_get_main_queue(), ...)` in `migrateRefreshToken:` then immediately clean up the auth session; the pending block fires during `testLogin`'s `waitForExpectations:timeout:20`, triggering `NSInternalInconsistencyException: Use SFRestAPI sharedInstance for authenticated requests` (seen in [Actions run 32898781351](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/actions/runs/32898781351))
- Add a session-alive guard (`authSessions[authSession.sceneId]`) in both the outer and inner `dispatch_async` block so stale sessions are silently skipped
- Fix `testLogin`'s empty failure block to surface errors via `XCTFail` — previously silent failures masked real timeouts

## Test plan

- [x] Ran `SFUserAccountManagerTests` locally: 24 tests, 0 failures (including `testLogin` passing in ~0.9 s with a real network token refresh)
- [x] Validated against CI failure scenario: `testDowngradeFromDPoP_*` tests run before `testLogin` with no crash