### PR TITLE
Marshal login/authenticate scene access to the main thread

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -418,6 +418,17 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 #pragma clang diagnostic pop
 
 - (BOOL)loginWithCompletion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
+    // -[UIApplication connectedScenes] is a main-thread-only UIKit API. This entry point can be
+    // reached on a background thread (e.g. a REST request that triggers login from a background
+    // queue), so marshal to the main thread to avoid unsafe UIKit access and Main Thread Checker
+    // warnings. dispatch_sync preserves the synchronous BOOL return that callers rely on.
+    if (![NSThread isMainThread]) {
+        __block BOOL result = NO;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            result = [self loginWithCompletion:completionBlock failure:failureBlock];
+        });
+        return result;
+    }
     BOOL result = NO;
     for (UIScene *scene in [SFApplicationHelper sharedApplication].connectedScenes) {
         result |= [self loginWithCompletion:completionBlock failure:failureBlock scene:scene];
@@ -547,6 +558,25 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
                 frontDoorBridgeUrl:(NSURL * )frontDoorBridgeUrl
                       codeVerifier:(NSString *)codeVerifier
 {
+    // -[UIScene session] (below) is a main-thread-only UIKit API, and this is the common
+    // chokepoint for the scene-based login paths (loginWithCompletion:...). Marshal to the main
+    // thread when invoked from a background thread so scene access and the auth UI it drives run
+    // on the main thread. (loginWithJwtToken: and SP-app authentication call authenticateWithRequest:
+    // directly and do not pass through here.)
+    // dispatch_sync preserves the synchronous BOOL return that callers (e.g. SFSDKAuthHelper) rely on.
+    if (![NSThread isMainThread]) {
+        __block BOOL result = NO;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            result = [self authenticateWithCompletion:completionBlock
+                                              failure:failureBlock
+                                                scene:scene
+                                            loginHint:loginHint
+                                            loginHost:loginHost
+                                   frontDoorBridgeUrl:frontDoorBridgeUrl
+                                         codeVerifier:codeVerifier];
+        });
+        return result;
+    }
     SFSDKAuthSession *authSession = self.authSessions[scene.session.persistentIdentifier];
     if (authSession && authSession.isAuthenticating) {
         [SFSDKCoreLogger e:[self class] format:@"Login has already been called. Stop current authentication using SFUserAccountManager::stopCurrentAuthentication and then retry."];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
@@ -500,6 +500,16 @@ static NSString *const kSFScreenLockWindowKey = @"screenlock";
 }
 
 - (UIScene *)defaultScene {
+    // -[UIApplication connectedScenes] is a main-thread-only UIKit API. This can be reached from
+    // a background thread via the auth flow, so marshal to the main thread to avoid unsafe UIKit
+    // access and Main Thread Checker warnings.
+    if (![NSThread isMainThread]) {
+        __block UIScene *scene = nil;
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            scene = [self defaultScene];
+        });
+        return scene;
+    }
     NSArray *connectedScenes = [SFApplicationHelper sharedApplication].connectedScenes.allObjects;
     for (UIScene *connectedScene in connectedScenes) {
         if (connectedScene.activationState == UISceneActivationStateForegroundActive) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
@@ -267,4 +267,25 @@
     [self waitForExpectations:@[expectation] timeout:10];
 }
 
+// Regression test for the background-thread UIKit fix: -[SFSDKWindowManager defaultScene] iterates
+// [UIApplication connectedScenes], a main-thread-only UIKit API. The auth flow can reach it from a
+// background thread, so it marshals to the main thread. Verify a background invocation returns the
+// same scene as the main-thread invocation and completes without hanging (the dispatch_sync guard
+// must not deadlock when the caller is off the main thread).
+- (void)testDefaultSceneFromBackgroundThreadMatchesMainThread {
+    UIScene *mainThreadScene = [[SFSDKWindowManager sharedManager] defaultScene];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"defaultScene returns from a background thread"];
+    __block UIScene *backgroundScene = nil;
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        XCTAssertFalse([NSThread isMainThread], @"Precondition: the call must originate off the main thread");
+        backgroundScene = [[SFSDKWindowManager sharedManager] defaultScene];
+        [expectation fulfill];
+    });
+    [self waitForExpectations:@[expectation] timeout:10];
+
+    XCTAssertEqualObjects(backgroundScene, mainThreadScene,
+                          @"A background invocation should return the same scene as the main-thread invocation");
+}
+
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFUserAccountManagerTests.m
@@ -1216,4 +1216,90 @@ static NSString * const kOrgIdFormatString = @"00D000000000062EA%lu";
     // Clean up
     [[NSNotificationCenter defaultCenter] removeObserver:observer];
 }
