### PR TITLE
Fix REST retry completion race

### DIFF
--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -1,0 +1,10 @@
+# Authentication engineering documentation
+
+This directory contains implementation guides for authentication behavior in the iOS Mobile
+SDK.
+
+## Documents
+
+| Document | Purpose |
+|---|---|
+| [`token-lifecycle.md`](token-lifecycle.md) | Code exchange, token refresh, DPoP nonce handling, Refresh Token Rotation, and REST replay concurrency. |

--- a/docs/auth/token-lifecycle.md
+++ b/docs/auth/token-lifecycle.md
@@ -332,6 +332,12 @@ task 1 -> HTTP 400 use_dpop_nonce + DPoP-Nonce
   -> any later task-1 completion is stale and ignored
 ```
 
+If authentication replay installs a successor after task 1 recognizes the nonce challenge but
+before it claims retry ownership, task 1 fails its ownership recheck and does not install another
+successor. Conversely, if the DPoP retry claim wins the lock first, authentication replay can only
+replace the successor it published. The two retry mechanisms therefore preserve one current-task
+chain rather than creating independent successors.
+
 ### 9.4 Completion racing authentication replay
 
 ```text

--- a/docs/auth/token-lifecycle.md
+++ b/docs/auth/token-lifecycle.md
@@ -205,8 +205,9 @@ When an attempt receives an authentication failure accepted by the retry policy:
 2. Under `@synchronized(self)`, `replayRequest` elects one refresh cycle for the API instance.
 3. The API asks the shared `SFSDKTokenRefreshCoordinator` to refresh the credential.
 4. Other failed requests remain in `activeRequests`; they do not start another refresh cycle.
-5. On refresh success, `resendActiveRequestsRequiringAuthentication` snapshots the active set and
-   installs a new task for each pending request with automatic auth retry disabled.
+5. On refresh success, `resendActiveRequestsRequiringAuthentication` snapshots the active set. It
+   skips any newly admitted request whose initial task has not been published yet, and installs a
+   successor for each request that already owns a task, with automatic auth retry disabled.
 6. Each old task is cancelled after its successor is installed.
 7. On refresh failure, the active set is atomically drained and each request receives one failure.
 
@@ -247,6 +248,12 @@ replace the task between parsing and delivery.
 The successor is created and assigned to `request.sessionDataTask` while holding the state lock.
 `SFNetwork.sendRequest` resumes its task before returning, so the lock prevents an exceptionally
 fast asynchronous completion from observing the request before task ownership is published.
+
+Admission to `activeRequests` intentionally happens before initial request preparation, so a newly
+submitted request can appear in a refresh replay snapshot while `sessionDataTask` is still nil.
+Replay skips that entry: only the original sender may publish the first task, while replay may only
+replace an existing task. This prevents replay and the original sender from independently creating
+two initial attempts for the same request.
 
 **Invariant:** `SFNetwork.sendRequest` must remain nonblocking and must not invoke its completion
 synchronously. Changing that contract could introduce a lock-ordering or reentrancy hazard.
@@ -339,6 +346,20 @@ Whichever acquires the ownership lock first wins:
 
 The request receives one terminal result in either ordering.
 
+### 9.5 New request racing the replay snapshot
+
+```text
+new send adds request B to activeRequests
+request B pauses before publishing its first task
+refresh replay snapshots request B and sees sessionDataTask == nil
+replay skips request B
+the original send publishes B's first task
+B's sole task claims and delivers its terminal callback
+```
+
+This is the admission-side counterpart to the completion race. Replay owns replacement of a
+published attempt; it never creates the initial attempt on behalf of an in-progress sender.
+
 ---
 
 ## 10. Concurrency Invariants
@@ -353,6 +374,8 @@ The request receives one terminal result in either ordering.
 7. Application and delegate callbacks execute outside the request-state lock.
 8. Cleanup invalidates request ownership before cancellation or client notification.
 9. A replayed REST request cannot automatically start a second auth refresh cycle.
+10. Refresh replay skips an active request with no published task; only its original sender may
+    publish the first attempt.
 
 The focused regression coverage lives in `SFRestAPIDataTaskRaceTests`, with coordinator behavior
 covered by `SFSDKTokenRefreshCoordinatorTests` and token-endpoint nonce handling covered by the

--- a/docs/auth/token-lifecycle.md
+++ b/docs/auth/token-lifecycle.md
@@ -139,19 +139,26 @@ look like a rotation.
 ```text
 applyAuthHeaders(request, scope, accessToken, tokenType):
   if accessToken is empty -> leave request unchanged
-  set Authorization to "DPoP <token>" when tokenType is DPoP,
-                       or "Bearer <token>" otherwise
-  if shouldAttachDPoP(scope, tokenType):
+  if isDPoPTokenType(tokenType):
+    set Authorization to "DPoP <token>"
     load or create the credential-scoped EC P-256 keypair
     canonicalize the request URL for htu
     read a cached nonce for the URL and credential scope
     build a fresh proof with htm, htu, iat, jti, nonce, and ath
     set the DPoP header
+  else:
+    set Authorization to "Bearer <token>"
 ```
 
-The gate is per credential. An explicitly DPoP-bound credential continues to receive proofs even
-if the process-wide DPoP preference later changes. Token-endpoint proofs omit `ath`; resource
-proofs bind the proof to the current access token with `ath`.
+The four-argument overload used by `SFRestRequest` treats the credential's explicit `tokenType` as
+authoritative and attaches a proof only when that value is DPoP. It does not consult the
+process-wide DPoP preference.
+
+The credential-object convenience overload uses `shouldAttachDPoP(scope:tokenType:)`. An explicit
+token type is still authoritative, but when `tokenType` is nil during the `/authorize` to `/token`
+transition, that overload can fall back to credential-scoped key material. This fallback also does
+not consult the global preference. Token-endpoint proofs omit `ath`; resource proofs bind the proof
+to the current access token with `ath`.
 
 ---
 
@@ -171,6 +178,10 @@ built proof.
 2. Confirm that this request has not already used its one resource nonce retry.
 3. Harvest `DPoP-Nonce` for the response URL and credential scope.
 4. Rebuild and enqueue the request, producing a fresh proof.
+
+This REST branch deliberately checks `statusCode == 400` and searches the response body directly
+for `use_dpop_nonce`. It does not call `DPoPRequestDecorator.isNonceChallenge`, whose broader token
+endpoint detection also recognizes a 401 carrying `DPoP-Nonce`.
 
 Resource-server 401 responses do not take this inline nonce path. They enter normal access-token
 refresh, where the token endpoint can provide a fresh nonce before the resource request is replayed.

