### PR TITLE
[iOS] Truncate credential identifier in SFSDKTokenRefreshCoordinator logs

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKTokenRefreshCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFSDKTokenRefreshCoordinator.m
@@ -57,9 +57,36 @@ SFSDK_USE_DEPRECATED_END
 @interface SFSDKTokenRefreshCoordinator ()
 @property (nonatomic, strong) NSMutableDictionary<NSString *, SFSDKTokenRefreshEntry *> *activeRefreshes;
 @property (nonatomic, strong) dispatch_queue_t serialQueue;
+// Returns the last 8 characters of key prefixed with "..." for safe log output.
++ (NSString *)truncatedKey:(NSString *)key;
 @end
 
 @implementation SFSDKTokenRefreshCoordinator
+
+#pragma mark - Helpers
+
++ (NSString *)truncatedKey:(NSString *)key {
+    // Identifier format: <consumerKey>-<randomUInt32>
+    // Show first 5 + last 4 of consumer key, last 4 of random number.
+    NSRange lastDash = [key rangeOfString:@"-" options:NSBackwardsSearch];
+    if (lastDash.location != NSNotFound) {
+        NSString *rnd = [key substringFromIndex:lastDash.location + 1];
+        NSCharacterSet *nonDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
+        if (rnd.length > 0 && [rnd rangeOfCharacterFromSet:nonDigits].location == NSNotFound) {
+            NSString *ck = [key substringToIndex:lastDash.location];
+            NSString *ckPrefix = ck.length >= 5 ? [ck substringToIndex:5] : ck;
+            NSString *ckSuffix = ck.length > 5 ? [ck substringFromIndex:ck.length - 4] : @"";
+            NSString *rndSuffix = rnd.length >= 4 ? [rnd substringFromIndex:rnd.length - 4] : rnd;
+            if (ckSuffix.length > 0) {
+                return [NSString stringWithFormat:@"%@...%@...%@", ckPrefix, ckSuffix, rndSuffix];
+            } else {
+                return [NSString stringWithFormat:@"%@...%@", ckPrefix, rndSuffix];
+            }
+        }
+    }
+    // Fallback for unexpected format: show last 8 chars
+    return key.length <= 8 ? @"[redacted]" : [NSString stringWithFormat:@"...%@", [key substringFromIndex:key.length - 8]];
+}
 
 #pragma mark - Singleton
 
@@ -115,7 +142,7 @@ SFSDK_USE_DEPRECATED_END
         }
 
         if (alreadyInFlight) {
-            [SFSDKCoreLogger d:[self class] format:@"Refresh already in-flight for credential %@. Coalescing request.", key];
+            [SFSDKCoreLogger d:[self class] format:@"Refresh already in-flight for credential %@. Coalescing request.", [SFSDKTokenRefreshCoordinator truncatedKey:key]];
             return;
         }
 
@@ -137,7 +164,7 @@ SFSDK_USE_DEPRECATED_END
 
         self.activeRefreshes[key] = entry;
 
