### PR TITLE
Deprecate useWebServerAuthentication (OAuth user agent flow)

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager+Internal.h
@@ -34,6 +34,13 @@ API_UNAVAILABLE(visionos)
  -Wdeprecated-declarations. Delete this alongside the public property in 15.0.
  */
 @property (nonatomic, assign) BOOL sdk_forceAdvancedAuthentication;
+
+/** Non-deprecated internal accessor for the same backing storage as the public
+ `useWebServerAuthentication` property (deprecated in 14.0, removed in 15.0). Internal SDK code
+ reads and writes the flag through this accessor so that its own use does not trip
+ -Wdeprecated-declarations. Delete this alongside the public property in 15.0.
+ */
+@property (nonatomic, assign) BOOL sdk_useWebServerAuthentication;
 @property (nonatomic, strong, nonnull) SFSDKSafeMutableDictionary<NSString *, UIViewController *> *snapshotViewControllers;
 @property (nonatomic, strong, nullable) SFSDKSafeMutableDictionary<NSString *, UIViewController *> *nativeLoginViewControllers;
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -260,7 +260,7 @@ NS_SWIFT_NAME(SalesforceManager)
 
 /** Whether or not the app should use web server oauth flow in web view. If false, user-agent will be used.
  */
-@property (nonatomic, assign) BOOL useWebServerAuthentication;
+@property (nonatomic, assign) BOOL useWebServerAuthentication SFSDK_DEPRECATED(14.0, 15.0, "The OAuth user agent flow is being retired; the web server flow will be used going forward. This flag may be removed sooner than 15.0 if the server no longer supports the user agent flow.");
 
 /** Whether hybrid authentication flow should be used. Defaults to YES.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -151,6 +151,18 @@ SFNativeLoginManagerInternal *nativeLogin;
     _forceAdvancedAuthentication = sdk_forceAdvancedAuthentication;
 }
 
+// Non-deprecated internal accessor over the same backing ivar as the deprecated public
+// useWebServerAuthentication property (see SalesforceSDKManager+Internal.h). Lets internal SDK
+// code read/write the flag without tripping -Wdeprecated-declarations. Remove with the public
+// property in 15.0.
+- (BOOL)sdk_useWebServerAuthentication {
+    return _useWebServerAuthentication;
+}
+
+- (void)setSdk_useWebServerAuthentication:(BOOL)sdk_useWebServerAuthentication {
+    _useWebServerAuthentication = sdk_useWebServerAuthentication;
+}
+
 + (void)setInstanceClass:(Class)className {
     InstanceClass = className;
 }
@@ -231,7 +243,7 @@ SFNativeLoginManagerInternal *nativeLogin;
 
 - (void)resetAuthFlags {
     self.useEphemeralSessionForAdvancedAuth = YES;
-    self.useWebServerAuthentication = YES;
+    self.sdk_useWebServerAuthentication = YES;
     self.useHybridAuthentication = YES;
     self.useDPoP = YES;
     self.sdk_forceAdvancedAuthentication = YES;
@@ -618,7 +630,7 @@ static NSString *SFSDKISO8601StringFromDate(NSDate *date) {
     // Auth configuration
     [devInfos addObject:@"section:Auth Config"];
     [devInfos addObjectsFromArray:@[
-            @"Use Web Server Authentication", [self useWebServerAuthentication]  ? @"YES" : @"NO",
+            @"Use Web Server Authentication", [self sdk_useWebServerAuthentication]  ? @"YES" : @"NO",
             @"Use Hybrid Authentication", [self useHybridAuthentication]  ? @"YES" : @"NO",
             @"Use DPoP", [self useDPoP] ? @"YES" : @"NO",
             @"Force Advanced Authentication", [self sdk_forceAdvancedAuthentication]  ? @"YES" : @"NO",

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/AuthFlowTypesView.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/DevConfig/AuthFlowTypesView.swift
@@ -42,7 +42,7 @@ public struct AuthFlowTypesView: View {
     @State private var importJSONText: String = ""
 
     public init() {
-        _useWebServerFlow = State(initialValue: SalesforceManager.shared.useWebServerAuthentication)
+        _useWebServerFlow = State(initialValue: Self.readUseWebServerAuthentication())
         _useHybridFlow = State(initialValue: SalesforceManager.shared.useHybridAuthentication)
         _forceAdvancedAuth = State(initialValue: Self.readForceAdvancedAuthentication())
     }
@@ -72,7 +72,7 @@ public struct AuthFlowTypesView: View {
                 }
                 .accessibilityIdentifier("useWebServerFlowToggle")
                 .onChange(of: useWebServerFlow) { _, newValue in
-                    SalesforceManager.shared.useWebServerAuthentication = newValue
+                    Self.writeUseWebServerAuthentication(newValue)
                 }
                 .padding(.horizontal)
 
@@ -119,7 +119,7 @@ public struct AuthFlowTypesView: View {
 
         if let webServerFlow = json[AuthFlowTypesJSONKeys.useWebServerFlow] as? Bool {
             useWebServerFlow = webServerFlow
-            SalesforceManager.shared.useWebServerAuthentication = webServerFlow
+            Self.writeUseWebServerAuthentication(webServerFlow)
         }
         if let hybridFlow = json[AuthFlowTypesJSONKeys.useHybridFlow] as? Bool {
             useHybridFlow = hybridFlow
@@ -148,6 +148,25 @@ public struct AuthFlowTypesView: View {
 
     private static func writeForceAdvancedAuthentication(_ newValue: Bool) {
         SalesforceManager.shared.setValue(newValue, forKey: forceAdvancedAuthenticationKey)
+    }
+
+    // MARK: - useWebServerAuthentication access
+    //
+    // `SalesforceManager.useWebServerAuthentication` is deprecated (14.0, removed in 15.0). Internal
+    // Objective-C SDK code reaches the same backing storage through the non-deprecated
+    // `sdk_useWebServerAuthentication` accessor in SalesforceSDKManager+Internal.h, but that class
+    // extension is not visible to this framework's own Swift, and Swift has no inline way to silence a
+    // deprecation warning. This dev-only toggle therefore reads and writes the flag through key-value
+    // coding so it stays warning-free without deprecating this view's public API. Remove these helpers
+    // when the property is removed in 15.0.
+    private static let useWebServerAuthenticationKey = "useWebServerAuthentication"
+
+    private static func readUseWebServerAuthentication() -> Bool {
+        (SalesforceManager.shared.value(forKey: useWebServerAuthenticationKey) as? Bool) ?? true
+    }
+
+    private static func writeUseWebServerAuthentication(_ newValue: Bool) {
+        SalesforceManager.shared.setValue(newValue, forKey: useWebServerAuthenticationKey)
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -131,7 +131,7 @@
 }
 
 - (BOOL)shouldUseWebServerFlow {
-    return [[SalesforceSDKManager sharedManager] useWebServerAuthentication] || [SFUserAccountManager sharedInstance].appAttestationEnabled;
+    return [[SalesforceSDKManager sharedManager] sdk_useWebServerAuthentication] || [SFUserAccountManager sharedInstance].appAttestationEnabled;
 }
 
 - (void)authenticate {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AuthFlowTypesViewTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/AuthFlowTypesViewTests.swift
@@ -32,8 +32,9 @@ class AuthFlowTypesViewTests: XCTestCase {
     var originalUseHybridAuth: Bool!
     var originalForceAdvancedAuth: Bool!
 
-    // Touches the deprecated `forceAdvancedAuthentication` (removed in 15.0) to save/restore it.
-    @available(*, deprecated, message: "Exercises deprecated forceAdvancedAuthentication; remove with the property in 15.0.")
+    // Touches the deprecated `forceAdvancedAuthentication` and `useWebServerAuthentication`
+    // (both removed in 15.0) to save/restore them.
+    @available(*, deprecated, message: "Exercises deprecated forceAdvancedAuthentication and useWebServerAuthentication; remove with the properties in 15.0.")
     override func setUp() {
         super.setUp()
 
@@ -43,7 +44,7 @@ class AuthFlowTypesViewTests: XCTestCase {
         originalForceAdvancedAuth = SalesforceManager.shared.forceAdvancedAuthentication
     }
 
-    @available(*, deprecated, message: "Exercises deprecated forceAdvancedAuthentication; remove with the property in 15.0.")
+    @available(*, deprecated, message: "Exercises deprecated forceAdvancedAuthentication and useWebServerAuthentication; remove with the properties in 15.0.")
     override func tearDown() {
         // Restore original state
         SalesforceManager.shared.useWebServerAuthentication = originalUseWebServerAuth
@@ -53,6 +54,7 @@ class AuthFlowTypesViewTests: XCTestCase {
         super.tearDown()
     }
     
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testAuthFlowTypesViewRendersSuccessfully() {
         let expectation = XCTestExpectation(description: "View renders without crashing")
         
@@ -92,6 +94,7 @@ class AuthFlowTypesViewTests: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
     }
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testImportAuthFlowTypesFromJSON() {
         // Set initial state
         SalesforceManager.shared.useWebServerAuthentication = true
@@ -128,6 +131,7 @@ class AuthFlowTypesViewTests: XCTestCase {
                       "Hybrid authentication should be false after import")
     }
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testImportAuthFlowTypesFromJSONPartialUpdate() {
         // Set initial state
         SalesforceManager.shared.useWebServerAuthentication = true
@@ -239,6 +243,7 @@ class AuthFlowTypesViewTests: XCTestCase {
                      "forceAdvancedAuthentication must remain true when it is not present in the imported JSON")
     }
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testImportAuthFlowTypesFromInvalidJSON() {
         // Set initial state
         SalesforceManager.shared.useWebServerAuthentication = true
@@ -260,6 +265,7 @@ class AuthFlowTypesViewTests: XCTestCase {
                      "Hybrid authentication should remain true after invalid JSON")
     }
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testImportAuthFlowTypesFromEmptyJSON() {
         // Set initial state
         SalesforceManager.shared.useWebServerAuthentication = true

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginForAdminTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/LoginForAdminTests.swift
@@ -32,12 +32,14 @@ class LoginForAdminTests: XCTestCase {
     private var originalUseWebServerAuth: Bool = true
     private var originalUseHybridAuth: Bool = false
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     override func setUp() {
         super.setUp()
         originalUseWebServerAuth = SalesforceManager.shared.useWebServerAuthentication
         originalUseHybridAuth = SalesforceManager.shared.useHybridAuthentication
     }
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     override func tearDown() {
         SalesforceManager.shared.useWebServerAuthentication = originalUseWebServerAuth
         SalesforceManager.shared.useHybridAuthentication = originalUseHybridAuth
@@ -111,6 +113,7 @@ class LoginForAdminTests: XCTestCase {
         session.oauthCoordinator.stopAuthentication()
     }
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testGivenWebServerAuth_whenAuthenticate_thenAuthInfoIsWebServer() {
         createTestAppIdentity()
         SalesforceManager.shared.useWebServerAuthentication = true
@@ -129,6 +132,7 @@ class LoginForAdminTests: XCTestCase {
         session.oauthCoordinator.stopAuthentication()
     }
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testGivenUserAgentAuth_whenAuthenticate_thenAuthInfoIsUserAgent() {
         createTestAppIdentity()
         SalesforceManager.shared.useWebServerAuthentication = false
@@ -149,6 +153,7 @@ class LoginForAdminTests: XCTestCase {
 
     // MARK: - Approval URL Web Server Flow
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testGivenLoginAsAdmin_whenGenerateApprovalUrl_thenUsesWebServerFlow() {
         createTestAppIdentity()
         SalesforceManager.shared.useWebServerAuthentication = false
@@ -165,6 +170,7 @@ class LoginForAdminTests: XCTestCase {
                        "Approval URL should not use response_type=token when loginAsAdmin is true")
     }
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testGivenNoLoginAsAdmin_whenWebServerAuthDisabled_thenUsesUserAgentFlow() {
         createTestAppIdentity()
         SalesforceManager.shared.useWebServerAuthentication = false
@@ -183,6 +189,7 @@ class LoginForAdminTests: XCTestCase {
 
     // MARK: - No Global State Mutation
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testGivenLoginAsAdmin_whenSet_thenGlobalWebServerAuthUnchanged() {
         let originalValue = SalesforceManager.shared.useWebServerAuthentication
 
@@ -193,6 +200,7 @@ class LoginForAdminTests: XCTestCase {
                        "Setting loginAsAdmin should not change the global useWebServerAuthentication")
     }
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testGivenLoginAsAdmin_whenAuthSessionCreated_thenGlobalStateUnchanged() {
         SalesforceManager.shared.useWebServerAuthentication = false
 
@@ -226,6 +234,7 @@ class LoginForAdminTests: XCTestCase {
                        "Coordinator should not use browser auth after loginAsAdmin is cleared")
     }
 
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func testGivenLoginAsAdminCancelled_whenNewSession_thenAuthInfoMatchesGlobalSetting() {
         createTestAppIdentity()
         SalesforceManager.shared.useWebServerAuthentication = true

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.m
@@ -365,9 +365,9 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
 - (void)test_givenAttestationEnabled_andWebServerFlowDisabled_whenAuthenticateCalled_thenUsesWebServerFlowType {
     // Arrange
     BOOL originalAttestation = [SFUserAccountManager sharedInstance].appAttestationEnabled;
-    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] useWebServerAuthentication];
+    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] sdk_useWebServerAuthentication];
     [SFUserAccountManager sharedInstance].appAttestationEnabled = YES;
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = NO;
+    [SalesforceSDKManager sharedManager].sdk_useWebServerAuthentication = NO;
 
     SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"testFlowType" clientId:@"testClient" encrypted:NO];
     creds.domain = @"mydomain.my.salesforce.com";
@@ -390,7 +390,7 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
 
     // Cleanup
     [SFUserAccountManager sharedInstance].appAttestationEnabled = originalAttestation;
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = originalWebServer;
+    [SalesforceSDKManager sharedManager].sdk_useWebServerAuthentication = originalWebServer;
     [SFSDKAppFeatureMarkers unregisterAppFeature:kSFAppFeatureAppAttestation];
     [creds revoke];
 }
@@ -398,9 +398,9 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
 - (void)test_givenAttestationDisabled_andWebServerFlowDisabled_whenAuthenticateCalled_thenUsesUserAgentFlowType {
     // Arrange
     BOOL originalAttestation = [SFUserAccountManager sharedInstance].appAttestationEnabled;
-    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] useWebServerAuthentication];
+    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] sdk_useWebServerAuthentication];
     [SFUserAccountManager sharedInstance].appAttestationEnabled = NO;
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = NO;
+    [SalesforceSDKManager sharedManager].sdk_useWebServerAuthentication = NO;
 
     SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"testFlowType2" clientId:@"testClient2" encrypted:NO];
     creds.domain = @"mydomain.my.salesforce.com";
@@ -423,16 +423,16 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
 
     // Cleanup
     [SFUserAccountManager sharedInstance].appAttestationEnabled = originalAttestation;
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = originalWebServer;
+    [SalesforceSDKManager sharedManager].sdk_useWebServerAuthentication = originalWebServer;
     [creds revoke];
 }
 
 - (void)test_givenAttestationEnabled_whenGeneratingApprovalUrl_thenContainsResponseTypeCode {
     // Arrange
     BOOL originalAttestation = [SFUserAccountManager sharedInstance].appAttestationEnabled;
-    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] useWebServerAuthentication];
+    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] sdk_useWebServerAuthentication];
     [SFUserAccountManager sharedInstance].appAttestationEnabled = YES;
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = NO;
+    [SalesforceSDKManager sharedManager].sdk_useWebServerAuthentication = NO;
 
     SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"testApprovalUrl" clientId:@"testClient" encrypted:NO];
     creds.domain = @"mydomain.my.salesforce.com";
@@ -453,16 +453,16 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
 
     // Cleanup
     [SFUserAccountManager sharedInstance].appAttestationEnabled = originalAttestation;
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = originalWebServer;
+    [SalesforceSDKManager sharedManager].sdk_useWebServerAuthentication = originalWebServer;
     [creds revoke];
 }
 
 - (void)test_givenAttestationDisabled_andWebServerFlowDisabled_whenGeneratingApprovalUrl_thenDoesNotContainResponseTypeCode {
     // Arrange
     BOOL originalAttestation = [SFUserAccountManager sharedInstance].appAttestationEnabled;
-    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] useWebServerAuthentication];
+    BOOL originalWebServer = [[SalesforceSDKManager sharedManager] sdk_useWebServerAuthentication];
     [SFUserAccountManager sharedInstance].appAttestationEnabled = NO;
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = NO;
+    [SalesforceSDKManager sharedManager].sdk_useWebServerAuthentication = NO;
 
     SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"testApprovalUrl2" clientId:@"testClient2" encrypted:NO];
     creds.domain = @"mydomain.my.salesforce.com";
@@ -481,7 +481,7 @@ static NSString * const kExpectedUnscopedSceneIdPrefix = @"com.salesforce.mobile
 
     // Cleanup
     [SFUserAccountManager sharedInstance].appAttestationEnabled = originalAttestation;
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = originalWebServer;
+    [SalesforceSDKManager sharedManager].sdk_useWebServerAuthentication = originalWebServer;
     [creds revoke];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCoordinatorTests.swift
@@ -403,6 +403,7 @@ class SFOAuthCoordinatorTests: XCTestCase {
     /// emits `response_type=token` (or `hybrid_token` when hybrid mode is on),
     /// but the dpop_jkt append happens after the flow branch, so the gate
     /// result must be identical.
+    @available(*, deprecated, message: "Exercises deprecated useWebServerAuthentication; remove with the property in 15.0.")
     func test_givenDPoPEnabledAndUserAgentFlow_whenGenerateApprovalUrlString_thenUrlStillContainsDPoPJkt() throws {
         SalesforceManager.shared.usesDPoP = true
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SalesforceSDKManagerTests.m
@@ -404,7 +404,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     credentials.redirectUri = @"test";
     
     // Hybrid enabled, web server enabled
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = YES;
+    [self setUseWebServerAuthenticationForTest:YES];
     SFOAuthCoordinator *coordinator = [[SFOAuthCoordinator alloc] initWithCredentials:credentials];
     SFOAuthTestFlowCoordinatorDelegate *delegate = [SFOAuthTestFlowCoordinatorDelegate new];
     coordinator.delegate = delegate;
@@ -415,7 +415,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     [coordinator stopAuthentication];
     
     // Hybrid enabled, web server disabled
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = NO;
+    [self setUseWebServerAuthenticationForTest:NO];
     approvalUrl = [coordinator generateApprovalUrlString];
     XCTAssert([approvalUrl containsString:@"response_type=hybrid_token"]);
     [coordinator authenticate];
@@ -424,7 +424,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     
     // Hybrid disabled, web server enabled
     [SalesforceSDKManager sharedManager].useHybridAuthentication = NO;
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = YES;
+    [self setUseWebServerAuthenticationForTest:YES];
     approvalUrl = [coordinator generateApprovalUrlString];
     XCTAssert([approvalUrl containsString:@"response_type=code"]);
     [coordinator authenticate];
@@ -433,7 +433,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     
     // Hybrid disabled, web server disabled
     [SalesforceSDKManager sharedManager].useHybridAuthentication = NO;
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = NO;
+    [self setUseWebServerAuthenticationForTest:NO];
     approvalUrl = [coordinator generateApprovalUrlString];
     XCTAssert([approvalUrl containsString:@"response_type=token"]);
     [coordinator authenticate];
@@ -630,7 +630,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     // implicit flow (response_type=token). The native-browser path hardcodes webServerFlow:YES
     // (SFOAuthCoordinator.m:420-425) and never consults useWebServerAuthentication.
     [self setForceAdvancedAuthenticationForTest:YES];
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = NO;
+    [self setUseWebServerAuthenticationForTest:NO];
     [SalesforceSDKManager sharedManager].useHybridAuthentication = NO;
 
     SFOAuthCredentials *credentials = [self standardLoginCredentialsWithIdentifier:@"securityInvariant"];
@@ -814,6 +814,24 @@ static NSString* const kTestAppName = @"OverridenAppName";
     SFSDK_USE_DEPRECATED_END
 }
 
+// useWebServerAuthentication is deprecated (14.0, removed in 15.0). These tests intentionally
+// exercise the public property a consumer would set, so all reads/writes are funneled through these
+// two helpers to localize the sanctioned -Wdeprecated-declarations suppression to one place. Remove
+// both helpers (and inline the property access) when the property is removed in 15.0.
+- (BOOL)currentUseWebServerAuthentication
+{
+    SFSDK_USE_DEPRECATED_BEGIN
+    return [SalesforceSDKManager sharedManager].useWebServerAuthentication;
+    SFSDK_USE_DEPRECATED_END
+}
+
+- (void)setUseWebServerAuthenticationForTest:(BOOL)enabled
+{
+    SFSDK_USE_DEPRECATED_BEGIN
+    [SalesforceSDKManager sharedManager].useWebServerAuthentication = enabled;
+    SFSDK_USE_DEPRECATED_END
+}
+
 - (void)setupSdkManagerState
 {
     _currentSdkManagerFlow = [[SFTestSDKManagerFlow alloc] init];
@@ -829,7 +847,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     // Auth-flow flags are process-global on the shared manager; snapshot so tests that flip
     // them (forced Advanced Auth, web-server/hybrid) cannot leak into other tests.
     _origForceAdvancedAuthentication = [self currentForceAdvancedAuthentication];
-    _origUseWebServerAuthentication = [SalesforceSDKManager sharedManager].useWebServerAuthentication;
+    _origUseWebServerAuthentication = [self currentUseWebServerAuthentication];
     _origUseHybridAuthentication = [SalesforceSDKManager sharedManager].useHybridAuthentication;
 }
 
@@ -844,7 +862,7 @@ static NSString* const kTestAppName = @"OverridenAppName";
     SalesforceSDKManager.ailtnAppName = _origAppName;
     [SalesforceSDKManager sharedManager].brandLoginPath = _origBrandLoginPath;
     [self setForceAdvancedAuthenticationForTest:_origForceAdvancedAuthentication];
-    [SalesforceSDKManager sharedManager].useWebServerAuthentication = _origUseWebServerAuthentication;
+    [self setUseWebServerAuthenticationForTest:_origUseWebServerAuthentication];
     [SalesforceSDKManager sharedManager].useHybridAuthentication = _origUseHybridAuthentication;
 }
 


### PR DESCRIPTION
Deprecates `useWebServerAuthentication` on `SalesforceSDKManager` (14.0, for removal in 15.0). The OAuth user agent flow is being retired; the web server flow will be used going forward. The flag may be removed sooner than 15.0 if the server no longer supports the user agent flow.

- Public property annotated with `SFSDK_DEPRECATED(14.0, 15.0, ...)`.
- Internal SDK code reaches the same backing storage through a new non-deprecated `sdk_useWebServerAuthentication` accessor (dev menu uses KVC) so no internal usage trips `-Wdeprecated-declarations`.
- Tests annotated `@available(*, deprecated)` / routed through helpers to stay warning-free.