### PR TITLE
Deprecate IDP (Identity Provider) login flow

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.h
@@ -167,12 +167,12 @@ NS_SWIFT_NAME(SalesforceManager)
 /**
  The block to provide custom view to use for IDP selection flow.
  */
-@property (nonatomic, copy, nullable) SFIDPLoginFlowSelectionBlock idpLoginFlowSelectionBlock  NS_SWIFT_NAME(loginFlowSelectionViewProvider);
+@property (nonatomic, copy, nullable) SFIDPLoginFlowSelectionBlock idpLoginFlowSelectionBlock  NS_SWIFT_NAME(loginFlowSelectionViewProvider) SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 /**
  The block to provide custom view to use for IDP user selection flow.
  */
-@property (nonatomic, copy, nullable) SFIDPUserSelectionBlock idpUserSelectionBlock NS_SWIFT_NAME(idpUserSelectionViewProvider);
+@property (nonatomic, copy, nullable) SFIDPUserSelectionBlock idpUserSelectionBlock NS_SWIFT_NAME(idpUserSelectionViewProvider) SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 /**
  The block to provide custom view to use as the "image" that represents the app display when it is backgrounded.
  @discussion
@@ -226,11 +226,11 @@ NS_SWIFT_NAME(SalesforceManager)
 
 /** Use this flag to indicate if the APP will be an identity provider. When enabled this flag allows this application to perform authentication on behalf of another app.
  */
-@property (nonatomic,assign) BOOL isIdentityProvider NS_SWIFT_NAME(isIdentityProvider);
+@property (nonatomic,assign) BOOL isIdentityProvider NS_SWIFT_NAME(isIdentityProvider) SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 /** Use this flag to indicate if the scheme for the identity provider app
  */
-@property (nonatomic, copy, nullable) NSString *idpAppURIScheme NS_SWIFT_NAME(identityProviderURLScheme);
+@property (nonatomic, copy, nullable) NSString *idpAppURIScheme NS_SWIFT_NAME(identityProviderURLScheme) SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 /**
  A user friendly display name for use in UI by the SDK on behalf of the app.  This value will be used on various authentication screens

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -415,6 +415,8 @@ SFNativeLoginManagerInternal *nativeLogin;
     return _appConfig;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (SFIDPLoginFlowSelectionBlock)idpLoginFlowSelectionBlock {
     return [SFUserAccountManager sharedInstance].idpLoginFlowSelectionAction;
 }
@@ -438,9 +440,10 @@ SFNativeLoginManagerInternal *nativeLogin;
 - (void)setIsIdentityProvider:(BOOL)isIdentityProvider {
    [SFUserAccountManager sharedInstance].isIdentityProvider = isIdentityProvider;
 }
+#pragma clang diagnostic pop
 
 - (BOOL)idpEnabled {
-    return [SFUserAccountManager sharedInstance].idpAppURIScheme!=nil;
+    return [SFUserAccountManager sharedInstance].sdk_idpAppURIScheme!=nil;
 }
 
 - (NSString *)appDisplayName {
@@ -451,6 +454,8 @@ SFNativeLoginManagerInternal *nativeLogin;
     [SFUserAccountManager sharedInstance].appDisplayName = appDisplayName;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (NSString *)idpAppURIScheme{
     return [SFUserAccountManager sharedInstance].idpAppURIScheme;
 }
@@ -458,6 +463,7 @@ SFNativeLoginManagerInternal *nativeLogin;
 - (void)setIdpAppURIScheme:(NSString *)idpAppURIScheme {
     [SFUserAccountManager sharedInstance].idpAppURIScheme = idpAppURIScheme;
 }
+#pragma clang diagnostic pop
 
 - (NSString *)brandLoginPath
 {
@@ -629,6 +635,7 @@ static NSString *SFSDKISO8601StringFromDate(NSDate *date) {
     
     // Auth configuration
     [devInfos addObject:@"section:Auth Config"];
+    SFSDK_USE_DEPRECATED_BEGIN
     [devInfos addObjectsFromArray:@[
             @"Use Web Server Authentication", [self sdk_useWebServerAuthentication]  ? @"YES" : @"NO",
             @"Use Hybrid Authentication", [self useHybridAuthentication]  ? @"YES" : @"NO",
@@ -638,6 +645,7 @@ static NSString *SFSDKISO8601StringFromDate(NSDate *date) {
             @"IDP Enabled", [self idpEnabled] ? @"YES" : @"NO",
             @"Identity Provider", [self isIdentityProvider] ? @"YES" : @"NO"
     ]];
+    SFSDK_USE_DEPRECATED_END
 
     // Static bootconfig
     [devInfos addObject:@"section:Bootconfig"];
@@ -809,9 +817,11 @@ static NSString *SFSDKISO8601StringFromDate(NSDate *date) {
         self.appConfig.oauthRedirectURI = [SFManagedPreferences sharedPreferences].connectedAppCallbackUri;
     }
     
+    SFSDK_USE_DEPRECATED_BEGIN
     if ([SFManagedPreferences sharedPreferences].idpAppURLScheme) {
         self.idpAppURIScheme = [SFManagedPreferences sharedPreferences].idpAppURLScheme;
     }
+    SFSDK_USE_DEPRECATED_END
 }
 
 - (void)setupServiceConfiguration

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/UserAccountManager.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Extensions/UserAccountManager.swift
@@ -117,6 +117,7 @@ extension UserAccountManager: UserAccountManaging {
     ///    - options: Dictionary of name-value pairs received from open URL
     ///    - completion: Completion block to invoke with a UserAccount on success or UserAccountManagerError on failure wrapped in a Result type.
     /// - Returns: true if this is a valid URL response from IDP authentication that should be handled, false otherwise.
+    @available(*, deprecated, message: "The IDP (Identity Provider) login flow is deprecated and will be removed in Salesforce Mobile SDK 15.0. Apps should use advanced (browser-based) authentication.")
     public func handleIdentityProviderCommand(from url: URL, with options: [AnyHashable: Any], completion: @escaping (Result<(UserAccount, AuthInfo), UserAccountManagerError>) -> Void) -> Bool {
         return __handleIDPAuthenticationCommand(url, options: options, completion: { (authInfo, userAccount) in
             completion(Result.success((userAccount, authInfo)))

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKLoginFlowSelectionView.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKLoginFlowSelectionView.h
@@ -29,6 +29,7 @@
 
 #import <Foundation/Foundation.h>
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 @protocol SFSDKLoginFlowSelectionViewDelegate<NSObject>
 /**
  * Used to notify the SDK of user selection on the login flow selection view
@@ -46,6 +47,7 @@
 
 @end
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 @protocol SFSDKLoginFlowSelectionView<NSObject>
 @property (weak,nonatomic) id <SFSDKLoginFlowSelectionViewDelegate> selectionFlowDelegate;
 @property (nonatomic,strong) NSDictionary *appOptions;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUITableViewCell.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUITableViewCell.h
@@ -28,7 +28,9 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
+SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.")
 @interface SFSDKUITableViewCell : UITableViewCell
 @property (nonatomic,assign) NSString *userName;
 @property (nonatomic,assign) NSString *hostName;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUITableViewCell.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUITableViewCell.m
@@ -41,6 +41,8 @@ static CGFloat kImageHeight = 60;
 @property (strong,nonatomic) UIImageView *profileImageView;
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFSDKUITableViewCell
 
 - (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUITableViewCell.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUITableViewCell.m
@@ -136,4 +136,5 @@ static CGFloat kImageHeight = 60;
     UIGraphicsEndImageContext();
     return image;
 }
+#pragma clang diagnostic pop
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUserSelectionNavViewController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUserSelectionNavViewController.h
@@ -28,11 +28,13 @@
  */
 #import <UIKit/UIKit.h>
 #import <SalesforceSDKCore/SFSDKUserSelectionView.h>
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 
 @class SFUserAccount;
 @class SFSDKUserSelectionTableViewController;
 
+SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.")
 @interface SFSDKUserSelectionNavViewController : UINavigationController<SFSDKUserSelectionView>
 @property (nonatomic,weak) id<SFSDKUserSelectionViewDelegate> userSelectionDelegate;
 @property (nonatomic,strong) NSDictionary *spAppOptions;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUserSelectionNavViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUserSelectionNavViewController.m
@@ -35,6 +35,8 @@
 }
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFSDKUserSelectionNavViewController
 @synthesize userSelectionDelegate = _userSelectionDelegate;
 
@@ -86,3 +88,4 @@
     return [[SFSDKUserSelectionTableViewController alloc] initWithNibName:nil bundle:nil];
 }
 @end
+#pragma clang diagnostic pop

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUserSelectionTableViewController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUserSelectionTableViewController.h
@@ -28,9 +28,11 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 @class SFUserAccount;
 @class SFSDKIDPAuthClient;
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 @protocol SFSDKUserSelectionTableViewControllerDelegate
 
 -(void) createNewuser:(NSDictionary *) options;
@@ -39,6 +41,7 @@
 
 @end
 
+SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.")
 @interface SFSDKUserSelectionTableViewController : UIViewController<UITableViewDelegate,UITableViewDataSource>
 @property (nonatomic,strong) SFUserAccount *selectedAccount;
 @property (nonatomic,weak) id<SFSDKUserSelectionTableViewControllerDelegate> listViewDelegate;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUserSelectionTableViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUserSelectionTableViewController.m
