### PR TITLE
[iOS] Capture ui_sid from DPoP token response and use it in mainSid

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials+Internal.h
@@ -42,6 +42,7 @@ extern NSString * _Nonnull const kSFOAuthServiceVfSid;
 extern NSString * _Nonnull const kSFOAuthServiceContentSid;
 extern NSString * _Nonnull const kSFOAuthServiceCsrf;
 extern NSString * _Nonnull const kSFOAuthServiceParentSid;
+extern NSString * _Nonnull const kSFOAuthServiceUiSid;
 extern NSString * _Nonnull const kSFOAuthServiceBeaconChildConsumerKey;
 extern NSString * _Nonnull const kSFOAuthServiceBeaconChildConsumerSecret;
 
@@ -82,6 +83,7 @@ extern NSException * _Nullable SFOAuthInvalidIdentifierException(void);
 @property (nonatomic, readwrite, nullable) NSString *cookieSidClient;
 @property (nonatomic, readwrite, nullable) NSString *sidCookieName;
 @property (nonatomic, readwrite, nullable) NSString *parentSid;
+@property (nonatomic, readwrite, nullable) NSString *uiSid;
 @property (nonatomic, readwrite, nullable) NSString *tokenFormat;
 @property (nonatomic, readwrite, nullable) NSString *tokenType;
 @property (nonatomic, readwrite, nullable) NSString *beaconChildConsumerKey;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.h
@@ -143,6 +143,9 @@ NS_SWIFT_NAME(OAuthCredentials)
  Returns parentSid for JWT token format, accessToken otherwise.
  */
 @property (nonatomic, readonly, nullable) NSString *mainSid;
+
+/** UI session ID returned by the token endpoint for DPoP token flows. */
+@property (nonatomic, readonly, nullable) NSString *uiSid;
 @property (nonatomic, readonly, nullable) NSString *tokenType;
 @property (nonatomic, readonly, nullable) NSString *beaconChildConsumerKey;
 @property (nonatomic, readonly, nullable) NSString *beaconChildConsumerSecret;

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -37,6 +37,7 @@ NSString * const kSFOAuthServiceVfSid           = @"com.salesforce.mobilesdk.oau
 NSString * const kSFOAuthServiceContentSid      = @"com.salesforce.mobilesdk.oauth.contentSid";
 NSString * const kSFOAuthServiceCsrf            = @"com.salesforce.mobilesdk.oauth.csrf";
 NSString * const kSFOAuthServiceParentSid       = @"com.salesforce.mobilesdk.oauth.parentSid";
+NSString * const kSFOAuthServiceUiSid           = @"com.salesforce.mobilesdk.oauth.uiSid";
 NSString * const kSFOAuthServiceBeaconChildConsumerKey    = @"com.salesforce.mobilesdk.oauth.beaconChildConsumerKey";
 NSString * const kSFOAuthServiceBeaconChildConsumerSecret = @"com.salesforce.mobilesdk.oauth.beaconChildConsumerSecret";
 
@@ -234,6 +235,7 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     copyCreds.cookieSidClient = self.cookieSidClient;
     copyCreds.sidCookieName = self.sidCookieName;
     copyCreds.parentSid = self.parentSid;
+    copyCreds.uiSid = self.uiSid;
     copyCreds.tokenFormat = self.tokenFormat;
     copyCreds.tokenType = self.tokenType;
     copyCreds.beaconChildConsumerKey = self.beaconChildConsumerKey;
@@ -349,6 +351,7 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     self.cookieSidClient = nil;
     self.sidCookieName = nil;
     self.parentSid = nil;
+    self.uiSid = nil;
     self.tokenFormat = nil;
     self.tokenType = nil;
     self.beaconChildConsumerKey = nil;
@@ -483,6 +486,9 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     if (params[kSFOAuthParentSid]) {
         self.parentSid = params[kSFOAuthParentSid];
     }
+    if (params[kSFOAuthUiSid] && [@"dpop" isEqualToString:params[kSFOAuthTokenType]]) {
+        self.uiSid = params[kSFOAuthUiSid];
+    }
     if (params[kSFOAuthTokenFormat]) {
         self.tokenFormat = params[kSFOAuthTokenFormat];
     }
@@ -507,6 +513,7 @@ NSException * SFOAuthInvalidIdentifierException(void) {
 }
 
 - (NSString *)mainSid {
+    if (self.uiSid) { return self.uiSid; }
     return [@"jwt" isEqualToString:self.tokenFormat] ? self.parentSid : self.accessToken;
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthKeychainCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthKeychainCredentials.m
@@ -106,6 +106,14 @@
     [self encryptToken:sid forService:kSFOAuthServiceParentSid];
 }
 
+- (NSString *)uiSid {
+    return [self decryptedTokenForService:kSFOAuthServiceUiSid];
+}
+
+- (void)setUiSid:(NSString *)sid {
+    [self encryptToken:sid forService:kSFOAuthServiceUiSid];
+}
+
 - (NSString *)beaconChildConsumerKey {
     return [self decryptedTokenForService:kSFOAuthServiceBeaconChildConsumerKey];
 }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -91,6 +91,7 @@ static NSString * const kSFOAuthCookieClientSrc                 = @"cookie-clien
 static NSString * const kSFOAuthCookieSidClient                 = @"cookie-sid_Client";
 static NSString * const kSFOAuthSidCookieName                   = @"sidCookieName";
 static NSString * const kSFOAuthParentSid                       = @"parent_sid";