--- a/docs/auth/token-lifecycle.md
+++ b/docs/auth/token-lifecycle.md
@@ -1,0 +1,348 @@
+# Token Lifecycle: Code Exchange, Refresh, DPoP, and RTR
+
+This document describes how the iOS SDK acquires and renews OAuth tokens, attaches DPoP proofs,
+manages nonces, handles Refresh Token Rotation (RTR), and safely replays REST requests under
+concurrency.
+
+The primary classes are:
+
+- **`SFOAuthCoordinator`** — drives interactive authentication and authorization-code exchange.
+- **`SFSDKOAuth2`** — sends token-endpoint requests and handles DPoP nonce challenges.
+- **`SFSDKTokenRefreshCoordinator`** — coalesces refresh requests per credential.
+- **`SFOAuthSessionRefresher`** — builds a refresh request, updates credentials, and records RTR.
+- **`SFRestRequest`** — builds an authenticated resource request with Bearer or DPoP headers.
+- **`SFRestAPI`** — tracks request attempts, starts refresh, and replays active requests.
+- **`DPoPRequestDecorator`**, **`DPoPProofBuilder`**, **`DPoPKeyStore`**, **`DPoPURL`**, and
+  **`DPoPNonceCache`** — DPoP proof construction, key storage, URL canonicalization, and nonce
+  caching.
+
+---
+
+## 1. Authorization Code Exchange
+
+**Entry point:** `SFOAuthCoordinator.beginTokenEndpointFlow`
+
+After browser authentication returns an authorization code, `SFOAuthCoordinator`:
+
+1. Obtains an App Attestation assertion when attestation is enabled for the login domain.
+2. Creates `SFSDKOAuthTokenEndpointRequest` with the client ID, redirect URI, server URL,
+   credential identifier, token type, authorization code, PKCE verifier, and optional assertion.
+3. Calls `SFSDKOAuth2.accessTokenForApprovalCode`.
+4. `SFSDKOAuth2` builds `POST /services/oauth2/token` using the authorization-code grant.
+5. If the credential is on the DPoP path, it adds a proof without `ath`, because no access token
+   exists yet.
+6. `sendTokenEndpointRequest` harvests `DPoP-Nonce` and retries exactly once when the server
+   returns a nonce challenge.
+7. On success, `SFOAuthCoordinator` updates `SFOAuthCredentials` with the access token, refresh
+   token, instance URL, token type, and additional OAuth fields.
+
+The credential identifier is established before token exchange. It is the stable scope for the
+DPoP keypair, nonce cache, and later refresh coalescing.
+
+---
+
+## 2. Token Refresh
+
+Refresh can be requested by multiple SDK components, including `SFRestAPI`,
+`SFIdentityCoordinator`, and `SFUserAccountManager`. They all use the shared
+`SFSDKTokenRefreshCoordinator`; callers should not construct an independent refresher.
+
+### 2.1 Per-credential coordination
+
+**Entry point:** `SFSDKTokenRefreshCoordinator.refreshSessionForCredentials`
+
+The coordinator owns a serial queue and a dictionary keyed by `credentials.identifier`:
+
+```text
+activeRefreshes[credentials.identifier] = {
+    refresher,
+    completionBlocks[],
+    errorBlocks[],
+    backgroundTaskId
+}
+```
+
+The first caller for a credential creates the entry and starts one `SFOAuthSessionRefresher`.
+Later callers for that credential append their callbacks to the same entry. Refreshes for different
+credential identifiers remain independent.
+
+```text
+Caller A                         Caller B, same credential
+-------------------------------- --------------------------------
+serial queue:
+  no active entry
+  create entry
+  append A callbacks
+  start refresher
+                                 serial queue:
+                                   find active entry
+                                   append B callbacks
+                                   return without another POST
+
+token endpoint completes
+serial queue:
+  remove active entry
+  end background task
+main queue:
+  notify A and B with one result
+```
+
+The coordinator serial queue protects only bookkeeping. It is not held during App Attestation or
+network I/O. Completion and error callbacks are delivered on the main queue.
+
+If iOS background time expires, the coordinator removes the active entry and delivers a
+cancellation error to its waiters. A later network completion for that removed entry is ignored.
+
+### 2.2 Refresh execution
+
+`SFOAuthSessionRefresher` validates that the credentials contain an instance URL, client ID, and
+refresh token. It then:
+
+1. Obtains an App Attestation assertion when enabled.
+2. Builds `SFSDKOAuthTokenEndpointRequest` from the current credentials.
+3. Calls `SFSDKOAuth2.accessTokenForRefresh`.
+4. Sends `grant_type=refresh_token` (or the configured hybrid refresh grant).
+5. Attaches a DPoP proof and handles one token-endpoint nonce challenge when required.
+6. Updates the shared `SFOAuthCredentials` object from the response.
+7. Posts `kSFNotificationUserDidRefreshToken` on success.
+8. Returns the updated credentials to the coordinator, which fans the result out to every waiter.
+
+---
+
+## 3. Refresh Token Rotation
+
+With RTR, a successful refresh can return a new refresh token and invalidate the token used for
+that exchange. Concurrent refresh POSTs with the same old token can therefore cause a successful
+request to be followed by `invalid_grant` and logout.
+
+`SFSDKTokenRefreshCoordinator` prevents that double spend by allowing at most one refresh request
+per credential identifier. Unlike the Android winner/loser wait model, iOS stores callback arrays
+on the in-flight entry and broadcasts the single result asynchronously.
+
+On a successful response, `SFOAuthSessionRefresher` compares the updated refresh token with the
+one used for the request. When it changed, the refresher:
+
+- records `lastTokenRotationDate` on `SFOAuthCredentials`; and
+- registers the `RT` app feature marker for the account.
+
+If a refresh response omits `refresh_token`, `SFSDKOAuth2` carries the request's existing refresh
+token into the parsed response. This preserves non-RTR sessions without making an omitted value
+look like a rotation.
+
+---
+
+## 4. DPoP Proof Attachment
+
+`SFRestRequest.prepareRequestForSend` delegates authentication headers to
+`DPoPRequestDecorator.applyAuthHeaders` unless the caller already supplied `Authorization`.
+
+```text
+applyAuthHeaders(request, scope, accessToken, tokenType):
+  if accessToken is empty -> leave request unchanged
+  set Authorization to "DPoP <token>" when tokenType is DPoP,
+                       or "Bearer <token>" otherwise
+  if shouldAttachDPoP(scope, tokenType):
+    load or create the credential-scoped EC P-256 keypair
+    canonicalize the request URL for htu
+    read a cached nonce for the URL and credential scope
+    build a fresh proof with htm, htu, iat, jti, nonce, and ath
+    set the DPoP header
+```
+
+The gate is per credential. An explicitly DPoP-bound credential continues to receive proofs even
+if the process-wide DPoP preference later changes. Token-endpoint proofs omit `ath`; resource
+proofs bind the proof to the current access token with `ath`.
+
+---
+
+## 5. DPoP Nonce Lifecycle
+
+`DPoPNonceCache` is a process-lifetime, thread-safe cache keyed by canonicalized `htu` and
+credential scope. Reads are non-destructive. A scope-wide fallback lets a resource request reuse
+the most recently observed token-endpoint nonce when no exact URL entry exists.
+
+Salesforce normally seeds and rotates the nonce at the token endpoint. `SFSDKOAuth2` harvests the
+response header before interpreting a token response and retries one nonce challenge with a newly
+built proof.
+
+`SFRestAPI` also defensively handles a resource-server HTTP 400 `use_dpop_nonce` response:
+
+1. Confirm that the response belongs to the request's current data task.
+2. Confirm that this request has not already used its one resource nonce retry.
+3. Harvest `DPoP-Nonce` for the response URL and credential scope.
+4. Rebuild and enqueue the request, producing a fresh proof.
+
+Resource-server 401 responses do not take this inline nonce path. They enter normal access-token
+refresh, where the token endpoint can provide a fresh nonce before the resource request is replayed.
+
+Account deletion clears both the credential-scoped DPoP keypair and cached nonces. Credential
+migration clears the old credential's DPoP state after the new credential state is established.
+
+---
+
+## 6. REST Refresh and Replay
+
+An authenticated `SFRestAPI` instance maintains:
+
+- `activeRequests`, containing requests that have not reached a terminal outcome;
+- `refreshCycleActive`, coalescing expired-token responses within that API instance; and
+- `SFRestRequest.sessionDataTask`, identifying the request's current network attempt.
+
+When an attempt receives an authentication failure accepted by the retry policy:
+
+1. The completion verifies that its data task is still current.
+2. Under `@synchronized(self)`, `replayRequest` elects one refresh cycle for the API instance.
+3. The API asks the shared `SFSDKTokenRefreshCoordinator` to refresh the credential.
+4. Other failed requests remain in `activeRequests`; they do not start another refresh cycle.
+5. On refresh success, `resendActiveRequestsRequiringAuthentication` snapshots the active set and
+   installs a new task for each pending request with automatic auth retry disabled.
+6. Each old task is cancelled after its successor is installed.
+7. On refresh failure, the active set is atomically drained and each request receives one failure.
+
+The local `refreshCycleActive` flag groups requests for one `SFRestAPI`. The shared refresh
+coordinator is the cross-component, per-credential protection that prevents a second token POST.
+
+---
+
+## 7. Request-Attempt Ownership
+
+Refresh coalescing alone does not make REST replay safe. An old task can finish while refresh is
+installing its replacement. `SFRestAPI` therefore treats `request.sessionDataTask` as an ownership
+token for one network attempt.
+
+All compound ownership transitions use the same `@synchronized(self)` domain:
+
+```text
+terminal completion:
+  lock
+    require callbackTask == request.sessionDataTask
+    request.sessionDataTask = nil
+    remove request from activeRequests
+    copy the attempt's callback block
+  unlock
+  invoke application or delegate code
+
+authentication or DPoP retry:
+  lock
+    require callbackTask == request.sessionDataTask
+    build, start, and publish the successor task
+  unlock
+```
+
+There is an inexpensive current-task check before response parsing, followed by another check in
+the terminal claim. The second check is essential: parsing runs outside the lock, so refresh could
+replace the task between parsing and delivery.
+
+The successor is created and assigned to `request.sessionDataTask` while holding the state lock.
+`SFNetwork.sendRequest` resumes its task before returning, so the lock prevents an exceptionally
+fast asynchronous completion from observing the request before task ownership is published.
+
+**Invariant:** `SFNetwork.sendRequest` must remain nonblocking and must not invoke its completion
+synchronously. Changing that contract could introduce a lock-ordering or reentrancy hazard.
+
+Application blocks and delegate methods always run after the state lock is released. The terminal
+claim removes the completed request before client code runs. This also permits a callback to reuse
+the same `SFRestRequest`: the new send re-adds the request and cannot be removed later by cleanup
+belonging to the old attempt.
+
+---
+
+## 8. Cleanup and Failure Semantics
+
+Normal success, network error, timeout, and terminal HTTP failure all use the terminal ownership
+claim and can deliver at most one callback.
+
+Logout cleanup and refresh-failure flushing follow an invalidate/drain/cancel/notify sequence:
+
+1. Under the state lock, clear each current task, copy its failure block, drain `activeRequests`,
+   and clear `refreshCycleActive`.
+2. Release the lock.
+3. Cancel the invalidated tasks.
+4. Invoke the copied failure blocks.
+
+Cancellation can enqueue a URL-session completion, but that completion sees that its task no longer
+owns the request and is ignored. Calling client code outside the lock permits safe re-entry into
+`SFRestAPI`.
+
+On token-refresh failure, `SFRestAPI` preserves the established policy:
+
+- `invalid_grant` triggers logout with `SFLogoutReasonTokenExpired`;
+- `appAttestationFailed` triggers logout with `SFLogoutReasonAppAttestationFailed`; and
+- `appAttestationFailedRetry` is reported without automatic logout.
+
+---
+
+## 9. End-to-End Scenarios
+
+### 9.1 Successful authenticated request
+
+```text
+send request
+  -> build Authorization and optional DPoP proof
+  -> install current data task
+  -> receive 2xx
+  -> atomically claim terminal success
+  -> invoke success callback outside the lock
+```
+
+### 9.2 Concurrent expired-token responses with RTR
+
+```text
+REST request A -> auth failure ----+     one token refresh POST
+REST request B -> auth failure ----+---> SFSDKTokenRefreshCoordinator
+identity request -> 401 -----------+     keyed by credentials.identifier
+                                             |
+                                             v
+                                    rotated credentials published once
+                                             |
+                      +----------------------+----------------------+
+                      v                      v                      v
+                 replay A               replay B            retry identity
+```
+
+Each `SFRestAPI` still performs its own active-request replay, but every component observes the
+same coordinated refresh result.
+
+### 9.3 Resource-server nonce challenge
+
+```text
+task 1 -> HTTP 400 use_dpop_nonce + DPoP-Nonce
+  -> verify task 1 is current
+  -> harvest nonce and install task 2 under the ownership lock
+  -> task 2 carries a fresh proof
+  -> task 2 completes terminally
+  -> any later task-1 completion is stale and ignored
+```
+
+### 9.4 Completion racing authentication replay
+
+```text
+old task passes the early stale check
+old task parses outside the lock
+refresh attempts to install a successor
+
+Whichever acquires the ownership lock first wins:
+  - terminal claim removes the request, so refresh cannot replay it; or
+  - replay publishes the successor, so the old task fails its terminal recheck.
+```
+
+The request receives one terminal result in either ordering.
+
+---
+
+## 10. Concurrency Invariants
+
+1. At most one active coordinator entry exists per credential identifier; concurrent callers
+   coalesce onto that entry.
+2. A refresh network call never runs while the coordinator serial queue is synchronously held.
+3. At most one data-task attempt can deliver a terminal result for an `SFRestRequest`.
+4. Terminal completion and successor installation use the same request-state lock.
+5. A successor task is published before its asynchronous completion can claim ownership.
+6. DPoP and authentication retries remain nonterminal; they transfer ownership to a successor.
+7. Application and delegate callbacks execute outside the request-state lock.
+8. Cleanup invalidates request ownership before cancellation or client notification.
+9. A replayed REST request cannot automatically start a second auth refresh cycle.
+
+The focused regression coverage lives in `SFRestAPIDataTaskRaceTests`, with coordinator behavior
+covered by `SFSDKTokenRefreshCoordinatorTests` and token-endpoint nonce handling covered by the
+`SFSDKOAuth2` test suites.

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -341,6 +341,7 @@ successBlock:(SFRestResponseBlock)successBlock
 
         __block NSURLSessionDataTask *dataTask;
         @synchronized (self) {
+            // Invariant: sendRequest: must remain nonblocking and invoke its completion asynchronously.
             dataTask = [network sendRequest:finalRequest dataResponseBlock:^(NSData *data, NSURLResponse *response, NSError *error) {
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 [SFNetwork removeSharedInstanceForIdentifier:instanceIdentifier];
@@ -359,6 +360,7 @@ successBlock:(SFRestResponseBlock)successBlock
                 // Network error.
                 if (error) {
                     [SFSDKCoreLogger d:[strongSelf class] format:@"REST request failed with error: Error Code: %ld, Description: %@, URL: %@", (long) error.code, error.localizedDescription, finalRequest.URL];
+                    id dataForDelegate = [strongSelf prepareDataForDelegate:data request:request response:response];
                     __block SFRestRequestFailBlock failureBlock;
                     BOOL claimed = [strongSelf performIfCurrentDataTask:dataTask forRequest:request action:^{
                         request.sessionDataTask = nil;
@@ -368,7 +370,6 @@ successBlock:(SFRestResponseBlock)successBlock
                     if (!claimed) {
                         return;
                     }
-                    id dataForDelegate = [strongSelf prepareDataForDelegate:data request:request response:response];
                     if (failureBlock) {
                         failureBlock(dataForDelegate, error, response);
                     }
@@ -623,6 +624,8 @@ successBlock:(SFRestResponseBlock)successBlock
         NSSet *pendingRequests = [self.activeRequests asSet];
         for (SFRestRequest *request in pendingRequests) {
             NSURLSessionDataTask *oldTask = request.sessionDataTask;
+            // This recursive send relies on enqueueRequest's documented nonblocking,
+            // asynchronous SFNetwork callback invariant while the state lock is held.
             [self send:request
           failureBlock:request.failureBlock
           successBlock:request.successBlock

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -624,6 +624,12 @@ successBlock:(SFRestResponseBlock)successBlock
         NSSet *pendingRequests = [self.activeRequests asSet];
         for (SFRestRequest *request in pendingRequests) {
             NSURLSessionDataTask *oldTask = request.sessionDataTask;
+            if (!oldTask) {
+                // activeRequests admission precedes initial task publication. If a new request
+                // reaches this snapshot in that interval, its original sender still owns
+                // publication; replay must replace an existing attempt, not create the first one.
+                continue;
+            }
             // This recursive send relies on enqueueRequest's documented nonblocking,
             // asynchronous SFNetwork callback invariant while the state lock is held.
             [self send:request

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/RestAPI/SFRestAPI.m
@@ -60,6 +60,10 @@ static SFSDKSafeMutableDictionary *sfRestApiList = nil;
 @property (readwrite, assign) BOOL refreshCycleActive;
 @property (nonatomic, strong, readwrite) SFUserAccount *user;
 
+- (BOOL)performIfCurrentDataTask:(NSURLSessionDataTask *)dataTask
+                      forRequest:(SFRestRequest *)request
+                          action:(nullable dispatch_block_t)action;
+
 @end
 
 @implementation SFRestAPI
@@ -98,6 +102,12 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
 #pragma mark - Cleanup / cancel all
 
 - (void)cleanup {
+    NSMutableArray<NSURLSessionDataTask *> *tasksToCancel = [NSMutableArray new];
+    NSMutableArray *failureBlocks = [NSMutableArray new];
+    NSError *logoutError = [NSError errorWithDomain:kSFRestErrorDomain
+                                                code:kSFRestErrorCode
+                                            userInfo:@{NSLocalizedDescriptionKey: @"User logged out"}];
+
     @synchronized (self) {
         NSSet *pendingRequests = [self.activeRequests asSet];
         for (SFRestRequest *request in pendingRequests) {
@@ -107,16 +117,24 @@ __strong static NSDateFormatter *httpDateFormatter = nil;
             // double-deliver failureBlock.
             NSURLSessionDataTask *oldTask = request.sessionDataTask;
             request.sessionDataTask = nil;
-            [oldTask cancel];
+            if (oldTask) {
+                [tasksToCancel addObject:oldTask];
+            }
             if (request.failureBlock) {
-                NSError *logoutError = [NSError errorWithDomain:kSFRestErrorDomain
-                                                           code:kSFRestErrorCode
-                                                      userInfo:@{NSLocalizedDescriptionKey: @"User logged out"}];
-                request.failureBlock(nil, logoutError, nil);
+                [failureBlocks addObject:[request.failureBlock copy]];
             }
         }
         [self.activeRequests removeAllObjects];
         self.refreshCycleActive = NO;
+    }
+
+    // Cancellation and client callbacks may synchronously call back into SFRestAPI.
+    // Keep them outside the state lock after every request has been invalidated.
+    for (NSURLSessionDataTask *task in tasksToCancel) {
+        [task cancel];
+    }
+    for (SFRestRequestFailBlock failureBlock in failureBlocks) {
+        failureBlock(nil, logoutError, nil);
     }
 }
 
@@ -270,17 +288,10 @@ static dispatch_once_t pred;
 - (void)send:(SFRestRequest *)request
 failureBlock:(SFRestRequestFailBlock)failureBlock
 successBlock:(SFRestResponseBlock)successBlock {
-    [self send:request failureBlock:^(id  _Nullable response, NSError * _Nullable e, NSURLResponse * _Nullable rawResponse) {
-        if (failureBlock) {
-            failureBlock(response, e, rawResponse);
-        }
-        [self removeActiveRequestObject:request];
-    } successBlock:^(id  _Nullable response, NSURLResponse * _Nullable rawResponse) {
-        if (successBlock) {
-            successBlock(response, rawResponse);
-        }
-        [self removeActiveRequestObject:request];
-    }shouldRetry:self.requiresAuthentication && request.requiresAuthentication];
+    [self send:request
+   failureBlock:failureBlock
+   successBlock:successBlock
+    shouldRetry:self.requiresAuthentication && request.requiresAuthentication];
 }
 
 - (void)send:(SFRestRequest *)request
@@ -328,71 +339,133 @@ successBlock:(SFRestResponseBlock)successBlock
             network = [self networkForRequest:request];
         }
 
-        __block NSURLSessionDataTask *dataTask = [network sendRequest:finalRequest dataResponseBlock:^(NSData *data, NSURLResponse *response, NSError *error) {
-            __strong typeof(weakSelf) strongSelf = weakSelf;
-            [SFNetwork removeSharedInstanceForIdentifier:instanceIdentifier];
+        __block NSURLSessionDataTask *dataTask;
+        @synchronized (self) {
+            dataTask = [network sendRequest:finalRequest dataResponseBlock:^(NSData *data, NSURLResponse *response, NSError *error) {
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [SFNetwork removeSharedInstanceForIdentifier:instanceIdentifier];
 
-            // Guard: ignore callbacks from stale dataTasks superseded by retry.
-            if (dataTask != request.sessionDataTask) {
-                [SFSDKCoreLogger d:[strongSelf class] format:@"Ignoring callback from stale task for request: %@", request.path];
-                return;
-            }
-
-            // Network error.
-            if (error) {
-                [SFSDKCoreLogger d:[strongSelf class] format:@"REST request failed with error: Error Code: %ld, Description: %@, URL: %@", (long) error.code, error.localizedDescription, finalRequest.URL];
-                id dataForDelegate = [strongSelf prepareDataForDelegate:data request:request response:response];
-                if (request.failureBlock) {
-                    request.failureBlock(dataForDelegate, error, response);
-                }
-                return;
-            }
-            
-            // Timeout.
-            if (!response) {
-                if (request.failureBlock) {
-                    request.failureBlock(nil, nil, nil);
-                }
-                return;
-            }
-            NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
-
-            // 2xx indicates success.
-            if ([SFRestAPI isStatusCodeSuccess:statusCode]) {
-                id dataForDelegate = [strongSelf prepareDataForDelegate:data request:request response:response];
-                if (request.successBlock) {
-                    request.successBlock(dataForDelegate, response);
-                }
-            } else {
-                // DPoP nonce challenge (HTTP 400 with use_dpop_nonce in body): harvest the
-                // server-issued nonce and retry the request once with the updated proof.
-                // This covers the post-restart case where the in-memory nonce cache is empty
-                // and the first outbound DPoP call (e.g. revoke) triggers a nonce challenge.
-                // RFC 9449 §8 — the server SHOULD return the desired nonce in DPoP-Nonce.
-                NSString *bodyStr = data ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : nil;
-                if (statusCode == 400
-                    && !request.dpopNonceRetried
-                    && [bodyStr containsString:SFSDKDPoPRequestDecorator.nonceErrorCode]) {
-                    request.dpopNonceRetried = YES;
-                    [SFSDKDPoPRequestDecorator harvestNonceFromResponse:response
-                                                            requestURL:finalRequest.URL
-                                                                 scope:strongSelf.user.credentials.identifier];
-                    [strongSelf enqueueRequest:request shouldRetry:shouldRetry];
+                if (!strongSelf) {
                     return;
                 }
-                if (shouldRetry && [strongSelf shouldRetryTask:dataTask withData:data]) {
-                    [strongSelf replayRequest:request response:response];
-                } else {
-                    // Other status codes indicate failure.
-                    NSError *errorForDelegate = [strongSelf prepareErrorForDelegate:data response:response];
+
+                // This early check avoids parsing responses from attempts already superseded by
+                // retry. Terminal paths re-check while atomically claiming completion below;
+                // the re-check is what closes the check-then-replay race.
+                if (![strongSelf performIfCurrentDataTask:dataTask forRequest:request action:nil]) {
+                    return;
+                }
+
+                // Network error.
+                if (error) {
+                    [SFSDKCoreLogger d:[strongSelf class] format:@"REST request failed with error: Error Code: %ld, Description: %@, URL: %@", (long) error.code, error.localizedDescription, finalRequest.URL];
+                    __block SFRestRequestFailBlock failureBlock;
+                    BOOL claimed = [strongSelf performIfCurrentDataTask:dataTask forRequest:request action:^{
+                        request.sessionDataTask = nil;
+                        [strongSelf.activeRequests removeObject:request];
+                        failureBlock = [request.failureBlock copy];
+                    }];
+                    if (!claimed) {
+                        return;
+                    }
                     id dataForDelegate = [strongSelf prepareDataForDelegate:data request:request response:response];
-                    if (request.failureBlock) {
-                        request.failureBlock(dataForDelegate, errorForDelegate, response);
+                    if (failureBlock) {
+                        failureBlock(dataForDelegate, error, response);
+                    }
+                    return;
+                }
+
+                // Timeout.
+                if (!response) {
+                    __block SFRestRequestFailBlock failureBlock;
+                    BOOL claimed = [strongSelf performIfCurrentDataTask:dataTask forRequest:request action:^{
+                        request.sessionDataTask = nil;
+                        [strongSelf.activeRequests removeObject:request];
+                        failureBlock = [request.failureBlock copy];
+                    }];
+                    if (claimed && failureBlock) {
+                        failureBlock(nil, nil, nil);
+                    }
+                    return;
+                }
+
+                NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
+
+                // 2xx indicates success.
+                if ([SFRestAPI isStatusCodeSuccess:statusCode]) {
+                    id dataForDelegate = [strongSelf prepareDataForDelegate:data request:request response:response];
+                    __block SFRestResponseBlock successBlock;
+                    BOOL claimed = [strongSelf performIfCurrentDataTask:dataTask forRequest:request action:^{
+                        // Claim terminal delivery and make the request non-replayable as one
+                        // operation. Client code runs after the lock is released.
+                        request.sessionDataTask = nil;
+                        [strongSelf.activeRequests removeObject:request];
+                        successBlock = [request.successBlock copy];
+                    }];
+                    if (claimed && successBlock) {
+                        successBlock(dataForDelegate, response);
+                    }
+                } else {
+                    // DPoP nonce challenge (HTTP 400 with use_dpop_nonce in body): harvest the
+                    // server-issued nonce and retry the request once with the updated proof.
+                    // This covers the post-restart case where the in-memory nonce cache is empty
+                    // and the first outbound DPoP call (e.g. revoke) triggers a nonce challenge.
+                    // RFC 9449 §8 — the server SHOULD return the desired nonce in DPoP-Nonce.
+                    NSString *bodyStr = data ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : nil;
+                    if (statusCode == 400
+                        && !request.dpopNonceRetried
+                        && [bodyStr containsString:SFSDKDPoPRequestDecorator.nonceErrorCode]) {
+                        [strongSelf performIfCurrentDataTask:dataTask forRequest:request action:^{
+                            // Retire and replace this attempt while holding the same lock used by
+                            // terminal completion claims and authentication replay.
+                            request.dpopNonceRetried = YES;
+                            [SFSDKDPoPRequestDecorator harvestNonceFromResponse:response
+                                                                    requestURL:finalRequest.URL
+                                                                         scope:strongSelf.user.credentials.identifier];
+                            [strongSelf enqueueRequest:request shouldRetry:shouldRetry];
+                        }];
+                        return;
+                    }
+                    if (shouldRetry && [strongSelf shouldRetryTask:dataTask withData:data]) {
+                        [strongSelf performIfCurrentDataTask:dataTask forRequest:request action:^{
+                            [strongSelf replayRequest:request response:response];
+                        }];
+                    } else {
+                        // Other status codes indicate terminal failure.
+                        NSError *errorForDelegate = [strongSelf prepareErrorForDelegate:data response:response];
+                        id dataForDelegate = [strongSelf prepareDataForDelegate:data request:request response:response];
+                        __block SFRestRequestFailBlock failureBlock;
+                        BOOL claimed = [strongSelf performIfCurrentDataTask:dataTask forRequest:request action:^{
+                            request.sessionDataTask = nil;
+                            [strongSelf.activeRequests removeObject:request];
+                            failureBlock = [request.failureBlock copy];
+                        }];
+                        if (claimed && failureBlock) {
+                            failureBlock(dataForDelegate, errorForDelegate, response);
+                        }
                     }
                 }
-            }
-        }];
-        request.sessionDataTask = dataTask;
+            }];
+
+            // SFNetwork resumes before returning. Publishing the task while holding the state
+            // lock makes an exceptionally fast callback wait until ownership is installed.
+            request.sessionDataTask = dataTask;
+        }
+    }
+}
+
+- (BOOL)performIfCurrentDataTask:(NSURLSessionDataTask *)dataTask
+                      forRequest:(SFRestRequest *)request
+                          action:(dispatch_block_t)action {
+    @synchronized (self) {
+        if (dataTask != request.sessionDataTask) {
+            [SFSDKCoreLogger d:[self class] format:@"Ignoring callback from stale task for request: %@", request.path];
+            return NO;
+        }
+        if (action) {
+            action();
+        }
+        return YES;
     }
 }
 
@@ -494,10 +567,7 @@ successBlock:(SFRestResponseBlock)successBlock
      error:^(NSError *refreshError) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         [SFSDKCoreLogger e:[strongSelf class] format:@"Failed to refresh expired session. Error: %@", refreshError];
-        @synchronized (strongSelf) {
-            [strongSelf flushPendingRequestQueue:refreshError rawResponse:response];
-            strongSelf.refreshCycleActive = NO;
-        }
+        [strongSelf flushPendingRequestQueue:refreshError rawResponse:response];
         if ([refreshError.domain isEqualToString:kSFOAuthErrorDomain]) {
             SFUserAccount *user = strongSelf.user;
             void (^triggerLogout)(SFLogoutReason, NSString *) = ^(SFLogoutReason reason, NSString *logMessage) {
@@ -519,16 +589,32 @@ successBlock:(SFRestResponseBlock)successBlock
 }
 
 - (void)flushPendingRequestQueue:(NSError *)error rawResponse:(NSURLResponse *)rawResponse {
+    NSMutableArray<NSURLSessionDataTask *> *tasksToCancel = [NSMutableArray new];
+    NSMutableArray *failureBlocks = [NSMutableArray new];
+
     @synchronized (self) {
         NSSet *pendingRequests = [self.activeRequests asSet];
         for (SFRestRequest *request in pendingRequests) {
             NSURLSessionDataTask *oldTask = request.sessionDataTask;
             request.sessionDataTask = nil;
-            [oldTask cancel];
+            if (oldTask) {
+                [tasksToCancel addObject:oldTask];
+            }
             if (request.failureBlock) {
-                request.failureBlock(nil, error, rawResponse);
+                [failureBlocks addObject:[request.failureBlock copy]];
             }
         }
+        [self.activeRequests removeAllObjects];
+        self.refreshCycleActive = NO;
+    }
+
+    // Requests are no longer current before cancellation can enqueue its callback.
+    // Invoke client blocks outside the lock to permit safe re-entry into SFRestAPI.
+    for (NSURLSessionDataTask *task in tasksToCancel) {
+        [task cancel];
+    }
+    for (SFRestRequestFailBlock failureBlock in failureBlocks) {
+        failureBlock(nil, error, rawResponse);
     }
 }
 
@@ -550,14 +636,12 @@ successBlock:(SFRestResponseBlock)successBlock
     if ([delegate respondsToSelector:@selector(request:didSucceed:rawResponse:)]) {
         [delegate request:request didSucceed:data rawResponse:rawResponse];
     }
-    [self removeActiveRequestObject:request];
 }
 
 - (void)notifyDelegateOfFailure:(id<SFRestRequestDelegate>)delegate request:(SFRestRequest *)request data:(id)data rawResponse:(NSURLResponse *)rawResponse error:(NSError *)error {
     if ([delegate respondsToSelector:@selector(request:didFail:rawResponse:error:)]) {
         [delegate request:request didFail:data rawResponse:rawResponse error:error];
     }
-    [self removeActiveRequestObject:request];
 }
 
 #pragma mark - SFRestRequest factory methods

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFRestAPIDataTaskRaceTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFRestAPIDataTaskRaceTests.m
@@ -42,8 +42,46 @@ successBlock:(SFRestResponseBlock)successBlock
 - (void)resendActiveRequestsRequiringAuthentication;
 - (void)flushPendingRequestQueue:(NSError *)error rawResponse:(NSURLResponse *)rawResponse;
 - (void)replayRequest:(SFRestRequest *)request response:(NSURLResponse *)response;
+- (id)prepareDataForDelegate:(NSData *)data request:(SFRestRequest *)request response:(NSURLResponse *)response;
 
 @property (readwrite, assign) BOOL refreshCycleActive;
+
+@end
+
+#pragma mark - CompletionRaceRestAPI
+
+/**
+ * Test-only SFRestAPI that can pause response preparation. The production race
+ * occurs after the old task passes its first stale-task check but before it
+ * invokes a terminal block, which is exactly where this override provides a
+ * deterministic scheduling point.
+ */
+@interface CompletionRaceRestAPI : SFRestAPI
+@property (atomic, assign) BOOL pauseNextResponsePreparation;
+@property (nonatomic, strong) dispatch_semaphore_t responsePreparationStarted;
+@property (nonatomic, strong) dispatch_semaphore_t allowResponsePreparation;
+@end
+
+@implementation CompletionRaceRestAPI
+
+- (instancetype)initWithUser:(SFUserAccount *)user {
+    self = [super initWithUser:user];
+    if (self) {
+        _responsePreparationStarted = dispatch_semaphore_create(0);
+        _allowResponsePreparation = dispatch_semaphore_create(0);
+    }
+    return self;
+}
+
+- (id)prepareDataForDelegate:(NSData *)data request:(SFRestRequest *)request response:(NSURLResponse *)response {
+    if (self.pauseNextResponsePreparation) {
+        self.pauseNextResponsePreparation = NO;
+        dispatch_semaphore_signal(self.responsePreparationStarted);
+        dispatch_semaphore_wait(self.allowResponsePreparation,
+                                dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC)));
+    }
+    return [super prepareDataForDelegate:data request:request response:response];
+}
 
 @end
 
@@ -133,7 +171,7 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
     config.protocolClasses = @[[DeferredURLProtocol class]];
     [SFNetwork setSessionConfiguration:config identifier:kSFNetworkEphemeralInstanceIdentifier];
 
-    self.api = [[SFRestAPI alloc] initWithUser:nil];
+    self.api = [[CompletionRaceRestAPI alloc] initWithUser:nil];
 }
 
 - (void)tearDown {
@@ -167,7 +205,88 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
     return condition();
 }
 
+/**
+ * Forces the interleaving missing from the original stale-task regression test:
+ *
+ *   1. Task #1 passes the early stale-task check and pauses while preparing data.
+ *   2. Authentication refresh replay installs task #2 for the same request.
+ *   3. Task #1 resumes and attempts to deliver its terminal callback.
+ *
+ * The terminal claim must revalidate task ownership under the replay lock, so
+ * task #1 is ignored and only task #2 is allowed to call client code.
+ */
+- (void)runTerminalCallbackRaceWithStatusCode:(NSInteger)statusCode expectSuccess:(BOOL)expectSuccess {
+    CompletionRaceRestAPI *api = (CompletionRaceRestAPI *)self.api;
+    api.pauseNextResponsePreparation = YES;
+
+    __block NSInteger successCount = 0;
+    __block NSInteger failureCount = 0;
+    XCTestExpectation *terminalCallback = [self expectationWithDescription:@"one terminal callback"];
+    terminalCallback.assertForOverFulfill = YES;
+
+    SFRestRequest *request = [self makeRequest];
+    [api send:request failureBlock:^(id response, NSError *error, NSURLResponse *rawResponse) {
+        @synchronized (self) {
+            failureCount++;
+        }
+        if (expectSuccess) {
+            XCTFail(@"Expected success, received failure: %@", error);
+        }
+        [terminalCallback fulfill];
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
+        @synchronized (self) {
+            successCount++;
+        }
+        if (!expectSuccess) {
+            XCTFail(@"Expected terminal HTTP failure, received success");
+        }
+        [terminalCallback fulfill];
+    }];
+
+    XCTAssertTrue([self waitForCondition:^BOOL{
+        return [DeferredURLProtocol pendingCount] >= 1;
+    } timeout:2], @"task #1 should be pending");
+    NSURLSessionDataTask *originalTask = request.sessionDataTask;
+
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        [DeferredURLProtocol deliverResponseAtIndex:0 statusCode:statusCode];
+    });
+    XCTAssertEqual(dispatch_semaphore_wait(api.responsePreparationStarted,
+                                           dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC))), 0,
+                   @"task #1 should pause after its early stale-task check");
+
+    dispatch_semaphore_t resendFinished = dispatch_semaphore_create(0);
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        [api resendActiveRequestsRequiringAuthentication];
+        dispatch_semaphore_signal(resendFinished);
+    });
+    XCTAssertEqual(dispatch_semaphore_wait(resendFinished,
+                                           dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC))), 0,
+                   @"replay must not wait for response parsing or client code");
+    XCTAssertNotEqual(request.sessionDataTask, originalTask, @"replay should install task #2");
+
+    dispatch_semaphore_signal(api.allowResponsePreparation);
+    XCTAssertTrue([self waitForCondition:^BOOL{
+        return [DeferredURLProtocol pendingCount] >= 2;
+    } timeout:2], @"task #2 should be pending");
+    [DeferredURLProtocol deliverResponseAtIndex:1 statusCode:statusCode];
+
+    [self waitForExpectationsWithTimeout:5 handler:nil];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.25]];
+
+    XCTAssertEqual(successCount, expectSuccess ? 1 : 0);
+    XCTAssertEqual(failureCount, expectSuccess ? 0 : 1);
+}
+
 #pragma mark - Test: resendActiveRequestsRequiringAuthentication race
