### PR TITLE
[iOS] Speed up AuthFlowTester UI tests and fix RT marker expectations

### DIFF
--- a/native/SampleApps/AuthFlowTester/AuthFlowTester.xctestplan
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester.xctestplan
@@ -20,7 +20,7 @@
           "identifier" : "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
         },
         "maximumTestExecutionTimeAllowance" : 480,
-        "maximumTestRepetitions" : 3,
+        "maximumTestRepetitions" : 2,
         "region" : "US",
         "targetForVariableExpansion" : {
           "containerPath" : "container:AuthFlowTester.xcodeproj",
@@ -51,7 +51,7 @@
       "identifier" : "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
     },
     "maximumTestExecutionTimeAllowance" : 480,
-    "maximumTestRepetitions" : 3,
+    "maximumTestRepetitions" : 2,
     "region" : "US",
     "targetForVariableExpansion" : {
       "containerPath" : "container:AuthFlowTester.xcodeproj",

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester.xctestplan
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester.xctestplan
@@ -20,7 +20,7 @@
           "identifier" : "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
         },
         "maximumTestExecutionTimeAllowance" : 480,
-        "maximumTestRepetitions" : 2,
+        "maximumTestRepetitions" : 1,
         "region" : "US",
         "targetForVariableExpansion" : {
           "containerPath" : "container:AuthFlowTester.xcodeproj",
@@ -51,7 +51,7 @@
       "identifier" : "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
     },
     "maximumTestExecutionTimeAllowance" : 480,