+
+#pragma mark - Background-thread UIKit access regression tests
+
+// Seed an in-progress auth session for every connected scene so that
+// -authenticateWithCompletion:...scene:... short-circuits to NO synchronously (see
+// SFUserAccountManager.m) without starting a live auth flow. Returns the scene ids that were seeded
+// so the caller can remove them in teardown.
+- (NSArray<NSString *> *)seedAuthenticatingSessionsForAllConnectedScenes {
+    NSMutableArray<NSString *> *seededSceneIds = [NSMutableArray array];
+    for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+        NSString *sceneId = scene.session.persistentIdentifier;
+        if (!sceneId) {
+            continue;
+        }
+        SFSDKAuthRequest *request = [self.uam defaultAuthRequest];
+        SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] initWith:request credentials:nil];
+        authSession.isAuthenticating = YES;
+        self.uam.authSessions[sceneId] = authSession;
+        [seededSceneIds addObject:sceneId];
+    }
+    return seededSceneIds;
+}
+
+// Regression test for the background-thread UIKit fix: -[SFUserAccountManager loginWithCompletion:failure:]
+// iterates [UIApplication connectedScenes], a main-thread-only UIKit API. A REST request that hits the
+// login branch can call this on a background thread, so the entry point marshals to the main thread.
+// With an in-progress auth session seeded for every scene, the call short-circuits to a synchronous NO.
+// Verify the background invocation preserves that BOOL result and completes without hanging.
+- (void)testLoginWithCompletionFromBackgroundThreadPreservesResult {
+    NSArray<NSString *> *seededSceneIds = [self seedAuthenticatingSessionsForAllConnectedScenes];
+    XCTAssertTrue(seededSceneIds.count > 0, @"Precondition: at least one connected scene is required");
+
+    BOOL mainThreadResult = [self.uam loginWithCompletion:nil failure:nil];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"loginWithCompletion returns from a background thread"];
+    __block BOOL backgroundResult = YES;
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        XCTAssertFalse([NSThread isMainThread], @"Precondition: the call must originate off the main thread");
+        backgroundResult = [self.uam loginWithCompletion:nil failure:nil];
+        [expectation fulfill];
+    });
+    [self waitForExpectations:@[expectation] timeout:10];
+
+    XCTAssertEqual(backgroundResult, mainThreadResult,
+                   @"A background invocation must preserve the synchronous BOOL result of the main-thread invocation");
+    XCTAssertFalse(backgroundResult,
+                   @"With an in-progress auth session seeded for every scene, login should short-circuit to NO");
+
+    for (NSString *sceneId in seededSceneIds) {
+        [self.uam.authSessions removeObject:sceneId];
+    }
+}
+
+// Regression test for the background-thread UIKit fix: the scene-based login path reaches
+// -[SFUserAccountManager authenticateWithCompletion:failure:scene:...], which reads
+// scene.session.persistentIdentifier — a main-thread-only UIKit API. It marshals to the main thread
+// when invoked off it. Drive it through the public -loginWithCompletion:failure:scene: wrapper from a
+// background queue and verify the synchronous BOOL result is preserved and the call does not hang.
+- (void)testLoginWithCompletionForSceneFromBackgroundThreadPreservesResult {
+    UIScene *scene = [UIApplication sharedApplication].connectedScenes.allObjects.firstObject;
+    XCTAssertNotNil(scene, @"Precondition: at least one connected scene is required");
+    NSString *sceneId = scene.session.persistentIdentifier;
+
+    SFSDKAuthRequest *request = [self.uam defaultAuthRequest];
+    SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] initWith:request credentials:nil];
+    authSession.isAuthenticating = YES;
+    self.uam.authSessions[sceneId] = authSession;
+
+    BOOL mainThreadResult = [self.uam loginWithCompletion:nil failure:nil scene:scene];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"scene login returns from a background thread"];
+    __block BOOL backgroundResult = YES;
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        XCTAssertFalse([NSThread isMainThread], @"Precondition: the call must originate off the main thread");
+        backgroundResult = [self.uam loginWithCompletion:nil failure:nil scene:scene];
+        [expectation fulfill];
+    });
+    [self waitForExpectations:@[expectation] timeout:10];
+
+    XCTAssertEqual(backgroundResult, mainThreadResult,
+                   @"A background invocation must preserve the synchronous BOOL result of the main-thread invocation");
+    XCTAssertFalse(backgroundResult,
+                   @"With an in-progress auth session seeded for the scene, authentication should short-circuit to NO");
+
+    [self.uam.authSessions removeObject:sceneId];
+}
 @end


### PR DESCRIPTION
## Summary

`SFUserAccountManager` and `SFSDKWindowManager` touch main-thread-only UIKit APIs on whatever thread the caller is on:

- `-[SFUserAccountManager loginWithCompletion:failure:]` iterates `UIApplication.connectedScenes`
- `-[SFUserAccountManager authenticateWithCompletion:failure:scene:...]` reads `scene.session.persistentIdentifier`
- `-[SFSDKWindowManager defaultScene]` iterates `UIApplication.connectedScenes`

When a REST request that requires authentication is issued from a background thread and the SDK takes the "no valid tokens → login" branch, these run on that background thread. Apple's Main Thread Checker flags the violations (`UIApplication connectedScenes`, `UIScene session`), and background UIKit access is unsafe. This was surfaced externally by the Agentforce React Native SDK team, whose bridge routes traffic through `RestClient.send` on a Swift-concurrency cooperative executor.

## Fix

Guard each entry point with an `if (![NSThread isMainThread])` check and marshal to the main queue via `dispatch_sync`. `dispatch_sync` (not `dispatch_async`) is required because callers such as `SFSDKAuthHelper` consume the synchronous `BOOL` return. This matches the existing `isMainThread` guards already present elsewhere in `SFUserAccountManager` (e.g. `resumeBrowserAuthentication:`, `stopCurrentAuthentication`).

## Tests

Added background-thread regression tests for all three methods. Each invokes the method from a background queue and verifies the synchronous `BOOL` result matches the main-thread invocation (and `defaultScene` returns the same scene), that the off-main path is actually exercised, and that the call completes without hanging. Uses `XCTestExpectation` — no sleeps or main-thread blocking.

All three new tests pass.

## Reviewer note

This changes authentication execution flow, so it needs explicit human auth-flow review per repository policy.