### PR TITLE
fix(AuthFlowTesterUITests): remove beacon RTR workaround (W-24028119)

### DIFF
--- a/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestConfigUtils.swift
+++ b/native/SampleApps/AuthFlowTester/AuthFlowTesterUITests/Util/UITestConfigUtils.swift
@@ -139,10 +139,9 @@ struct AppConfig: Codable {
     }
 
     /// Whether a normal refresh is expected to rotate this configuration's refresh token.
-    /// W-23971480: beacon apps behave as RTR due to a server bug; drop the beacon_ clause when fixed.
     /// This is deliberately distinct from the per-user RT user-agent feature marker.
     var expectsRefreshTokenRotation: Bool {
-        return name.contains("_rtr") || name.hasPrefix("beacon_")
+        return name.contains("_rtr")
     }
 
     /// Returns true if the app uses DPoP (name contains "_dpop")


### PR DESCRIPTION
## Summary

Removes the `beacon_` clause from `expectsRefreshTokenRotation` in `UITestConfigUtils.swift`.

The server bug (W-23971480) that caused beacon apps to unconditionally rotate the refresh token on every refresh has been fixed in sdb38. The workaround and its comment are no longer needed — `beacon_opaque` and `beacon_jwt` tests should now pass without the special-case RTR expectation.

## Test plan

- [x] `BeaconLoginTests.testBeaconOpaque_DefaultScopes` — was failing with RTR mismatch, now passes
- [ ] Full beacon test suite on a connected org