+
+- (void)testConcurrentReplayWhileSuccessfulResponseIsBeingPreparedDeliversOnce {
+    [self runTerminalCallbackRaceWithStatusCode:200 expectSuccess:YES];
+}
+
+- (void)testConcurrentReplayWhileFailureResponseIsBeingPreparedDeliversOnce {
+    [self runTerminalCallbackRaceWithStatusCode:500 expectSuccess:NO];
+}
 
 /**
  * Reproduces the crash scenario:

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFRestAPIDataTaskRaceTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFRestAPIDataTaskRaceTests.m
@@ -43,6 +43,7 @@ successBlock:(SFRestResponseBlock)successBlock
 - (void)flushPendingRequestQueue:(NSError *)error rawResponse:(NSURLResponse *)rawResponse;
 - (void)replayRequest:(SFRestRequest *)request response:(NSURLResponse *)response;
 - (id)prepareDataForDelegate:(NSData *)data request:(SFRestRequest *)request response:(NSURLResponse *)response;
+- (SFNetwork *)networkForRequest:(SFRestRequest *)request;
 
 @property (readwrite, assign) BOOL refreshCycleActive;
 
@@ -60,6 +61,7 @@ successBlock:(SFRestResponseBlock)successBlock
 @property (atomic, assign) BOOL pauseNextResponsePreparation;
 @property (nonatomic, strong) dispatch_semaphore_t responsePreparationStarted;
 @property (nonatomic, strong) dispatch_semaphore_t allowResponsePreparation;
+@property (nonatomic, strong) SFNetwork *networkOverride;
 @end
 
 @implementation CompletionRaceRestAPI
@@ -83,6 +85,59 @@ successBlock:(SFRestResponseBlock)successBlock
     return [super prepareDataForDelegate:data request:request response:response];
 }
 
+- (SFNetwork *)networkForRequest:(SFRestRequest *)request {
+    return self.networkOverride ?: [super networkForRequest:request];
+}
+
+@end
+
+#pragma mark - ControlledCompletionNetwork
+
+/**
+ * Test-only network that can produce response combinations NSURLProtocol cannot,
+ * such as a completion with neither a response nor an error.
+ */
+@interface ControlledCompletionNetwork : SFNetwork
+@property (nonatomic, strong) NSMutableArray<NSURLSessionDataTask *> *tasks;
+@property (nonatomic, strong) NSMutableArray *completionBlocks;
+- (NSUInteger)pendingCount;
+- (void)deliverData:(NSData *)data response:(NSURLResponse *)response error:(NSError *)error atIndex:(NSUInteger)index;
+@end
+
+@implementation ControlledCompletionNetwork
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _tasks = [NSMutableArray new];
+        _completionBlocks = [NSMutableArray new];
+    }
+    return self;
+}
+
+- (NSURLSessionDataTask *)sendRequest:(NSURLRequest *)urlRequest dataResponseBlock:(SFDataResponseBlock)dataResponseBlock {
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:urlRequest];
+    @synchronized (self) {
+        [self.tasks addObject:task];
+        [self.completionBlocks addObject:[dataResponseBlock copy]];
+    }
+    return task;
+}
+
+- (NSUInteger)pendingCount {
+    @synchronized (self) {
+        return self.completionBlocks.count;
+    }
+}
+
+- (void)deliverData:(NSData *)data response:(NSURLResponse *)response error:(NSError *)error atIndex:(NSUInteger)index {
+    SFDataResponseBlock completionBlock;
+    @synchronized (self) {
+        completionBlock = [self.completionBlocks[index] copy];
+    }
+    completionBlock(data, response, error);
+}
+
 @end
 
 #pragma mark - DeferredURLProtocol