@@ -75,7 +75,9 @@ static CGFloat kHorizontalSpace = 12;
 {
     UIImage *logotmp = [[SFSDKResourceUtils imageNamed:@"salesforce-logo"]  imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
     
+    SFSDK_USE_DEPRECATED_BEGIN
     UIImage *logo  = [SFSDKUserSelectionTableViewController  resizeImage:logotmp resizeSize:CGSizeMake(150,120)];
+    SFSDK_USE_DEPRECATED_END
     self.logoView = [[UIImageView alloc]initWithImage:logo];
     self.logoView.contentMode = UIViewContentModeScaleToFill;
     self.backgroundColor = [UIColor salesforceSystemBackgroundColor];
@@ -112,7 +114,9 @@ static CGFloat kHorizontalSpace = 12;
     [super layoutSubviews];
     self.backgroundColor = [UIColor salesforceSystemBackgroundColor];
     UIImage *addAccountImageTmp = [[SFSDKResourceUtils imageNamed:@"account-add"]  imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+    SFSDK_USE_DEPRECATED_BEGIN
     UIImage *addAccountImage  = [SFSDKUserSelectionTableViewController  resizeImage:addAccountImageTmp resizeSize:CGSizeMake(18,18)];
+    SFSDK_USE_DEPRECATED_END
     self.addButton = [UIButton buttonWithType:UIButtonTypeCustom];
     [self.addButton setBackgroundImage:addAccountImage forState:UIControlStateNormal];
     self.descriptionLabel = [[UILabel alloc] init];
@@ -136,6 +140,8 @@ static CGFloat kHorizontalSpace = 12;
 }
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 @implementation SFSDKUserSelectionTableViewController
 @synthesize spAppOptions;
 @synthesize listViewDelegate;
@@ -310,3 +316,4 @@ static CGFloat kHorizontalSpace = 12;
 }
 
 @end
+#pragma clang diagnostic pop

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUserSelectionView.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFSDKUserSelectionView.h
@@ -31,12 +31,14 @@
 
 @class SFUserAccount;
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 @protocol SFSDKUserSelectionViewDelegate
 - (void)createNewUser:(NSDictionary *)spAppOptions;
 - (void)selectedUser:(SFUserAccount *)user spAppContext:(NSDictionary *)spAppOptions;
 - (void)cancel:(NSDictionary *)spAppOptions;
 @end
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 @protocol SFSDKUserSelectionView<NSObject>
 @property (nonatomic,weak) id<SFSDKUserSelectionViewDelegate> userSelectionDelegate;
 @property (nonatomic,strong) NSDictionary *spAppOptions;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFUserAccountManager+URLHandlers.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SFUserAccountManager+URLHandlers.m
@@ -119,7 +119,9 @@
 
     if (showSelection) {
         dispatch_async(dispatch_get_main_queue(), ^{
+            SFSDK_USE_DEPRECATED_BEGIN
             UIViewController<SFSDKUserSelectionView> *controller = self.idpUserSelectionAction();
+            SFSDK_USE_DEPRECATED_END
             controller.spAppOptions = request.allParams;
             controller.userSelectionDelegate = self;
             controller.modalPresentationStyle = UIModalPresentationFullScreen;
@@ -139,7 +141,9 @@
         sceneId = [[SFSDKWindowManager sharedManager] defaultScene].session.persistentIdentifier;
     }
     if (self.authSessions[sceneId]) {
+        SFSDK_USE_DEPRECATED_BEGIN
         [self.authSessions[sceneId].oauthCoordinator handleIDPAuthenticationResponse:[response requestURL]];
+        SFSDK_USE_DEPRECATED_END
     } else {
         SFSDKAlertMessage *messageObject = [SFSDKAlertMessage messageWithBlock:^(SFSDKAlertMessageBuilder *builder) {
             builder.actionOneTitle = [SFSDKResourceUtils localizedString:@"authAlertCancelButton"];
@@ -164,7 +168,9 @@
     }
     
     if (self.authSessions[sceneId]) {
-           [self.authSessions[sceneId].oauthCoordinator handleIDPAuthenticationResponse:[response requestURL]];
+        SFSDK_USE_DEPRECATED_BEGIN
+        [self.authSessions[sceneId].oauthCoordinator handleIDPAuthenticationResponse:[response requestURL]];
+        SFSDK_USE_DEPRECATED_END
     } else if (response.keychainReference) {
         // IDP - SP: Need to create auth session
         NSString *userHint = response.userHint;
@@ -187,7 +193,9 @@
         authSession.authFailureCallback = failureBlock;
         authSession.authSuccessCallback = completionBlock;
         self.authSessions[sceneId] = authSession;
+        SFSDK_USE_DEPRECATED_BEGIN
         [self.authSessions[sceneId].oauthCoordinator handleIDPAuthenticationResponse:[response requestURL]];
+        SFSDK_USE_DEPRECATED_END
         authSession.isAuthenticating = YES;
         authSession.oauthCoordinator.delegate = self;
     }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SPConfig.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/IDP/SPConfig.swift
@@ -29,12 +29,14 @@ import Foundation
 
 
 @objc(SFSDKSPConfig)
+@available(*, deprecated, message: "The IDP (Identity Provider) login flow is deprecated and will be removed in Salesforce Mobile SDK 15.0. Apps should use advanced (browser-based) authentication.")
 public class SPConfig: NSObject {
     @objc public let oauthClientId: String
     @objc public let oauthCallbackURL: String
     @objc public let oauthScopes: Set<String>
     @objc public let keychainGroup: String
-    
+
+    @available(*, deprecated, message: "The IDP (Identity Provider) login flow is deprecated and will be removed in Salesforce Mobile SDK 15.0. Apps should use advanced (browser-based) authentication.")
     @objc public init(oauthClientId: String, oauthCallbackURL: String, oauthScopes: Set<String>, keychainGroup: String) {
         self.oauthClientId = oauthClientId
         self.oauthCallbackURL = oauthCallbackURL

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/LoginHost/SFSDKLoginHostListViewController.m
@@ -32,6 +32,7 @@
 #import "SFSDKResourceUtils.h"
 #import "SFManagedPreferences.h"
 #import "SFUserAccountManager.h"
+#import "SFUserAccountManager+Internal.h"
 #import "SFSDKViewUtils.h"
 #import "SFSDKLoginViewControllerConfig.h"
 #import "SFSDKWindowManager.h"
@@ -237,7 +238,7 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
         && ((SFSDKLoginViewControllerConfig *)self.config).shouldDisplayBackButton) {
         return YES;
     }
-    if (accountManager.idpEnabled || accountManager.shouldFallbackToWebAuthentication) {
+    if (accountManager.sdk_idpEnabled || accountManager.shouldFallbackToWebAuthentication) {
         return YES;
     }
     NSInteger totalAccounts = accountManager.allUserAccounts.count;
@@ -263,7 +264,7 @@ static NSString * const SFDCLoginHostListCellIdentifier = @"SFDCLoginHostListCel
         [accountManager loginWithCompletion:nil failure:nil];
     }
 
-    if (!accountManager.idpEnabled) {
+    if (!accountManager.sdk_idpEnabled) {
         [[[SFSDKWindowManager sharedManager] authWindow:scene].viewController.presentedViewController dismissViewControllerAnimated:NO completion:^{
             [[[SFSDKWindowManager sharedManager] authWindow:scene] dismissWindow];
         }];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -246,7 +246,7 @@
         return NO;
     }
     
-    if (self.config.shouldDisplayBackButton || [SFUserAccountManager sharedInstance].idpEnabled
+    if (self.config.shouldDisplayBackButton || [SFUserAccountManager sharedInstance].sdk_idpEnabled
         || [SFUserAccountManager sharedInstance].shouldFallbackToWebAuthentication) {
         return YES;
     }
@@ -437,7 +437,7 @@
         [[SFUserAccountManager sharedInstance] loginWithCompletion:nil failure:nil];
     }
     
-    if (![SFUserAccountManager sharedInstance].idpEnabled) {
+    if (![SFUserAccountManager sharedInstance].sdk_idpEnabled) {
         [[[SFSDKWindowManager sharedManager] authWindow:scene].viewController.presentedViewController dismissViewControllerAnimated:NO completion:^{
             [[[SFSDKWindowManager sharedManager] authWindow:scene] dismissWindow];
         }];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.h
@@ -149,7 +149,7 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
  Sent to notify the delegate that a  authentication code was retrieved during idp flow.
    @param coordinator The SFOAuthCoordinator instance processing this message.
  */
-- (void)oauthCoordinatorDidFetchAuthCode:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)authInfo;
+- (void)oauthCoordinatorDidFetchAuthCode:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)authInfo SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 @required
 
@@ -342,9 +342,9 @@ typedef void (^SFOAuthBrowserFlowCallbackBlock)(BOOL);
  */
 - (BOOL)handleAdvancedAuthenticationResponse:(NSURL *)appUrlResponse;
 
-- (BOOL)handleIDPAuthenticationResponse:(NSURL *)appUrlResponse;
+- (BOOL)handleIDPAuthenticationResponse:(NSURL *)appUrlResponse SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
-- (void)beginIDPFlow:(SFUserAccount *)user success:(void(^)(void))successBlock failure:(void(^)(NSError *))failureBlock;
+- (void)beginIDPFlow:(SFUserAccount *)user success:(void(^)(void))successBlock failure:(void(^)(NSError *))failureBlock SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -299,6 +299,8 @@
     [self.credentials revoke];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (BOOL)handleIDPAuthenticationResponse:(NSURL *)appUrlResponse {
     self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeIDP];
    
@@ -335,6 +337,7 @@
     });
     return YES;
 }
+#pragma clang diagnostic pop
 
 - (BOOL)handleAdvancedAuthenticationResponse:(NSURL *)appUrlResponse {
     self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeAdvancedBrowser];
@@ -673,6 +676,8 @@
 }
 
 // IDP related
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)beginIDPFlow:(SFUserAccount *)user success:(void(^)(void))successBlock failure:(void(^)(NSError *))failureBlock {
     self.authInfo = [[SFOAuthInfo alloc] initWithAuthType:SFOAuthTypeIDP];
     self.initialRequestLoaded = NO;
@@ -693,6 +698,7 @@
         }];
     }
 }
