### PR TITLE
[iOS] Fix stale uiSid after DPoP-to-Bearer downgrade

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -486,8 +486,10 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     if (params[kSFOAuthParentSid]) {
         self.parentSid = params[kSFOAuthParentSid];
     }
-    if (params[kSFOAuthUiSid] && [@"dpop" isEqualToString:params[kSFOAuthTokenType]]) {
-        self.uiSid = params[kSFOAuthUiSid];
+    // Clear uiSid when the token type is known and non-DPoP so a stale DPoP
+    // uiSid is not left behind after a DPoP-to-Bearer downgrade.
+    if (params[kSFOAuthTokenType]) {
+        self.uiSid = [@"dpop" isEqualToString:params[kSFOAuthTokenType]] ? params[kSFOAuthUiSid] : nil;
     }
     if (params[kSFOAuthTokenFormat]) {
         self.tokenFormat = params[kSFOAuthTokenFormat];

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCredentialsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCredentialsTests.m
@@ -171,4 +171,23 @@
     XCTAssertEqualObjects(creds.mainSid, @"test-parent-sid");
 }
 
+- (void)test_givenExistingUiSid_whenUpdateCredentialsWithBearerTokenType_thenUiSidCleared {
+    SFOAuthCredentials *creds = [[SFOAuthCredentials alloc] initWithIdentifier:@"test-uisid-stale" clientId:@"test-client" encrypted:NO storageType:SFOAuthCredentialsStorageTypeNone];
+
+    NSMutableDictionary *dpopParams = [NSMutableDictionary dictionary];
+    [dpopParams setObject:@"dpop-access-token" forKey:@"access_token"];
+    [dpopParams setObject:@"test-ui-sid" forKey:@"ui_sid"];
+    [dpopParams setObject:@"dpop" forKey:@"token_type"];
+    [creds updateCredentials:dpopParams];
+    XCTAssertEqualObjects(creds.uiSid, @"test-ui-sid", @"Precondition: uiSid must be set after DPoP login");
+
+    NSMutableDictionary *bearerParams = [NSMutableDictionary dictionary];
+    [bearerParams setObject:@"bearer-access-token" forKey:@"access_token"];
+    [bearerParams setObject:@"bearer" forKey:@"token_type"];
+    [creds updateCredentials:bearerParams];
+
+    XCTAssertNil(creds.uiSid, @"uiSid must be cleared after DPoP-to-Bearer downgrade");
+    XCTAssertEqualObjects(creds.mainSid, @"bearer-access-token", @"mainSid must return access token after uiSid is cleared");
+}
+
 @end


### PR DESCRIPTION
## Summary

Addresses review feedback on the merged PR #4154.

- **`SFOAuthCredentials.m`**: when `token_type` is present in the token endpoint response and is not `dpop`, explicitly sets `self.uiSid = nil`. This clears any stale DPoP `uiSid` from the keychain after a DPoP-to-Bearer downgrade; without this, `mainSid` would return the old session ID instead of the Bearer access token.
- **`SFOAuthCredentialsTests.m`**: adds a regression test (`test_givenExistingUiSid_whenUpdateCredentialsWithBearerTokenType_thenUiSidCleared`) that exercises the full DPoP-to-Bearer transition through `updateCredentials:`.

## Tracking
- W-24024985
- Fixes W-23984602