### PR TITLE
fix(AuthFlowTester): update isRtr to treat beacon apps as RTR because of server bug

### DIFF
--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestConfigUtils.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestConfigUtils.swift
@@ -138,9 +138,9 @@ struct AppConfig: Codable {
         return name.hasPrefix("beacon_")
     }
 
-    /// Returns true if the app uses Refresh Token Rotation (name contains "_rtr")
+    // W-23971480: beacon apps behave as RTR due to a server bug; drop the beacon_ clause when fixed
     var isRtr: Bool {
-        return name.contains("_rtr")
+        return name.contains("_rtr") || name.hasPrefix("beacon_")
     }
 
     /// Returns true if the app uses DPoP (name contains "_dpop")


### PR DESCRIPTION
## Summary

Update `isRtr` in `UITestConfigUtils.swift` to treat `beacon_` apps as RTR:

```swift
// W-23971480: beacon apps behave as RTR due to a server bug; drop the beacon_ clause when fixed
var isRtr: Bool {
    return name.contains("_rtr") || name.hasPrefix("beacon_")
}
```

## Server-side bug

W-23971480 tracks a server bug where beacon apps rotate the refresh token even though their app config name does not contain `"_rtr"`. Without this fix, `assertRevokeAndRefreshWorks` incorrectly expects the refresh token to stay the same for beacon logins, causing `BeaconLoginTests` and `AdvancedAuthBeaconLoginTests` to fail. The `beacon_` clause should be dropped once W-23971480 is fixed on the server side.

## Tests run locally

All beacon test suites passed locally on iPhone 16 simulator (iOS 18.6):

| Suite | Result |
|-------|--------|
| `BeaconLoginTests` (6 tests) | All passed |
| `AdvancedAuthBeaconLoginTests` (6 tests) | All passed |

## Re-created beacon apps on sdb38
The environment had been reset a while back. Updated UI_TEST_CONFIG secret.