@@ -96,6 +151,11 @@ successBlock:(SFRestResponseBlock)successBlock
 + (void)reset;
 + (NSUInteger)pendingCount;
 + (void)deliverResponseAtIndex:(NSUInteger)index statusCode:(NSInteger)statusCode;
++ (void)deliverResponseAtIndex:(NSUInteger)index
+                    statusCode:(NSInteger)statusCode
+                          body:(NSString *)body
+                  headerFields:(NSDictionary<NSString *, NSString *> *)headerFields;
++ (void)deliverErrorAtIndex:(NSUInteger)index error:(NSError *)error;
 @end
 
 static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
@@ -139,6 +199,16 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
 }
 
 + (void)deliverResponseAtIndex:(NSUInteger)index statusCode:(NSInteger)statusCode {
+    [self deliverResponseAtIndex:index
+                      statusCode:statusCode
+                            body:@"{\"ok\":true}"
+                    headerFields:nil];
+}
+
++ (void)deliverResponseAtIndex:(NSUInteger)index
+                    statusCode:(NSInteger)statusCode
+                          body:(NSString *)body
+                  headerFields:(NSDictionary<NSString *, NSString *> *)headerFields {
     DeferredURLProtocol *proto;
     @synchronized (sPendingProtocols) {
         proto = sPendingProtocols[index];
@@ -146,11 +216,19 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:proto.request.URL
                                                              statusCode:statusCode
                                                             HTTPVersion:@"HTTP/1.1"
-                                                           headerFields:nil];
-    NSData *body = [@"{\"ok\":true}" dataUsingEncoding:NSUTF8StringEncoding];
+                                                           headerFields:headerFields];
+    NSData *bodyData = [body dataUsingEncoding:NSUTF8StringEncoding];
     [proto.client URLProtocol:proto didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
-    [proto.client URLProtocol:proto didLoadData:body];
+    [proto.client URLProtocol:proto didLoadData:bodyData];
     [proto.client URLProtocolDidFinishLoading:proto];
+}
+
++ (void)deliverErrorAtIndex:(NSUInteger)index error:(NSError *)error {
+    DeferredURLProtocol *proto;
+    @synchronized (sPendingProtocols) {
+        proto = sPendingProtocols[index];
+    }
+    [proto.client URLProtocol:proto didFailWithError:error];
 }
 
 @end
