### PR TITLE
Re-enable Named JWT hybrid flow tests

### DIFF
--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/DPoPLoginTests.swift
@@ -55,10 +55,10 @@ class DPoPLoginTests: BaseAuthFlowTester {
 
     // MARK: - ECA JWT DPoP+RTR Tests
 
-    /// Login with ECA JWT DPoP+RTR using hybrid flow (pending server fix for Named JWTs + hybrid + RTR).
-    // TODO: Re-enable when server enables Named JWTs for Hybrid Flows (Salesforce server bug — see internal tracker).
-    func test_givenDPoPRtrHybrid_whenLogin_pendingServerFix() throws {
-        throw XCTSkip("TODO: Pending server fix for Named JWTs + RTR + hybrid flow")
+    /// Login with ECA JWT DPoP+RTR using hybrid flow and verify refresh token rotation and DPoP binding.
+    func test_givenDPoPRtrHybrid_whenLogin_thenRefreshTokenRotatesAndDPoPBindingHolds() throws {
+        launchLoginAndValidate(staticAppConfigName: .ecaJwtDpopRtr, useDPoP: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: true, isDPoP: true, isJwt: true)
     }
 
     /// Login with ECA JWT DPoP+RTR without hybrid flow and verify refresh token rotation and DPoP binding.

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Tests/RTRLoginTests.swift
@@ -36,21 +36,15 @@ class RTRLoginTests: BaseAuthFlowTester {
     // MARK: - ECA JWT RTR Tests
 
     /// Login with ECA JWT RTR using hybrid flow.
-    // TODO: W-22512846 — Remove the skip when server enables Named JWTs for Hybrid Flows.
-    // Server currently returns invalid_grant for RTR + JWT tokens in hybrid flow.
     func testECAJwtRtr_Hybrid() throws {
-        throw XCTSkip("TODO: W-22512846 — Re-enable when server enables Named JWTs for Hybrid Flows")
         launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr)
     }
 
     /// Login with ECA JWT RTR using hybrid flow, restart app, and verify session persists.
-    // TODO: W-22512846 — Remove the skip when server enables Named JWTs for Hybrid Flows.
-    // Server currently returns invalid_grant for RTR + JWT tokens in hybrid flow.
     func testECAJwtRtr_Hybrid_WithRestart() throws {
-        throw XCTSkip("TODO: W-22512846 — Re-enable when server enables Named JWTs for Hybrid Flows")
         launchLoginAndValidate(staticAppConfigName: .ecaJwtRtr)
         restartAndValidateUser(userAppConfigName: .ecaJwtRtr)
-        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: true)
+        assertRevokeAndRefreshWorks(expectsRefreshTokenRotation: true, isJwt: true)
     }
 
     /// Login with ECA JWT RTR without hybrid flow.

--- a/native/SampleApps/AuthFlowTester/README.md
+++ b/native/SampleApps/AuthFlowTester/README.md
@@ -59,7 +59,7 @@ All DPoP tests live here — basic login, RTR, multi-user, migration, server enf
 |------|-----------|--------|-------|
 | `test_givenDPoPHybrid_whenLogin_thenTokenTypeIsDPoPAndRefreshWorks` | ECA JWT DPoP | Yes | |
 | `test_givenDPoPNoHybrid_whenLogin_thenTokenTypeIsDPoPAndRefreshWorks` | ECA JWT DPoP | No | |
-| `test_givenDPoPRtrHybrid_whenLogin_pendingServerFix` | ECA JWT DPoP RTR | Yes | `XCTSkip` (pending server fix for Named JWTs + RTR + hybrid) |
+| `test_givenDPoPRtrHybrid_whenLogin_thenRefreshTokenRotatesAndDPoPBindingHolds` | ECA JWT DPoP RTR | Yes | DPoP + refresh token rotation |
 | `test_givenDPoPRtrNoHybrid_whenLogin_thenRefreshTokenRotatesAndDPoPBindingHolds` | ECA JWT DPoP RTR | No | DPoP + refresh token rotation |
 | `test_givenTwoDPoPUsers_whenSwitchAndRefresh_thenTokensAndNoncesAreIsolated` | ECA JWT DPoP | — | Two users; unique tokens and nonces; independent revoke+refresh per user |
 | `test_givenDPoPUserWithSubsetScopes_whenMigrateToAllScopes_thenDPoPBindingPreserved` | ECA JWT DPoP | — | Scope upgrade; DPoP binding preserved |


### PR DESCRIPTION
## Summary
Server bug **W-22512846** (Enable Named JWTs for Hybrid Flows) is now **Fixed** in build 266, so the AuthFlowTester UI tests that were skipped for it can run again.

- Remove `XCTSkip` from `testECAJwtRtr_Hybrid` and `testECAJwtRtr_Hybrid_WithRestart` (`RTRLoginTests`).
- Restore the hollowed-out DPoP+RTR hybrid test in `DPoPLoginTests` (it had only the skip, no body): renamed `test_givenDPoPRtrHybrid_whenLogin_pendingServerFix` → `test_givenDPoPRtrHybrid_whenLogin_thenRefreshTokenRotatesAndDPoPBindingHolds` and gave it a body mirroring the passing `NoHybrid` sibling.
- Fix a latent bug the skip was masking: `testECAJwtRtr_Hybrid_WithRestart` called `assertRevokeAndRefreshWorks` without `isJwt: true`, so it wrongly asserted the JWT (`JT`) user-agent flag should be absent for the JWT-issuing `.ecaJwtRtr` config. The `NoHybrid` sibling already passes `isJwt: true`.
- Update the AuthFlowTester README to list the DPoP+RTR hybrid test as active.

## Test plan
Ran on iPhone 16 simulator (iOS 18.6) against the live test org:
- [x] `RTRLoginTests/testECAJwtRtr_Hybrid` — passes
- [x] `RTRLoginTests/testECAJwtRtr_Hybrid_WithRestart` — passes (after the `isJwt: true` fix)
- [x] `DPoPLoginTests/test_givenDPoPRtrHybrid_whenLogin_thenRefreshTokenRotatesAndDPoPBindingHolds` — passes

The passing DPoP+RTR+hybrid case confirms the server-side Named-JWT-for-hybrid fix works end to end.