### PR TITLE
Fix native CocoaPods template pod deployment target floor for Xcode 27

### DIFF
--- a/mobilesdk_pods.rb
+++ b/mobilesdk_pods.rb
@@ -60,10 +60,10 @@ end
 # Post Install: fix deployment targets
 def mobile_sdk_post_install(installer)
   installer.pods_project.targets.each do |target|
-    # ARC code targeting iOS 8 does not build on Xcode 14.3. Force to at least iOS 9.
-    force_to_arc_supported_min = target.deployment_target.to_i < 9
-    if force_to_arc_supported_min
-      change_deployment_target(target, '9.0')
+    # Xcode 27 dropped support for deployment targets below iOS 15.0. Force to at least iOS 15.
+    force_to_xcode_27_min = target.deployment_target.to_f < 15.0
+    if force_to_xcode_27_min
+      change_deployment_target(target, '15.0')
     end
     
     # Mobile SDK targets


### PR DESCRIPTION
## Summary

Fixes Xcode 27 build failures for all native iOS CocoaPods template apps: iOSNativeSwiftTemplate, iOSNativeSwiftEncryptedNotificationTemplate, iOSNativeLoginTemplate, iOSIDPTemplate, MobileSyncExplorerSwift. Also fixes the same failure in the ReactNative repo's `iosTests/ios/Podfile`, which loads `mobilesdk_pods.rb` from the iOS SDK clone.

**Root cause:** `mobile_sdk_post_install` in `mobilesdk_pods.rb` raised any pod with a deployment target below iOS 9 to `9.0`. Xcode 27 dropped support for deployment targets below 15.0, so pods like SQLCipher and FMDB triggered the error _"the range of supported deployment target versions is 15.0 to 27.0.x"_ during pod install.

**Fix:** Raise the floor from `9.0` to `15.0` (and the comparison threshold from `< 9` to `< 15.0`). One-line change.

**Not addressed here — Hybrid templates (W-24057371):** These use a Cordova-generated Podfile that does not call `mobile_sdk_post_install`. Fix required in CordovaPlugin repo (`tools/postinstall-ios.js`).

**Not addressed here — React Native templates:** Fail on Xcode 27 with "Failed frontend command" (Metro bundler / RN build toolchain issue), unrelated to pod deployment targets.

Addresses W-24057370.

## Test plan

Tested on **Xcode 27.0** (Build 27A5237l) — clean run with all templates:

| Template | Xcode 27 | Notes |
|---|---|---|
| iOSNativeSwiftTemplate | ✅ Pass | |
| iOSNativeSwiftPackageManagerTemplate | ✅ Pass | SPM, no CocoaPods |
| iOSNativeSwiftEncryptedNotificationTemplate | ✅ Pass | |
| iOSIDPTemplate | ✅ Pass | |
| MobileSyncExplorerSwift | ✅ Pass | |
| iOSNativeLoginTemplate | ✅ Pass | |
| HybridLocalTemplate | ❌ Fail | Cordova pod deployment target — W-24057371 |
| HybridRemoteTemplate | ❌ Fail | Same — W-24057371 |
| ReactNativeTemplate | ❌ Fail | "Failed frontend command" — separate RN/Xcode 27 issue |
| ReactNativeDeferredTemplate | ❌ Fail | Same |
| ReactNativeTypeScriptTemplate | ❌ Fail | Same |
| MobileSyncExplorerReactNative | ❌ Fail | Same |

Also validated on **Xcode 26.6**: 12/12 passed.