-        [SFSDKCoreLogger i:[self class] format:@"Starting token refresh for credential %@.", key];
+        [SFSDKCoreLogger i:[self class] format:@"Starting token refresh for credential %@.", [SFSDKTokenRefreshCoordinator truncatedKey:key]];
 
         [entry.refresher refreshSessionWithCompletion:^(SFOAuthCredentials *updatedCredentials) {
             dispatch_async(self.serialQueue, ^{
@@ -175,13 +202,13 @@ SFSDK_USE_DEPRECATED_END
     dispatch_async(dispatch_get_main_queue(), ^{
         if (error) {
             [SFSDKCoreLogger e:[self class] format:@"Token refresh failed for credential %@. Notifying %lu waiter(s). Error: %@",
-             key, (unsigned long)entry.errorBlocks.count, error];
+             [SFSDKTokenRefreshCoordinator truncatedKey:key], (unsigned long)entry.errorBlocks.count, error];
             for (void (^errorBlock)(NSError *) in entry.errorBlocks) {
                 errorBlock(error);
             }
         } else {
             [SFSDKCoreLogger i:[self class] format:@"Token refresh succeeded for credential %@. Notifying %lu waiter(s).",
-             key, (unsigned long)entry.completionBlocks.count];
+             [SFSDKTokenRefreshCoordinator truncatedKey:key], (unsigned long)entry.completionBlocks.count];
             for (void (^completionBlock)(SFOAuthCredentials *) in entry.completionBlocks) {
                 completionBlock(credentials);
             }
@@ -194,7 +221,7 @@ SFSDK_USE_DEPRECATED_END
         SFSDKTokenRefreshEntry *entry = self.activeRefreshes[key];
         if (!entry) return;
 
-        [SFSDKCoreLogger w:[self class] format:@"Background task expired during token refresh for credential %@. Delivering cancellation error.", key];
+        [SFSDKCoreLogger w:[self class] format:@"Background task expired during token refresh for credential %@. Delivering cancellation error.", [SFSDKTokenRefreshCoordinator truncatedKey:key]];
 
         NSError *bgError = [NSError errorWithDomain:@"SFSDKTokenRefreshCoordinator"
                                                code:-2

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKTokenRefreshCoordinatorTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKTokenRefreshCoordinatorTests.m
@@ -46,6 +46,11 @@ SFSDK_USE_DEPRECATED_BEGIN
 - (instancetype)initWithDictionary:(NSDictionary *)dict parseAdditionalFields:(NSArray<NSString *> *)additionalFields;
 @end
 
+// Expose private truncation helper for unit testing
+@interface SFSDKTokenRefreshCoordinator (Testing)
++ (NSString *)truncatedKey:(NSString *)key;
+@end
+
 #pragma mark - Single-Use Token Mock Refresher
 
 /**
@@ -517,6 +522,39 @@ SFSDK_USE_DEPRECATED_BEGIN
                              @"Token should have rotated again in cycle 2");
     XCTAssertEqual(self.mockRefresher.refreshCallCount, 2,
                    @"Two sequential cycles should each make exactly one refresh call");
+}
+
+#pragma mark - Log Key Truncation Tests
+
+- (void)test_givenFullIdentifier_whenTruncated_thenShowsKeyPrefixSuffixAndRandomSuffix {
+    // Consumer key: "3MVG9" (5) + 76 'a's + "bbbb" (4) = 85 chars — matches real SF consumer key length
+    // Random part:  "cccccc" (6) + "7777" (4) = 10 chars — matches max u_int32_t digit count
+    // (Random must be all-digit characters; 'c' chars here represent hidden leading digits)
+    NSString *ck = [[@"3MVG9" stringByPaddingToLength:81 withString:@"a" startingAtIndex:0]
+                    stringByAppendingString:@"bbbb"];
+    NSString *identifier = [NSString stringWithFormat:@"%@-6666667777", ck];
+    XCTAssertEqualObjects([SFSDKTokenRefreshCoordinator truncatedKey:identifier], @"3MVG9...bbbb...7777");
+}
+
+- (void)test_givenShortConsumerKey_whenTruncated_thenShowsFullKeyAndRandomSuffix {
+    // Consumer key 3 chars (< 5): show full key prefix only, no suffix segment
+    XCTAssertEqualObjects([SFSDKTokenRefreshCoordinator truncatedKey:@"3MV-6666667777"],
+                          @"3MV...7777");
+}
+
+- (void)test_givenShortRandomPart_whenTruncated_thenShowsFullRandom {
+    // Random part < 4 digits: show the full (short) random without truncation
+    NSString *ck = [[@"3MVG9" stringByPaddingToLength:81 withString:@"a" startingAtIndex:0]
+                    stringByAppendingString:@"bbbb"];
+    NSString *identifier = [NSString stringWithFormat:@"%@-123", ck];
+    XCTAssertEqualObjects([SFSDKTokenRefreshCoordinator truncatedKey:identifier], @"3MVG9...bbbb...123");
+}
+
+- (void)test_givenIdentifierWithNonDigitSuffix_whenTruncated_thenFallsBackToTailTruncation {
+    // Part after last "-" contains letters → not a valid random number → fall back to last 8 chars
+    // Last 8 chars of "1234567890-nope" (15 chars) = "890-nope"
+    XCTAssertEqualObjects([SFSDKTokenRefreshCoordinator truncatedKey:@"1234567890-nope"],
+                          @"...890-nope");
 }
 
 #pragma mark - Nil Identifier Test


### PR DESCRIPTION
## Summary

- Five log statements in `SFSDKTokenRefreshCoordinator.m` printed the full `credentials.identifier` (OAuth consumer key) at debug/info/error/warn level
- Fix adds a `+truncatedKey:` class method that returns the last 8 characters prefixed with `...`, and applies it to all five log sites
- Log entries remain correlatable (e.g. `...22527001`) without exposing the full identifier

## Changed files

- `SFSDKTokenRefreshCoordinator.m` — `+truncatedKey:` helper + five log-site updates
- `SFSDKTokenRefreshCoordinatorTests.m` — four unit tests for the truncation helper (long key, exactly-8-char key, short/empty key, 9-char key)

## Test plan

- [x] `xcodebuild test -scheme SalesforceSDKCore -only-testing:SalesforceSDKCoreTests/SFSDKTokenRefreshCoordinatorTests` — 15/15 pass
- [x] Log output confirmed: credentials now appear as `...XXXXXXXX` in all five message types

Fixes W-24033040