### PR TITLE
fix(AuthFlowTesterUITests): fix mainSid and uiSid assertions for non-hybrid flows

### DIFF
--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -1429,7 +1429,7 @@ class BaseAuthFlowTester: XCTestCase {
 
         assertNotEmpty(userCredentialsData.parentSid, shouldNotBeEmpty: useJwt && useHybridFlow, "Parent SID")
 
-        assertNotEmpty(userCredentialsData.uiSid, shouldNotBeEmpty: isDPoP, "UI SID")
+        assertNotEmpty(userCredentialsData.uiSid, shouldNotBeEmpty: isDPoP && useHybridFlow, "UI SID")
 
         if useHybridFlow {
             if isDPoP {

--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/BaseAuthFlowTester.swift
@@ -1429,15 +1429,16 @@ class BaseAuthFlowTester: XCTestCase {
 
         assertNotEmpty(userCredentialsData.parentSid, shouldNotBeEmpty: useJwt && useHybridFlow, "Parent SID")
 
-        assertNotEmpty(userCredentialsData.mainSid, shouldNotBeEmpty: true, "Main SID")
         assertNotEmpty(userCredentialsData.uiSid, shouldNotBeEmpty: isDPoP, "UI SID")
 
-        if !userCredentialsData.uiSid.isEmpty {
-            XCTAssertEqual(userCredentialsData.mainSid, userCredentialsData.uiSid, "Main SID should equal UI SID when UI SID is present")
-        } else if !userCredentialsData.parentSid.isEmpty {
-            XCTAssertEqual(userCredentialsData.mainSid, userCredentialsData.parentSid, "Main SID should equal Parent SID when UI SID is absent and Parent SID is present")
-        } else {
-            XCTAssertEqual(userCredentialsData.mainSid, userCredentialsData.accessToken, "Main SID should equal Access Token when neither UI SID nor Parent SID is present")
+        if useHybridFlow {
+            if isDPoP {
+                XCTAssertEqual(userCredentialsData.mainSid, userCredentialsData.uiSid, "Main SID should equal UI SID in DPoP hybrid flow")
+            } else if useJwt {
+                XCTAssertEqual(userCredentialsData.mainSid, userCredentialsData.parentSid, "Main SID should equal Parent SID in JWT hybrid flow")
+            } else {
+                XCTAssertEqual(userCredentialsData.mainSid, userCredentialsData.accessToken, "Main SID should equal Access Token in opaque hybrid flow")
+            }
         }
     }
     


### PR DESCRIPTION
## Summary

### Fix 1: `mainSid` assertion scoped to hybrid flows only
- Removes the unconditional `assertNotEmpty` on `mainSid` in `assertSIDs`
- Replaces the flat `if/else if/else` cascade with a `useHybridFlow`-gated block: DPoP→`uiSid`, JWT→`parentSid`, opaque→`accessToken`
- Non-hybrid flows skip `mainSid` assertion entirely — `mainSid` is only semantically meaningful in hybrid flows (WebView cookie injection). In non-hybrid JWT flows, `parentSid` is not returned by the server so `mainSid` is correctly empty.

### Fix 2: `uiSid` assertNotEmpty scoped to hybrid flows only
- Adds `&& useHybridFlow` guard to the `uiSid` assertion so non-hybrid DPoP flows no longer require a UI SID.

## Test plan

- [x] `RTRLoginTests.testECAJwtRtr_NoHybrid` — was failing, now passes
- [ ] Full `AuthFlowTesterUITests` suite on a connected org