+#pragma clang diagnostic pop
 
 - (NSString*)computeAuthorizationPathForSP {
     NSString *approvalUrlString = [self approvalURLForEndpoint:kSFOAuthEndPointAuthorize
@@ -877,7 +883,9 @@
         NSDictionary *params = [SFSDKOAuth2 parseQueryString:response decodeParams:NO];
         self.spAppCredentials.authCode = params[kSFOAuthApprovalCode];
         if ([self.delegate respondsToSelector:@selector(oauthCoordinatorDidFetchAuthCode:authInfo:)]) {
+            SFSDK_USE_DEPRECATED_BEGIN
             [self.delegate oauthCoordinatorDidFetchAuthCode:self authInfo:self.authInfo];
+            SFSDK_USE_DEPRECATED_END
         }
     }
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKAuthPreferences.m
@@ -178,12 +178,14 @@ NSString * const kOAuthAppName = @"oauth_app_name";
 
 - (NSString *)idpAppURIScheme
 {
+    SFSDK_USE_DEPRECATED_BEGIN
     if ([SFManagedPreferences sharedPreferences].idpAppURLScheme.length > 0) {
         return [SFManagedPreferences sharedPreferences].idpAppURLScheme;
     } else {
         NSUserDefaults *defs = [NSUserDefaults msdkUserDefaults];
         return [defs stringForKey:kSFIDPKey];
     }
+    SFSDK_USE_DEPRECATED_END
 }
 
 - (void)setIdpAppURIScheme:(NSString *)appIdentifier

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager+Internal.h
@@ -94,6 +94,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong, nonnull) SFSDKAuthPreferences *authPreferences;
 
