### PR TITLE
[iOS] NativeLoginManager Basic-Auth header uses URL-safe Base64 instead of standard Base64, breaking login for some username/password combinations

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/NativeLogin/NativeLoginManagerInternal.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/NativeLogin/NativeLoginManagerInternal.swift
@@ -768,8 +768,11 @@ public class NativeLoginManagerInternal: NSObject, NativeLoginManager {
         guard let valuesUtf8EncodedData = "\(value1):\(value2)".data(
             using: .utf8
         ) else { return nil }
-        
-        return urlSafeBase64Encode(data: valuesUtf8EncodedData)
+
+        /* HTTP Basic Authentication (RFC 7617) requires the standard base64
+         * alphabet with padding, not the URL-safe alphabet used elsewhere in
+         * this file for PKCE values. */
+        return valuesUtf8EncodedData.base64EncodedString()
     }
     
     /// Generates either the reCAPTCHA token parameter for non-enterprise reCAPTCHA configurations or

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/NativeLoginManagerTests.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/NativeLoginManagerTests.swift
@@ -97,6 +97,88 @@ final class NativeLoginManagerTests: XCTestCase {
         XCTAssertEqual(.invalidCredentials, result, "Password should be acceptable.")
     }
     
+    /// Tests that `login` builds the Basic-Auth `Authorization` header using
+    /// the standard Base64 alphabet with padding (RFC 4648 §4, as required by
+    /// RFC 7617), rather than the URL-safe alphabet. The credentials below are
+    /// chosen so that the colon-concatenated, UTF-8-encoded username:password
+    /// bytes Base64-encode differently under the standard and URL-safe
+    /// alphabets (contains `/` and requires `=` padding under the standard
+    /// alphabet), so a regression back to URL-safe encoding would be caught.
+    func testLoginUsesStandardBase64ForAuthorizationHeader() async throws {
+        let identifier = NetworkEphemeralInstanceIdentifier
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ScriptedURLProtocol.self] + (config.protocolClasses ?? [])
+        ScriptedURLProtocol.installScripts([
+            .init(statusCode: 401, headers: nil, body: Data())
+        ], identifier: identifier)
+        Network.setSessionConfiguration(config, identifier: identifier)
+        defer {
+            Network.removeSharedInstance(forIdentifier: identifier)
+            ScriptedURLProtocol.removeScripts(identifier: identifier)
+        }
+
+        let manager = SalesforceManager.shared.useNativeLogin(
+            withConsumerKey: "c",
+            callbackUrl: "r",
+            communityUrl: "https://login.example.com",
+            nativeLoginViewController: UIViewController(),
+            scene: nil)
+
+        let username = "regdemouser501@salesforce.com"
+        let password = "Winter2026!?!"
+        _ = await manager.login(username: username, password: password)
+
+        let authRequest = try XCTUnwrap(
+            ScriptedURLProtocol.capturedRequests(identifier: identifier).first {
+                $0.value(forHTTPHeaderField: "Authorization") != nil
+            })
+        let expectedCreds = Data("\(username):\(password)".utf8).base64EncodedString()
+        XCTAssertEqual(
+            authRequest.value(forHTTPHeaderField: "Authorization"),
+            "Basic \(expectedCreds)")
+    }
+
+    /// Tests that `submitPasswordlessAuthorizationRequest`, which shares the
+    /// same colon-concatenated Base64 encoding helper as `login`, also produces
+    /// a standard-alphabet, padded Basic-Auth header rather than URL-safe
+    /// encoding.
+    func testSubmitPasswordlessAuthorizationRequestUsesStandardBase64ForAuthorizationHeader() async throws {
+        let identifier = NetworkEphemeralInstanceIdentifier
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ScriptedURLProtocol.self] + (config.protocolClasses ?? [])
+        ScriptedURLProtocol.installScripts([
+            .init(statusCode: 401, headers: nil, body: Data())
+        ], identifier: identifier)
+        Network.setSessionConfiguration(config, identifier: identifier)
+        defer {
+            Network.removeSharedInstance(forIdentifier: identifier)
+            ScriptedURLProtocol.removeScripts(identifier: identifier)
+        }
+
+        let manager = SalesforceManager.shared.useNativeLogin(
+            withConsumerKey: "c",
+            callbackUrl: "r",
+            communityUrl: "https://login.example.com",
+            nativeLoginViewController: UIViewController(),
+            scene: nil)
+
+        let otpIdentifier = "regdemouser501@salesforce.com"
+        let otp = "Winter2026!?!"
+        _ = await manager.submitPasswordlessAuthorizationRequest(
+            otp: otp,
+            otpIdentifier: otpIdentifier,
+            otpVerificationMethod: .email)
+
+        let authRequest = try XCTUnwrap(
+            ScriptedURLProtocol.capturedRequests(identifier: identifier).first {
+                $0.value(forHTTPHeaderField: "Authorization") != nil
+            })
+        let expectedCreds = Data("\(otpIdentifier):\(otp)".utf8).base64EncodedString()
+        XCTAssertEqual(
+            authRequest.value(forHTTPHeaderField: "Authorization"),
+            "Basic \(expectedCreds)")
+    }
+
     func testShouldShowBackButton() {
         let accountManager = UserAccountManager.shared
         XCTAssertNil(accountManager.currentUserAccount)


### PR DESCRIPTION
## Summary

`NativeLoginManagerInternal`'s helper for building the Basic-Auth `Authorization` header (`generateColonConcatenatedBase64String()`) encoded the colon-concatenated username and password with the URL-safe Base64 alphabet and no padding (via `urlSafeBase64Encode()`). HTTP Basic Authentication (RFC 7617) requires the standard Base64 alphabet with padding. For most credential pairs the two alphabets produce identical output, which is why this went unnoticed — they only diverge when the encoded bytes would contain `+`, `/`, or need `=` padding under the standard alphabet. When that happens, login fails with a generic "check your username and password" error even though the credentials are correct (confirmed working via web login for the same user).

The equivalent fix already shipped on Android for the same defect class in its own Basic-Auth encoding helper; the iOS Swift implementation independently had the identical bug and that fix was never ported over.

- Changed `generateColonConcatenatedBase64String()` to encode with the standard Base64 alphabet (plain `data.base64EncodedString()`) instead of `urlSafeBase64Encode()`.
- This helper is shared by `login()`, `submitAuthorizationRequest()` (used by the OTP/registration-completion flows), and `submitPasswordlessAuthorizationRequest()` (OTP/passwordless login), so all three call sites are fixed by the one change.

## Scope note

This does not touch `urlSafeBase64Encode()`'s other callers in the same file — `generateCodeVerifier()` and `generateChallenge()` — which correctly need URL-safe Base64 per RFC 7636 for PKCE `codeVerifier`/`codeChallenge` values and are unrelated to this HTTP Basic-Auth header.

## Test plan

- [x] Added a regression test covering `login()`, using a username/password pair whose combined UTF-8 bytes diverge between the standard and URL-safe alphabets (contains `/` and requires `=` padding under the standard alphabet); asserts the `Authorization` header matches standard Base64 output.
- [x] Added a regression test covering `submitPasswordlessAuthorizationRequest()` (a call site sharing the same helper), same divergent credential pair.
- [x] Ran `NativeLoginManagerTests` on the iOS simulator — both new tests pass. (Two pre-existing, unrelated failures in this suite — `testShouldShowBackButton`/`testShouldShowBackButtonWithBioAuth` — are keychain-entitlement issues in this local sandboxed environment, reproduced identically on unmodified `dev`.)
- [x] Found via a real reproduction during release validation: fresh self-registration on iOS 26 (Native Login template) followed by an immediate logout and login attempt with the identical, just-set password failed; the same password worked correctly via Salesforce web login for the same user, isolating the defect to this SDK's Basic-Auth header encoding.

*This response was generated by an AI agent on behalf of @JohnsonEricAtSalesforce.*
