### PR TITLE
Fix nightly CI: ^26 jobs silently dropped due to missing macos runner label

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,6 +22,7 @@ jobs:
             macos: xcode-27
           - ios: ^26
             xcode: ^26
+            macos: macos-latest
           - ios: ^18
             xcode: ^16
             macos: macos-15
@@ -50,6 +51,7 @@ jobs:
             macos: xcode-27
           - ios: ^26
             xcode: ^26
+            macos: macos-latest
           - ios: ^18
             xcode: ^16
             macos: macos-15


### PR DESCRIPTION
## Problem

Since `W-24027227: Add iOS 27 to nightly CI` (#4156), the `^26` test and sample-build jobs have been silently absent from every nightly run (e.g. [33235375451](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/actions/runs/33235375451)).

**Root cause**: The `^26` include entry was left without a `macos:` field. The nightly passes `macos: ${{ matrix.macos }}` to the reusable workflow; for `^26` combinations `matrix.macos` evaluates to `""`, which **overrides** the reusable workflow's `default: macos-latest`. The result is `runs-on: ""` — GitHub Actions silently drops jobs with an empty runner label instead of falling back to the default.

## Fix

Add `macos: macos-latest` to the `^26` include in both the `ios-nightly` and `native-samples-nightly` jobs, matching the explicit `macos:` already set for `^27` (`xcode-27`) and `^18` (`macos-15`).

## Test plan

- [ ] Trigger a manual workflow dispatch of Nightly Tests and confirm `^26` jobs appear alongside `^27` and `^18`
- [ ] Confirm `^26` jobs complete successfully (they ran fine before #4156)