+/** Non-deprecated internal accessor for the same backing storage as the public
+ `idpEnabled` property (deprecated in 14.0, removed in 15.0). Internal SDK code
+ reads the flag through this accessor so that its own use does not trip
+ -Wdeprecated-declarations. Delete this alongside the public property in 15.0.
+ */
+@property (nonatomic, readonly, assign) BOOL sdk_idpEnabled;
+
+/** Non-deprecated internal accessor for the same backing storage as the public
+ `idpAppURIScheme` property (deprecated in 14.0, removed in 15.0). Internal SDK code
+ reads the value through this accessor so that its own use does not trip
+ -Wdeprecated-declarations. Delete this alongside the public property in 15.0.
+ */
+@property (nonatomic, readonly, copy, nullable) NSString *sdk_idpAppURIScheme;
+
 /** SFSDKAlertView used to wrap display of SFSDKMessage using an AlertController.
  *
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -109,22 +109,27 @@ FOUNDATION_EXTERN NSNotificationName kSFNotificationUserWillLogIn NS_SWIFT_NAME(
  */
 FOUNDATION_EXTERN NSNotificationName kSFNotificationUserDidLogIn NS_SWIFT_NAME(UserAccountManager.didLogInUser);
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 /**  Notification sent before SP APP invokes IDP APP for authentication. In swift access this constant using Notification.Name.SFUserAccountManagerWillSendIDPRequest
  */
 FOUNDATION_EXTERN NSNotificationName kSFNotificationUserWillSendIDPRequest NS_SWIFT_NAME(UserAccountManager.willSendIDPRequest);
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 /**  Notification sent before IDP APP invokes SP APP with auth code. In swift access this constant using Notification.Name.SFUserAccountManagerWillSendIDPResponse
  */
 FOUNDATION_EXTERN NSNotificationName kSFNotificationUserWillSendIDPResponse NS_SWIFT_NAME(UserAccountManager.willSendIDPResponse);
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 /**  Notification sent when  IDP APP receives request for authentication from SP APP. In swift access this constant using Notification.Name.SFUserAccountManagerDidReceiveIDPRequest
  */
 FOUNDATION_EXTERN NSNotificationName kSFNotificationUserDidReceiveIDPRequest NS_SWIFT_NAME(UserAccountManager.didReceiveIDPRequest);
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 /**  Notification sent when  SP APP receives successful response of authentication from IDP APP. In swift access this constant using Notification.Name.SFUserAccountManagerDidReceiveIDPResponse
  */
 FOUNDATION_EXTERN NSNotificationName kSFNotificationUserDidReceiveIDPResponse NS_SWIFT_NAME(UserAccountManager.didReceiveIDPResponse);
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 /**  Notification sent when  SP APP has log in  is successful when initiated from IDP APP. In swift access this constant using Notification.Name.SFUserAccountManagerDidLogInAfterIDPInit
  */
 FOUNDATION_EXTERN NSNotificationName kSFNotificationUserIDPInitDidLogIn  NS_SWIFT_NAME(UserAccountManager.didLogInAfterIDPInit);