-    "maximumTestRepetitions" : 2,
+    "maximumTestRepetitions" : 1,
     "region" : "US",
     "targetForVariableExpansion" : {
       "containerPath" : "container:AuthFlowTester.xcodeproj",

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester/Classes/AppDelegate.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester/Classes/AppDelegate.swift
@@ -34,6 +34,13 @@ import UniformTypeIdentifiers
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
+
+    private struct UITestLoginHost {
+        let name: String
+        let host: String
+    }
+
+    private static let uiTestLoginHostsInfoKey = "SFDCOAuthLoginHosts"
     
     override init() {
         
@@ -41,9 +48,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         SalesforceManager.initializeSDK()
         #if DEBUG
-        if CommandLine.arguments.contains("--resetSDKForUITesting") {
+        let shouldResetForUITesting = CommandLine.arguments.contains("--resetSDKForUITesting")
+        if shouldResetForUITesting {
             SalesforceManager.resetForUITesting()
         }
+        seedUITestLoginHosts(selectDefaultHost: shouldResetForUITesting)
         if CommandLine.arguments.contains("--disableDPoPAtStart") {
             SalesforceManager.shared.usesDPoP = false
         }
@@ -98,6 +107,35 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     // MARK: - Private methods
+
+    /// Seeds AuthFlowTester's fixed UI-test servers after the SDK initializes.  The reset helper
+    /// intentionally clears custom hosts, so it must run before the test login flow starts.
+    /// Ordinary restarts seed missing entries without changing the selected host or session.
+    private func seedUITestLoginHosts(selectDefaultHost: Bool) {
+        guard let hosts = Bundle.main.object(forInfoDictionaryKey: Self.uiTestLoginHostsInfoKey) as? [[String: String]] else {
+            return
+        }
+
+        let uiTestHosts = hosts.compactMap { entry -> UITestLoginHost? in
+            guard let name = entry["name"], let host = entry["host"], !host.isEmpty else {
+                return nil
+            }
+            return UITestLoginHost(name: name, host: host)
+        }
+        guard let defaultHost = uiTestHosts.first else {
+            return
+        }
+
+        let storage = SFSDKLoginHostStorage.sharedInstance()
+        for host in uiTestHosts where storage.loginHost(forHostAddress: host.host) == nil {
+            storage.add(SalesforceLoginHost(name: host.name, host: host.host, deletable: false))
+        }
+
+        if selectDefaultHost {
+            UserAccountManager.shared.loginHost = defaultHost.host
+        }
+    }
+
     func registerForRemotePushNotifications() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { (granted, error) in
             if granted {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester/Supporting Files/Info.plist
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester/Supporting Files/Info.plist
@@ -56,7 +56,34 @@
 	<key>NSFaceIDUsageDescription</key>
 	<string>&quot;Use FaceID&quot;</string>
 	<key>SFDCOAuthLoginHost</key>
-	<string>login.salesforce.com</string>
+	<string>authflowtestingmsdksdb38.test1.my.pc-rnd.salesforce.com</string>
+	<key>SFDCOAuthLoginHosts</key>
+	<array>
+		<dict>
+			<key>name</key>
+			<string>UITests</string>
+			<key>host</key>
+			<string>authflowtestingmsdksdb38.test1.my.pc-rnd.salesforce.com</string>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>UITests Adv Auth</string>
+			<key>host</key>
+			<string>advauthflowtestingmsdksdb38.test1.my.pc-rnd.salesforce.com</string>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>UITests Login Pool</string>
+			<key>host</key>
+			<string>login.test1.pc-rnd.salesforce.com</string>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Welcome Discovery</string>
+			<key>host</key>
+			<string>welcome.salesforce.com/discovery</string>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/LoginPageObject.swift
@@ -94,13 +94,15 @@ class LoginPageObject {
     }
 
     /// Selects (or adds) the given login host. Assumes the host list ("Change Server") is already
-    /// showing — call `returnToHostList()` first. Selecting or adding a host causes the SDK to
-    /// restart authentication (relaunching the browser under forced advanced auth, or reloading
+    /// showing — call `returnToHostList()` first. `displayName` is used for a preconfigured server
+    /// whose user-visible label differs from its address. Selecting or adding a host causes the SDK
+    /// to restart authentication (relaunching the browser under forced advanced auth, or reloading
     /// the in-app WebView when the flag is off).
-    func configureLoginHost(host: String) -> Void {
-        if (hasHost(host: host)) {
+    func configureLoginHost(host: String, displayName: String? = nil) -> Void {
+        let hostRowName = displayName ?? host
+        if (hasHost(host: hostRowName)) {
             // Select host if it exists already
-            tap(hostRow(host: host))
+            tap(hostRow(host: hostRowName))
         } else {
             // Add host if it does not exist
             tap(addConnectionButton())
@@ -447,4 +449,3 @@ class LoginPageObject {
         return row.waitForExistence(timeout: UITestTimeouts.short)
     }
 }
-

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
@@ -40,8 +40,8 @@ class DPoPLoginTests: BaseAuthFlowTester {
         launchLoginAndValidate(staticAppConfigName: .ecaJwtDpop, useDPoP: true)
         // Two revoke/refresh cycles verify DPoP binding survives a second nonce rotation
         // (parity with Android's `testECAJwtDPoP_Hybrid`).
-        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: true, isJwt: true)
-        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: true, isJwt: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: false, isDPoP: true, isJwt: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: false, isDPoP: true, isJwt: true)
     }
 
     /// Login with ECA JWT DPoP without hybrid flow and verify DPoP token binding.
@@ -49,8 +49,8 @@ class DPoPLoginTests: BaseAuthFlowTester {
         launchLoginAndValidate(staticAppConfigName: .ecaJwtDpop, useHybridFlow: false, useDPoP: true)
         // Two revoke/refresh cycles verify DPoP binding survives a second nonce rotation
         // (parity with Android's `testECAJwtDPoP_NoHybrid`).
-        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: true, useHybridFlow: false, isJwt: true)
-        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: true, useHybridFlow: false, isJwt: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: false, isDPoP: true, useHybridFlow: false, isJwt: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: false, isDPoP: true, useHybridFlow: false, isJwt: true)
     }
 
     // MARK: - ECA JWT DPoP+RTR Tests
@@ -64,7 +64,7 @@ class DPoPLoginTests: BaseAuthFlowTester {
     /// Login with ECA JWT DPoP+RTR without hybrid flow and verify refresh token rotation and DPoP binding.
     func test_givenDPoPRtrNoHybrid_whenLogin_thenRefreshTokenRotatesAndDPoPBindingHolds() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaJwtDpopRtr, useHybridFlow: false, useDPoP: true)
-        assertRevokeAndRefreshWorks(isRtr: true, isDPoP: true, useHybridFlow: false, isJwt: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: true, isDPoP: true, useHybridFlow: false, isJwt: true)
     }
 
     // MARK: - Multi-User
@@ -87,13 +87,13 @@ class DPoPLoginTests: BaseAuthFlowTester {
 
         // Switch back to user A and verify nonce persisted
         switchToUserAndValidateUser(loginHost: .regularAuth, user: .first, userAppConfigName: .ecaJwtDpop, isMultiUser: true)
-        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: true, isMultiUser: true, isJwt: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: false, isDPoP: true, isMultiUser: true, isJwt: true)
         let userACredentialsAfterSwitch = getUserCredentials()
         XCTAssertEqual(userACredentialsAfterSwitch.dpopNonce, userANonceBeforeSwitch, "User A nonce should persist across switch")
 
         // Switch to user B and verify nonce persisted
         switchToUserAndValidateUser(loginHost: .regularAuth, user: .second, userAppConfigName: .ecaJwtDpop, isMultiUser: true)
-        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: true, isMultiUser: true, isJwt: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: false, isDPoP: true, isMultiUser: true, isJwt: true)
         let userBCredentialsAfterRefresh = getUserCredentials()
         XCTAssertEqual(userBCredentialsAfterRefresh.dpopNonce, userBNonce, "User B nonce should persist across switch and refresh")
     }
@@ -134,7 +134,7 @@ class DPoPLoginTests: BaseAuthFlowTester {
         )
 
         // Verify RTR is enabled post-migration
-        assertRevokeAndRefreshWorks(isRtr: true, isDPoP: true, expectAdvancedAuth: true, useHybridFlow: false, wasMigrated: true, isJwt: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: true, isDPoP: true, expectAdvancedAuth: true, useHybridFlow: false, wasMigrated: true, isJwt: true)
     }
 
     // MARK: - Enforcement
@@ -200,7 +200,7 @@ class DPoPLoginTests: BaseAuthFlowTester {
             userAppConfigName: .ecaJwtDpop,
             useHybridFlow: false
         )
-        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: true, useHybridFlow: false, isJwt: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: false, isDPoP: true, useHybridFlow: false, isJwt: true)
     }
 
     // MARK: - Pool Server Login