@@ -215,7 +293,8 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
  * The terminal claim must revalidate task ownership under the replay lock, so
  * task #1 is ignored and only task #2 is allowed to call client code.
  */
-- (void)runTerminalCallbackRaceWithStatusCode:(NSInteger)statusCode expectSuccess:(BOOL)expectSuccess {
+- (void)runTerminalCallbackRaceWithDelivery:(void (^)(NSUInteger index))deliverResponse
+                               expectSuccess:(BOOL)expectSuccess {
     CompletionRaceRestAPI *api = (CompletionRaceRestAPI *)self.api;
     api.pauseNextResponsePreparation = YES;
 
@@ -249,7 +328,7 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
     NSURLSessionDataTask *originalTask = request.sessionDataTask;
 
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-        [DeferredURLProtocol deliverResponseAtIndex:0 statusCode:statusCode];
+        deliverResponse(0);
     });
     XCTAssertEqual(dispatch_semaphore_wait(api.responsePreparationStarted,
                                            dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC))), 0,
@@ -269,7 +348,7 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
     XCTAssertTrue([self waitForCondition:^BOOL{
         return [DeferredURLProtocol pendingCount] >= 2;
     } timeout:2], @"task #2 should be pending");
-    [DeferredURLProtocol deliverResponseAtIndex:1 statusCode:statusCode];
+    deliverResponse(1);
 
     [self waitForExpectationsWithTimeout:5 handler:nil];
     [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.25]];