@@ -170,16 +175,19 @@ FOUNDATION_EXTERN NSString * const kSFNotificationFromUserKey NS_SWIFT_NAME(User
  */
 FOUNDATION_EXTERN NSString * const kSFNotificationToUserKey NS_SWIFT_NAME(UserAccountManager.userInfoToUserKey);
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 /**  Key used to provide triggering scene info for IDP flow from a scene delegate.
  */
 FOUNDATION_EXTERN NSString * const kSFIDPSceneIdKey NS_SWIFT_NAME(UserAccountManager.IDPSceneKey);
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 typedef NS_ENUM(NSUInteger, SFSPLoginStatus) {
     SFSPLoginStatusLaunchingSPWithUserHint,
     SFSPLoginStatusCodeVerifierStoredInKeychain,
     SFSPLoginStatusGettingAuthCodeFromServer
 } NS_SWIFT_NAME(SPLoginStatus);
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 typedef NS_ENUM(NSUInteger, SFSPLoginError) {
     SFSPLoginErrorNoScheme,
     SFSPLoginErrorNoUserIdentity,
@@ -329,12 +337,12 @@ NS_SWIFT_NAME(UserAccountManager)
 /** Use this block to replace the Login flow selection dialog
  *
  */
-@property (nonatomic, copy, nullable) SFIDPLoginFlowSelectionBlock idpLoginFlowSelectionAction;
+@property (nonatomic, copy, nullable) SFIDPLoginFlowSelectionBlock idpLoginFlowSelectionAction SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 /** Use this to replace the default User Selection Screen
  *
  */
-@property (nonatomic, copy, nullable) SFIDPUserSelectionBlock idpUserSelectionAction;
+@property (nonatomic, copy, nullable) SFIDPUserSelectionBlock idpUserSelectionAction SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 
 /** Use this to add handling for navigation actions like email and custom links on the login screen, return WKNavigationActionPolicyAllow for any other actions to make sure that the login flow isn't interrupted
@@ -348,17 +356,17 @@ NS_SWIFT_NAME(UserAccountManager)
 /**  Use this property to enable an app to become and IdentityProvider for other apps
  *
  */
-@property (nonatomic,assign) BOOL isIdentityProvider;
+@property (nonatomic,assign) BOOL isIdentityProvider SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 /**  Use this property to enable this app to be able to use another app that is an Identity Provider
  *
  */
-@property (nonatomic,assign, readonly) BOOL idpEnabled  NS_SWIFT_NAME(isIDPEnabled);
+@property (nonatomic,assign, readonly) BOOL idpEnabled  NS_SWIFT_NAME(isIDPEnabled) SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 /** Use this property to indicate the url scheme  for the Identity Provider app
  *
  */
-@property (nonatomic, copy, nullable) NSString *idpAppURIScheme;
+@property (nonatomic, copy, nullable) NSString *idpAppURIScheme SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 /** Use this property to indicate to provide a user-friendly name for your app. This name will be displayed
  *  in the user selection view of the identity provider app.
@@ -679,7 +687,7 @@ Use this method to stop/clear any authentication which is has already been start
  @param options Dictionary of name-value pairs received from open URL
  @return YES if this is a valid URL response from IDP authentication that should be handled, NO otherwise.
  */
-- (BOOL)handleIDPAuthenticationResponse:(NSURL *)url options:(nonnull NSDictionary *)options NS_SWIFT_NAME(handleIdentityProviderResponse(from:with:));
+- (BOOL)handleIDPAuthenticationResponse:(NSURL *)url options:(nonnull NSDictionary *)options NS_SWIFT_NAME(handleIdentityProviderResponse(from:with:)) SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 
 /**
@@ -693,7 +701,7 @@ Use this method to stop/clear any authentication which is has already been start
 - (BOOL)handleIDPAuthenticationCommand:(NSURL *)url
                                options:(nonnull NSDictionary *)options
                             completion:(nullable SFUserAccountManagerSuccessCallbackBlock)completionBlock
-                               failure:(nullable SFUserAccountManagerFailureCallbackBlock)failureBlock NS_REFINED_FOR_SWIFT;
+                               failure:(nullable SFUserAccountManagerFailureCallbackBlock)failureBlock NS_REFINED_FOR_SWIFT SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 
 /**
@@ -704,7 +712,7 @@ Use this method to stop/clear any authentication which is has already been start
  */
 - (void)kickOffIDPInitiatedLoginFlowForSP:(SFSDKSPConfig *)config
                              statusUpdate:(void(^)(SFSPLoginStatus))statusBlock
-                                  failure:(void(^)(SFSPLoginError))failureBlock;
+                                  failure:(void(^)(SFSPLoginError))failureBlock SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 
 /**
  Triggers the "Login for Admin" flow for the active login session associated with the given

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -200,7 +200,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         };
         
        _idpUserSelectionAction = ^UIViewController<SFSDKUserSelectionView> * _Nonnull{
+            SFSDK_USE_DEPRECATED_BEGIN
             SFSDKUserSelectionNavViewController *controller = [[SFSDKUserSelectionNavViewController alloc] init];
+            SFSDK_USE_DEPRECATED_END
             controller.userSelectionDelegate = [SFUserAccountManager sharedInstance];
             return controller;
         };
@@ -271,6 +273,8 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     self.authPreferences.oauthClientId = newClientId;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (BOOL)isIdentityProvider {
     return self.authPreferences.isIdentityProvider;
 }
@@ -283,8 +287,16 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     }
     self.authPreferences.isIdentityProvider = isIdentityProvider;
 }
+#pragma clang diagnostic pop
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (BOOL)idpEnabled {
+    return self.authPreferences.idpEnabled;
+}
+#pragma clang diagnostic pop
+
+- (BOOL)sdk_idpEnabled {
     return self.authPreferences.idpEnabled;
 }
 
@@ -296,7 +308,14 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     self.authPreferences.appDisplayName = appDisplayName;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (NSString *)idpAppURIScheme {
+    return self.authPreferences.idpAppURIScheme;
+}
+#pragma clang diagnostic pop
+
+- (NSString *)sdk_idpAppURIScheme {
     return self.authPreferences.idpAppURIScheme;
 }
 
@@ -308,6 +327,8 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
      self.authPreferences.requireBrowserAuthentication = useBrowserAuth;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)setIdpAppURIScheme:(NSString *)idpAppURIScheme {
     if (idpAppURIScheme && [idpAppURIScheme sfsdk_trim].length > 0) {
         [SFSDKAppFeatureMarkers registerAppFeature:kSFSPAppFeatureIDPLogin];
@@ -316,6 +337,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     }
     self.authPreferences.idpAppURIScheme = idpAppURIScheme;
 }
+#pragma clang diagnostic pop
 
 - (SFSDKLoginViewControllerConfig *) loginViewControllerConfig {
     if (!_loginViewControllerConfig) {
@@ -332,6 +354,8 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 
 #pragma  mark - login & logout
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (BOOL)handleIDPAuthenticationResponse:(NSURL *)appUrlResponse options:(NSDictionary *)options {
     return [self handleIDPAuthenticationCommand:appUrlResponse options:options completion:nil failure:nil];
 }
@@ -391,6 +415,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         failureBlock(SFSPLoginErrorCredentialRefreshFailed);
     }];
 }
+#pragma clang diagnostic pop
 
 - (BOOL)loginWithCompletion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
     BOOL result = NO;
@@ -561,8 +586,10 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     request.scopes = self.scopes;
     request.retryLoginAfterFailure = self.retryLoginAfterFailure;
     request.useBrowserAuth = self.useBrowserAuth;
+    SFSDK_USE_DEPRECATED_BEGIN
     request.spAppLoginFlowSelectionAction = self.idpLoginFlowSelectionAction;
-    request.idpAppURIScheme = self.idpAppURIScheme;
+    SFSDK_USE_DEPRECATED_END
+    request.idpAppURIScheme = self.sdk_idpAppURIScheme;
     request.scene = [[SFSDKWindowManager sharedManager] defaultScene];
     return request;
 }
@@ -1060,6 +1087,8 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     });
 }
 // IDP related code fetched as an identity provider app
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)oauthCoordinatorDidFetchAuthCode:(SFOAuthCoordinator *)coordinator authInfo:(SFOAuthInfo *)authInfo {
     SFSDKAuthCommand *authCommand;
     NSString *keychainReference = coordinator.authSession.oauthRequest.keychainReference;
@@ -1085,6 +1114,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
         [self dismissAuthViewControllerIfPresent];
     }];
 }
+#pragma clang diagnostic pop
 
 - (void)oauthCoordinator:(SFOAuthCoordinator *)coordinator didBeginAuthenticationWithView:(WKWebView *)view {
     SFLoginViewController *loginViewController = [self createLoginViewControllerInstance:coordinator];
@@ -2004,7 +2034,9 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     dispatch_async(dispatch_get_main_queue(), ^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
         [strongSelf dismissAuthViewControllerIfPresentForScene:authSession.oauthRequest.scene completion:^{
+            SFSDK_USE_DEPRECATED_BEGIN
             [strongSelf.authSessions[authSession.sceneId].oauthCoordinator beginIDPFlow:user success:successBlock failure:failureBlock];
+            SFSDK_USE_DEPRECATED_END
         }];
     });
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.h
@@ -23,6 +23,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <SalesforceSDKCore/SalesforceSDKConstants.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -84,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The idp App's URL Scheme
  */
-@property (nonatomic,readonly) NSString *idpAppURLScheme;
+@property (nonatomic,readonly) NSString *idpAppURLScheme SFSDK_DEPRECATED(14.0, 15.0, "The IDP (Identity Provider) login flow is deprecated. Apps should use advanced (browser-based) authentication.");
 /**
  The raw NSDictionary of managed preferences.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFManagedPreferences.m
@@ -110,9 +110,12 @@ static NSString * const kSFDisableExternalPaste = @"DISABLE_EXTERNAL_PASTE";
     return [self.rawPreferences[kManagedKeyOnlyShowAuthorizedHosts] boolValue];
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (NSString *)idpAppURLScheme {
     return self.rawPreferences[kManagedKeyIDPAppURLScheme];
 }
+#pragma clang diagnostic pop
 
 - (NSArray *)loginHosts {
     id objLoginHosts = self.rawPreferences[kManagedKeyLoginHosts];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SalesforceSDKCoreDefines.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SalesforceSDKCoreDefines.h
@@ -45,11 +45,13 @@ enum {
  */
 typedef NSString*_Nonnull (^SFSDKUserAgentCreationBlock)(NSString *qualifier) NS_SWIFT_NAME(UserAgentGeneratorBlock);
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 /**
  Block typedef for creating a custom login flow selection dialog.
  */
 typedef UIViewController<SFSDKLoginFlowSelectionView>*_Nonnull (^SFIDPLoginFlowSelectionBlock)(void) NS_SWIFT_NAME(IDPLoginFlowSelectionBlock);
 
+/// Deprecated: part of the IDP login flow, removed in 15.0.
 /**
  Block typedef for creating a custom user selection flow for idp provider app.
  */

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFManagedPreferencesTest.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFManagedPreferencesTest.m
@@ -71,9 +71,13 @@ static NSException *authException = nil;
     
     XCTAssertEqualObjects([SFManagedPreferences sharedPreferences].connectedAppId,[SFUserAccountManager sharedInstance].oauthClientId, @"SFUserAccountManager should have been setup to use SFManagedPreferences connectedAppId");
     
+    // idpAppURLScheme / idpAppURIScheme are deprecated (14.0, removed in 15.0). These assertions
+    // intentionally exercise the deprecated IDP config path, so suppress the deprecation warning here.
+    SFSDK_USE_DEPRECATED_BEGIN
     XCTAssertTrue([SFManagedPreferences sharedPreferences].idpAppURLScheme, @"SFManagedPreferences idpAppURLScheme should have been set");
-    
+
     XCTAssertEqualObjects([SFManagedPreferences sharedPreferences].idpAppURLScheme,[SFUserAccountManager sharedInstance].idpAppURIScheme, @"SFUserAccountManager should have been setup to use SFManagedPreferences connectedAppId");
+    SFSDK_USE_DEPRECATED_END
 }
 
 - (void)testManagedPreferenceLoginHost {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLoginHostTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKLoginHostTests.m
@@ -116,7 +116,11 @@ static NSUInteger gPresentBiometricWithSceneCallCount = 0;
     self.originalDevSupportEnabled = [SalesforceSDKManager sharedManager].isDevSupportEnabled;
     self.originalShouldFallbackToWebAuthentication = [SFUserAccountManager sharedInstance].shouldFallbackToWebAuthentication;
     self.originalBiometricLocked = [SFBiometricAuthenticationManagerInternal shared].locked;
+    // idpAppURIScheme is deprecated (14.0, removed in 15.0); these tests exercise the IDP branch of
+    // shouldShowBackButton on purpose, so the deprecated accessor use here is intentional.
+    SFSDK_USE_DEPRECATED_BEGIN
     self.originalIdpAppURIScheme = [SFUserAccountManager sharedInstance].idpAppURIScheme;
+    SFSDK_USE_DEPRECATED_END
     self.originalCurrentUser = [SFUserAccountManager sharedInstance].currentUser;
 }
 
@@ -127,7 +131,9 @@ static NSUInteger gPresentBiometricWithSceneCallCount = 0;
     [SalesforceSDKManager sharedManager].isDevSupportEnabled = self.originalDevSupportEnabled;
     [SFUserAccountManager sharedInstance].shouldFallbackToWebAuthentication = self.originalShouldFallbackToWebAuthentication;
     [SFBiometricAuthenticationManagerInternal shared].locked = self.originalBiometricLocked;
+    SFSDK_USE_DEPRECATED_BEGIN
     [SFUserAccountManager sharedInstance].idpAppURIScheme = self.originalIdpAppURIScheme;
+    SFSDK_USE_DEPRECATED_END
     [[SFUserAccountManager sharedInstance] setCurrentUserInternal:self.originalCurrentUser];
     [[SFUserAccountManager sharedInstance] stopCurrentAuthentication:nil];
 
@@ -370,7 +376,9 @@ static NSUInteger gPresentBiometricWithSceneCallCount = 0;
 
     // idp is disabled by default in the test environment; with no current user the account-based
     // branch returns NO.
+    SFSDK_USE_DEPRECATED_BEGIN
     XCTAssertFalse([SFUserAccountManager sharedInstance].idpEnabled, @"Test precondition: idp should be disabled");
+    SFSDK_USE_DEPRECATED_END
     XCTAssertNil([SFUserAccountManager sharedInstance].currentUser, @"Test precondition: there should be no current user");
     XCTAssertFalse([vc shouldShowBackButton], @"Back button should not show when unlocked with no flow and no account to return to");
 }