@@ -217,7 +217,7 @@ class DPoPLoginTests: BaseAuthFlowTester {
             useDPoP: true,
             useLoginPoolHost: true
         )
-        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: true, useHybridFlow: false, isJwt: true, useLoginPoolHost: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: false, isDPoP: true, useHybridFlow: false, isJwt: true, useLoginPoolHost: true)
     }
 
     /// Login via the pool server with DPoP + RTR and verify the refresh token survives the identity
@@ -234,7 +234,7 @@ class DPoPLoginTests: BaseAuthFlowTester {
             useDPoP: true,
             useLoginPoolHost: true
         )
-        assertRevokeAndRefreshWorks(isRtr: true, isDPoP: true, useHybridFlow: false, isJwt: true, useLoginPoolHost: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: true, isDPoP: true, useHybridFlow: false, isJwt: true, useLoginPoolHost: true)
     }
 
     // MARK: - Admin Login

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
@@ -49,8 +49,8 @@ class RTRLoginTests: BaseAuthFlowTester {
     func testECAJwtRtr_Hybrid_WithRestart() throws {
         throw XCTSkip("TODO: W-22512846 — Re-enable when server enables Named JWTs for Hybrid Flows")
         launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr)
-        restartAndValidateUser(userAppConfigName: .ecaJwtRtr, isRtr: true)
-        assertRevokeAndRefreshWorks(isRtr: true)
+        restartAndValidateUser(userAppConfigName: .ecaJwtRtr)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: true)
     }
 
     /// Login with ECA JWT RTR without hybrid flow.
@@ -61,8 +61,8 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA JWT RTR without hybrid flow, restart app, and verify session persists.
     func testECAJwtRtr_NoHybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr, useHybridFlow: false)
-        restartAndValidateUser(userAppConfigName: .ecaJwtRtr, useHybridFlow: false, isRtr: true)
-        assertRevokeAndRefreshWorks(isRtr: true, useHybridFlow: false, isJwt: true)
+        restartAndValidateUser(userAppConfigName: .ecaJwtRtr, useHybridFlow: false)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: true, useHybridFlow: false, isJwt: true)
     }
 
     // MARK: - ECA Opaque RTR Tests
@@ -75,8 +75,8 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA Opaque RTR using hybrid flow, restart app, and verify session persists.
     func testECAOpaqueRtr_Hybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr)
-        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, isRtr: true)
-        assertRevokeAndRefreshWorks(isRtr: true)
+        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: true)
     }
 
     /// Login with ECA Opaque RTR without hybrid flow.