@@ -281,11 +360,114 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
 #pragma mark - Test: resendActiveRequestsRequiringAuthentication race
 
 - (void)testConcurrentReplayWhileSuccessfulResponseIsBeingPreparedDeliversOnce {
-    [self runTerminalCallbackRaceWithStatusCode:200 expectSuccess:YES];
+    [self runTerminalCallbackRaceWithDelivery:^(NSUInteger index) {
+        [DeferredURLProtocol deliverResponseAtIndex:index statusCode:200];
+    } expectSuccess:YES];
 }
 
 - (void)testConcurrentReplayWhileFailureResponseIsBeingPreparedDeliversOnce {
-    [self runTerminalCallbackRaceWithStatusCode:500 expectSuccess:NO];
+    [self runTerminalCallbackRaceWithDelivery:^(NSUInteger index) {
+        [DeferredURLProtocol deliverResponseAtIndex:index statusCode:500];
+    } expectSuccess:NO];
+}
+
+- (void)testConcurrentReplayWhileNetworkErrorIsBeingPreparedDeliversOnce {
+    NSError *networkError = [NSError errorWithDomain:NSURLErrorDomain
+                                                code:NSURLErrorNetworkConnectionLost
+                                            userInfo:nil];
+    [self runTerminalCallbackRaceWithDelivery:^(NSUInteger index) {
+        [DeferredURLProtocol deliverErrorAtIndex:index error:networkError];
+    } expectSuccess:NO];
+}
+
+- (void)testCompletionWithoutResponseOrErrorDeliversFailureOnce {
+    CompletionRaceRestAPI *api = (CompletionRaceRestAPI *)self.api;
+    ControlledCompletionNetwork *network = [ControlledCompletionNetwork new];
+    api.networkOverride = network;
+
+    __block NSInteger failureCount = 0;
+    XCTestExpectation *failureDelivered = [self expectationWithDescription:@"timeout-style failure delivered"];
+    SFRestRequest *request = [self makeRequest];
+    [api send:request failureBlock:^(id response, NSError *error, NSURLResponse *rawResponse) {
+        failureCount++;
+        XCTAssertNil(response);
+        XCTAssertNil(error);
+        XCTAssertNil(rawResponse);
+        [failureDelivered fulfill];
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
+        XCTFail(@"A completion without a response must not succeed");
+    }];
+
+    XCTAssertEqual(network.pendingCount, 1u);
+    [network deliverData:nil response:nil error:nil atIndex:0];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+
+    XCTAssertEqual(failureCount, 1);
+    XCTAssertNil(request.sessionDataTask);
+    XCTAssertEqual(api.activeRequests.count, 0u);
+}
+
+- (void)testDPoPNonceChallengeRetriesThenDeliversOnce {
+    __block NSInteger successCount = 0;
+    __block NSInteger failureCount = 0;
+    XCTestExpectation *successDelivered = [self expectationWithDescription:@"retry succeeds"];
+    SFRestRequest *request = [self makeRequest];
+
+    [self.api send:request failureBlock:^(id response, NSError *error, NSURLResponse *rawResponse) {
+        failureCount++;
+        XCTFail(@"DPoP nonce retry should not fail: %@", error);
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
+        successCount++;
+        [successDelivered fulfill];
+    }];
+
+    XCTAssertTrue([self waitForCondition:^BOOL{
+        return [DeferredURLProtocol pendingCount] >= 1;
+    } timeout:2]);
+    NSURLSessionDataTask *originalTask = request.sessionDataTask;
+
+    [DeferredURLProtocol deliverResponseAtIndex:0
+                                     statusCode:400
+                                           body:@"{\"error\":\"use_dpop_nonce\"}"
+                                   headerFields:nil];
+
+    XCTAssertTrue([self waitForCondition:^BOOL{
+        return [DeferredURLProtocol pendingCount] >= 2;
+    } timeout:2], @"nonce challenge should install a successor task");
+    XCTAssertTrue(request.dpopNonceRetried);
+    XCTAssertNotEqual(request.sessionDataTask, originalTask);
+
+    [DeferredURLProtocol deliverResponseAtIndex:1 statusCode:200];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+
+    XCTAssertEqual(successCount, 1);
+    XCTAssertEqual(failureCount, 0);
+}
+
+- (void)testCompletionAfterRestAPIDeallocationIsIgnored {
+    __block NSInteger callbackCount = 0;
+    __weak SFRestAPI *weakAPI;
+
+    @autoreleasepool {
+        SFRestAPI *api = [[CompletionRaceRestAPI alloc] initWithUser:nil];
+        weakAPI = api;
+        SFRestRequest *request = [self makeRequest];
+        [api send:request failureBlock:^(id response, NSError *error, NSURLResponse *rawResponse) {
+            callbackCount++;
+        } successBlock:^(id response, NSURLResponse *rawResponse) {
+            callbackCount++;
+        }];
+
+        XCTAssertTrue([self waitForCondition:^BOOL{
+            return [DeferredURLProtocol pendingCount] >= 1;
+        } timeout:2]);
+        api = nil;
+    }
+
+    XCTAssertNil(weakAPI);
+    [DeferredURLProtocol deliverResponseAtIndex:0 statusCode:200];
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.25]];
+    XCTAssertEqual(callbackCount, 0);
 }
 
 /**

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFRestAPIDataTaskRaceTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFRestAPIDataTaskRaceTests.m
@@ -91,6 +91,38 @@ successBlock:(SFRestResponseBlock)successBlock
 
 @end
 
+#pragma mark - AdmissionRaceRestRequest
+
+/**
+ * Test-only request that pauses its first preparation after SFRestAPI has added
+ * it to activeRequests but before enqueueRequest can publish sessionDataTask.
+ * A recursive replay preparation is allowed through so the old behavior fails
+ * deterministically instead of deadlocking the test.
+ */
+@interface AdmissionRaceRestRequest : SFRestRequest
+@property (nonatomic, strong) dispatch_semaphore_t initialPreparationStarted;
+@property (nonatomic, strong) dispatch_semaphore_t allowInitialPreparation;
+@property (nonatomic, assign) NSUInteger preparationCount;
+@end
+
+@implementation AdmissionRaceRestRequest
+
+- (NSURLRequest *)prepareRequestForSend:(SFUserAccount *)user {
+    BOOL shouldPause;
+    @synchronized (self) {
+        self.preparationCount++;
+        shouldPause = (self.preparationCount == 1);
+    }
+    if (shouldPause) {
+        dispatch_semaphore_signal(self.initialPreparationStarted);
+        dispatch_semaphore_wait(self.allowInitialPreparation,
+                                dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC)));
+    }
+    return [super prepareRequestForSend:user];
+}
+
+@end
+
 #pragma mark - ControlledCompletionNetwork
 
 /**
@@ -358,6 +390,82 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
 }
 
 #pragma mark - Test: resendActiveRequestsRequiringAuthentication race
+
+/**
+ * Forces a new-request admission to overlap the refresh replay snapshot:
+ *
+ *   1. send: adds the request to activeRequests, then pauses its first preparation
+ *      before sessionDataTask has been published.
+ *   2. Refresh replay snapshots the active request while its task is still nil.
+ *   3. Replay must skip it; the original sender remains responsible for publishing
+ *      the first attempt and delivering the sole terminal callback.
+ *
+ * Without the nil-task guard, replay creates a task for the request while its
+ * original send is paused. That violates the replace-an-existing-attempt invariant
+ * and permits the two independently created attempts to deliver twice.
+ */
+- (void)testNewRequestAdmissionRacingReplayPublishesOneTaskAndDeliversOnce {
+    CompletionRaceRestAPI *api = (CompletionRaceRestAPI *)self.api;
+    ControlledCompletionNetwork *network = [ControlledCompletionNetwork new];
+    api.networkOverride = network;
+
+    NSString *url = @"https://test.example.com/api/admission-race";
+    AdmissionRaceRestRequest *request = [AdmissionRaceRestRequest requestWithMethod:SFRestMethodGET
+                                                                               path:url
+                                                                        queryParams:nil];
+    request.initialPreparationStarted = dispatch_semaphore_create(0);
+    request.allowInitialPreparation = dispatch_semaphore_create(0);
+    request.requiresAuthentication = NO;
+
+    __block NSInteger successCount = 0;
+    __block NSInteger failureCount = 0;
+    XCTestExpectation *terminalCallback = [self expectationWithDescription:@"one terminal callback"];
+    terminalCallback.assertForOverFulfill = YES;
+    dispatch_semaphore_t initialSendFinished = dispatch_semaphore_create(0);
+
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        [api send:request failureBlock:^(id response, NSError *error, NSURLResponse *rawResponse) {
+            failureCount++;
+            [terminalCallback fulfill];
+        } successBlock:^(id response, NSURLResponse *rawResponse) {
+            successCount++;
+            [terminalCallback fulfill];
+        } shouldRetry:NO];
+        dispatch_semaphore_signal(initialSendFinished);
+    });
+
+    XCTAssertEqual(dispatch_semaphore_wait(request.initialPreparationStarted,
+                                           dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC))), 0,
+                   @"initial send should pause before publishing its task");
+    XCTAssertTrue([api.activeRequests containsObject:request]);
+    XCTAssertNil(request.sessionDataTask);
+
+    [api resendActiveRequestsRequiringAuthentication];
+
+    XCTAssertEqual(network.pendingCount, 0u,
+                   @"replay must not create the initial task for an unpublished request");
+    XCTAssertNil(request.sessionDataTask);
+
+    dispatch_semaphore_signal(request.allowInitialPreparation);
+    XCTAssertEqual(dispatch_semaphore_wait(initialSendFinished,
+                                           dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC))), 0,
+                   @"original send should publish after its preparation is released");
+    XCTAssertEqual(network.pendingCount, 1u);
+    XCTAssertNotNil(request.sessionDataTask);
+
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:url]
+                                                              statusCode:200
+                                                             HTTPVersion:@"HTTP/1.1"
+                                                            headerFields:nil];
+    NSData *data = [@"{\"ok\":true}" dataUsingEncoding:NSUTF8StringEncoding];
+    [network deliverData:data response:response error:nil atIndex:0];
+
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+    XCTAssertEqual(successCount, 1);
+    XCTAssertEqual(failureCount, 0);
+    XCTAssertNil(request.sessionDataTask);
+    XCTAssertEqual(api.activeRequests.count, 0u);
+}
 
 - (void)testConcurrentReplayWhileSuccessfulResponseIsBeingPreparedDeliversOnce {
     [self runTerminalCallbackRaceWithDelivery:^(NSUInteger index) {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFRestAPIDataTaskRaceTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFRestAPIDataTaskRaceTests.m
@@ -44,6 +44,9 @@ successBlock:(SFRestResponseBlock)successBlock
 - (void)replayRequest:(SFRestRequest *)request response:(NSURLResponse *)response;
 - (id)prepareDataForDelegate:(NSData *)data request:(SFRestRequest *)request response:(NSURLResponse *)response;
 - (SFNetwork *)networkForRequest:(SFRestRequest *)request;
+- (BOOL)performIfCurrentDataTask:(NSURLSessionDataTask *)dataTask
+                      forRequest:(SFRestRequest *)request
+                          action:(dispatch_block_t)action;
 
 @property (readwrite, assign) BOOL refreshCycleActive;
 
@@ -61,6 +64,10 @@ successBlock:(SFRestResponseBlock)successBlock
 @property (atomic, assign) BOOL pauseNextResponsePreparation;
 @property (nonatomic, strong) dispatch_semaphore_t responsePreparationStarted;
 @property (nonatomic, strong) dispatch_semaphore_t allowResponsePreparation;
+@property (atomic, assign) BOOL pauseNextCurrentTaskAction;
+@property (nonatomic, strong) dispatch_semaphore_t currentTaskActionStarted;
+@property (nonatomic, strong) dispatch_semaphore_t allowCurrentTaskAction;
+@property (nonatomic, strong) dispatch_semaphore_t currentTaskActionFinished;
 @property (nonatomic, strong) SFNetwork *networkOverride;
 @end
 
@@ -71,6 +78,9 @@ successBlock:(SFRestResponseBlock)successBlock
     if (self) {
         _responsePreparationStarted = dispatch_semaphore_create(0);
         _allowResponsePreparation = dispatch_semaphore_create(0);
+        _currentTaskActionStarted = dispatch_semaphore_create(0);
+        _allowCurrentTaskAction = dispatch_semaphore_create(0);
+        _currentTaskActionFinished = dispatch_semaphore_create(0);
     }
     return self;
 }
@@ -87,6 +97,24 @@ successBlock:(SFRestResponseBlock)successBlock
 
 - (SFNetwork *)networkForRequest:(SFRestRequest *)request {
     return self.networkOverride ?: [super networkForRequest:request];
+}
+
+- (BOOL)performIfCurrentDataTask:(NSURLSessionDataTask *)dataTask
+                      forRequest:(SFRestRequest *)request
+                          action:(dispatch_block_t)action {
+    BOOL shouldPause = action && self.pauseNextCurrentTaskAction;
+    if (shouldPause) {
+        self.pauseNextCurrentTaskAction = NO;
+        dispatch_semaphore_signal(self.currentTaskActionStarted);
+        dispatch_semaphore_wait(self.allowCurrentTaskAction,
+                                dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC)));
+    }
+
+    BOOL performed = [super performIfCurrentDataTask:dataTask forRequest:request action:action];
+    if (shouldPause) {
+        dispatch_semaphore_signal(self.currentTaskActionFinished);
+    }
+    return performed;
 }
 
 @end
