### PR TITLE
[iOS] AuthFlowTester: display mainSid/uiSid and assert them in tests

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Common/SalesforceSDKManager.m
@@ -660,7 +660,7 @@ static NSString *SFSDKISO8601StringFromDate(NSDate *date) {
             @"Beacon Child Consumer Key", creds.beaconChildConsumerKey ?: @"(empty)"
         ]];
 
-        if ([creds.tokenType isEqualToString:@"DPoP"]) {
+        if ([creds.tokenType isEqualToString:kSFOAuthDPoPTokenType]) {
             [devInfos addObjectsFromArray:@[
                 @"DPoP Nonce", [SFSDKDPoPNonceCache.shared latestForScope:creds.identifier] ?: @"None"
             ]];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCredentials.m
@@ -489,7 +489,7 @@ NSException * SFOAuthInvalidIdentifierException(void) {
     // Clear uiSid when the token type is known and non-DPoP so a stale DPoP
     // uiSid is not left behind after a DPoP-to-Bearer downgrade.
     if (params[kSFOAuthTokenType]) {
-        self.uiSid = [@"dpop" isEqualToString:params[kSFOAuthTokenType]] ? params[kSFOAuthUiSid] : nil;
+        self.uiSid = [kSFOAuthDPoPTokenType isEqualToString:params[kSFOAuthTokenType]] ? params[kSFOAuthUiSid] : nil;
     }
     if (params[kSFOAuthTokenFormat]) {
         self.tokenFormat = params[kSFOAuthTokenFormat];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKOAuthConstants.h
@@ -94,6 +94,7 @@ static NSString * const kSFOAuthParentSid                       = @"parent_sid";
 static NSString * const kSFOAuthUiSid                           = @"ui_sid";
 static NSString * const kSFOAuthTokenFormat                     = @"token_format";
 static NSString * const kSFOAuthTokenType                       = @"token_type";
+static NSString * const kSFOAuthDPoPTokenType                   = @"DPoP";
 static NSString * const kSFOAuthAttestation                     = @"attestation";
 static NSString * const kSFOAuthBeaconChildConsumerKey          = @"auto_installed_app_org_consumer_key";
 static NSString * const kSFOAuthBeaconChildConsumerSecret       = @"auto_installed_app_org_consumer_secret";

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCredentialsTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFOAuthCredentialsTests.m
@@ -133,7 +133,7 @@
     NSMutableDictionary *params = [NSMutableDictionary dictionary];
     [params setObject:@"test-access-token" forKey:@"access_token"];
     [params setObject:@"test-ui-sid" forKey:@"ui_sid"];
-    [params setObject:@"dpop" forKey:@"token_type"];
+    [params setObject:@"DPoP" forKey:@"token_type"];
     [creds updateCredentials:params];
     XCTAssertEqualObjects(creds.uiSid, @"test-ui-sid");
 }
@@ -155,7 +155,7 @@
     [params setObject:@"test-parent-sid" forKey:@"parent_sid"];
     [params setObject:@"jwt" forKey:@"token_format"];
     [params setObject:@"test-ui-sid" forKey:@"ui_sid"];
-    [params setObject:@"dpop" forKey:@"token_type"];
+    [params setObject:@"DPoP" forKey:@"token_type"];
     [creds updateCredentials:params];
     XCTAssertEqualObjects(creds.mainSid, @"test-ui-sid");
 }
@@ -177,7 +177,7 @@
     NSMutableDictionary *dpopParams = [NSMutableDictionary dictionary];
     [dpopParams setObject:@"dpop-access-token" forKey:@"access_token"];
     [dpopParams setObject:@"test-ui-sid" forKey:@"ui_sid"];
-    [dpopParams setObject:@"dpop" forKey:@"token_type"];
+    [dpopParams setObject:@"DPoP" forKey:@"token_type"];
     [creds updateCredentials:dpopParams];
     XCTAssertEqualObjects(creds.uiSid, @"test-ui-sid", @"Precondition: uiSid must be set after DPoP login");
 

--- a/native/SampleApps/AuthFlowTester/AuthFlowTester/Views/UserCredentialsView.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTester/Views/UserCredentialsView.swift
@@ -83,6 +83,8 @@ public struct CredentialsLabels {
     public static let contentDomain = "Content Domain"
     public static let contentSid = "Content SID"
     public static let parentSid = "Parent SID"
+    public static let mainSid = "Main SID"
+    public static let uiSid = "UI SID"
     public static let sidCookieName = "SID Cookie Name"
     
     // Cookies and Security fields
@@ -205,6 +207,8 @@ struct UserCredentialsView: View {
                         InfoRowView(label: "\(CredentialsLabels.contentDomain):", value: contentDomain)
                         InfoRowView(label: "\(CredentialsLabels.contentSid):", value: contentSid, isSensitive: true)
                         InfoRowView(label: "\(CredentialsLabels.parentSid):", value: parentSid, isSensitive: true)
+                        InfoRowView(label: "\(CredentialsLabels.mainSid):", value: mainSid, isSensitive: true)
+                        InfoRowView(label: "\(CredentialsLabels.uiSid):", value: uiSid, isSensitive: true)
                         InfoRowView(label: "\(CredentialsLabels.sidCookieName):", value: sidCookieName)
                     }
                     
@@ -315,6 +319,8 @@ struct UserCredentialsView: View {
             CredentialsLabels.contentDomain: contentDomain,
             CredentialsLabels.contentSid: contentSid,
             CredentialsLabels.parentSid: parentSid,
+            CredentialsLabels.mainSid: mainSid,
+            CredentialsLabels.uiSid: uiSid,
             CredentialsLabels.sidCookieName: sidCookieName
         ]
         
@@ -498,7 +504,15 @@ struct UserCredentialsView: View {
     private var parentSid: String {
         return credentials?.parentSid ?? ""
     }
-    
+
+    private var mainSid: String {
+        return credentials?.mainSid ?? ""
+    }
+
+    private var uiSid: String {
+        return credentials?.uiSid ?? ""
+    }
+
     private var sidCookieName: String {
         return credentials?.sidCookieName ?? ""
     }

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTesterMainPageObject.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/PageObjects/AuthFlowTesterMainPageObject.swift
@@ -85,6 +85,8 @@ struct CredentialsLabels {
     static let contentDomain = "Content Domain"
     static let contentSid = "Content SID"
     static let parentSid = "Parent SID"
+    static let mainSid = "Main SID"
+    static let uiSid = "UI SID"
     static let sidCookieName = "SID Cookie Name"
     
     // Cookies and Security fields
@@ -175,6 +177,8 @@ struct UserCredentialsData {
     var contentDomain: String
     var contentSid: String
     var parentSid: String
+    var mainSid: String
+    var uiSid: String
     var sidCookieName: String
     
     // Cookies and Security
@@ -645,6 +649,8 @@ class AuthFlowTesterMainPageObject {
             contentDomain: domainsAndSids[CredentialsLabels.contentDomain] ?? "",
             contentSid: domainsAndSids[CredentialsLabels.contentSid] ?? "",
             parentSid: domainsAndSids[CredentialsLabels.parentSid] ?? "",
+            mainSid: domainsAndSids[CredentialsLabels.mainSid] ?? "",
+            uiSid: domainsAndSids[CredentialsLabels.uiSid] ?? "",
             sidCookieName: domainsAndSids[CredentialsLabels.sidCookieName] ?? "",
             csrfToken: cookiesAndSecurity[CredentialsLabels.csrfToken] ?? "",
             cookieClientSrc: cookiesAndSecurity[CredentialsLabels.cookieClientSrc] ?? "",

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -1243,7 +1243,7 @@ class BaseAuthFlowTester: XCTestCase {
         )
 
         // Additional login-specific validations
-        assertSIDs(userCredentialsData: userCredentials, useHybridFlow: useHybridFlow, useJwt: issuesJwt)
+        assertSIDs(userCredentialsData: userCredentials, useHybridFlow: useHybridFlow, useJwt: issuesJwt, isDPoP: effectiveExpectDP)
         assertURLs(userCredentialsData: userCredentials, useWebServerFlow: useWebServerFlow)
 
         // DPoP token binding: assert on any DPoP-app path (login, switch, restart, migration)
@@ -1413,21 +1413,32 @@ class BaseAuthFlowTester: XCTestCase {
         return jwtDetails
     }
     
-    private func assertSIDs(userCredentialsData: UserCredentialsData, useHybridFlow: Bool, useJwt: Bool) {
+    private func assertSIDs(userCredentialsData: UserCredentialsData, useHybridFlow: Bool, useJwt: Bool, isDPoP: Bool) {
         let hasContentScope = userCredentialsData.credentialsScopes.contains("content")
         let hasLightningScope = userCredentialsData.credentialsScopes.contains("lightning")
         let hasVisualforceScope = userCredentialsData.credentialsScopes.contains("visualforce")
-        
+
         assertNotEmpty(userCredentialsData.contentDomain, shouldNotBeEmpty: hasContentScope && useHybridFlow, "Content domain")
         assertNotEmpty(userCredentialsData.contentSid, shouldNotBeEmpty: hasContentScope && useHybridFlow, "Content SID")
-        
+
         assertNotEmpty(userCredentialsData.lightningDomain, shouldNotBeEmpty: hasLightningScope && useHybridFlow, "Lightning domain")
         assertNotEmpty(userCredentialsData.lightningSid, shouldNotBeEmpty: hasLightningScope && useHybridFlow, "Lightning SID")
-        
+
         assertNotEmpty(userCredentialsData.vfDomain, shouldNotBeEmpty: hasVisualforceScope && useHybridFlow, "VF domain")
         assertNotEmpty(userCredentialsData.vfSid, shouldNotBeEmpty: hasVisualforceScope && useHybridFlow, "VF SID")
-        
+
         assertNotEmpty(userCredentialsData.parentSid, shouldNotBeEmpty: useJwt && useHybridFlow, "Parent SID")
+
+        assertNotEmpty(userCredentialsData.mainSid, shouldNotBeEmpty: true, "Main SID")
+        assertNotEmpty(userCredentialsData.uiSid, shouldNotBeEmpty: isDPoP, "UI SID")
+
+        if !userCredentialsData.uiSid.isEmpty {
+            XCTAssertEqual(userCredentialsData.mainSid, userCredentialsData.uiSid, "Main SID should equal UI SID when UI SID is present")
+        } else if !userCredentialsData.parentSid.isEmpty {
+            XCTAssertEqual(userCredentialsData.mainSid, userCredentialsData.parentSid, "Main SID should equal Parent SID when UI SID is absent and Parent SID is present")
+        } else {
+            XCTAssertEqual(userCredentialsData.mainSid, userCredentialsData.accessToken, "Main SID should equal Access Token when neither UI SID nor Parent SID is present")
+        }
     }
     
     private func assertURLs(userCredentialsData: UserCredentialsData, useWebServerFlow: Bool) {


### PR DESCRIPTION
## Summary

- **UserCredentialsView**: Adds \`mainSid\` and \`uiSid\` rows in the Domains and SIDs section and includes them in the JSON export (used by UI tests).
- **AuthFlowTesterMainPageObject**: Adds \`mainSid\` and \`uiSid\` to \`UserCredentialsData\` struct and parses them from the exported JSON.
- **BaseAuthFlowTester.assertSIDs**: Adds \`isDPoP\` parameter and new assertions:
  - \`mainSid\` is always non-empty
  - \`uiSid\` is non-empty when DPoP is active
  - \`mainSid == uiSid\` (DPoP), \`mainSid == parentSid\` (JWT hybrid), or \`mainSid == accessToken\` (opaque Bearer)

### Bug fix: uiSid was never captured in DPoP sessions

\`SFOAuthCredentials.updateCredentials:\` compared the server-returned token type against the lowercase literal \`@"dpop"\`, but the server returns \`@"DPoP"\` (mixed case). The case-sensitive \`isEqualToString:\` comparison always failed, so \`uiSid\` was set to \`nil\` on every DPoP login.

Fix: added \`kSFOAuthDPoPTokenType = @"DPoP"\` to \`SFSDKOAuthConstants.h\` and replaced all bare string literals in production code with this constant. Updated \`SFOAuthCredentialsTests.m\` to pass the correct mixed-case token type the server actually sends.

Note: \`DPoPRequestDecorator.isDPoPTokenType(_:)\` already performs a case-insensitive comparison (RFC-compliant); the existing test that passes \`"dpop"\` to that method is intentional and unchanged.

## Dependencies

Builds on top of merged PRs:
- [#4154](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/4154) — feat: capture ui_sid from DPoP token responses
- [#4155](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/pull/4155) — fix: clear stale uiSid on DPoP-to-Bearer downgrade

Related Android PR: [forcedotcom/SalesforceMobileSDK-Android#3020](https://github.com/forcedotcom/SalesforceMobileSDK-Android/pull/3020)

## Test plan

- [ ] DPoP test: \`test_givenDPoPHybrid_whenLogin_thenTokenTypeIsDPoPAndRefreshWorks\` — verifies uiSid non-empty and mainSid == uiSid
- [ ] JWT + hybrid test: \`testECAJwt_DefaultScopes\` — verifies mainSid == parentSid
- [ ] Non-DPoP non-JWT test: \`testCAOpaque_DefaultScopes_WebServerFlow\` — verifies mainSid == accessToken