@@ -87,7 +87,7 @@ class RTRLoginTests: BaseAuthFlowTester {
     /// Login with ECA Opaque RTR without hybrid flow, restart app, and verify session persists.
     func testECAOpaqueRtr_NoHybrid_WithRestart() throws {
         launchLoginAndValidate(staticAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
-        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, useHybridFlow: false, isRtr: true)
-        assertRevokeAndRefreshWorks(isRtr: true, useHybridFlow: false)
+        restartAndValidateUser(userAppConfigName: .ecaOpaqueRtr, useHybridFlow: false)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: true, useHybridFlow: false)
     }
 }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -63,6 +63,11 @@ class BaseAuthFlowTester: XCTestCase {
     // Test configuration
     private let testConfig = UITestConfigUtils.shared
 
+    // RT is a per-user, sticky SDK marker. It starts absent after login and is set only when a
+    // normal refresh observes a changed refresh token. Keep the expected state independently of
+    // whether the current app configuration is capable of refresh-token rotation.
+    private var expectedRTRFeatureMarkerByUsername: [String: Bool] = [:]
+
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
@@ -92,6 +97,8 @@ class BaseAuthFlowTester: XCTestCase {
     /// Initializes the app and page objects on the regular UI-test login server. Fresh launches
     /// reset all auth state, seed the fixed test servers, and select regular auth by default.
     func launch() {
+        // launch() requests --resetSDKForUITesting, which clears the SDK's per-user markers.
+        expectedRTRFeatureMarkerByUsername.removeAll()
         app = XCUIApplication()
 
         // Set environment variable to indicate we're running UI tests
@@ -234,6 +241,11 @@ class BaseAuthFlowTester: XCTestCase {
         else {
             loginPage.performLogin(username: userConfig.username, password: userConfig.password, advancedAuth: usesBrowser)
         }
+
+        // An authorization-code login does not use SFOAuthSessionRefresher, so it cannot set RT.
+        // Record this explicitly: later migration/restart checks must preserve this value until a
+        // test-triggered normal refresh observes token rotation.
+        expectedRTRFeatureMarkerByUsername[userConfig.username] = false
 
         // Invalid scope
         if (dynamicScopeSelection == .invalid || (dynamicAppConfig == nil && staticScopeSelection == .invalid)) {
@@ -604,7 +616,6 @@ class BaseAuthFlowTester: XCTestCase {
         loginForAdmin: Bool = false,
         usesWelcomeDiscovery: Bool = false,
         isMultiUser: Bool = false,
-        isRtr: Bool = false,
         wasMigrated: Bool = false
     ) {
         // Restart without --resetSDKForUITesting so the session persists across the restart
@@ -640,7 +651,6 @@ class BaseAuthFlowTester: XCTestCase {
             expectAdvancedAuth: expectAdvancedAuth,
             usesWelcomeDiscovery: usesWelcomeDiscovery,
             isMultiUser: isMultiUser,
-            isRtr: isRtr,
             expectedBMarker: expectedBMarker,
             expectedLMarker: expectedLMarker,
             expectedAMarker: aMarker,
@@ -755,7 +765,7 @@ class BaseAuthFlowTester: XCTestCase {
         // `upgradeToDPoP` delegates to the refresh-token migration path, so the "TM"
         // (token-migration) UA feature flag is legitimately registered — the marker tracks the
         // migration mechanism, not whether the connected app changed. Assert its presence.
-        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: true, wasMigrated: true, isJwt: isJwt)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: false, isDPoP: true, wasMigrated: true, isJwt: isJwt)
     }
 
     /// Downgrades the current DPoP-bound session back to Bearer in place (same connected app, via
@@ -796,7 +806,7 @@ class BaseAuthFlowTester: XCTestCase {
         // (token-migration) UA feature flag is legitimately registered — the marker tracks the
         // migration mechanism, not whether the connected app changed. Assert its presence, and
         // that "DP" is absent now that the session is Bearer-bound.
-        assertRevokeAndRefreshWorks(isRtr: false, isDPoP: false, wasMigrated: true, isJwt: isJwt)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: false, isDPoP: false, wasMigrated: true, isJwt: isJwt)
     }
 
     /// Launches the app and attempts a login expected to fail before any credentials are entered.
@@ -913,15 +923,15 @@ class BaseAuthFlowTester: XCTestCase {
     ///   - expectAdvancedAuth: Whether advanced auth (browser-based) was used, which sets the BW flag. Defaults to `false`.
     ///   - usesWelcomeDiscovery: Whether welcome domain discovery was used. Defaults to `false`.
     ///   - isMultiUser: Whether multiple users are currently logged in. Defaults to `false`.
-    ///   - isRtr: Whether Refresh Token Rotation is enabled, which sets the RT flag. Defaults to `false`.
+    ///   - expectedRTRFeatureMarker: Whether the SDK should already have registered RT for this user.
     ///   - expectedBMarker: The single B-marker code expected in the UA (e.g. "B3", "B4"). Pass `nil` when no browser login occurred.
     ///   - expectedLMarker: The single L-marker code expected in the UA (e.g. "L3", "L4"). Pass `nil` to assert no L-markers are present.
     ///   - expectedAMarker: The single A-marker code expected in the UA (e.g. "A1", "A5"). Pass `nil` to assert no A-markers are present.
     ///   - wasMigrated: Whether a refresh token migration occurred (TM flag). Defaults to `false`.
     ///   - isJwt: Whether the session uses JWT token format (JT flag). Defaults to `false`, asserting OT instead.
     ///   - isBeacon: Whether this is a beacon child app (BN flag). Defaults to `false`.
-    func validateUserAgent(userCredentials: UserCredentialsData, loginHost: KnownLoginHostConfig, expectAdvancedAuth: Bool = false, usesWelcomeDiscovery: Bool = false, isMultiUser: Bool = false, isRtr: Bool = false, expectDP: Bool = false, expectedBMarker: String? = nil, expectedLMarker: String? = nil, expectedAMarker: String? = nil, wasMigrated: Bool = false, isJwt: Bool = false, isBeacon: Bool = false) {
-        validateUserAgent(ua: userCredentials.userAgent, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, usesWelcomeDiscovery: usesWelcomeDiscovery, isMultiUser: isMultiUser, isRtr: isRtr, expectDP: expectDP, expectedBMarker: expectedBMarker, expectedLMarker: expectedLMarker, expectedAMarker: expectedAMarker, wasMigrated: wasMigrated, isJwt: isJwt, isBeacon: isBeacon)
+    func validateUserAgent(userCredentials: UserCredentialsData, loginHost: KnownLoginHostConfig, expectAdvancedAuth: Bool = false, usesWelcomeDiscovery: Bool = false, isMultiUser: Bool = false, expectDP: Bool = false, expectedBMarker: String? = nil, expectedLMarker: String? = nil, expectedAMarker: String? = nil, wasMigrated: Bool = false, isJwt: Bool = false, isBeacon: Bool = false) {
+        validateUserAgent(ua: userCredentials.userAgent, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, usesWelcomeDiscovery: usesWelcomeDiscovery, isMultiUser: isMultiUser, expectedRTRFeatureMarker: expectedRTRFeatureMarker(for: userCredentials.username), expectDP: expectDP, expectedBMarker: expectedBMarker, expectedLMarker: expectedLMarker, expectedAMarker: expectedAMarker, wasMigrated: wasMigrated, isJwt: isJwt, isBeacon: isBeacon)
     }
 
     /// Validates a pre-fetched user agent string. Called from validate() which already has the UA.
@@ -932,14 +942,14 @@ class BaseAuthFlowTester: XCTestCase {
     ///   - expectAdvancedAuth: Whether advanced auth (browser-based) was used, which sets the BW flag. Defaults to `false`.
     ///   - usesWelcomeDiscovery: Whether welcome domain discovery was used. Defaults to `false`.
     ///   - isMultiUser: Whether multiple users are currently logged in. Defaults to `false`.
-    ///   - isRtr: Whether Refresh Token Rotation is enabled, which sets the RT flag. Defaults to `false`.
+    ///   - expectedRTRFeatureMarker: Whether the SDK should already have registered RT for this user.
     ///   - expectedBMarker: The single B-marker code expected in the UA (e.g. "B3", "B4"). Pass `nil` when no browser login occurred.
     ///   - expectedLMarker: The single L-marker code expected in the UA (e.g. "L3", "L4"). Pass `nil` to skip the assertion.
     ///   - expectedAMarker: The single A-marker code expected in the UA (e.g. "A1", "A5"). Pass `nil` to assert no A-markers are present.
     ///   - wasMigrated: Whether a refresh token migration occurred (TM flag). Defaults to `false`.
     ///   - isJwt: Whether the session uses JWT token format (JT flag). Defaults to `false`.
     ///   - isBeacon: Whether this is a beacon child app (BN flag). Defaults to `false`.
-    private func validateUserAgent(ua: String, loginHost: KnownLoginHostConfig, expectAdvancedAuth: Bool = false, usesWelcomeDiscovery: Bool = false, isMultiUser: Bool = false, isRtr: Bool = false, expectDP: Bool = false, expectedBMarker: String? = nil, expectedLMarker: String? = nil, expectedAMarker: String? = nil, wasMigrated: Bool = false, isJwt: Bool = false, isBeacon: Bool = false) {
+    private func validateUserAgent(ua: String, loginHost: KnownLoginHostConfig, expectAdvancedAuth: Bool = false, usesWelcomeDiscovery: Bool = false, isMultiUser: Bool = false, expectedRTRFeatureMarker: Bool, expectDP: Bool = false, expectedBMarker: String? = nil, expectedLMarker: String? = nil, expectedAMarker: String? = nil, wasMigrated: Bool = false, isJwt: Bool = false, isBeacon: Bool = false) {
         XCTAssertTrue(ua.contains("SalesforceMobileSDK/"), "User agent should contain 'SalesforceMobileSDK/' prefix; got: \(ua)")
         XCTAssertTrue(ua.contains("ftr_"), "User agent should contain 'ftr_' feature flag segment; got: \(ua)")
 
@@ -971,12 +981,12 @@ class BaseAuthFlowTester: XCTestCase {
             XCTAssertFalse(flagSet.contains("MU"), "User agent should NOT contain 'MU' flag when only one user is logged in; flags: \(flagSet), ua: \(ua)")
         }
 
-        if isRtr {
+        if expectedRTRFeatureMarker {
             XCTAssertTrue(flagSet.contains("RT"),
-                          "User agent should contain 'RT' flag after Refresh Token Rotation; flags: \(flagSet), ua: \(ua)")
+                          "User agent should contain 'RT' after the SDK observed Refresh Token Rotation; flags: \(flagSet), ua: \(ua)")
         } else {
             XCTAssertFalse(flagSet.contains("RT"),
-                           "User agent should NOT contain 'RT' flag when Refresh Token Rotation has not occurred; flags: \(flagSet), ua: \(ua)")
+                           "User agent should NOT contain 'RT' before the SDK observes Refresh Token Rotation; flags: \(flagSet), ua: \(ua)")
         }
 
         if expectDP {
@@ -1199,7 +1209,6 @@ class BaseAuthFlowTester: XCTestCase {
         expectAdvancedAuth: Bool = false,
         usesWelcomeDiscovery: Bool = false,
         isMultiUser: Bool = false,
-        isRtr: Bool = false,
         expectedBMarker: String? = nil,
         expectedLMarker: String? = nil,
         expectedAMarker: String? = nil,
@@ -1243,7 +1252,7 @@ class BaseAuthFlowTester: XCTestCase {
         }
 
         // Validate feature flags using UA already present in the fetched credentials
-        validateUserAgent(ua: userCredentials.userAgent, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, usesWelcomeDiscovery: usesWelcomeDiscovery, isMultiUser: isMultiUser, isRtr: isRtr, expectDP: effectiveExpectDP, expectedBMarker: expectedBMarker, expectedLMarker: expectedLMarker, expectedAMarker: expectedAMarker, wasMigrated: wasMigrated, isJwt: issuesJwt, isBeacon: isBeacon)
+        validateUserAgent(ua: userCredentials.userAgent, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, usesWelcomeDiscovery: usesWelcomeDiscovery, isMultiUser: isMultiUser, expectedRTRFeatureMarker: expectedRTRFeatureMarker(for: userConfig.username), expectDP: effectiveExpectDP, expectedBMarker: expectedBMarker, expectedLMarker: expectedLMarker, expectedAMarker: expectedAMarker, wasMigrated: wasMigrated, isJwt: issuesJwt, isBeacon: isBeacon)
 
         return userCredentials
     }
@@ -1317,8 +1326,6 @@ class BaseAuthFlowTester: XCTestCase {
         let effectiveWebServerFlow = loginForAdmin ? true : useWebServerFlow
         let aMarker = expectedAMarkerOverride ?? aMarkerFor(useWebServerFlow: effectiveWebServerFlow, useHybridFlow: useHybridFlow)
         let userAppConfig = getAppConfig(named: userAppConfigName)
-        // After migration the RTR flag is active immediately (the migration token exchange IS a rotation).
-        let isRtr = wasMigrated ? userAppConfig.isRtr : false
 
         let effectiveExpectDP = useDPoP || userAppConfig.isDPoP
         let userCredentials = validateUser(
@@ -1331,7 +1338,6 @@ class BaseAuthFlowTester: XCTestCase {
             expectAdvancedAuth: expectAdvancedAuth,
             usesWelcomeDiscovery: usesWelcomeDiscovery,
             isMultiUser: isMultiUser,
-            isRtr: isRtr,
             expectedBMarker: expectedBMarker,
             expectedLMarker: expectedLMarker,
             expectedAMarker: aMarker,
@@ -1341,7 +1347,7 @@ class BaseAuthFlowTester: XCTestCase {
         )
 
         // Revoke and refresh cycle
-        assertRevokeAndRefreshWorks(previousCredentials: userCredentials, isRtr: userAppConfig.isRtr, isDPoP: effectiveExpectDP, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, usesWelcomeDiscovery: usesWelcomeDiscovery, isMultiUser: isMultiUser, expectedBMarker: expectedBMarker, expectedLMarker: expectedLMarker, expectedAMarker: aMarker, wasMigrated: wasMigrated, isJwt: userAppConfig.issuesJwt, isBeacon: userAppConfig.isBeacon)
+        assertRevokeAndRefreshWorks(previousCredentials: userCredentials, expectsRefreshTokenRotation: userAppConfig.expectsRefreshTokenRotation, isDPoP: effectiveExpectDP, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, usesWelcomeDiscovery: usesWelcomeDiscovery, isMultiUser: isMultiUser, expectedBMarker: expectedBMarker, expectedLMarker: expectedLMarker, expectedAMarker: aMarker, wasMigrated: wasMigrated, isJwt: userAppConfig.issuesJwt, isBeacon: userAppConfig.isBeacon)
 
         // Check the oauth configuration
         _ = checkOauthConfiguration(
@@ -1483,14 +1489,14 @@ class BaseAuthFlowTester: XCTestCase {
     /// `expectAdvancedAuth` defaults to `true`, matching the `forceAdvancedAuthentication` default.
     /// Pass `false` for tests that logged in with the in-app WebView or post-migration validations
     /// where BW is not re-registered.
-    func assertRevokeAndRefreshWorks(isRtr: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = true, isMultiUser: Bool = false, useWebServerFlow: Bool = true, useHybridFlow: Bool = true, wasMigrated: Bool = false, isJwt: Bool = false, isBeacon: Bool = false, useLoginPoolHost: Bool = false) {
+    func assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = true, isMultiUser: Bool = false, useWebServerFlow: Bool = true, useHybridFlow: Bool = true, wasMigrated: Bool = false, isJwt: Bool = false, isBeacon: Bool = false, useLoginPoolHost: Bool = false) {
         let expectedBMarker: String? = expectAdvancedAuth ? kBrowserLoginForceFlag : nil
         let expectedLMarker: String? = useLoginPoolHost ? kLoginServerProduction : kLoginServerMyDomain
         let aMarker = aMarkerFor(useWebServerFlow: useWebServerFlow, useHybridFlow: useHybridFlow)
-        assertRevokeAndRefreshWorks(previousCredentials: getUserCredentials(), isRtr: isRtr, isDPoP: isDPoP, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, isMultiUser: isMultiUser, expectedBMarker: expectedBMarker, expectedLMarker: expectedLMarker, expectedAMarker: aMarker, wasMigrated: wasMigrated, isJwt: isJwt, isBeacon: isBeacon)
+        assertRevokeAndRefreshWorks(previousCredentials: getUserCredentials(), expectsRefreshTokenRotation: expectsRefreshTokenRotation, isDPoP: isDPoP, loginHost: loginHost, expectAdvancedAuth: expectAdvancedAuth, isMultiUser: isMultiUser, expectedBMarker: expectedBMarker, expectedLMarker: expectedLMarker, expectedAMarker: aMarker, wasMigrated: wasMigrated, isJwt: isJwt, isBeacon: isBeacon)
     }
 
-    private func assertRevokeAndRefreshWorks(previousCredentials: UserCredentialsData, isRtr: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = true, usesWelcomeDiscovery: Bool = false, isMultiUser: Bool = false, expectedBMarker: String? = nil, expectedLMarker: String? = nil, expectedAMarker: String? = nil, wasMigrated: Bool = false, isJwt: Bool = false, isBeacon: Bool = false) {
+    private func assertRevokeAndRefreshWorks(previousCredentials: UserCredentialsData, expectsRefreshTokenRotation: Bool, isDPoP: Bool = false, loginHost: KnownLoginHostConfig = .regularAuth, expectAdvancedAuth: Bool = true, usesWelcomeDiscovery: Bool = false, isMultiUser: Bool = false, expectedBMarker: String? = nil, expectedLMarker: String? = nil, expectedAMarker: String? = nil, wasMigrated: Bool = false, isJwt: Bool = false, isBeacon: Bool = false) {
         // Revoke access token
         XCTAssert(mainPage.revokeAccessToken(), "Failed to revoke access token")
 
@@ -1506,8 +1512,9 @@ class BaseAuthFlowTester: XCTestCase {
             "Access token should have been refreshed"
         )
 
-        // Assert refresh token rotated (RTR) or stayed the same (non-RTR)
-        if isRtr {
+        // Assert refresh token rotated (RTR) or stayed the same (non-RTR).
+        let refreshTokenRotated = previousCredentials.refreshToken != credentialsAfterRefresh.refreshToken
+        if expectsRefreshTokenRotation {
             XCTAssertNotEqual(
                 previousCredentials.refreshToken,
                 credentialsAfterRefresh.refreshToken,
@@ -1521,6 +1528,11 @@ class BaseAuthFlowTester: XCTestCase {
             )
         }
 
+        // RT is sticky per user and is registered only by a normal refresh that observes a
+        // changed refresh token. Migration and login never advance this state.
+        let expectedRTRFeatureMarkerAfterRefresh = expectedRTRFeatureMarker(for: previousCredentials.username) || refreshTokenRotated
+        expectedRTRFeatureMarkerByUsername[previousCredentials.username] = expectedRTRFeatureMarkerAfterRefresh
+
         // Assert DPoP token type and nonce presence if DPoP is enabled
         if isDPoP {
             assertDPoPCredentials(credentialsAfterRefresh, context: "after refresh")
@@ -1531,7 +1543,6 @@ class BaseAuthFlowTester: XCTestCase {
                           expectAdvancedAuth: expectAdvancedAuth,
                           usesWelcomeDiscovery: usesWelcomeDiscovery,
                           isMultiUser: isMultiUser,
-                          isRtr: isRtr,
                           expectDP: isDPoP,
                           expectedBMarker: expectedBMarker,
                           expectedLMarker: expectedLMarker,
@@ -1539,6 +1550,14 @@ class BaseAuthFlowTester: XCTestCase {
                           wasMigrated: wasMigrated,
                           isJwt: isJwt,
                           isBeacon: isBeacon)
+    }
+
+    private func expectedRTRFeatureMarker(for username: String) -> Bool {
+        guard let expectedRTRFeatureMarker = expectedRTRFeatureMarkerByUsername[username] else {
+            XCTFail("No RT feature-marker state recorded for user \(username)")
+            return false
+        }
+        return expectedRTRFeatureMarker
     }
 
     /// Asserts the DPoP token-type and nonce triad on a set of credentials.

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -47,6 +47,11 @@ let kAuthTypeUserAgentHybrid      = "A4"
 let kAuthTypeNative               = "A5"
 private let kAllAMarkers          = ["A1", "A2", "A3", "A4", "A5"]
 
+private let kRegularAuthLoginHostName = "UITests"
+private let kAdvancedAuthLoginHostName = "UITests Adv Auth"
+private let kLoginPoolHostName = "UITests Login Pool"
+private let kWelcomeDiscoveryLoginHostName = "Welcome Discovery"
+
 class BaseAuthFlowTester: XCTestCase {
     // App object
     private var app: XCUIApplication!
@@ -84,12 +89,8 @@ class BaseAuthFlowTester: XCTestCase {
     
     /// Launches the application and ensures it starts in a logged-out state on a known login server.
     ///
-    /// Initializes the app and page objects, launches the app, and logs out if a user is already
-    /// logged in. Then resets the login server to `login.salesforce.com`: the login host persists
-    /// across tests, so a prior test that selected a discovery or advanced-auth org would otherwise
-    /// strand the next test (its `login()` assumes the browser is showing on entry). Leaves the app
-    /// on the external browser surface (the default, advanced auth forced on) against the standard
-    /// server, which is exactly the state `login()` expects on entry.
+    /// Initializes the app and page objects on the regular UI-test login server. Fresh launches
+    /// reset all auth state, seed the fixed test servers, and select regular auth by default.
     func launch() {
         app = XCUIApplication()
 
@@ -97,9 +98,8 @@ class BaseAuthFlowTester: XCTestCase {
         // This is used to show/hide certain UI elements like DiscoveryResultEditor
         app.launchEnvironment["IS_UI_TESTING"] = "1"
 
-        // Instruct the app to reset all SDK auth state (users, login host, custom servers, flags)
-        // in-process at startup, before loginIfRequired fires. This replaces the UI-driven logout
-        // and host-reset that previously ran in tearDown and here in launch().
+        // Instruct the app to reset all SDK auth state and select the first static test server
+        // in-process at startup, before loginIfRequired fires.
         app.launchArguments = ["--resetSDKForUITesting"]
 
         loginPage = LoginPageObject(testApp: app)
@@ -179,31 +179,39 @@ class BaseAuthFlowTester: XCTestCase {
             useDPoP: useDPoP
         )
 
-        // Closing login options restarts authentication, so the login surface reappears — the
-        // browser when advanced auth is on, the in-app WebView when it was disabled. Return to the
-        // host list to select the login host. Configuring the host last matches how a real user
-        // arrives at the picker and keeps the login-options gear reachable until then.
-        // When useWelcomeDiscovery is true, use welcome.salesforce.com/discovery as the login server.
-        // When useLoginPoolHost is true, use the top-level loginPoolHost URL from ui_test_config.json
-        // so the auth code binding goes through the pool server while credentials come from loginHost.
-        loginPage.returnToHostList(expectingBrowser: advancedAuthEnabled)
-        let loginHostToUse: String
-        if useWelcomeDiscovery {
-            loginHostToUse = "welcome.salesforce.com/discovery"
-        } else if useLoginPoolHost {
-            do {
-                let poolHost = try UITestConfigUtils.shared.getLoginPoolHost()
-                loginHostToUse = poolHost
-                    .replacingOccurrences(of: "https://", with: "")
-                    .replacingOccurrences(of: "http://", with: "")
-            } catch {
-                XCTFail("useLoginPoolHost is true but getLoginPoolHost() failed: \(error)")
-                return
+        // Closing Login Options restarts authentication on the selected server. A fresh launch
+        // already selected regular auth, so avoid cancelling and re-selecting it for the common
+        // case. Special paths still choose their required server explicitly.
+        if useWelcomeDiscovery || useLoginPoolHost || loginHost != .regularAuth {
+            loginPage.returnToHostList(expectingBrowser: advancedAuthEnabled)
+            let loginHostToUse: String
+            if useWelcomeDiscovery {
+                loginHostToUse = "welcome.salesforce.com/discovery"
+            } else if useLoginPoolHost {
+                do {
+                    let poolHost = try UITestConfigUtils.shared.getLoginPoolHost()
+                    loginHostToUse = poolHost
+                        .replacingOccurrences(of: "https://", with: "")
+                        .replacingOccurrences(of: "http://", with: "")
+                } catch {
+                    XCTFail("useLoginPoolHost is true but getLoginPoolHost() failed: \(error)")
+                    return
+                }
+            } else {
+                loginHostToUse = hostConfig.urlNoProtocol
             }
-        } else {
-            loginHostToUse = hostConfig.urlNoProtocol
+            let loginHostDisplayName: String
+            if useWelcomeDiscovery {
+                loginHostDisplayName = kWelcomeDiscoveryLoginHostName
+            } else if useLoginPoolHost {
+                loginHostDisplayName = kLoginPoolHostName
+            } else if loginHost == .advancedAuth {
+                loginHostDisplayName = kAdvancedAuthLoginHostName
+            } else {
+                loginHostDisplayName = kRegularAuthLoginHostName
+            }
+            loginPage.configureLoginHost(host: loginHostToUse, displayName: loginHostDisplayName)
         }
-        loginPage.configureLoginHost(host: loginHostToUse)
 
         // Invalid app config
         if (dynamicAppConfigName == .invalid || (dynamicAppConfigName == nil && staticAppConfigName == .invalid)) {
@@ -838,12 +846,12 @@ class BaseAuthFlowTester: XCTestCase {
             useDPoP: useDPoP
         )
 
-        loginPage.returnToHostList(expectingBrowser: advancedAuthEnabled)
-
-        // Selecting the login host triggers /authorize. For an enforced ECA with useDPoP: false,
-        // the server rejects before any login form renders, so there is nothing further to drive —
-        // assert on the outcome instead of attempting performLogin.
-        loginPage.configureLoginHost(host: hostConfig.urlNoProtocol)
+        // Closing Login Options already triggers /authorize on the reset default regular server.
+        // Other hosts still require explicit selection.
+        if loginHost != .regularAuth {
+            loginPage.returnToHostList(expectingBrowser: advancedAuthEnabled)
+            loginPage.configureLoginHost(host: hostConfig.urlNoProtocol)
+        }
 
         // We assert on absence-of-main-page rather than on error text because there is no error
         // surface to read here. This path uses advanced auth (ASWebAuthenticationSession), and the

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestConfigUtils.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestConfigUtils.swift
@@ -138,8 +138,10 @@ struct AppConfig: Codable {
         return name.hasPrefix("beacon_")
     }
 
-    // W-23971480: beacon apps behave as RTR due to a server bug; drop the beacon_ clause when fixed
-    var isRtr: Bool {
+    /// Whether a normal refresh is expected to rotate this configuration's refresh token.
+    /// W-23971480: beacon apps behave as RTR due to a server bug; drop the beacon_ clause when fixed.
+    /// This is deliberately distinct from the per-user RT user-agent feature marker.
+    var expectsRefreshTokenRotation: Bool {
         return name.contains("_rtr") || name.hasPrefix("beacon_")
     }
 


### PR DESCRIPTION
## Summary
- Seed AuthFlowTester’s fixed UI-test server list and reset to the regular server.
- Skip the server picker for regular-host tests; select static named rows for advanced, pool, and discovery paths.
- Cap UI-test runs at two total attempts (one initial run plus one retry).
- Separate a configuration that rotates refresh tokens from the per-user RT user-agent marker: RT starts absent after login, is preserved through migration/restart, and becomes present only after a normal refresh observes rotation.

## Validation
- ECALoginTests / testECAOpaque_DefaultScopes: passed.
- AdvancedAuthBeaconLoginTests / testBeaconOpaque_DefaultScopes: passed.
- ECALoginTests / test_givenNoDPoP_whenLoginViaPoolServer_thenSessionIsValid: passed.
- DPoPLoginTests: 13 passed, 1 skipped, 0 failed.
- RefreshTokenMigrationTests / testMigrateCAToBeacon: passed.
- RefreshTokenMigrationWithRestartTests / testMigrateCAToBeacon_WithRestart: passed.
- MultiUserLoginTests / testFlagDiversity_BeaconNonHybridJwtVsHybridOpaque reached an unrelated UI automation failure: exportCredentialsButton was not hittable; no RT assertion failed.