+static NSString * const kSFOAuthUiSid                           = @"ui_sid";
 static NSString * const kSFOAuthTokenFormat                     = @"token_format";
 static NSString * const kSFOAuthTokenType                       = @"token_type";
 static NSString * const kSFOAuthAttestation                     = @"attestation";

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCredentialsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCredentialsTests.m
@@ -128,4 +128,47 @@
     XCTAssertEqualObjects(creds.mainSid, @"test-parent-sid");
 }
 
+- (void)test_givenDPoPTokenType_whenUpdateCredentials_thenUiSidCaptured {
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"test-uisid-dpop" clientId:@"test-client" encrypted:NO storageType:SFOAuthCredentialsStorageTypeNone];
+    NSMutableDictionary *params = [NSMutableDictionary dictionary];
+    [params setObject:@"test-access-token" forKey:@"access_token"];
+    [params setObject:@"test-ui-sid" forKey:@"ui_sid"];
+    [params setObject:@"dpop" forKey:@"token_type"];
+    [creds updateCredentials:params];
+    XCTAssertEqualObjects(creds.uiSid, @"test-ui-sid");
+}
+
+- (void)test_givenNonDPoPTokenType_whenUpdateCredentials_thenUiSidNotCaptured {
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"test-uisid-nondpop" clientId:@"test-client" encrypted:NO storageType:SFOAuthCredentialsStorageTypeNone];
+    NSMutableDictionary *params = [NSMutableDictionary dictionary];
+    [params setObject:@"test-access-token" forKey:@"access_token"];
+    [params setObject:@"test-ui-sid" forKey:@"ui_sid"];
+    [params setObject:@"bearer" forKey:@"token_type"];
+    [creds updateCredentials:params];
+    XCTAssertNil(creds.uiSid);
+}
+
+- (void)test_givenUiSidPresent_whenGetMainSid_thenReturnsUiSid {
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"test-mainsid-uisid" clientId:@"test-client" encrypted:NO storageType:SFOAuthCredentialsStorageTypeNone];
+    NSMutableDictionary *params = [NSMutableDictionary dictionary];
+    [params setObject:@"test-access-token" forKey:@"access_token"];
+    [params setObject:@"test-parent-sid" forKey:@"parent_sid"];
+    [params setObject:@"jwt" forKey:@"token_format"];
+    [params setObject:@"test-ui-sid" forKey:@"ui_sid"];
+    [params setObject:@"dpop" forKey:@"token_type"];
+    [creds updateCredentials:params];
+    XCTAssertEqualObjects(creds.mainSid, @"test-ui-sid");
+}
+
+- (void)test_givenUiSidAbsent_whenGetMainSid_thenFallsBackToExistingLogic {
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"test-mainsid-fallback" clientId:@"test-client" encrypted:NO storageType:SFOAuthCredentialsStorageTypeNone];
+    NSMutableDictionary *params = [NSMutableDictionary dictionary];
+    [params setObject:@"test-access-token" forKey:@"access_token"];
+    [params setObject:@"test-parent-sid" forKey:@"parent_sid"];
+    [params setObject:@"jwt" forKey:@"token_format"];
+    [creds updateCredentials:params];
+    XCTAssertNil(creds.uiSid);
+    XCTAssertEqualObjects(creds.mainSid, @"test-parent-sid");
+}
+
 @end


### PR DESCRIPTION
## Summary

- Adds `uiSid` property to `SFOAuthCredentials` (public readonly in `.h`, readwrite in `+Internal.h`)
- Persists `uiSid` to the keychain in `SFOAuthKeychainCredentials` under `com.salesforce.mobilesdk.oauth.uiSid`
- In `updateCredentials:`, reads `ui_sid` from the token endpoint response, guarded on `tokenType == "dpop"`
- Updates `mainSid` getter: returns `uiSid` if present, otherwise falls back to existing logic (`parentSid` for jwt, `accessToken` otherwise)
- Adds 4 unit tests in `SFOAuthCredentialsTests.m`

## Dependencies

**This PR depends on (already merged):**
- [SalesforceMobileSDK-iOS#4153](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/4153) — [iOS] Move mainSid calculation to SFOAuthCredentials ✅

**Related PRs (same feature):**
- [SalesforceMobileSDK-Android#3019](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/3019) — [Android] Capture ui_sid from DPoP token response and use it in mainSid
- [SalesforceMobileSDK-Android#3017](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/3017) — [Android] Move mainSid calculation to UserAccount
- [SalesforceMobileSDK-iOS-Hybrid#323](https://github.com/forcedotcom/SalesforceMobileSDK-iOS-Hybrid/pull/323) — [iOS-Hybrid] Use creds.mainSid in SalesforceWebViewCookieManager

## Tracking
- W-24024985 — [iOS] Capture ui_sid from token endpoint and use it in mainSid
- Fixes W-23984602