### PR TITLE
[iOS] Move mainSid calculation to SFOAuthCredentials

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
@@ -138,6 +138,11 @@ NS_SWIFT_NAME(OAuthCredentials)
 @property (nonatomic, readonly, nullable) NSString *sidCookieName;
 @property (nonatomic, readonly, nullable) NSString *parentSid;
 @property (nonatomic, readonly, nullable) NSString *tokenFormat;
+
+/** Session ID to use as the main SID cookie.
+ Returns parentSid for JWT token format, accessToken otherwise.
+ */
+@property (nonatomic, readonly, nullable) NSString *mainSid;
 @property (nonatomic, readonly, nullable) NSString *tokenType;
 @property (nonatomic, readonly, nullable) NSString *beaconChildConsumerKey;
 @property (nonatomic, readonly, nullable) NSString *beaconChildConsumerSecret;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -506,4 +506,8 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     return self.beaconChildConsumerKey.length != 0 ? self.beaconChildConsumerKey : self.clientId;
 }
 
+- (NSString *)mainSid {
+    return [@"jwt" isEqualToString:self.tokenFormat] ? self.parentSid : self.accessToken;
+}
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCredentialsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCredentialsTests.m
@@ -108,4 +108,24 @@
     XCTAssertEqualObjects(creds.beaconChildConsumerSecret, @"test-beacon-child-consumer-secret");
 }
 
+- (void)testMainSid_withNonJwtFormat_returnsAccessToken {
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"test-main-sid" clientId:@"test-client" encrypted:NO storageType:SFOAuthCredentialsStorageTypeNone];
+    NSMutableDictionary *params = [NSMutableDictionary dictionary];
+    [params setObject:@"test-access-token" forKey:@"access_token"];
+    [params setObject:@"test-parent-sid" forKey:@"parent_sid"];
+    [params setObject:@"access_token" forKey:@"token_format"];
+    [creds updateCredentials:params];
+    XCTAssertEqualObjects(creds.mainSid, @"test-access-token");
+}
+
+- (void)testMainSid_withJwtFormat_returnsParentSid {
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"test-main-sid-jwt" clientId:@"test-client" encrypted:NO storageType:SFOAuthCredentialsStorageTypeNone];
+    NSMutableDictionary *params = [NSMutableDictionary dictionary];
+    [params setObject:@"test-access-token" forKey:@"access_token"];
+    [params setObject:@"test-parent-sid" forKey:@"parent_sid"];
+    [params setObject:@"jwt" forKey:@"token_format"];
+    [creds updateCredentials:params];
+    XCTAssertEqualObjects(creds.mainSid, @"test-parent-sid");
+}
+
 @end


### PR DESCRIPTION
## Summary

- Adds a `mainSid` computed property to `SFOAuthCredentials` that returns `parentSid` for JWT token format and `accessToken` otherwise
- Simplifies `SalesforceWebViewCookieManager.swift` (in the iOS-Hybrid repo) to use `creds.mainSid` directly — that change is in a separate draft PR (SalesforceMobileSDK-iOS-Hybrid) blocked on this one merging first
- Adds 2 unit tests to `SFOAuthCredentialsTests.m` covering both branches of the logic

## GUS

- W-24023805

## Test plan

- [ ] `testMainSid_withNonJwtFormat_returnsAccessToken` — passes (new)
- [ ] `testMainSid_withJwtFormat_returnsParentSid` — passes (new)
- [ ] Full `SalesforceSDKCore` test suite — no regressions