@@ -550,6 +578,72 @@ static NSMutableArray<DeferredURLProtocol *> *sPendingProtocols;
 
     XCTAssertEqual(successCount, 1);
     XCTAssertEqual(failureCount, 0);
+}
+
+/**
+ * Forces authentication replay to replace task #1 after its DPoP challenge has
+ * been recognized but before the DPoP retry can claim ownership. The stale DPoP
+ * path must lose its recheck and therefore must not install task #3.
+ */
+- (void)testDPoPNonceRetryClaimRacingAuthenticationReplayDoesNotInstallSecondSuccessor {
+    CompletionRaceRestAPI *api = (CompletionRaceRestAPI *)self.api;
+    api.pauseNextCurrentTaskAction = YES;
+
+    __block NSInteger successCount = 0;
+    __block NSInteger failureCount = 0;
+    XCTestExpectation *terminalCallback = [self expectationWithDescription:@"one terminal callback"];
+    terminalCallback.assertForOverFulfill = YES;
+    SFRestRequest *request = [self makeRequest];
+
+    [api send:request failureBlock:^(id response, NSError *error, NSURLResponse *rawResponse) {
+        failureCount++;
+        [terminalCallback fulfill];
+    } successBlock:^(id response, NSURLResponse *rawResponse) {
+        successCount++;
+        [terminalCallback fulfill];
+    }];
+
+    XCTAssertTrue([self waitForCondition:^BOOL{
+        return [DeferredURLProtocol pendingCount] >= 1;
+    } timeout:2], @"task #1 should be pending");
+    NSURLSessionDataTask *originalTask = request.sessionDataTask;
+
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        [DeferredURLProtocol deliverResponseAtIndex:0
+                                         statusCode:400
+                                               body:@"{\"error\":\"use_dpop_nonce\"}"
+                                       headerFields:nil];
+    });
+    XCTAssertEqual(dispatch_semaphore_wait(api.currentTaskActionStarted,
+                                           dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC))), 0,
+                   @"task #1 should pause immediately before its DPoP retry claim");
+
+    // Authentication replay wins ownership while the DPoP retry is paused.
+    [api resendActiveRequestsRequiringAuthentication];
+    NSURLSessionDataTask *replayTask = request.sessionDataTask;
+    XCTAssertNotEqual(replayTask, originalTask, @"authentication replay should install task #2");
+    XCTAssertTrue([self waitForCondition:^BOOL{
+        return [DeferredURLProtocol pendingCount] >= 2;
+    } timeout:2], @"task #2 should be pending");
+
+    dispatch_semaphore_signal(api.allowCurrentTaskAction);
+    XCTAssertEqual(dispatch_semaphore_wait(api.currentTaskActionFinished,
+                                           dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC))), 0,
+                   @"the stale DPoP claim should finish after the barrier is released");
+
+    XCTAssertEqual([DeferredURLProtocol pendingCount], 2u,
+                   @"the stale DPoP response must not install task #3");
+    XCTAssertEqual(request.sessionDataTask, replayTask);
+    XCTAssertFalse(request.dpopNonceRetried,
+                   @"the stale DPoP retry action must not mutate request state");
+
+    [DeferredURLProtocol deliverResponseAtIndex:1 statusCode:200];
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+
+    XCTAssertEqual(successCount, 1);
+    XCTAssertEqual(failureCount, 0);
+    XCTAssertNil(request.sessionDataTask);
+    XCTAssertEqual(api.activeRequests.count, 0u);
 }
 
 - (void)testCompletionAfterRestAPIDeallocationIsIgnored {


### PR DESCRIPTION
## Context

PR #4001 added a stale-task guard so a response from an attempt superseded by authentication replay would be ignored. The guard compared the callback task with `SFRestRequest.sessionDataTask`, but the comparison was outside the synchronization domain used by refresh replay.

That left this check-then-replay interleaving possible:

1. Task 1 completes and passes the stale-task check.
2. Before Task 1 invokes its terminal callback, token refresh replay sees the request as active and installs Task 2.
3. Task 1 invokes the original success or failure block.
4. Task 2 completes and invokes the same block again.

For the Swift async API, those two Objective-C callbacks attempt to resume the same checked continuation twice.

This PR also closes the admission-side interleaving: `send:` adds a new request to `activeRequests` before `enqueueRequest:` publishes its first `sessionDataTask`. A refresh replay snapshot can therefore observe a newly admitted request with no task yet. Replay must not create that request's first attempt while its original sender is still preparing the same request.

## Relationship to refresh-token rotation work

The stale-task guard was sufficient for the ordering covered by the original regression test: replay fully installs Task 2 before Task 1 enters its completion handler. It was not a general synchronization guarantee because Task 1 could already be between its identity check and terminal callback.

The refresh-token-rotation marker work in #4092 did not touch `SFRestAPI` or its callback scheduling. The rotation-motivated refresh coordinator in #4087 did change `SFRestAPI` to coalesce refreshes across SDK consumers, but its final implementation kept refresh completion callbacks on the main queue, matching the prior `SFOAuthSessionRefresher` behavior. REST completions were already delivered on the independent URL-session delegate queue.

The missing atomicity therefore predates the rotation work. Coordinator-driven coalescing and larger replay batches may make the latent timing window easier to encounter in production, but they did not create the underlying race.

## Timing summary

| When request B arrives relative to request A's refresh replay | What replay observes for B | Before this PR | After this PR |
|---|---|---|---|
| After replay has taken its snapshot or finished | B is absent from the snapshot | B's original send publishes one task | Same: B's original send publishes one task |
| Before the snapshot, with B's first task already published | B is active with a non-nil current task | Replay could replace B, but B's old completion could pass the stale check and still call back | Replay and terminal completion use one ownership lock; only the winning task can call back |
| Exactly across admission and publication | B is active but `sessionDataTask` is nil | Replay could create a task while B's original sender was still preparing, allowing two independently created attempts | Replay skips B; the original sender remains the sole owner of initial task publication |
| While B's published task is finishing | B is active with a current task whose completion is in progress | The check-then-callback window could allow both the old and replayed attempts to call back | Terminal claim and successor installation serialize; exactly one path wins |
| After B recognizes a DPoP nonce challenge but before it claims retry ownership | Authentication replay can replace B's task during the gap | The stale DPoP path could independently publish another successor | The DPoP path rechecks under the ownership lock, loses as stale, and cannot publish or mutate retry state |

## What changed

- Add a private current-task operation protected by the existing synchronized `SFRestAPI` state lock.
- Keep the early stale-task check to avoid unnecessary response parsing, then revalidate ownership immediately before every terminal callback.
- Make terminal completion an atomic state transition that:
  - confirms the callback belongs to the current data task;
  - clears `SFRestRequest.sessionDataTask`;
  - removes the request from `activeRequests`; and
  - copies the success or failure block for delivery.
- Invoke copied application callbacks only after releasing the state lock, allowing safe re-entry into `SFRestAPI`.
- Serialize authentication replay and DPoP nonce replay with the same current-task ownership check.
- Create/resume and publish successor tasks while holding the state lock. `SFNetwork` resumes a task before returning it, so this prevents an exceptionally fast completion from observing task ownership before publication.
- Skip active replay entries whose `sessionDataTask` is nil. Admission precedes initial task publication, so only the original sender may create the first attempt; replay may replace only an existing attempt.
- Document the required `SFNetwork` invariant: `sendRequest` must remain nonblocking and must invoke completion asynchronously.
- Update cleanup and refresh-failure flushing to invalidate and drain requests under the lock, then cancel tasks and invoke failure blocks outside the lock.
- Use consistent parse-then-terminal-claim ordering for success, HTTP failure, and network-error paths.
- Add a self-contained iOS token-lifecycle guide covering code exchange, refresh coordination, RTR, DPoP nonce handling, REST replay, request-attempt ownership, and the admission guard.

Authentication and DPoP retry responses remain nonterminal and keep the request active for their successor task. Public API signatures and retry policy are unchanged.

## Behavior note

Terminal requests are now removed from `activeRequests` before application success, failure, or delegate code is invoked; previously normal removal happened after application code returned.

This is an intentional callback-timing change on a public-facing behavior. It is required to make terminal delivery and replay eligibility one atomic transition. It also fixes a latent request-reuse issue: if application code sends the same `SFRestRequest` again from its callback, cleanup from the previous attempt can no longer remove the newly active attempt.

## Regression tests

The completion-race tests use a test-only `SFRestAPI` subclass to pause Task 1 during response preparation, after its early stale check but before terminal delivery. While Task 1 is paused, the test concurrently replays active requests and verifies Task 2 is installed. Task 1 is then released and Task 2 is completed.

The admission-race test uses a test-only `SFRestRequest` subclass to pause request B after it has entered `activeRequests` but before it publishes its first task. Replay takes its snapshot during that pause. The test verifies replay creates no task, releases the original sender, then verifies exactly one task and one terminal callback.

The DPoP race test pauses Task 1 after recognizing `use_dpop_nonce` but immediately before its retry ownership claim. Authentication replay installs Task 2 during the pause. When released, Task 1 must fail its ownership recheck without setting `dpopNonceRetried` or installing Task 3; Task 2 then delivers the only terminal callback.

The suite now covers:

- A new background-thread submission exactly concurrent with the replay snapshot.
- HTTP 200 terminal success racing replay.
- HTTP 500 terminal failure racing replay.
- Network-error terminal completion racing replay.
- A DPoP nonce retry claim racing authentication replay.
- A sequential DPoP nonce challenge installing and completing a successor task.
- A completion with neither response nor error.
- A response arriving after the owning `SFRestAPI` has been deallocated.
- Existing sequential replay, refresh-failure, cancellation, and cleanup cases.

The replay barriers invoke `resendActiveRequestsRequiringAuthentication` directly. This deterministically exercises the same ownership transition used by successful refresh completion without requiring a live token exchange.

## Test boundary

Barrier-forced concurrent races cover new-request admission during the replay snapshot; Task 1 terminal completion during replay for HTTP 200, HTTP 500, and network-error paths; and a DPoP nonce retry claim racing authentication replay. The no-response/no-error fallback and post-deallocation callback paths are covered by focused tests without a concurrent barrier.

The replay barriers deliberately call the successful-refresh replay transition directly rather than performing a live token exchange. Token refresh coordination and token-endpoint DPoP behavior remain covered by their dedicated suites.

## Coverage follow-up

The initial Codecov report identified 18 uncovered changed lines: the deallocated-API guard, stale network-error return, no-response fallback, and DPoP nonce-retry branch. Four focused tests exercise all of those groups. The admission and DPoP race tests additionally force the nil-task replay guard and the competing-retry ownership recheck.

A local coverage-enabled run confirmed that every one of the original 18 missed production lines executes at least once. CI will report coverage for the two additional race guards at the current head.

## Documentation

- `docs/auth/README.md` indexes the iOS authentication implementation documentation.
- `docs/auth/token-lifecycle.md` is self-contained for contributors to this public repository; it does not depend on internal Workspace documentation.
- The guide explains the separate responsibilities of the per-credential refresh coordinator and the per-request `SFRestAPI` ownership lock.
- The REST lifecycle explicitly documents that replay replaces published attempts but skips a newly admitted request until its original sender publishes the first task.
- The DPoP lifecycle explains how a nonce retry and authentication replay remain one current-task chain regardless of which ownership claim wins.

## Validation

- Focused `SFRestAPIDataTaskRaceTests` run after the DPoP race follow-up: 15 passed, 0 failed, 0 skipped.
- Fresh complete `SalesforceSDKCore` suite after the DPoP race follow-up: 1,034 passed, 0 failed, 0 skipped.
- Test environment: iPhone 16 simulator, iOS 18.6.
- Complete-suite coverage was disabled to avoid the previously observed Xcode coverage-finalization hang.
- Confirmed the diff introduces no public header or API changes.
- Documentation and source changes pass `git diff --check`.

The initial full-suite attempt completed test execution but Xcode stalled while merging coverage data and finalizing its result bundle. Complete-suite runs with code coverage disabled avoid that Xcode tooling issue and complete normally.
