### PR TITLE
W-24027227: Add iOS 27 to nightly CI

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -15,8 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         lib: [SalesforceSDKCommon, SalesforceAnalytics, SalesforceSDKCore, SmartStore, MobileSync]
-        ios: [^26, ^18]
+        ios: [^27, ^26, ^18]
         include:
+          - ios: ^27
+            xcode: ^27
+            macos: xcode-27
           - ios: ^26
             xcode: ^26
           - ios: ^18
@@ -40,8 +43,11 @@ jobs:
       fail-fast: false
       matrix:
         app: [RestAPIExplorer, MobileSyncExplorer, AuthFlowTester]
-        ios: [^26, ^18]
+        ios: [^27, ^26, ^18]
         include:
+          - ios: ^27
+            xcode: ^27
+            macos: xcode-27
           - ios: ^26
             xcode: ^26
           - ios: ^18

--- a/.github/workflows/ui-test-nightly.yaml
+++ b/.github/workflows/ui-test-nightly.yaml
@@ -13,8 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ios: [^26, ^18]
+        ios: [^27, ^26, ^18]
         include:
+          - ios: ^27
+            xcode: ^27
+            macos: xcode-27
           - ios: ^26
             xcode: ^26
           - ios: ^18


### PR DESCRIPTION
## Summary
- add iOS 27 and Xcode 27 to nightly library tests
- add iOS 27 to nightly native sample builds and AuthFlowTester UI tests
- retain existing iOS 18 and iOS 26 coverage

## Validation
- parsed the edited workflows as YAML
- verified each iOS 27 matrix entry resolves to Xcode 27 on the xcode-27 runner
- ran git diff --check

Work item: [W-24027227](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002j5NcnYAE/view)