@@ -432,8 +440,10 @@ static NSUInteger gPresentBiometricWithSceneCallCount = 0;
 - (void)test_givenIdpEnabled_whenShouldShowBackButton_thenYes {
     [SFBiometricAuthenticationManagerInternal shared].locked = NO;
     [SFUserAccountManager sharedInstance].shouldFallbackToWebAuthentication = NO;
+    SFSDK_USE_DEPRECATED_BEGIN
     [SFUserAccountManager sharedInstance].idpAppURIScheme = @"testidp";
     XCTAssertTrue([SFUserAccountManager sharedInstance].idpEnabled, @"Test precondition: idp should be enabled");
+    SFSDK_USE_DEPRECATED_END
 
     SFSDKLoginHostListViewController *vc = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
 
@@ -445,8 +455,10 @@ static NSUInteger gPresentBiometricWithSceneCallCount = 0;
 // is a safe no-op that returns cleanly.
 - (void)test_givenIdpEnabled_whenHandleBackButtonAction_thenHandlesWithoutCrashing {
     [SFUserAccountManager sharedInstance].shouldFallbackToWebAuthentication = NO;
+    SFSDK_USE_DEPRECATED_BEGIN
     [SFUserAccountManager sharedInstance].idpAppURIScheme = @"testidp";
     XCTAssertTrue([SFUserAccountManager sharedInstance].idpEnabled, @"Test precondition: idp should be enabled");
+    SFSDK_USE_DEPRECATED_END
 
     SFSDKLoginHostListViewController *vc = [[SFSDKLoginHostListViewController alloc] initWithStyle:UITableViewStylePlain];
     [vc loadViewIfNeeded];


### PR DESCRIPTION
## Summary

Marks the **IDP (Identity Provider) login flow** public API as **deprecated** (deprecated in 14.0, targeted for removal in 15.0).

As Mobile SDK moves to advanced (browser-based) authentication as the default and only auth mechanism, the IDP flow — where one app acts as an identity provider so other "service provider" apps on the device log in without their own browser round-trip — is being retired. **There is no drop-in replacement**; apps should move to advanced (browser-based) authentication.

This PR **only adds deprecation annotations**. It does not remove the flow or change any runtime behavior — IDP keeps working in 14.0. App developers now get a compiler deprecation warning one major release ahead of removal.

## What changed

- `SFSDK_DEPRECATED(14.0, 15.0, …)` (Obj-C) / `@available(*, deprecated, …)` (Swift) on the public IDP entry points:
  - `SalesforceManager` (`SalesforceSDKManager`): `isIdentityProvider`, `identityProviderURLScheme`, `loginFlowSelectionViewProvider`, `idpUserSelectionViewProvider`
  - `UserAccountManager` (`SFUserAccountManager`): the IDP members (`isIdentityProvider`, `isIDPEnabled`, `idpAppURIScheme`, `idpLoginFlowSelectionAction`, `idpUserSelectionAction`, IDP response/command handlers, `kickOffIDPInitiatedLoginFlowForSP`)
  - `SPConfig`, `SFOAuthCoordinator` IDP methods, the IDP UI classes, and `SFManagedPreferences.idpAppURLScheme`
- The SDK's own internal usages are routed around the annotations (non-deprecated `sdk_`-prefixed accessors over the same backing storage), and implementations of the deprecated methods/accessors are wrapped with `-Wdeprecated-implementations` pragmas — so the SDK still builds **warning-clean**.

## Notes

- Mirrors the `useWebServerAuthentication` (OAuth user agent flow) deprecation landed the same release.
- Annotation-only, no behavior change. `SalesforceSDKCore` builds with **zero** `-Wdeprecated-declarations` / `-Wdeprecated-implementations` warnings.
- **Public API surface change** — flagging for human review per the repo's escalation policy.
- Companion Android PR marks the equivalent Android IDP surface deprecated.

## Test

- `xcodebuild build -scheme SalesforceSDKCore` → BUILD SUCCEEDED, warning-clean for the touched files.